### PR TITLE
Fix devcontainer permission issue

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,8 +1,15 @@
 FROM mcr.microsoft.com/devcontainers/rust:latest
 
+# Run system-level installs as root.
+USER root
+
 RUN apt-get update && \
-    cargo install cargo-sort && \
-    apt install -y python3-pip && \
+    apt-get install -y python3-pip && \
     pip3 install pre-commit --break-system-packages
+
+# Now switch to vscode user for cargo installations, otherwise later cargo commands required root permission.
+USER vscode
+
+RUN cargo install cargo-sort
 
 WORKDIR /workspaces/pg_moonlink


### PR DESCRIPTION
## Summary

Fix permission for https://github.com/Mooncake-Labs/moonlink/pull/269

Did some further testing:
- `pip3` already installed
- precommit hook already installed and triggered at push
- `cargo build` and `cargo test` works with no problem

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
