### PR TITLE
Send interval update

### DIFF
--- a/src/moonlink_connectors/src/replication_connection.rs
+++ b/src/moonlink_connectors/src/replication_connection.rs
@@ -1,4 +1,4 @@
-use crate::pg_replicate::conversions::cdc_event::{CdcEvent, CdcEventConversionError};
+use crate::pg_replicate::conversions::cdc_event::CdcEventConversionError;
 use crate::pg_replicate::moonlink_sink::Sink;
 use crate::pg_replicate::postgres_source::CdcStream;
 use crate::pg_replicate::postgres_source::{CdcStreamError, PostgresSource, TableNamesFrom};


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

Currently, we wait for the primary to request a reply before sending a status update. This can timeout of the primary is slow to send the request for reply. 

Instead, we should mimic the behavior of `wal_receiver` and send a status update from the client every `wal_sender_timeout/6 = 10s` to prevent timeout.

## Related Issues

Closes #309 

## Changes

- 
- 
- 

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
