### PR TITLE
[minor] Avoid create tokio task when no associated files

### DIFF
--- a/src/moonlink/src/union_read/read_state.rs
+++ b/src/moonlink/src/union_read/read_state.rs
@@ -18,6 +18,9 @@ pub struct ReadState {
 
 impl Drop for ReadState {
     fn drop(&mut self) {
+        if self.associated_files.is_empty() {
+            return;
+        }
         let associated_files = std::mem::take(&mut self.associated_files);
         println!("Dropping files: {:?}", associated_files);
         // Perform best-effort deletion by spawning detached task.


### PR DESCRIPTION
## Summary

No need to create tokio task, when there's no associate files to drop.

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
