### PR TITLE
Always set record.pos

### DIFF
--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -296,6 +296,7 @@ impl MooncakeTable {
         let pos = stream_state
             .mem_slice
             .delete(&record, &self.metadata.identity);
+        record.pos = pos;
         if pos.is_none() {
             // Edge‑case: txn deletes a row that's still in the main mem_slice
             // TODO(nbiscaro): This is a bit of a hack. We can likely resolve this in a cleaner way during snapshot.


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

If pos resolves we want to set it so that it skips trying to remap in snapshot. (The delete will materialize on flush here since its within the mem slice)

## Related Issues

Closes #<issue-number> or links to related issues.

## Changes

- 
- 
- 

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
