### PR TITLE
Consolidate flush logic

### DIFF
--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -533,16 +533,15 @@ impl MooncakeTable {
         if let Some(stream_state) = self.transaction_stream_states.get_mut(&xact_id) {
             let next_file_id = self.next_file_id;
             self.next_file_id += 1;
-            let disk_slice =
-                Self::flush_mem_slice(
-                    &mut stream_state.mem_slice,
-                    &self.metadata,
-                    next_file_id,
-                    None,
-                    None,
-                    true,
-                )
-                .await?;
+            let disk_slice = Self::flush_mem_slice(
+                &mut stream_state.mem_slice,
+                &self.metadata,
+                next_file_id,
+                None,
+                None,
+                true,
+            )
+            .await?;
 
             stream_state.new_disk_slices.push(disk_slice);
 


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

We can clean up our flush logic to use the same underlying flush function. Temporarily we pass a `sync_write` flag. Once we support async flush for streaming transactions this can be removed. 

## Related Issues

Closes #<issue-number> or links to related issues.

## Changes

- 
- 
- 

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
