### PR TITLE
Update devcontainer to use dockerfile

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,8 @@
+FROM mcr.microsoft.com/devcontainers/rust:latest
+
+RUN apt-get update && \
+    cargo install cargo-sort && \
+    apt install -y python3-pip && \
+    pip3 install pre-commit --break-system-packages
+
+WORKDIR /workspaces/pg_moonlink

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
     "dockerComposeFile": "docker-compose.yml",
     "service": "devcontainer",
-    "workspaceFolder": "/workspaces/mooncake",
+    "workspaceFolder": "/workspaces/pg_moonlink",
     "features": {
         "ghcr.io/robbert229/devcontainer-features/postgresql-client": {
             "version": "17"

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   devcontainer:
-    image: mcr.microsoft.com/devcontainers/rust:latest
+    build: 
+      context: .
+      dockerfile: Dockerfile
     volumes:
       - ..:/workspaces/pg_moonlink:cached
     networks:

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -5,11 +5,7 @@ git config devcontainers-theme.show-dirty 1
 echo alias psql=\'psql -h localhost -U postgres\' >> ~/.bashrc
 
 # rust precommit hook requirements.
-sudo apt update -y
-cargo install cargo-sort
 rustup component add clippy
 
 # precommit hook requirement.
-sudo apt install -y python3-pip
-pip3 install pre-commit --break-system-packages
 pre-commit install -t pre-push


### PR DESCRIPTION
## Summary

Place dependency installation to dockerfile, so we could leverage docker image layer to avoid re-installation everytime devcontainer gets re-created.

I destroyed devcontainer and re-created, it works on my end.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/159

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
