### PR TITLE
Fix typo in mooncake_table documentation

### DIFF
--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -107,7 +107,7 @@ pub struct Snapshot {
     ///   So likely they are not consistent from LSN's perspective.
     ///
     /// At iceberg snapshot creation, we should only dump consistent data files and deletion logs.
-    /// Data file flush LSN is recorded here, to get correponding deletion logs from "committed deletion logs".
+    /// Data file flush LSN is recorded here, to get corresponding deletion logs from "committed deletion logs".
     pub(crate) data_file_flush_lsn: Option<u64>,
     /// indices
     pub(crate) indices: MooncakeIndex,


### PR DESCRIPTION
## Summary
- fix a typo in mooncake_table.rs documentation

## Related Issues

## Changes
- doc comment text update

## Checklist
- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes