### PR TITLE
[storage] Fix blocking snapshot creation

### DIFF
--- a/src/moonlink/src/table_handler.rs
+++ b/src/moonlink/src/table_handler.rs
@@ -158,8 +158,6 @@ impl TableHandler {
                     assert!(!has_outstanding_iceberg_snapshot_request, "There should be at most one outstanding iceberg snapshot request for one table!");
                     // Only create a snapshot if there isn't already one in progress
                     if snapshot_handle.is_none() {
-                        // It's possible that there're not enough arrow record batches or deletion logs at the moment, so snapshot won't be created right away.
-                        // Receiver will only get notified at next successful snapshot.
                         snapshot_handle = table.create_snapshot();
                     }
 


### PR DESCRIPTION
## Summary

Currently snapshot creation `create_iceberg_snapshot` could block when there's nothing to flush.
This PR makes immediate returns, and add corresponding test case.

Also half-resolve a flaky test: without a proper barrier implementation, process order is not guaranteed.
Potential solution: https://docs.rs/tokio/latest/tokio/sync/struct.Barrier.html

How I tested: manually run `cargo test` for 30 times with no issue discovered

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
