### PR TITLE
[storage] Fix empty iceberg snapshot creation

### DIFF
--- a/src/moonlink/src/storage/iceberg/tests.rs
+++ b/src/moonlink/src/storage/iceberg/tests.rs
@@ -542,7 +542,7 @@ async fn test_create_snapshot_when_no_committed_deletion_log_to_flush() {
         .await
         .unwrap();
 
-    // Second time only delete in-memory but not flush.
+    // Second time snapshot check, committed deletion logs haven't reached flush LSN.
     table.delete(row.clone(), /*lsn=*/ 20).await;
     table.commit(/*lsn=*/ 30);
     let handle = table.create_snapshot().unwrap();

--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -309,7 +309,7 @@ impl SnapshotTableState {
         if self.current_snapshot.data_file_flush_lsn.is_some()
             && (flush_by_data_files || flush_by_deletion_logs)
         {
-            // Getting persistable committed deeltion logs is not cheap, which requires iterating through all logs,
+            // Getting persistable committed deletion logs is not cheap, which requires iterating through all logs,
             // so we only aggregate when there's committed deletion.
             let flush_lsn = self.current_snapshot.data_file_flush_lsn.unwrap();
             let aggregated_committed_deletion_logs =


### PR DESCRIPTION
## Summary

I met an assertion failure
```sh
thread 'tokio-runtime-worker' panicked at moonlink/src/moonlink/src/storage/mooncake_table.rs:406:9:
assertion failed: self.last_iceberg_snapshot_lsn.is_none() ||
    self.last_iceberg_snapshot_lsn.unwrap() < iceberg_flush_lsn
```
which is used to make sure flush LSN always progresses.

The reason is, when 
(1) there're committed deletion logs
and (2) none of them are persistable

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
