### PR TITLE
[storage] Provide snapshot option to skip iceberg snapshot check

### DIFF
--- a/src/moonlink/src/storage/iceberg/state_tests.rs
+++ b/src/moonlink/src/storage/iceberg/state_tests.rs
@@ -38,6 +38,7 @@ use crate::storage::iceberg::test_utils::{
 };
 use crate::storage::mooncake_table::delete_vector::BatchDeletionVector;
 use crate::storage::mooncake_table::Snapshot;
+use crate::storage::mooncake_table::SnapshotOption;
 use crate::storage::MooncakeTable;
 
 // Test util function to prepare for committed and persisted data file,
@@ -245,7 +246,7 @@ async fn test_state_1_1() -> IcebergResult<()> {
     table.append(row).unwrap();
 
     // Request to create snapshot.
-    assert!(!table.create_snapshot());
+    assert!(!table.create_snapshot(SnapshotOption::default()));
 
     // Check iceberg snapshot status.
     let snapshot = iceberg_table_manager.load_snapshot_from_table().await?;
@@ -275,7 +276,7 @@ async fn test_state_1_2() -> IcebergResult<()> {
     table.delete(row.clone(), /*lsn=*/ 1).await;
 
     // Request to create snapshot.
-    assert!(!table.create_snapshot());
+    assert!(!table.create_snapshot(SnapshotOption::default()));
 
     // Check iceberg snapshot status.
     let snapshot = iceberg_table_manager.load_snapshot_from_table().await?;

--- a/src/moonlink/src/storage/iceberg/test_utils.rs
+++ b/src/moonlink/src/storage/iceberg/test_utils.rs
@@ -203,12 +203,10 @@ pub(crate) async fn create_table_and_iceberg_manager(
     (table, iceberg_table_manager, notify_rx)
 }
 
-/// Test util function to perform a mooncake snapshot, block wait its completion and get its result.
-pub(crate) async fn create_mooncake_snapshot(
-    table: &mut MooncakeTable,
+/// Test util function to block wait a mooncake snapshot and get its result.
+pub(crate) async fn get_mooncake_snapshot_result(
     notify_rx: &mut Receiver<TableNotify>,
 ) -> (u64, Option<IcebergSnapshotPayload>) {
-    assert!(table.create_snapshot(SnapshotOption::default()));
     let notification = notify_rx.recv().await.unwrap();
     match notification {
         TableNotify::MooncakeTableSnapshot {
@@ -219,6 +217,15 @@ pub(crate) async fn create_mooncake_snapshot(
             panic!("Expects to receive mooncake snapshot completion notification, but receives iceberg snapshot one.");
         }
     }
+}
+
+/// Test util function to perform a mooncake snapshot, block wait its completion and get its result.
+pub(crate) async fn create_mooncake_snapshot(
+    table: &mut MooncakeTable,
+    notify_rx: &mut Receiver<TableNotify>,
+) -> (u64, Option<IcebergSnapshotPayload>) {
+    assert!(table.create_snapshot(SnapshotOption::default()));
+    get_mooncake_snapshot_result(notify_rx).await
 }
 
 /// Test util function to perform an iceberg snapshot, block wait its completion and gets its result.

--- a/src/moonlink/src/storage/iceberg/test_utils.rs
+++ b/src/moonlink/src/storage/iceberg/test_utils.rs
@@ -7,6 +7,7 @@ use crate::storage::iceberg::puffin_utils;
 use crate::storage::mooncake_table::IcebergSnapshotPayload;
 use crate::storage::mooncake_table::IcebergSnapshotResult;
 use crate::storage::mooncake_table::Snapshot;
+use crate::storage::mooncake_table::SnapshotOption;
 use crate::storage::mooncake_table::{
     DiskFileDeletionVector, TableConfig as MooncakeTableConfig,
     TableMetadata as MooncakeTableMetadata,
@@ -207,7 +208,7 @@ pub(crate) async fn create_mooncake_snapshot(
     table: &mut MooncakeTable,
     notify_rx: &mut Receiver<TableNotify>,
 ) -> (u64, Option<IcebergSnapshotPayload>) {
-    assert!(table.create_snapshot());
+    assert!(table.create_snapshot(SnapshotOption::default()));
     let notification = notify_rx.recv().await.unwrap();
     match notification {
         TableNotify::MooncakeTableSnapshot {

--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -9,7 +9,7 @@ use crate::storage::iceberg::iceberg_table_manager::TableManager;
 use crate::storage::iceberg::puffin_utils::PuffinBlobRef;
 use crate::storage::index::{FileIndex, Index};
 use crate::storage::mooncake_table::shared_array::SharedRowBufferSnapshot;
-use crate::storage::mooncake_table::MoonlinkRow;
+use crate::storage::mooncake_table::{MoonlinkRow, SnapshotOption};
 use crate::storage::storage_utils::FileId;
 use crate::storage::storage_utils::{
     MooncakeDataFile, MooncakeDataFileRef, ProcessedDeletionRecord, RawDeletionRecord,
@@ -257,7 +257,7 @@ impl SnapshotTableState {
     pub(super) async fn update_snapshot(
         &mut self,
         mut task: SnapshotTask,
-        force_create: bool,
+        opt: SnapshotOption,
     ) -> (u64, Option<IcebergSnapshotPayload>) {
         // Reflect iceberg snapshot to mooncake snapshot.
         self.prune_committed_deletion_logs(&task);
@@ -308,11 +308,13 @@ impl SnapshotTableState {
             self.unpersisted_iceberg_records
                 .unpersisted_data_files
                 .as_slice(),
-            force_create,
+            opt.force_create,
         );
-        let flush_by_deletion_logs = self.create_iceberg_snapshot_by_committed_logs(force_create);
+        let flush_by_deletion_logs =
+            self.create_iceberg_snapshot_by_committed_logs(opt.force_create);
 
-        if self.current_snapshot.data_file_flush_lsn.is_some()
+        if !opt.skip_iceberg_snapshot
+            && self.current_snapshot.data_file_flush_lsn.is_some()
             && (flush_by_data_files || flush_by_deletion_logs)
         {
             // Getting persistable committed deletion logs is not cheap, which requires iterating through all logs,

--- a/src/moonlink/src/storage/mooncake_table/test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/test_utils.rs
@@ -144,7 +144,7 @@ pub async fn snapshot(
     table: &mut MooncakeTable,
     notify_rx: &mut Receiver<TableNotify>,
 ) -> (u64, Option<IcebergSnapshotPayload>) {
-    assert!(table.create_snapshot());
+    assert!(table.create_snapshot(SnapshotOption::default()));
     let table_notify = notify_rx.recv().await.unwrap();
     match table_notify {
         TableNotify::MooncakeTableSnapshot {

--- a/src/moonlink/src/table_handler.rs
+++ b/src/moonlink/src/table_handler.rs
@@ -270,9 +270,6 @@ impl TableHandler {
                             table.notify_snapshot_reader(lsn);
 
                             // Process iceberg snapshot and trigger iceberg snapshot if necessary.
-                            //
-                            // TODO(hjiang): same as mooncake snapshot, there should be at most one iceberg snapshot ongoing; for simplicity, we skip iceberg snapshot if there's already one.
-                            // An optimization is skip generating iceberg snapshot payload at mooncake snapshot if we know it's already taking place, but the risk is missing iceberg snapshot.
                             if can_initiate_iceberg_snapshot(iceberg_snapshot_result_consumed, iceberg_snapshot_ongoing) {
                                 if let Some(iceberg_snapshot_payload) = iceberg_snapshot_payload {
                                     table.persist_iceberg_snapshot(iceberg_snapshot_payload);


### PR DESCRIPTION
## Summary

Checking whether to create an iceberg snapshot could be expensive, specifically, aggregate committed deletion logs.
https://github.com/Mooncake-Labs/moonlink/blob/8da700a3e068a2a1ceb2bf4aefa8f7fd725ee248/src/moonlink/src/storage/mooncake_table/snapshot.rs#L119-L157

But at table handle level, before we initiate mooncake snapshot, we already know whether or not there's already an ongoing iceberg snapshot, so we could potentially skip the check if already.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/366

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
