### PR TITLE
[storage] Cleanup associated file deletion in async style

### DIFF
--- a/src/moonlink/src/union_read/read_state.rs
+++ b/src/moonlink/src/union_read/read_state.rs
@@ -21,7 +21,7 @@ impl Drop for ReadState {
         let associated_files = std::mem::take(&mut self.associated_files);
         println!("Dropping files: {:?}", associated_files);
         // Perform best-effort deletion by spawning detached task.
-        let _ = tokio::runtime::Handle::current().spawn(async move {
+        tokio::spawn(async move {
             for file in associated_files.into_iter() {
                 if let Err(e) = tokio::fs::remove_file(&file).await {
                     println!("Failed to delete file {} because {:?}", file, e);


### PR DESCRIPTION
## Summary

Our current way to delete associated files (temporary files for union read) are blocking, which blocks tokio runtime.
This PR turns it into fire-and-forget manner, with detached tokio tasks.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/205

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
