### PR TITLE
[storage] [minor] Remove hard-coded deletion vector size

### DIFF
--- a/src/moonlink/src/storage/iceberg/deletion_vector.rs
+++ b/src/moonlink/src/storage/iceberg/deletion_vector.rs
@@ -226,8 +226,6 @@ impl DeletionVector {
 
 #[cfg(test)]
 mod tests {
-    use crate::TableConfig;
-
     use super::*;
 
     fn create_test_blob_properties(deleted_rows: usize) -> HashMap<String, String> {

--- a/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
@@ -554,7 +554,7 @@ mod tests {
     use crate::storage::iceberg::iceberg_table_manager::IcebergTableManager;
     #[cfg(feature = "storage-s3")]
     use crate::storage::iceberg::s3_test_utils;
-    use crate::storage::index::Index;
+
     use crate::storage::mooncake_table::{
         TableConfig as MooncakeTableConfig, TableMetadata as MooncakeTableMetadata,
     };
@@ -886,7 +886,7 @@ mod tests {
             "test_table".to_string(),
             /*version=*/ 1,
             path,
-            identity_property.clone(),
+            identity_property,
             iceberg_table_config.clone(),
             mooncake_table_config,
         )


### PR DESCRIPTION
## Summary

As titled, remove the hard-coded table config.

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
