### PR TITLE
[storage] Fix deletion vector rows

### DIFF
--- a/src/moonlink/src/storage/iceberg/deletion_vector.rs
+++ b/src/moonlink/src/storage/iceberg/deletion_vector.rs
@@ -1,3 +1,6 @@
+/// Iceberg deletion vector is the persistent format of in-memory BatchDeletionVector.
+/// On persistence stage, batch deletion vector is converted to iceberg one, by serializing corresponding roaring bitmap and its properties;
+/// at recovery, batch deletion vector is constructed back by loading and deserializing the puffin blob binary.
 use crate::storage::iceberg::puffin_utils;
 use crate::storage::mooncake_table::delete_vector::BatchDeletionVector;
 

--- a/src/moonlink/src/storage/iceberg/deletion_vector.rs
+++ b/src/moonlink/src/storage/iceberg/deletion_vector.rs
@@ -18,10 +18,14 @@ const MIN_SERIALIZED_DELETION_VECTOR_BLOB: usize = 12;
 // Deletion vector puffin blob properties which must be contained.
 pub(crate) const DELETION_VECTOR_CADINALITY: &str = "cardinality";
 pub(crate) const DELETION_VECTOR_REFERENCED_DATA_FILE: &str = "referenced-data-file";
+/// Used to bookkeep max number of rows for batch deletion vector.
+pub(crate) const MOONCAKE_DELETION_VECTOR_NUM_ROWS: &str = "mooncake-deletion-vector-max-num-rows";
 
 pub(crate) struct DeletionVector {
     /// Roaring bitmap representing deleted rows.
     pub(crate) bitmap: RoaringTreemap,
+    /// Max number of rows correspond to mooncake batch deletion vector.
+    pub(crate) max_num_rows: Option<usize>,
 }
 
 impl DeletionVector {
@@ -29,6 +33,7 @@ impl DeletionVector {
     pub fn new() -> Self {
         Self {
             bitmap: RoaringTreemap::new(),
+            max_num_rows: None,
         }
     }
 
@@ -41,9 +46,12 @@ impl DeletionVector {
     }
 
     /// Deserializes a byte vector into a DeletionVector.
-    fn deserialize_roaring_map(data: &[u8]) -> IcebergResult<Self> {
+    fn deserialize_roaring_map(data: &[u8], max_num_rows: usize) -> IcebergResult<Self> {
         RoaringTreemap::deserialize_from(data)
-            .map(|bitmap| Self { bitmap })
+            .map(|bitmap| Self {
+                bitmap,
+                max_num_rows: Some(max_num_rows),
+            })
             .map_err(|e| {
                 IcebergError::new(
                     iceberg::ErrorKind::DataInvalid,
@@ -203,8 +211,16 @@ impl DeletionVector {
             ));
         }
 
+        // Get max number of rows for corresponding mooncake deletion vector.
+        let max_num_rows: usize = blob
+            .properties()
+            .get(MOONCAKE_DELETION_VECTOR_NUM_ROWS)
+            .unwrap()
+            .parse()
+            .unwrap();
+
         // Deserialize the bitmap.
-        DeletionVector::deserialize_roaring_map(bitmap_data)
+        DeletionVector::deserialize_roaring_map(bitmap_data, max_num_rows)
     }
 
     /// Load deletion vector from puffin file blob.
@@ -217,8 +233,9 @@ impl DeletionVector {
     }
 
     /// Convert self to `BatchDeletionVector`, after which self ownership is terminated.
-    pub fn take_as_batch_delete_vector(self, batch_size: usize) -> BatchDeletionVector {
-        let mut batch_delete_vector = BatchDeletionVector::new(batch_size);
+    pub fn take_as_batch_delete_vector(self) -> BatchDeletionVector {
+        let max_rows = self.max_num_rows.unwrap();
+        let mut batch_delete_vector = BatchDeletionVector::new(max_rows);
         for row_idx in self.bitmap.iter() {
             batch_delete_vector.delete_row(row_idx as usize);
         }
@@ -239,6 +256,10 @@ mod tests {
         properties.insert(
             DELETION_VECTOR_REFERENCED_DATA_FILE.to_string(),
             "/tmp/iceberg/data/filename".to_string(),
+        );
+        properties.insert(
+            MOONCAKE_DELETION_VECTOR_NUM_ROWS.to_string(),
+            "2000".to_string(),
         );
         properties
     }
@@ -267,7 +288,7 @@ mod tests {
         assert_eq!(dv.bitmap, deserialized_dv.bitmap);
 
         // Check conversion into BatchDeletionVector.
-        let batch_deletion_vector = dv.take_as_batch_delete_vector(1024);
+        let batch_deletion_vector = deserialized_dv.take_as_batch_delete_vector();
         assert_eq!(batch_deletion_vector.collect_deleted_rows(), deleted_rows);
     }
 }

--- a/src/moonlink/src/storage/iceberg/test_utils.rs
+++ b/src/moonlink/src/storage/iceberg/test_utils.rs
@@ -54,8 +54,7 @@ async fn check_deletion_vector_consistency(disk_dv_entry: &DiskFileDeletionVecto
     .await
     .unwrap();
     let iceberg_deletion_vector = DeletionVector::deserialize(blob).unwrap();
-    let batch_deletion_vector = iceberg_deletion_vector
-        .take_as_batch_delete_vector(MooncakeTableConfig::default().batch_size());
+    let batch_deletion_vector = iceberg_deletion_vector.take_as_batch_delete_vector();
     assert_eq!(batch_deletion_vector, disk_dv_entry.batch_deletion_vector);
 }
 

--- a/src/moonlink/src/storage/mooncake_table/test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/test_utils.rs
@@ -239,7 +239,7 @@ pub async fn verify_files_and_deletions(
     for (idx, cur_load_blob_res) in load_blob_results.into_iter().enumerate() {
         let blob = cur_load_blob_res.unwrap();
         let dv = DeletionVector::deserialize(blob).unwrap();
-        let batch_deletion_vector = dv.take_as_batch_delete_vector(TableConfig::DEFAULT_BATCH_SIZE);
+        let batch_deletion_vector = dv.take_as_batch_delete_vector();
         let deleted_rows = batch_deletion_vector.collect_deleted_rows();
         assert!(!deleted_rows.is_empty());
         position_deletes.append(

--- a/src/moonlink/src/table_handler/test_utils.rs
+++ b/src/moonlink/src/table_handler/test_utils.rs
@@ -320,7 +320,6 @@ pub(crate) async fn check_deletion_vector_consistency(disk_dv_entry: &DiskFileDe
     .await
     .unwrap();
     let iceberg_deletion_vector = DeletionVector::deserialize(blob).unwrap();
-    let batch_deletion_vector = iceberg_deletion_vector
-        .take_as_batch_delete_vector(MooncakeTableConfig::default().batch_size());
+    let batch_deletion_vector = iceberg_deletion_vector.take_as_batch_delete_vector();
     assert_eq!(batch_deletion_vector, disk_dv_entry.batch_deletion_vector);
 }


### PR DESCRIPTION
## Summary

Batch deletion vector is the in-memory format for iceberg deletion vector.
Similar to https://github.com/Mooncake-Labs/moonlink/pull/345, we should record max number of rows for batch deletion vector somewhere (aka, persistence), so it could be loaded at recovery.

The codepath (aka, recording and loading max number of rows) has been executed almost in most unit tests.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/376

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
