### PR TITLE
Move integration tests to `tests/`

### DIFF
--- a/src/moonlink_backend/src/lib.rs
+++ b/src/moonlink_backend/src/lib.rs
@@ -13,10 +13,10 @@ use tokio::sync::RwLock;
 const DEFAULT_MOONLINK_TABLE_BASE_PATH: &str = "./mooncake/";
 // Default local filesystem directory where all temporary files (used for union read) will be stored under.
 // The whole directory is cleaned up at moonlink backend start, to prevent file leak.
-const DEFAULT_MOONLINK_TEMP_FILE_PATH: &str = "/tmp/moonlink_temp_file";
+pub const DEFAULT_MOONLINK_TEMP_FILE_PATH: &str = "/tmp/moonlink_temp_file";
 
 /// Util function to delete and re-create the given directory.
-fn recreate_directory(dir: &str) -> Result<()> {
+pub fn recreate_directory(dir: &str) -> Result<()> {
     // Clean up directory to place moonlink temporary files.
     match std::fs::remove_dir_all(dir) {
         Ok(()) => {}
@@ -80,80 +80,5 @@ impl<T: Eq + Hash + Clone> MoonlinkBackend<T> {
         writer.initiate_snapshot(lsn).await;
         writer.sync_snapshot_completion().await?;
         Ok(())
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use tempfile::TempDir;
-    use tokio_postgres::{connect, Client, NoTls};
-
-    #[test]
-    fn test_recreate_directory() {
-        let temp_dir = TempDir::new().unwrap();
-        let file_path = temp_dir.path().join("temp_file.txt");
-        let file = std::fs::File::create(&file_path).unwrap();
-        drop(file);
-        assert!(std::fs::exists(&file_path).unwrap());
-
-        // Re-create an exising directory.
-        recreate_directory(temp_dir.path().to_str().unwrap()).unwrap();
-        assert!(!std::fs::exists(&file_path).unwrap());
-
-        // Re-create a non-existent directory.
-        let internal_dir = temp_dir.path().join("internal_dir");
-        assert!(!std::fs::exists(&internal_dir).unwrap());
-        recreate_directory(internal_dir.to_str().unwrap()).unwrap();
-        assert!(std::fs::exists(&internal_dir).unwrap());
-    }
-
-    /// Test util function to create a table and attempt basic sql statements to verify creation success.
-    async fn test_table_creation_impl(
-        service: &MoonlinkBackend<&'static str>,
-        client: &Client,
-        uri: &str,
-    ) {
-        client.simple_query("DROP TABLE IF EXISTS test; CREATE TABLE test (id bigint PRIMARY KEY, name VARCHAR(255));").await.unwrap();
-        service
-            .create_table("test", "public.test", uri)
-            .await
-            .unwrap();
-        client
-            .simple_query("INSERT INTO test VALUES (1 ,'foo');")
-            .await
-            .unwrap();
-        client
-            .simple_query("INSERT INTO test VALUES (2 ,'bar');")
-            .await
-            .unwrap();
-        let old = service.scan_table(&"test", None).await.unwrap();
-        // wait 2 second
-        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
-        let new = service.scan_table(&"test", None).await.unwrap();
-        assert_ne!(old.data, new.data);
-
-        // Clean up temporary files directory after test.
-        recreate_directory(DEFAULT_MOONLINK_TEMP_FILE_PATH).unwrap();
-    }
-
-    // Test table creation and drop.
-    #[tokio::test]
-    async fn test_moonlink_service() {
-        let temp_dir = TempDir::new().expect("tempdir failed");
-        let uri = "postgresql://postgres:postgres@postgres:5432/postgres";
-        let service =
-            MoonlinkBackend::<&'static str>::new(temp_dir.path().to_str().unwrap().to_string());
-        // connect to postgres and create a table
-        let (client, connection) = connect(uri, NoTls).await.unwrap();
-        tokio::spawn(async move {
-            if let Err(e) = connection.await {
-                eprintln!("connection error: {}", e);
-            }
-        });
-
-        test_table_creation_impl(&service, &client, uri).await;
-        service.drop_table("test").await.unwrap();
-        test_table_creation_impl(&service, &client, uri).await;
     }
 }

--- a/src/moonlink_backend/tests/test_backend.rs
+++ b/src/moonlink_backend/tests/test_backend.rs
@@ -1,0 +1,76 @@
+#[cfg(test)]
+mod tests {
+    use moonlink_backend::recreate_directory;
+    use moonlink_backend::MoonlinkBackend;
+    use moonlink_backend::DEFAULT_MOONLINK_TEMP_FILE_PATH;
+    use tempfile::TempDir;
+    use tokio_postgres::{connect, Client, NoTls};
+
+    #[test]
+    fn test_recreate_directory() {
+        let temp_dir = TempDir::new().unwrap();
+        let file_path = temp_dir.path().join("temp_file.txt");
+        let file = std::fs::File::create(&file_path).unwrap();
+        drop(file);
+        assert!(std::fs::exists(&file_path).unwrap());
+
+        // Re-create an exising directory.
+        recreate_directory(temp_dir.path().to_str().unwrap()).unwrap();
+        assert!(!std::fs::exists(&file_path).unwrap());
+
+        // Re-create a non-existent directory.
+        let internal_dir = temp_dir.path().join("internal_dir");
+        assert!(!std::fs::exists(&internal_dir).unwrap());
+        recreate_directory(internal_dir.to_str().unwrap()).unwrap();
+        assert!(std::fs::exists(&internal_dir).unwrap());
+    }
+
+    /// Test util function to create a table and attempt basic sql statements to verify creation success.
+    async fn test_table_creation_impl(
+        service: &MoonlinkBackend<&'static str>,
+        client: &Client,
+        uri: &str,
+    ) {
+        client.simple_query("DROP TABLE IF EXISTS test; CREATE TABLE test (id bigint PRIMARY KEY, name VARCHAR(255));").await.unwrap();
+        service
+            .create_table("test", "public.test", uri)
+            .await
+            .unwrap();
+        client
+            .simple_query("INSERT INTO test VALUES (1 ,'foo');")
+            .await
+            .unwrap();
+        client
+            .simple_query("INSERT INTO test VALUES (2 ,'bar');")
+            .await
+            .unwrap();
+        let old = service.scan_table(&"test", None).await.unwrap();
+        // wait 2 second
+        tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+        let new = service.scan_table(&"test", None).await.unwrap();
+        assert_ne!(old.data, new.data);
+
+        // Clean up temporary files directory after test.
+        recreate_directory(DEFAULT_MOONLINK_TEMP_FILE_PATH).unwrap();
+    }
+
+    // Test table creation and drop.
+    #[tokio::test]
+    async fn test_moonlink_service() {
+        let temp_dir = TempDir::new().expect("tempdir failed");
+        let uri = "postgresql://postgres:postgres@postgres:5432/postgres";
+        let service =
+            MoonlinkBackend::<&'static str>::new(temp_dir.path().to_str().unwrap().to_string());
+        // connect to postgres and create a table
+        let (client, connection) = connect(uri, NoTls).await.unwrap();
+        tokio::spawn(async move {
+            if let Err(e) = connection.await {
+                eprintln!("connection error: {}", e);
+            }
+        });
+
+        test_table_creation_impl(&service, &client, uri).await;
+        service.drop_table("test").await.unwrap();
+        test_table_creation_impl(&service, &client, uri).await;
+    }
+}


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

We shouldn't have any integration tests in the source files themselves. We should differentiate between our unit tests and integration tests by moving integration tests to their own `tests/` directory within a crate.

This allows us to 

Only run unit tests: `cargo test --lib`
Only run integration tests: `cargo test --test '*'`
Run all tests `cargo test`

## Related Issues

Closes #<issue-number> or links to related issues.

## Changes

- 
- 
- 

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [x] Documentation updated if necessary
- [x] I have reviewed my own changes
