### PR TITLE
[connector] Use end_lsn instead of commit_lsn

### DIFF
--- a/src/moonlink_connectors/src/pg_replicate/moonlink_sink.rs
+++ b/src/moonlink_connectors/src/pg_replicate/moonlink_sink.rs
@@ -90,7 +90,7 @@ impl Sink {
                     if let Some(event_sender) = event_sender {
                         event_sender
                             .send(TableEvent::Commit {
-                                lsn: commit_body.commit_lsn(),
+                                lsn: commit_body.end_lsn(),
                             })
                             .await
                             .unwrap();
@@ -109,7 +109,7 @@ impl Sink {
                         if let Some(event_sender) = event_sender {
                             event_sender
                                 .send(TableEvent::StreamCommit {
-                                    lsn: stream_commit_body.commit_lsn(),
+                                    lsn: stream_commit_body.end_lsn(),
                                     xact_id,
                                 })
                                 .await


### PR DESCRIPTION
## Summary

This PR updates / fixes to use `end_lsn` instead of `commit_lsn` for table event commit.
@nbiscaro has illustrated some context and impact at https://github.com/Mooncake-Labs/moonlink/issues/243

Discussed with Cheng 
```
If there is not concurrent write, the periodic snapshots can be used because COMMIT message alone doesn't change table so the snapshot is still clean
But when there are concurrent transaction writing to that table, the snapshot is not clean so the periodic snapshots can't be used
```

How I tested:
- Existing unit test for moonlink
- pg_mooncake SQL test

```sql
pg_mooncake (pid: 3978) =# DROP TABLE r;
DROP EXTENSION pg_mooncake CASCADE;
CREATE EXTENSION pg_mooncake;
CREATE TABLE r (a int primary key, b text);
CALL create_mooncake_table('c', 'r');
INSERT INTO r VALUES (1, 'a'), (2, 'b'), (3, 'c');
SELECT * FROM c;
ERROR:  table "r" does not exist
ERROR:  extension "pg_mooncake" does not exist
CREATE EXTENSION
CREATE TABLE
CALL
INSERT 0 3
 a | b 
---+---
 1 | a
 2 | b
 3 | c
(3 rows)

pg_mooncake (pid: 3978) =# CALL create_snapshot('c');
CALL
pg_mooncake (pid: 3978) =# SELECT * FROM c;
 a | b 
---+---
 1 | a
 2 | b
 3 | c
(3 rows)
```

Confirmed iceberg snapshot does create
```sh
vscode ➜ /workspaces/pg_mooncake (rust ✗) $ ls -lR /home/vscode/.pgrx/data-17/mooncake/default/
/home/vscode/.pgrx/data-17/mooncake/default/:
total 4
-rw------- 1 vscode vscode    0 May 25 07:00 indicator.text
drwx------ 4 vscode vscode 4096 May 25 07:00 public.r

/home/vscode/.pgrx/data-17/mooncake/default/public.r:
total 8
drwx------ 2 vscode vscode 4096 May 25 07:00 data
drwx------ 2 vscode vscode 4096 May 25 07:00 metadata

/home/vscode/.pgrx/data-17/mooncake/default/public.r/data:
total 12
-rw------- 1 vscode vscode 883 May 25 07:00 01560a2d-2ce2-451a-ad34-56b2bbd677d5-00000.parquet
-rw------- 1 vscode vscode 651 May 25 07:00 e60e21a9-e4b8-45bb-ab6c-0c38c10da4c3-hash-index-v1-puffin.bin
-rw------- 1 vscode vscode  49 May 25 07:00 index_block_55b965c6-ab87-4ebf-b2bf-3e20c31ad68e.bin

/home/vscode/.pgrx/data-17/mooncake/default/public.r/metadata:
total 24
-rw------- 1 vscode vscode 3511 May 25 07:00 0197063e-69cf-7363-ba36-8b31999eb61a-m0.avro
-rw------- 1 vscode vscode 3481 May 25 07:00 b5433abc-dff4-4a66-a100-9d1e95920e91-m0.avro
-rw------- 1 vscode vscode 1741 May 25 07:00 snap-5927057642061966899-0-0197063e-69cf-7363-ba36-8b31999eb61a.avro
-rw------- 1 vscode vscode  660 May 25 07:00 v0.metadata.json
-rw------- 1 vscode vscode 1433 May 25 07:00 v1.metadata.json
-rw------- 1 vscode vscode    1 May 25 07:00 version-hint.text
```

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/243

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
