### PR TITLE
Process cdc events with no batching

### DIFF
--- a/src/moonlink_connectors/src/pg_replicate/pipeline/sinks.rs
+++ b/src/moonlink_connectors/src/pg_replicate/pipeline/sinks.rs
@@ -31,6 +31,7 @@ pub trait BatchSink {
         rows: Vec<TableRow>,
         table_id: TableId,
     ) -> Result<(), Self::Error>;
+    async fn write_cdc_event(&mut self, event: CdcEvent) -> Result<PgLsn, Self::Error>;
     async fn write_cdc_events(&mut self, events: Vec<CdcEvent>) -> Result<PgLsn, Self::Error>;
     async fn table_copied(&mut self, table_id: TableId) -> Result<(), Self::Error>;
     async fn truncate_table(&mut self, table_id: TableId) -> Result<(), Self::Error>;


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

Currently `pg_replicate` wraps our cdc stream in a `batch_timeout_stream`. This batches stream events until a threshold is reached, and only then writes them to sink. We should be processing this stream directly and let moonlink handle any buffering.

This PR removes the `batch_timeout_stream` wrapper around `cdc_events` and polls this stream directly, passing each event to the sink immediately. 

## Related Issues

We should do a larger refactor of our replication. Given we don't require any batching or pipeline in general, the `Source` -> `Pipeline` -> `Sink` isn't necessary. 

https://github.com/Mooncake-Labs/moonlink/issues/97

We still use `batch_timeout_stream` when copying down the tables initially.
https://github.com/Mooncake-Labs/moonlink/issues/98

## Changes

- 
- 
- 

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
