### PR TITLE
Suppress clippy error for `arc_with_non_send_sync`

### DIFF
--- a/src/moonlink/src/storage/mooncake_table/shared_array.rs
+++ b/src/moonlink/src/storage/mooncake_table/shared_array.rs
@@ -24,6 +24,7 @@ unsafe impl Send for SharedRowBufferSnapshot {}
 unsafe impl Sync for SharedRowBufferSnapshot {}
 
 impl SharedRowBuffer {
+    #[allow(clippy::arc_with_non_send_sync)]
     pub fn new(capacity: usize) -> Self {
         let vec = Vec::with_capacity(capacity);
 


### PR DESCRIPTION
## Summary

```sh
error: usage of an `Arc` that is not `Send` and `Sync`
  --> src/moonlink/src/storage/mooncake_table/shared_array.rs:31:21
   |
31 |             buffer: Arc::new(UnsafeCell::new(vec)),
   |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `Arc<UnsafeCell<Vec<MoonlinkRow>>>` is not `Send` and `Sync` as `UnsafeCell<Vec<MoonlinkRow>>` is not `Sync`
   = help: if the `Arc` will not used be across threads replace it with an `Rc`
   = help: otherwise make `UnsafeCell<Vec<MoonlinkRow>>` `Send` and `Sync` or consider a wrapper type such as `Mutex`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#arc_with_non_send_sync
   = note: `-D clippy::arc-with-non-send-sync` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::arc_with_non_send_sync)]`
```

## Checklist

- [ ] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
