### PR TITLE
Remove unmaintained dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,7 +421,7 @@ dependencies = [
  "aws-smithy-types",
  "aws-types",
  "bytes",
- "fastrand 2.3.0",
+ "fastrand",
  "http 0.2.12",
  "http-body 0.4.6",
  "percent-encoding",
@@ -450,7 +450,7 @@ dependencies = [
  "aws-smithy-xml",
  "aws-types",
  "bytes",
- "fastrand 2.3.0",
+ "fastrand",
  "hex",
  "hmac",
  "http 0.2.12",
@@ -614,7 +614,7 @@ dependencies = [
  "aws-smithy-runtime-api",
  "aws-smithy-types",
  "bytes",
- "fastrand 2.3.0",
+ "fastrand",
  "http 0.2.12",
  "http 1.3.1",
  "http-body 0.4.6",
@@ -697,7 +697,7 @@ version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd0b50b1b78dbadd44ab18b3c794e496f3a139abb9fbc27d9c94c4eebbb96496"
 dependencies = [
- "fastrand 2.3.0",
+ "fastrand",
  "gloo-timers",
  "tokio",
 ]
@@ -1563,15 +1563,6 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "fastrand"
-version = "1.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
-
-[[package]]
-name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
@@ -2355,15 +2346,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "integer-encoding"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2790,7 +2772,6 @@ dependencies = [
  "parquet",
  "pprof",
  "rand 0.9.1",
- "randomizer",
  "roaring",
  "rstest",
  "rstest_reuse",
@@ -3624,15 +3605,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.3",
-]
-
-[[package]]
-name = "randomizer"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357f7bb79a7e4b1e2257b6b03c25425d3cf26d5f9f5a4112f0402c0db9763e20"
-dependencies = [
- "fastrand 1.9.0",
 ]
 
 [[package]]
@@ -4560,7 +4532,7 @@ version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
- "fastrand 2.3.0",
+ "fastrand",
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.7",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ opendal = { version = "0.53", default-features = false, features = [
 ] }
 parquet = { version = "55", default-features = false, features = ["arrow", "async", "arrow_canonical_extension_types"] }
 postgres-replication = { git = "https://github.com/Mooncake-labs/rust-postgres.git" }
+rand = "0.9"
 roaring = "0.10"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = "1"

--- a/deny.toml
+++ b/deny.toml
@@ -21,14 +21,12 @@ allow-git = [
 # TODO(hjiang): Cleanup these unmaintained crates.
 [advisories]
 ignore = [
-    "RUSTSEC-2024-0384", # instant - unmaintained
     "RUSTSEC-2024-0436", # paste - unmaintained
 ]
 
 # TODO(hjiang): Resolve all duplicate dependencies.
 [bans]
 skip = [
-    { name = "fastrand" },
     { name = "getrandom" },
     { name = "hashbrown" },
     { name = "itertools" },

--- a/src/moonlink/Cargo.toml
+++ b/src/moonlink/Cargo.toml
@@ -32,7 +32,7 @@ num-bigint = { workspace = true }
 num-traits = { workspace = true }
 opendal = { workspace = true }
 parquet = { workspace = true }
-randomizer = "0.1"
+rand = { workspace = true }
 roaring = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/src/moonlink/src/storage/iceberg/s3_test_utils.rs
+++ b/src/moonlink/src/storage/iceberg/s3_test_utils.rs
@@ -1,7 +1,7 @@
 /// This module provides a few test util functions.
 use crate::storage::iceberg::file_catalog::{CatalogConfig, FileCatalog};
 
-use randomizer::Randomizer;
+use rand::Rng;
 
 /// Minio related constants.
 ///
@@ -40,10 +40,15 @@ pub(crate) fn create_minio_s3_catalog(bucket: &str, warehouse_uri: &str) -> File
 pub(crate) fn get_test_minio_bucket_and_warehouse(
 ) -> (String /*bucket_name*/, String /*warehouse_url*/) {
     // minio bucket name only allows lowercase case letters, digits and hyphen.
-    let random_string = Randomizer::ALPHANUMERIC(TEST_BUCKET_NAME_LEN)
-        .string()
-        .unwrap()
-        .to_lowercase();
+    const TEST_BUCKET_NAME_LEN: usize = 12;
+    const ALLOWED_CHARS: &[u8] = b"abcdefghijklmnopqrstuvwxyz0123456789-";
+    let mut rng = rand::rng();
+    let random_string: String = (0..TEST_BUCKET_NAME_LEN)
+        .map(|_| {
+            let idx = rng.random_range(0..ALLOWED_CHARS.len());
+            ALLOWED_CHARS[idx] as char
+        })
+        .collect();
     (
         format!("{}{}", MINIO_TEST_BUCKET_PREFIX, random_string),
         format!("{}{}", MINIO_TEST_WAREHOUSE_URI_PREFIX, random_string),


### PR DESCRIPTION
## Summary

Old random library depends on `instant`, which is an unmaintained crate and exposes security issue.

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
