### PR TITLE
Don't panic on disconnection

### DIFF
--- a/src/moonlink_connectors/src/replication_connection.rs
+++ b/src/moonlink_connectors/src/replication_connection.rs
@@ -2,10 +2,7 @@ use crate::pg_replicate::conversions::cdc_event::CdcEventConversionError;
 use crate::pg_replicate::moonlink_sink::Sink;
 use crate::pg_replicate::postgres_source::CdcStream;
 use crate::pg_replicate::postgres_source::{
-    CdcStreamError,
-    PostgresSource,
-    PostgresSourceError,
-    TableNamesFrom,
+    CdcStreamError, PostgresSource, PostgresSourceError, TableNamesFrom,
 };
 use crate::pg_replicate::table_init::build_table_components;
 use crate::Result;
@@ -58,8 +55,9 @@ impl ReplicationConnection {
         table_base_path: String,
         table_temp_files_directory: String,
     ) -> Result<Self> {
-        let (postgres_client, connection) =
-            connect(&uri, NoTls).await.map_err(PostgresSourceError::from)?;
+        let (postgres_client, connection) = connect(&uri, NoTls)
+            .await
+            .map_err(PostgresSourceError::from)?;
         tokio::spawn(async move {
             if let Err(e) = connection.await {
                 warn!("connection error: {}", e);

--- a/src/moonlink_connectors/src/replication_connection.rs
+++ b/src/moonlink_connectors/src/replication_connection.rs
@@ -1,7 +1,12 @@
 use crate::pg_replicate::conversions::cdc_event::CdcEventConversionError;
 use crate::pg_replicate::moonlink_sink::Sink;
 use crate::pg_replicate::postgres_source::CdcStream;
-use crate::pg_replicate::postgres_source::{CdcStreamError, PostgresSource, TableNamesFrom};
+use crate::pg_replicate::postgres_source::{
+    CdcStreamError,
+    PostgresSource,
+    PostgresSourceError,
+    TableNamesFrom,
+};
 use crate::pg_replicate::table_init::build_table_components;
 use crate::Result;
 use moonlink::{IcebergTableEventManager, ReadStateManager};
@@ -19,6 +24,7 @@ use std::path::Path;
 use tokio::sync::{mpsc, watch};
 use tokio::task::JoinHandle;
 use tokio_postgres::{connect, Client, Config, NoTls};
+use tracing::warn;
 
 pub enum Command {
     AddTable {
@@ -52,10 +58,11 @@ impl ReplicationConnection {
         table_base_path: String,
         table_temp_files_directory: String,
     ) -> Result<Self> {
-        let (postgres_client, connection) = connect(&uri, NoTls).await.unwrap();
+        let (postgres_client, connection) =
+            connect(&uri, NoTls).await.map_err(PostgresSourceError::from)?;
         tokio::spawn(async move {
             if let Err(e) = connection.await {
-                panic!("connection error: {}", e);
+                warn!("connection error: {}", e);
             }
         });
         postgres_client
@@ -63,7 +70,7 @@ impl ReplicationConnection {
                 "DROP PUBLICATION IF EXISTS moonlink_pub; CREATE PUBLICATION moonlink_pub;",
             )
             .await
-            .unwrap();
+            .map_err(PostgresSourceError::from)?;
 
         let db_name = uri
             .parse::<Config>()


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

We shouldn't panic on connection errors. Currently, when the connection closes on the pg_mooncake side, when we restart moonlink will panic. Instead we log a message. 

Also removed `unwraps` and added proper errors. 

## Related Issues

Closes #<issue-number> or links to related issues.

## Changes

- 
- 
- 

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
