### PR TITLE
[storage] Use append to mark deleted rows

### DIFF
--- a/src/moonlink/src/storage/iceberg/deletion_vector.rs
+++ b/src/moonlink/src/storage/iceberg/deletion_vector.rs
@@ -33,8 +33,11 @@ impl DeletionVector {
     }
 
     /// Marks a row as deleted.
+    /// Pre-requisite: row indices must be in ascending order.
     pub fn mark_rows_deleted(&mut self, rows: Vec<u64>) {
-        self.bitmap.extend(rows);
+        let row_count = rows.len();
+        let appended_num = self.bitmap.append(rows).unwrap();
+        assert_eq!(appended_num as usize, row_count);
     }
 
     /// Deserializes a byte vector into a DeletionVector.

--- a/src/moonlink/src/storage/mooncake_table/delete_vector.rs
+++ b/src/moonlink/src/storage/mooncake_table/delete_vector.rs
@@ -90,6 +90,7 @@ impl BatchDeletionVector {
             .collect()
     }
 
+    /// Return deleted row index in ascending order.
     pub(crate) fn collect_deleted_rows(&self) -> Vec<u64> {
         let Some(bitmap) = &self.deletion_vector else {
             return Vec::new();


### PR DESCRIPTION
## Summary

Use [`append`](https://docs.rs/roaring/latest/roaring/treemap/struct.RoaringTreemap.html#method.append) to mark rows deleted for better performance, which in turn requires ordering.

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
