### PR TITLE
[storage] Address race condition between mooncake snapshot and iceberg snapshot

### DIFF
--- a/src/moonlink/src/table_handler.rs
+++ b/src/moonlink/src/table_handler.rs
@@ -130,6 +130,8 @@ impl TableHandler {
             };
 
         // Used to decide whether we could create an iceberg snapshot.
+        // The completion of an iceberg snapshot is **NOT** marked as the finish of snapshot thread, but the handling of its results.
+        // We can only create a new iceberg snapshot when (1) there's no ongoing iceberg snapshot; and (2) previous snapshot results have been acknowledged.
         let can_initiate_iceberg_snapshot =
             |iceberg_consumed: bool, iceberg_handle: &IcebergSnapshotHandle| {
                 iceberg_consumed && iceberg_handle.is_none()


### PR DESCRIPTION
## Summary

There're three "threads" in moonlink for one table:
- eventloop main thread
- mooncake snapshot thread
- iceberg snapshot thread 

Normal workflow (explained here in sequential order, but in reality there're multiple threads involved):
- initiate mooncake snapshot
- mooncake snapshot finishes, and get iceberg snapshot payload
- initiate iceberg snapshot
- iceberg snapshot finishes, and get iceberg snapshot result
- buffer the result to snapshot task and handle in the next mooncake snapshot

The issue is: mooncake snapshot and iceberg snapshot are executed in their own thread

Buggy workflow:
- start mooncake snapshot (in mooncake snapshot thread)
- iceberg snapshot completes (in iceberg snapshot thread)
- resets iceberg snapshot handle, buffer iceberg snapshot result to next mooncake snapshot (in eventloop thread)
- get iceberg snapshot payload from mooncake snapshot (in mooncake snapshot thread)
- create a new iceberg snapshot (in eventloop thread)

See the problem? 
**When mooncake snapshot decides, what to import into iceberg snapshot, it hasn't acknowledged the most recently finished iceberg snapshot**, leading to the same content (i.e. data files) to be repeated persisted into iceberg.
It's actually impossible (hard) to synchronize, because they happen in different threads.

Concept clarification and proposed fix:
- The completion of an iceberg snapshot is **NOT** marked as the completion of iceberg snapshot thread, **but the acknowledgement of its result**
  + We reset iceberg snapshot state before mooncake snapshot, which means the iceberg snapshot result will be properly handled in this mooncake snapshot iteration
- A new iceberg snapshot can only be created when previous iceberg snapshot result has been properly consumed

How I tested:
- It's hard to do a unit test, without (rewrite) refactoring the table handler and add synchronization logic for deterministic testing
- I used the broken SQL statements to test for 30 times

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/352

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [x] Documentation updated if necessary
- [x] I have reviewed my own changes
