### PR TITLE
[minor] Use iceberg arrow schema conversion

### DIFF
--- a/src/moonlink/src/storage/iceberg/iceberg_snapshot.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_snapshot.rs
@@ -42,11 +42,9 @@ use uuid::Uuid;
 
 // UNDONE(Iceberg):
 // 1. Implement deletion file related load and store operations.
-// (unrelated to functionality) 2. Support all data types, other than major primitive types.
-// (unrelated to functionality) 3. Update rest catalog service ip/port, currently it's hard-coded to devcontainer's config, which should be parsed from env variable or config files.
-// (unrelated to functionality) 4. Add timeout to rest catalog access.
-// (unrelated to functionality) 5. Use real namespace and table name, which we should be able to get it from moonlink, it's hard-coded to "default" and "test_table" for now.
-// Convert arrow data type to iceberg data type.
+// (unrelated to functionality) 2. Update rest catalog service ip/port, currently it's hard-coded to devcontainer's config, which should be parsed from env variable or config files.
+// (unrelated to functionality) 3. Add timeout to rest catalog access.
+// (unrelated to functionality) 4. Use real namespace and table name, which we should be able to get it from moonlink, it's hard-coded to "default" and "test_table" for now.
 
 // Get or create an iceberg table in the given catalog from the given namespace and table name.
 async fn get_or_create_iceberg_table<C: Catalog + ?Sized>(


### PR DESCRIPTION
## Summary

The schema conversion between arrow and iceberg is already well-supported in iceberg-rust, so we don't need to reinvent ourselves, and we don't do further type support.

This PR also does a few dependency cleanup, which is auto-fixed by `cargo fix --allow-dirty --allow-staged`.

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
