### PR TITLE
[DONT MERGE] [BAD COMMIT] reproduction for broken integration

### DIFF
--- a/src/moonlink/src/storage/iceberg.rs
+++ b/src/moonlink/src/storage/iceberg.rs
@@ -10,6 +10,7 @@ pub(crate) mod test_utils;
 pub(crate) mod tokio_retry_utils;
 pub(crate) mod utils;
 pub(crate) mod validation;
+pub(crate) mod broken_integration;
 
 #[cfg(feature = "storage-s3")]
 pub(crate) mod s3_test_utils;

--- a/src/moonlink/src/storage/iceberg/broken_integration.rs
+++ b/src/moonlink/src/storage/iceberg/broken_integration.rs
@@ -1,0 +1,37 @@
+use iceberg::Result as IcebergResult;
+use iceberg::io::FileIOBuilder;
+use iceberg::puffin::PuffinReader;
+use iceberg::table::Table as IcebergTable;
+
+struct IcebergTableManager {
+    iceberg_table: Option<IcebergTable>,
+}
+
+impl IcebergTableManager {
+    async fn do_something(&self) {}
+}
+
+async fn f() {}
+
+async fn create_iceberg_table_manager() -> IcebergTableManager {
+    async {
+        let file_io = FileIOBuilder::new_fs_io().build().unwrap();
+        let input_file = file_io.new_input("/tmp/iceberg/table").unwrap();
+        let puffin_reader = PuffinReader::new(input_file);
+        let puffin_file_metadata: &iceberg::puffin::FileMetadata =
+            puffin_reader.file_metadata().await.unwrap();
+    }.await;
+    IcebergTableManager {
+        iceberg_table: None
+    }
+}
+
+async fn fake_main() -> IcebergResult<()> {
+    let handle = tokio::spawn(async move {
+        let mgr = create_iceberg_table_manager().await;
+        mgr.do_something().await;
+    });
+
+    handle.await.unwrap();
+    Ok(())
+}


### PR DESCRIPTION
Error message:
```sh
error[E0277]: `(dyn FileRead + 'static)` cannot be shared between threads safely
   --> src/moonlink/src/storage/iceberg/broken_integration.rs:30:18
    |
30  |       let handle = tokio::spawn(async move {
    |  __________________^
31  | |         let mgr = create_iceberg_table_manager().await;
32  | |         mgr.do_something().await;
33  | |     });
    | |______^ `(dyn FileRead + 'static)` cannot be shared between threads safely
    |
    = help: the trait `Sync` is not implemented for `(dyn FileRead + 'static)`
    = note: required for `&(dyn FileRead + 'static)` to implement `std::marker::Send`
note: required because it's used within this `async` fn body
   --> /usr/local/cargo/git/checkouts/iceberg-rust-1cfaaa0dd97c960f/513376c/crates/iceberg/src/puffin/metadata.rs:187:22
    |
187 |       ) -> Result<u32> {
    |  ______________________^
188 | |         let start = input_file_length - FileMetadata::FOOTER_STRUCT_LENGTH as u64;
189 | |         let end = start + FileMetadata::FOOTER_STRUCT_PAYLOAD_LENGTH_LENGTH as u64;
190 | |         let footer_payload_length_bytes = file_read.read(start..end).await?;
...   |
194 | |         Ok(footer_payload_length)
195 | |     }
    | |_____^
note: required because it's used within this `async` fn body
   --> /usr/local/cargo/git/checkouts/iceberg-rust-1cfaaa0dd97c960f/513376c/crates/iceberg/src/puffin/metadata.rs:267:78
    |
267 |       pub(crate) async fn read(input_file: &InputFile) -> Result<FileMetadata> {
    |  ______________________________________________________________________________^
268 | |         let file_read = input_file.reader().await?;
269 | |
270 | |         let first_four_bytes = file_read.read(0..FileMetadata::MAGIC_LENGTH.into()).await?;
...   |
288 | |         FileMetadata::from_json_str(&footer_payload_str)
289 | |     }
    | |_____^
note: required because it's used within this `async` fn body
   --> /usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.45.0/src/sync/once_cell.rs:400:5
    |
400 | /     {
401 | |         crate::trace::async_trace_leaf().await;
402 | |
403 | |         if self.initialized() {
...   |
434 | |     }
    | |_____^
note: required because it's used within this `async` fn body
   --> /usr/local/cargo/git/checkouts/iceberg-rust-1cfaaa0dd97c960f/513376c/crates/iceberg/src/puffin/reader.rs:41:64
    |
41  |       pub async fn file_metadata(&self) -> Result<&FileMetadata> {
    |  ________________________________________________________________^
42  | |         self.file_metadata
43  | |             .get_or_try_init(|| FileMetadata::read(&self.input_file))
44  | |             .await
45  | |     }
    | |_____^
note: required because it's used within this `async` block
   --> src/moonlink/src/storage/iceberg/broken_integration.rs:17:5
    |
17  |     async {
    |     ^^^^^
note: required because it's used within this `async` fn body
   --> src/moonlink/src/storage/iceberg/broken_integration.rs:16:64
    |
16  |   async fn create_iceberg_table_manager() -> IcebergTableManager {
    |  ________________________________________________________________^
17  | |     async {
18  | |         let file_io = FileIOBuilder::new_fs_io().build().unwrap();
19  | |         let input_file = file_io.new_input("/tmp/iceberg/table").unwrap();
...   |
27  | | }
    | |_^
note: required because it's used within this `async` block
   --> src/moonlink/src/storage/iceberg/broken_integration.rs:30:31
    |
30  |     let handle = tokio::spawn(async move {
    |                               ^^^^^^^^^^
note: required by a bound in `tokio::spawn`
   --> /usr/local/cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.45.0/src/task/spawn.rs:168:21
    |
166 |     pub fn spawn<F>(future: F) -> JoinHandle<F::Output>
    |            ----- required by a bound in this function
167 |     where
168 |         F: Future + Send + 'static,
    |                     ^^^^ required by this bound in `spawn`
```