### PR TITLE
[minor] Dependency cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,11 @@ arrow-array = "55"
 arrow-schema = "55"
 async-trait = "0.1"
 bincode = "2"
-bitstream-io = "4"
 chrono = { version = "0.4", default-features = false }
 crc32fast = "1"
 futures = { version = "0.3", default-features = false }
 hashbrown = "0.15.3"
-iceberg = { git = "https://github.com/apache/iceberg-rust.git", rev = "111d0f3da525aad30335e211b5f29edd94c3ccf7", default-features = false, features = [
+iceberg = { git = "https://github.com/apache/iceberg-rust.git", rev = "e488f45b8e137e1e0ecc0e07fed864fd73985d21", default-features = false, features = [
   "storage-fs",
 ] }
 multimap = { version = "0.10", default-features = false }

--- a/src/moonlink/Cargo.toml
+++ b/src/moonlink/Cargo.toml
@@ -11,7 +11,6 @@ arrow-schema = { workspace = true }
 async-trait = { workspace = true }
 aws-sdk-s3 = { version = "1.14", optional = true }
 bincode = { workspace = true }
-bitstream-io = { workspace = true }
 crc32fast = { workspace = true }
 futures = { workspace = true }
 hashbrown = { workspace = true }


### PR DESCRIPTION
## Summary

Two changes here:
- Upgrade iceberg-rust: they use dependabot to upgrade dependency on weekly basis, would prefer to follow upstream, so we could reduce upgrade risk and burden in the future;
- Remove bitstream dependency, since we switch the usage from sync to async completely.

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
