### PR TITLE
[storage] Fix snapshot dump

### DIFF
--- a/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
@@ -11,8 +11,6 @@ use crate::storage::index::{FileIndex as MooncakeFileIndex, MooncakeIndex};
 use crate::storage::mooncake_table::delete_vector::BatchDeletionVector;
 use crate::storage::mooncake_table::Snapshot as MooncakeSnapshot;
 use crate::storage::mooncake_table::TableMetadata as MooncakeTableMetadata;
-use crate::storage::storage_utils;
-use crate::storage::storage_utils::ProcessedDeletionRecord;
 
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
@@ -540,7 +538,7 @@ mod tests {
     use crate::storage::mooncake_table::{
         TableConfig as MooncakeTableConfig, TableMetadata as MooncakeTableMetadata,
     };
-    use crate::storage::storage_utils::{FileId, RecordLocation};
+
     use crate::storage::MooncakeTable;
 
     use std::collections::HashMap;

--- a/src/moonlink/src/storage/storage_utils.rs
+++ b/src/moonlink/src/storage/storage_utils.rs
@@ -1,7 +1,6 @@
 use std::path::PathBuf;
 use std::sync::Arc;
 
-use super::mooncake_table::delete_vector::BatchDeletionVector;
 use crate::row::MoonlinkRow;
 
 // UNDONE(UPDATE_DELETE): a better way to handle file ids


### PR DESCRIPTION
## Summary

This PR is mostly bug fixing PR:
- We shouldn't create empty hash index puffin files;
- We should use committed deletion log for persistence, instead of disk-files ones.

An error cases for second fix:
- In txn-1, data file 1 and its deletion vector gets persisted into disk;
- In txn-2, we add new rows, and delete rows in data file 1, then commit
  + At mooncake table snapshot creation, new arrow batches still sits in memory, because we only flush to disk when overall size reaches threshold;
  + but deleted rows have been reflected to data file 1's deletion vector (in `disk_files` map)
  + There's inconsistency (from LSN's perspective) between data file and deletion vector

The solution here (fix in this PR), is to 
- generate iceberg snapshot based on persisted data files
- use flush LSN and committed deletion log as source of truth
- index file is not a problem, because it goes with data files (flush at the same time)

Some other changes:
- Rename deletion vector and hash index manifest file to better understand

## TODO items

- Reduce iceberg snapshot frequency, currently it's created every mooncake table snapshot creation
- Add state-based unit tests: https://docs.google.com/document/d/1hZ0H66_eefjFezFQf1Pdr-A63eJ94OH9TsInNS-6xao/edit?usp=sharing

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [x] Documentation updated if necessary
- [x] I have reviewed my own changes
