### PR TITLE
Fix null parse

### DIFF
--- a/src/moonlink_connectors/src/pg_replicate/conversions/text.rs
+++ b/src/moonlink_connectors/src/pg_replicate/conversions/text.rs
@@ -329,7 +329,8 @@ mod tests {
 
     #[test]
     fn parse_text_array_quoted_null_as_string() {
-        let cell = TextFormatConverter::try_from_str(&Type::TEXT_ARRAY, "{\"a\",\"null\"}").unwrap();
+        let cell =
+            TextFormatConverter::try_from_str(&Type::TEXT_ARRAY, "{\"a\",\"null\"}").unwrap();
         match cell {
             Cell::Array(ArrayCell::String(v)) => {
                 assert_eq!(v, vec![Some("a".to_string()), Some("null".to_string())]);


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

Fixed array parsing so that `"null"` only maps to `NULL` when the value is unquoted, preventing quoted `"null"` from being converted to `NULL`. Note that we need this special check for null in the `Type::TextArray` since otherwise `NULL` gets parsed to `"NULL"`. 

## Related Issues

Closes #<issue-number> or links to related issues.

## Changes

- add check for quotes
- add unit tests to check parsing of NULL vs "NULL"
- 

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [x] Documentation updated if necessary
- [x] I have reviewed my own changes
