### PR TITLE
fix: flaky test on macOS

### DIFF
--- a/src/moonlink/src/storage/iceberg/test_utils.rs
+++ b/src/moonlink/src/storage/iceberg/test_utils.rs
@@ -67,7 +67,7 @@ pub(crate) async fn check_deletion_vector_consistency_for_snapshot(snapshot: &Sn
 
 /// Test util functions to check recovered snapshot only contains remote filepaths and they do exist.
 pub(crate) async fn validate_recovered_snapshot(snapshot: &Snapshot, warehouse_uri: &str) {
-    let warehouse_directory = tokio::fs::canonicalize(&warehouse_uri).await.unwrap();
+    let warehouse_directory = std::path::PathBuf::from(warehouse_uri);
     let mut data_filepaths: HashSet<String> = HashSet::new();
 
     // Check data files and their puffin blobs.


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary


This patch fix flaky test on mac os

error:

```cli
---- storage::iceberg::tests::test_async_iceberg_snapshot stdout ----

thread 'storage::iceberg::tests::test_async_iceberg_snapshot' panicked at src/moonlink/src/storage/iceberg/test_utils.rs:76:9:
assertion failed: cur_disk_pathbuf.starts_with(&warehouse_directory)

---- storage::iceberg::tests::test_filesystem_sync_snapshots stdout ----

thread 'storage::iceberg::tests::test_filesystem_sync_snapshots' panicked at src/moonlink/src/storage/iceberg/test_utils.rs:76:9:
assertion failed: cur_disk_pathbuf.starts_with(&warehouse_directory)

---- storage::iceberg::tests::test_small_batch_size_and_large_parquet_size stdout ----

thread 'storage::iceberg::tests::test_small_batch_size_and_large_parquet_size' panicked at src/moonlink/src/storage/iceberg/test_utils.rs:76:9:
assertion failed: cur_disk_pathbuf.starts_with(&warehouse_directory)

---- storage::iceberg::tests::test_index_merge_and_create_snapshot stdout ----

thread 'storage::iceberg::tests::test_index_merge_and_create_snapshot' panicked at src/moonlink/src/storage/iceberg/test_utils.rs:76:9:
assertion failed: cur_disk_pathbuf.starts_with(&warehouse_directory)

---- storage::iceberg::tests::test_sync_snapshots stdout ----

thread 'storage::iceberg::tests::test_sync_snapshots' panicked at src/moonlink/src/storage/iceberg/test_utils.rs:76:9:
assertion failed: cur_disk_pathbuf.starts_with(&warehouse_directory)

```

the reason is that on mac os the path maybe different 

debug info

```cli
puffin_filepath: /var/folders/c3/51t_3cqj7bx98dq1ptyy0v700000gn/T/.tmpmy61Fb/namespace/test_table/data/e9ca7abb-cd64-4162-8dc8-5dde09fef63e-deletion-vector-v1-puffin.bin
warehouse_directory: /private/var/folders/c3/51t_3cqj7bx98dq1ptyy0v700000gn/T/.tmpmy61Fb
``` 

fix: as diff



## Related Issues

Closes #<issue-number> or links to related issues.

## Changes

- 
- 
- 

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
