### PR TITLE
Pin pg-replicate to stable version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2021"
 [workspace.dependencies]
 async-trait = "0.1"
 
-pg_replicate = { git = "https://github.com/Mooncake-Labs/pg_replicate"}
+pg_replicate = { git = "https://github.com/Mooncake-Labs/pg_replicate", rev = "a114e0942a25deeb73872973ac2e84e0cb97e436" }
 tokio.version = "1.38"
 tokio-postgres = { git = "https://github.com/imor/rust-postgres", rev = "20265ef38e32a06f76b6f9b678e2077fc2211f6b" }
 arrow = "54.2.1"


### PR DESCRIPTION
Pin pg_replicate to a known working revision to avoid implicit changes during development. 