### PR TITLE
No install clippy in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,10 +5,9 @@ RUN apt update && \
     pip3 install pre-commit --break-system-packages && \
     rm -rf /var/lib/apt/lists/*
 
-# Now switch to vscode user for cargo installations, otherwise later cargo commands required root permission.
+# Switch to vscode user for cargo installations, otherwise later cargo commands required root permission.
 USER vscode
 
-RUN cargo install cargo-sort && \
-    rustup component add clippy
+RUN cargo install cargo-sort
 
 WORKDIR /workspaces/moonlink


### PR DESCRIPTION
## Summary

It's contained in base image already.
Ref: https://github.com/microsoft/vscode-dev-containers/blob/main/containers/rust/history/dev.md#contents

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
