### PR TITLE
[storage] Dependency cleanup for iceberg related packages

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,5 @@
 [workspace]
-members = [
-    "src/moonlink",
-    "src/moonlink_connectors",
-    "src/moonlink_backend",
-]
+members = ["src/moonlink", "src/moonlink_connectors", "src/moonlink_backend"]
 resolver = "2"
 
 [workspace.package]
@@ -14,7 +10,7 @@ edition = "2021"
 async-trait = "0.1"
 bincode = "2"
 
-tokio-postgres = { git = "ssh://git@github.com/Mooncake-labs/rust-postgres.git"}
+tokio-postgres = { git = "ssh://git@github.com/Mooncake-labs/rust-postgres.git" }
 arrow = "54.2.1"
 thiserror = "2.0.12"
 parquet = "54.2.1"
@@ -24,21 +20,22 @@ multimap = "0.10.0"
 chrono = "=0.4.39"
 num-traits = "0.2.19"
 postgres-replication = { git = "ssh://git@github.com/Mooncake-labs/rust-postgres.git" }
-tokio = { version = "1.38", features = ["rt-multi-thread", "macros", "sync", "time"] }
+tokio = { version = "1.38", features = [
+  "rt-multi-thread",
+  "macros",
+  "sync",
+  "time",
+] }
 uuid = { version = "1.16.0", features = ["v4"] }
 arrow-array = "54.2.1"
 arrow-schema = "54.2.1"
 serde_json = { version = "1.0", features = ["std"] }
 iceberg = { git = "https://github.com/apache/iceberg-rust.git", rev = "b4bc6dd15ae4f7a4b1c9ce555e3458089a83e228" }
-iceberg-catalog-rest = { git = "https://github.com/apache/iceberg-rust.git", rev = "b4bc6dd15ae4f7a4b1c9ce555e3458089a83e228" }
 url = "2.5"
 roaring = { version = "0.10.12", git = "https://github.com/RoaringBitmap/roaring-rs.git" }
 crc32fast = "1.3"
 opendal = { version = "0.53.1", features = ["services-s3"] }
 bitstream-io = "3.2.0"
-aws-sdk-s3 = "1.14.0"
-tokio-retry = "0.3"
-randomizer = "0.1.2"
 
 [profile.release-with-debug]
 inherits = "release"

--- a/src/moonlink/Cargo.toml
+++ b/src/moonlink/Cargo.toml
@@ -17,21 +17,20 @@ bitstream-io.workspace = true
 arrow-array.workspace = true
 arrow-schema.workspace = true
 iceberg.workspace = true
-iceberg-catalog-rest.workspace = true
 serde_json.workspace = true
 url.workspace = true
 roaring.workspace = true
 crc32fast.workspace = true
 opendal.workspace = true
 memmap2 = "0.9.5"
-aws-sdk-s3.workspace = true
-tokio-retry = "0.3"
-randomizer.workspace = true
+randomizer = "0.1.2"
 
 [dev-dependencies]
 tempfile.workspace = true
 pprof = { version = "0.14", features = ["flamegraph"] }
 rand = "0.9.1"
+aws-sdk-s3 = "1.14.0"
+tokio-retry = "0.3"
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(profiling_enabled)'] }

--- a/src/moonlink/src/storage/iceberg/iceberg_snapshot.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_snapshot.rs
@@ -563,8 +563,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_store_and_load_snapshot_with_minio_catalog() -> IcebergResult<()> {
-        let (bucket_name, warehouse_uri) = test_utils::get_test_minio_bucket_and_warehouse();
-        test_utils::create_test_s3_bucket(bucket_name.clone()).await?;
+        let (bucket_name, warehouse_uri) =
+            crate::storage::iceberg::test_utils::get_test_minio_bucket_and_warehouse();
+        test_utils::test_utils::create_test_s3_bucket(bucket_name.clone()).await?;
 
         let catalog = create_catalog(&warehouse_uri)?;
         test_store_and_load_snapshot_impl(catalog, &warehouse_uri).await?;

--- a/src/moonlink/src/storage/iceberg/object_storage_catalog.rs
+++ b/src/moonlink/src/storage/iceberg/object_storage_catalog.rs
@@ -652,8 +652,9 @@ mod tests {
 
     // Create S3 catalog with local minio deployment.
     async fn create_s3_catalog() -> S3Catalog {
-        let (bucket_name, warehouse_uri) = test_utils::get_test_minio_bucket_and_warehouse();
-        test_utils::create_test_s3_bucket(bucket_name.clone())
+        let (bucket_name, warehouse_uri) =
+            crate::storage::iceberg::test_utils::get_test_minio_bucket_and_warehouse();
+        test_utils::test_utils::create_test_s3_bucket(bucket_name.clone())
             .await
             .unwrap();
         test_utils::create_minio_s3_catalog(&bucket_name, &warehouse_uri)


### PR DESCRIPTION
## Summary

Dependency cleanup:
- Remove currently unused rest catalog, we could add it back when needed
  + Also possible to make a catalog registry
- Move test related packages into `[dev-dependencies]`, which is only used in testing

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/80

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
