### PR TITLE
[storage] Fix iceberg table compression property

### DIFF
--- a/src/moonlink/src/storage/iceberg.rs
+++ b/src/moonlink/src/storage/iceberg.rs
@@ -5,6 +5,7 @@ pub(crate) mod index;
 pub(crate) mod moonlink_catalog;
 pub(crate) mod puffin_utils;
 pub(crate) mod puffin_writer_proxy;
+mod table_property;
 pub(crate) mod test_utils;
 pub(crate) mod tokio_retry_utils;
 pub(crate) mod utils;

--- a/src/moonlink/src/storage/iceberg/table_property.rs
+++ b/src/moonlink/src/storage/iceberg/table_property.rs
@@ -1,0 +1,10 @@
+/// This module defines a few iceberg table property related constants and utils.
+/// Reference: https://iceberg.apache.org/docs/latest/configuration/#table-properties
+///
+/// Compression codec for parquet files.
+pub(crate) const PARQUET_COMPRESSION: &str = "write.parquet.compression-codec";
+pub(crate) const PARQUET_COMPRESSION_DEFAULT: &str = "none";
+
+/// Compression codec for metadata.
+pub(crate) const METADATA_COMPRESSION: &str = "write.metadata.compression-codec";
+pub(crate) const METADATA_COMPRESSION_DEFAULT: &str = "none";

--- a/src/moonlink/src/storage/iceberg/utils.rs
+++ b/src/moonlink/src/storage/iceberg/utils.rs
@@ -2,6 +2,7 @@ use crate::storage::iceberg::file_catalog::{CatalogConfig, FileCatalog};
 use crate::storage::iceberg::moonlink_catalog::MoonlinkCatalog;
 #[cfg(feature = "storage-s3")]
 use crate::storage::iceberg::s3_test_utils;
+use crate::storage::iceberg::table_property;
 
 use futures::TryStreamExt;
 use std::collections::HashMap;
@@ -108,6 +109,22 @@ pub fn create_catalog(warehouse_uri: &str) -> IcebergResult<Box<dyn MoonlinkCata
     todo!("Need to take secrets from client side and create object storage catalog.")
 }
 
+// Create iceberg table properties from table config.
+//
+// TODO(hjiang): We don't allow iceberg table configuration for now, fill in default values.
+fn create_iceberg_table_properties() -> HashMap<String, String> {
+    let mut props = HashMap::with_capacity(3);
+    props.insert(
+        table_property::PARQUET_COMPRESSION.to_string(),
+        table_property::PARQUET_COMPRESSION_DEFAULT.to_string(),
+    );
+    props.insert(
+        table_property::METADATA_COMPRESSION.to_string(),
+        table_property::METADATA_COMPRESSION_DEFAULT.to_string(),
+    );
+    props
+}
+
 // Get or create an iceberg table in the given catalog from the given namespace and table name.
 pub(crate) async fn get_or_create_iceberg_table<C: MoonlinkCatalog + ?Sized>(
     catalog: &C,
@@ -139,7 +156,7 @@ pub(crate) async fn get_or_create_iceberg_table<C: MoonlinkCatalog + ?Sized>(
                     table_name
                 ))
                 .schema(iceberg_schema)
-                .properties(HashMap::new())
+                .properties(create_iceberg_table_properties())
                 .build();
             let table = catalog
                 .create_table(&table_ident.namespace, tbl_creation)
@@ -156,20 +173,6 @@ pub(crate) async fn get_or_create_iceberg_table<C: MoonlinkCatalog + ?Sized>(
 // The reason we keep the dummy style, instead of copying the file directly to target is we need the `DataFile` struct,
 // which is used when upload to iceberg table.
 // One way to resolve is to use DataFileWrite on local write, and remember the `DataFile` returned.
-//
-// 2. A few data file properties need to respect and consider.
-// Reference:
-// - https://iceberg.apache.org/docs/latest/configuration/#table-properties
-// - https://iceberg.apache.org/docs/latest/configuration/#table-behavior-properties
-//
-// - write.parquet.row-group-size-bytes
-// - write.parquet.page-size-bytes
-// - write.parquet.page-row-limit
-// - write.parquet.dict-size-bytes
-// - write.parquet.compression-codec
-// - write.parquet.compression-level
-// - write.parquet.bloom-filter-max-bytes
-// - write.metadata.compression-codec
 pub(crate) async fn write_record_batch_to_iceberg(
     table: &IcebergTable,
     parquet_filepath: &PathBuf,


### PR DESCRIPTION
## Summary

Iceberg table spec clarifies, by default data files are compression with zstd, which we don't.
This PR sets proper table property so external iceberg table reader could parse it out.
Checked a few other properties listed in the spec (https://iceberg.apache.org/docs/latest/configuration/#table-properties), don't think they affect functionality.

We currently have two parquet data files involved: one for write through cache, another for iceberg data file upload;
If we plan to compress, the ideal situation would be:
- Create write through cache with iceberg data file writer directly and get the `DataFile` struct;
- Copy the file to iceberg table, instead of reading it out then write again.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/173

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
