### PR TITLE
Fix moonlink compilation warnings

### DIFF
--- a/src/moonlink/src/storage/iceberg/catalog_utils.rs
+++ b/src/moonlink/src/storage/iceberg/catalog_utils.rs
@@ -8,28 +8,16 @@ use url::Url;
 #[derive(Debug, Clone)]
 pub enum CatalogInfo {
     /// Connection to a REST catalog server.
-    Rest { uri: String },
+    _Rest { uri: String },
     /// Local filesystem based catalog.
-    FileSystem { warehouse_location: String },
+    FileSystem { _warehouse_location: String },
 }
 
 // Default to use filesystem catalog with a default warehouse location.
 impl Default for CatalogInfo {
     fn default() -> Self {
         CatalogInfo::FileSystem {
-            warehouse_location: "/tmp/moonlink_iceberg_warehouse".to_string(),
-        }
-    }
-}
-
-impl CatalogInfo {
-    pub fn display(&self) -> String {
-        match self {
-            CatalogInfo::Rest { uri } => format!("REST catalog uri: {}", uri),
-            CatalogInfo::FileSystem { warehouse_location } => format!(
-                "Filesytem catalog with warehouse location: {}",
-                warehouse_location
-            ),
+            _warehouse_location: "/tmp/moonlink_iceberg_warehouse".to_string(),
         }
     }
 }

--- a/src/moonlink/src/storage/iceberg/iceberg_snapshot.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_snapshot.rs
@@ -343,7 +343,7 @@ mod tests {
         disk_files.insert(parquet_path.clone(), BatchDeletionVector::new(0));
 
         let mut snapshot = Snapshot::new(metadata);
-        snapshot.set_warehouse_info(warehouse_uri.to_string());
+        snapshot._set_warehouse_info(warehouse_uri.to_string());
         snapshot.disk_files = disk_files;
 
         snapshot._export_to_iceberg().await?;

--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -95,7 +95,7 @@ impl Snapshot {
 
     // TODO(hjiang): Currently development between mooncake table and iceberg is independent, this interface is left for unit test purpose.
     // After end-to-end integration, warehouse information should be passed down from postgres at `Snapshot` initialization.
-    pub fn set_warehouse_info(&mut self, warehouse_uri: String) {
+    pub fn _set_warehouse_info(&mut self, warehouse_uri: String) {
         self.warehouse_uri = warehouse_uri;
     }
 


### PR DESCRIPTION
## Summary

This PR addresses all compilation warnings in the repo.

How I tested:
```sh
cargo rustc -p moonlink- --tests -- -D warnings
cargo rustc -p moonlink_backend --tests -- -D warnings 
cargo rustc -p moonlink_connectors --tests -- -D warnings
```

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
