### PR TITLE
Remove deprecated into_path

### DIFF
--- a/src/moonlink/src/storage/index/persisted_bucket_hash_map.rs
+++ b/src/moonlink/src/storage/index/persisted_bucket_hash_map.rs
@@ -615,7 +615,7 @@ mod tests {
         let mut builder = GlobalIndexBuilder::new();
         builder
             .set_files(files)
-            .set_directory(tempfile::tempdir().unwrap().into_path());
+            .set_directory(tempfile::tempdir().unwrap().keep());
         let index = builder.build_from_flush(hash_entries.clone()).await;
 
         let data_file_ids = [FileId(data_file.clone())];
@@ -648,7 +648,7 @@ mod tests {
         let mut builder = GlobalIndexBuilder::new();
         builder
             .set_files(files)
-            .set_directory(tempfile::tempdir().unwrap().into_path());
+            .set_directory(tempfile::tempdir().unwrap().keep());
         let index1 = builder.build_from_flush(vec).await;
         let files = vec![
             Arc::new(PathBuf::from("4.parquet")),
@@ -658,10 +658,10 @@ mod tests {
         let mut builder = GlobalIndexBuilder::new();
         builder
             .set_files(files)
-            .set_directory(tempfile::tempdir().unwrap().into_path());
+            .set_directory(tempfile::tempdir().unwrap().keep());
         let index2 = builder.build_from_flush(vec).await;
         let mut builder = GlobalIndexBuilder::new();
-        builder.set_directory(tempfile::tempdir().unwrap().into_path());
+        builder.set_directory(tempfile::tempdir().unwrap().keep());
         let merged = builder._build_from_merge(vec![index1, index2]).await;
 
         for i in 0u64..100u64 {


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

Removes deprecated `into_path` and replaces with `keep()`. Triggering clippy errors preventing push with pre-commit.

## Related Issues

Closes #<issue-number> or links to related issues.

## Changes

- 
- 
- 

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
