### PR TITLE
Revert "Handle errors if no write perm"

### DIFF
--- a/src/moonlink_connectors/src/pg_replicate/clients/postgres.rs
+++ b/src/moonlink_connectors/src/pg_replicate/clients/postgres.rs
@@ -36,8 +36,8 @@ pub enum ReplicationClientError {
     #[error("oid column is not a valid u32")]
     OidColumnNotU32,
 
-    #[error("error writing replica identity: {0}")]
-    ReplicaIdentityWrite(String),
+    #[error("replica identity '{0}' not supported")]
+    ReplicaIdentityNotSupported(String),
 
     #[error("type modifier column is not a valid u32")]
     TypeModifierColumnNotI32,
@@ -442,10 +442,9 @@ impl ReplicationClient {
                         ))?;
 
                 if !(replica_identity == "f") {
-                    self.postgres_client
-                        .simple_query(&format!("ALTER TABLE {} REPLICA IDENTITY FULL;", table))
-                        .await
-                        .map_err(|e| ReplicationClientError::ReplicaIdentityWrite(e.to_string()))?;
+                    return Err(ReplicationClientError::ReplicaIdentityNotSupported(
+                        replica_identity.to_string(),
+                    ));
                 }
 
                 let oid: u32 = row

--- a/src/moonlink_connectors/src/postgres.rs
+++ b/src/moonlink_connectors/src/postgres.rs
@@ -58,6 +58,10 @@ impl MoonlinkPostgresSource {
             ))
             .await
             .unwrap();
+        self.postgres_client
+            .simple_query(&format!("ALTER TABLE {} REPLICA IDENTITY FULL;", table))
+            .await
+            .unwrap();
         let source = PostgresSource::new(
             &self.uri,
             Some("moonlink_slot".to_string()),


### PR DESCRIPTION
Reverts Mooncake-Labs/moonlink#93

We can't call ALTER from the replication client since at this point we have started our read only replication stream.

Reverting back to behavior where always set replica identity to full on `add_table`. 

Follow up work for long term fix is here: https://github.com/Mooncake-Labs/moonlink/issues/104