### PR TITLE
Track MoonlinkRows in MemSlice instead of snapshot

### DIFF
--- a/src/moonlink/src/storage/mooncake_table/disk_slice.rs
+++ b/src/moonlink/src/storage/mooncake_table/disk_slice.rs
@@ -216,8 +216,8 @@ mod tests {
             RowValue::ByteArray("Bob".as_bytes().to_vec()),
         ]);
 
-        mem_slice.append(1, &row1)?;
-        mem_slice.append(2, &row2)?;
+        mem_slice.append(1, row1)?;
+        mem_slice.append(2, row2)?;
         let (_new_batch, entries, _index) = mem_slice.drain().unwrap();
         let mut old_index = MemIndex::new();
         old_index.insert(1, RecordLocation::MemoryBatch(0, 0));
@@ -290,7 +290,7 @@ mod tests {
         ];
 
         // Insert original keys into the index
-        for row in rows.iter() {
+        for row in rows.into_iter() {
             let key = match row.values[0] {
                 RowValue::Int32(v) => v as u64,
                 _ => panic!("Expected i32"),

--- a/src/moonlink/src/storage/mooncake_table/mem_slice.rs
+++ b/src/moonlink/src/storage/mooncake_table/mem_slice.rs
@@ -2,6 +2,7 @@ use super::data_batches::{BatchEntry, ColumnStoreBuffer};
 use crate::error::Result;
 use crate::row::MoonlinkRow;
 use crate::storage::index::{Index, MemIndex};
+use crate::storage::mooncake_table::shared_array::SharedRowBufferSnapshot;
 use crate::storage::storage_utils::{RawDeletionRecord, RecordLocation};
 use arrow_array::RecordBatch;
 use arrow_schema::Schema;
@@ -66,7 +67,7 @@ impl MemSlice {
     pub(super) fn append(
         &mut self,
         lookup_key: u64,
-        row: &MoonlinkRow,
+        row: MoonlinkRow,
     ) -> Result<Option<(u64, Arc<RecordBatch>)>> {
         let (seg_idx, row_idx, new_batch) = self.column_store.append_row(row)?;
         self.mem_index.insert(lookup_key, (seg_idx, row_idx).into());
@@ -91,6 +92,10 @@ impl MemSlice {
     pub(super) fn get_commit_check_point(&self) -> RecordLocation {
         self.column_store.get_commit_check_point()
     }
+
+    pub(super) fn get_latest_rows(&self) -> SharedRowBufferSnapshot {
+        self.column_store.get_latest_rows()
+    }
 }
 
 #[cfg(test)]
@@ -114,7 +119,7 @@ mod tests {
         mem_table
             .append(
                 1,
-                &MoonlinkRow::new(vec![
+                MoonlinkRow::new(vec![
                     RowValue::Int32(1),
                     RowValue::ByteArray("John".as_bytes().to_vec()),
                     RowValue::Int32(30),
@@ -125,7 +130,7 @@ mod tests {
         mem_table
             .append(
                 2,
-                &MoonlinkRow::new(vec![
+                MoonlinkRow::new(vec![
                     RowValue::Int32(2),
                     RowValue::ByteArray("Jane".as_bytes().to_vec()),
                     RowValue::Int32(25),
@@ -136,7 +141,7 @@ mod tests {
         mem_table
             .append(
                 3,
-                &MoonlinkRow::new(vec![
+                MoonlinkRow::new(vec![
                     RowValue::Int32(3),
                     RowValue::ByteArray("Bob".as_bytes().to_vec()),
                     RowValue::Int32(40),

--- a/src/moonlink/src/storage/mooncake_table/shared_array.rs
+++ b/src/moonlink/src/storage/mooncake_table/shared_array.rs
@@ -1,0 +1,55 @@
+use std::{cell::UnsafeCell, sync::Arc};
+
+use crate::row::MoonlinkRow;
+
+/// Used to share rows between write and read threads
+///
+/// It is guaranteed only one thread is writing to the buffer
+/// And the buffer never needs to be resized
+#[allow(clippy::arc_with_non_send_sync)]
+pub(super) struct SharedRowBuffer {
+    buffer: Arc<UnsafeCell<Vec<MoonlinkRow>>>,
+}
+
+unsafe impl Send for SharedRowBuffer {}
+unsafe impl Sync for SharedRowBuffer {}
+
+#[allow(clippy::arc_with_non_send_sync)]
+pub(super) struct SharedRowBufferSnapshot {
+    pub buffer: Arc<UnsafeCell<Vec<MoonlinkRow>>>,
+    pub length: usize,
+}
+
+unsafe impl Send for SharedRowBufferSnapshot {}
+unsafe impl Sync for SharedRowBufferSnapshot {}
+
+impl SharedRowBuffer {
+    pub fn new(capacity: usize) -> Self {
+        let vec = Vec::with_capacity(capacity);
+
+        SharedRowBuffer {
+            buffer: Arc::new(UnsafeCell::new(vec)),
+        }
+    }
+
+    pub fn push(&self, row: MoonlinkRow) {
+        unsafe {
+            (*self.buffer.get()).push(row);
+        }
+    }
+
+    pub fn get_snapshot(&self) -> SharedRowBufferSnapshot {
+        let length = unsafe { (*self.buffer.get()).len() };
+        SharedRowBufferSnapshot {
+            buffer: self.buffer.clone(),
+            length,
+        }
+    }
+}
+
+impl SharedRowBufferSnapshot {
+    pub fn get_buffer(&self, size: usize) -> &[MoonlinkRow] {
+        assert!(size <= self.length);
+        unsafe { &(*self.buffer.get())[..size] }
+    }
+}


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

For replication identity != int pk, we need to access the latest rows to compare when applying deletes.
So memslice need to hold them.

Also it is cleaner structure (memslice is doing all the writes, and snapshot only accesses a snapshot of the buffer).

## Related Issues

## Changes

- 
- 
- 

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
