### PR TITLE
Fix postgres schema conversion

### DIFF
--- a/src/moonlink_connectors/Cargo.toml
+++ b/src/moonlink_connectors/Cargo.toml
@@ -11,7 +11,6 @@ byteorder = "1.5.0"
 bytes = "1.0"
 chrono = { workspace = true }
 futures = { workspace = true }
-iceberg = { workspace = true }
 moonlink = { path = "../moonlink" }
 num-traits = { workspace = true }
 pg_escape = "0.1.1"
@@ -23,3 +22,6 @@ tokio = { workspace = true }
 tokio-postgres = { workspace = true }
 tracing = { version = "0.1", default-features = true }
 uuid = { workspace = true }
+
+[dev-dependencies]
+iceberg = { workspace = true }

--- a/src/moonlink_connectors/src/postgres/util.rs
+++ b/src/moonlink_connectors/src/postgres/util.rs
@@ -4,7 +4,6 @@ use crate::pg_replicate::{
 };
 use arrow::datatypes::{DataType, Field, Schema};
 use chrono::Timelike;
-use iceberg::arrow as IcebergArrow;
 use moonlink::row::RowValue;
 use moonlink::row::{IdentityProp, MoonlinkRow};
 use num_traits::cast::ToPrimitive;
@@ -337,6 +336,7 @@ mod tests {
     use arrow::array::{Date32Array, StringArray, TimestampMicrosecondArray};
     use arrow::datatypes::DataType;
     use chrono::{DateTime, NaiveDate, NaiveDateTime, NaiveTime, Utc};
+    use iceberg::arrow as IcebergArrow;
     use moonlink::row::RowValue;
 
     #[test]


### PR DESCRIPTION
## Summary

This PR fixes postgres / arrow / iceberg schema conversion, which requires `field_id` metadata.
Iceberg spec for field id: https://iceberg.apache.org/spec/#identifier-field-ids

TLDR:
- It's used to differentiate each column
- Example usage: https://github.com/apache/iceberg-rust/blob/141b9974378bad70fb08b86a56866ffc70b71689/crates/iceberg/src/arrow/schema.rs#L1080-L1090

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/168
Closes https://github.com/Mooncake-Labs/moonlink/issues/164

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
