### PR TITLE
Use comparison macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2765,6 +2765,7 @@ dependencies = [
  "itertools 0.14.0",
  "memmap2",
  "mockall",
+ "more-asserts",
  "multimap",
  "num-bigint",
  "num-traits",
@@ -2824,6 +2825,12 @@ dependencies = [
  "tracing",
  "uuid",
 ]
+
+[[package]]
+name = "more-asserts"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fafa6961cabd9c63bcd77a45d7e3b7f3b552b70417831fb0f56db717e72407e"
 
 [[package]]
 name = "multimap"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ iceberg = { git = "https://github.com/apache/iceberg-rust.git", rev = "40b055a77
   "storage-fs",
 ] }
 itertools = { version = "0.14" }
+more-asserts = "0.3"
 multimap = { version = "0.10", default-features = false }
 num-bigint = { version = "0.4" }
 num-traits = "0.2"

--- a/src/moonlink/Cargo.toml
+++ b/src/moonlink/Cargo.toml
@@ -27,6 +27,7 @@ hashbrown = { workspace = true }
 iceberg = { workspace = true }
 itertools = { workspace = true }
 memmap2 = "0.9"
+more-asserts = { workspace = true }
 multimap = { workspace = true }
 num-bigint = { workspace = true }
 num-traits = { workspace = true }

--- a/src/moonlink/src/storage/index/persisted_bucket_hash_map.rs
+++ b/src/moonlink/src/storage/index/persisted_bucket_hash_map.rs
@@ -1,6 +1,7 @@
 use crate::storage::storage_utils::{MooncakeDataFileRef, RecordLocation};
 use futures::executor::block_on;
 use memmap2::Mmap;
+use more_asserts as ma;
 use std::collections::BinaryHeap;
 use std::fmt;
 use std::fmt::Debug;
@@ -138,7 +139,8 @@ impl IndexBlock {
         bucket_idx: u32,
         metadata: &GlobalIndex,
     ) -> Vec<RecordLocation> {
-        assert!(bucket_idx >= self.bucket_start_idx && bucket_idx < self.bucket_end_idx);
+        ma::assert_ge!(bucket_idx, self.bucket_start_idx);
+        ma::assert_lt!(bucket_idx, self.bucket_end_idx);
         let cursor = Cursor::new(self.data.as_ref().as_ref().unwrap().as_ref());
         let mut reader = AsyncBitReader::endian(cursor, AsyncBigEndian);
         let mut entry_reader = reader.clone();

--- a/src/moonlink/src/storage/mooncake_table/shared_array.rs
+++ b/src/moonlink/src/storage/mooncake_table/shared_array.rs
@@ -2,6 +2,8 @@ use std::{cell::UnsafeCell, sync::Arc};
 
 use crate::row::MoonlinkRow;
 
+use more_asserts::assert_le;
+
 /// Used to share rows between write and read threads
 ///
 /// It is guaranteed only one thread is writing to the buffer
@@ -54,7 +56,7 @@ impl SharedRowBuffer {
 
 impl SharedRowBufferSnapshot {
     pub fn get_buffer(&self, size: usize) -> &[MoonlinkRow] {
-        assert!(size <= self.length);
+        assert_le!(size, self.length);
         unsafe { &(*self.buffer.get())[..size] }
     }
 }

--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -15,6 +15,7 @@ use crate::storage::storage_utils::{
     MooncakeDataFile, MooncakeDataFileRef, ProcessedDeletionRecord, RawDeletionRecord,
     RecordLocation,
 };
+use more_asserts as ma;
 use parquet::arrow::AsyncArrowWriter;
 use parquet::basic::{Compression, Encoding};
 use parquet::file::properties::WriterProperties;
@@ -204,11 +205,12 @@ impl SnapshotTableState {
 
     /// Update unpersisted data files from successful iceberg snapshot operation.
     fn prune_persisted_data_files(&mut self, persisted_new_data_files: Vec<MooncakeDataFileRef>) {
-        assert!(self.unpersisted_iceberg_records.unpersisted_data_files.len() >= persisted_new_data_files.len(),
-            "There're in total {} unpersisted data files, but successful iceberg snapshot shows {} data file persisted.",
-            self.unpersisted_iceberg_records.unpersisted_data_files.len(),
-            persisted_new_data_files.len());
-
+        ma::assert_ge!(
+            self.unpersisted_iceberg_records
+                .unpersisted_data_files
+                .len(),
+            persisted_new_data_files.len()
+        );
         self.unpersisted_iceberg_records
             .unpersisted_data_files
             .drain(0..persisted_new_data_files.len());
@@ -216,11 +218,12 @@ impl SnapshotTableState {
 
     /// Update unpersisted file indices from successful iceberg snapshot operation.
     fn prune_persisted_file_indices(&mut self, persisted_new_file_indices: Vec<FileIndex>) {
-        assert!(self.unpersisted_iceberg_records.unpersisted_file_indices.len() >= persisted_new_file_indices.len(),
-            "There're in total {} unpersisted file indices, but successful iceberg snapshot shows {} file indices persisted.",
-            self.unpersisted_iceberg_records.unpersisted_file_indices.len(),
-            persisted_new_file_indices.len());
-
+        ma::assert_ge!(
+            self.unpersisted_iceberg_records
+                .unpersisted_file_indices
+                .len(),
+            persisted_new_file_indices.len()
+        );
         self.unpersisted_iceberg_records
             .unpersisted_file_indices
             .drain(0..persisted_new_file_indices.len());

--- a/src/moonlink/src/table_handler.rs
+++ b/src/moonlink/src/table_handler.rs
@@ -3,6 +3,7 @@ use crate::storage::mooncake_table::IcebergSnapshotPayload;
 use crate::storage::mooncake_table::IcebergSnapshotResult;
 use crate::storage::MooncakeTable;
 use crate::{Error, Result};
+use more_asserts as ma;
 use std::collections::BTreeMap;
 use tokio::sync::mpsc::{self, Receiver, Sender};
 use tokio::task::JoinHandle;
@@ -307,7 +308,7 @@ impl TableHandler {
                             // Notify all waiters with LSN satisfied.
                             let new_map = force_snapshot_lsns.split_off(&(iceberg_flush_lsn + 1));
                             for (requested_lsn, tx) in force_snapshot_lsns.iter() {
-                                assert!(*requested_lsn <= iceberg_flush_lsn);
+                                ma::assert_le!(*requested_lsn, iceberg_flush_lsn);
                                 for cur_tx in tx {
                                     cur_tx.send(Ok(())).await.unwrap();
                                 }

--- a/src/moonlink/src/union_read/table_metadata.rs
+++ b/src/moonlink/src/union_read/table_metadata.rs
@@ -2,6 +2,7 @@ use crate::storage::mooncake_table::PuffinDeletionBlobAtRead;
 
 use bincode::enc::{write::Writer, Encode, Encoder};
 use bincode::error::EncodeError;
+use more_asserts as ma;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(super) struct TableMetadata {
@@ -41,7 +42,7 @@ impl Encode for TableMetadata {
         // Write deletion vector puffin blob information.
         write_usize(writer, self.deletion_vectors.len())?;
         for deletion_vector in &self.deletion_vectors {
-            assert!(deletion_vector.data_file_index >= prev_data_file_index);
+            ma::assert_ge!(deletion_vector.data_file_index, prev_data_file_index);
             prev_data_file_index = deletion_vector.data_file_index;
 
             write_u32(writer, deletion_vector.data_file_index)?;
@@ -55,7 +56,7 @@ impl Encode for TableMetadata {
         // Write positional deletion records.
         write_usize(writer, self.position_deletes.len())?;
         for position_delete in &self.position_deletes {
-            assert!(position_delete.0 >= prev_position_delete_data_file_index);
+            ma::assert_ge!(position_delete.0, prev_position_delete_data_file_index);
             prev_position_delete_data_file_index = position_delete.0;
 
             write_u32(writer, position_delete.0)?;


### PR DESCRIPTION
## Summary

Use `assert_` macros, which is strictly better than the current `assert!` macro, since it prints out lhs / rhs when assertion failure. The introduced third-party dependency is a pretty lightweight one.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/344

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
