### PR TITLE
Add cargo-deny to devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,6 +8,6 @@ RUN apt update && \
 # Switch to vscode user for cargo installations, otherwise later cargo commands required root permission.
 USER vscode
 
-RUN cargo install cargo-sort
+RUN cargo install cargo-sort cargo-deny
 
 WORKDIR /workspaces/moonlink


### PR DESCRIPTION
## Summary

Followup PR for https://github.com/Mooncake-Labs/moonlink/pull/322
I confirmed it works on my end.
```sh
fmt..................................................(no files to check)Skipped
cargo-sort...........................................(no files to check)Skipped
clipper-fixlint......................................(no files to check)Skipped
clipper-check........................................(no files to check)Skipped
check-dependency-license.............................(no files to check)Skipped
```

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
