### PR TITLE
Fix clippy precommit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,5 +16,5 @@ repos:
       name: clipper-check
       language: system
       files: '\.rs$'
-      entry: cargo clippy --all-targets --allow-dirty --allow-staged -- -D warnings
+      entry: cargo clippy --all-targets -- -D warnings
       pass_filenames: false


### PR DESCRIPTION
## Summary

Current precommit hook for clippy is largely broken, because `--fix` and `-Dwarnings` argument conflict with each other, leading warning level issues to pass through silently.

Issue found:
```sh
error: usage of an `Arc` that is not `Send` and `Sync`
  --> src/moonlink/src/storage/mooncake_table/shared_array.rs:31:21
   |
31 |             buffer: Arc::new(UnsafeCell::new(vec)),
   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `Arc<UnsafeCell<Vec<MoonlinkRow>>>` is not `Send` and `Sync` as `UnsafeCell<Vec<MoonlinkRow>>` is not `Sync`
   = help: if the `Arc` will not used be across threads replace it with an `Rc`
   = help: otherwise make `UnsafeCell<Vec<MoonlinkRow>>` `Send` and `Sync` or consider a wrapper type such as `Mutex`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#arc_with_non_send_sync
   = note: `-D clippy::arc-with-non-send-sync` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::arc_with_non_send_sync)]`
```
With the old setting, the above warning is not correctly detected; it could be detected under the current setting.

Followup item:
Now the precommit hook needs to setup manually, I should either provide a setup guide,
or install it into the devcontainer so users don't need to consider.

## Checklist

- [ ] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [X] I have reviewed my own changes
