### PR TITLE
[storage] Use uuidv7 to generate filenames

### DIFF
--- a/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
@@ -144,14 +144,14 @@ impl IcebergTableManager {
             DefaultLocationGenerator::new(self.iceberg_table.as_ref().unwrap().metadata().clone())
                 .unwrap();
         location_generator
-            .generate_location(&format!("{}-deletion-vector-v1-puffin.bin", Uuid::new_v4()))
+            .generate_location(&format!("{}-deletion-vector-v1-puffin.bin", Uuid::now_v7()))
     }
     fn get_unique_hash_index_v1_filepath(&self) -> String {
         let location_generator =
             DefaultLocationGenerator::new(self.iceberg_table.as_ref().unwrap().metadata().clone())
                 .unwrap();
         location_generator
-            .generate_location(&format!("{}-hash-index-v1-puffin.bin", Uuid::new_v4()))
+            .generate_location(&format!("{}-hash-index-v1-puffin.bin", Uuid::now_v7()))
     }
 
     /// Get or create an iceberg table based on the iceberg manager config.

--- a/src/moonlink/src/storage/iceberg/puffin_writer_proxy.rs
+++ b/src/moonlink/src/storage/iceberg/puffin_writer_proxy.rs
@@ -324,7 +324,7 @@ fn create_manifest_writer_builder(
         file_io.new_output(format!(
             "{}/metadata/{}-m0.avro",
             table_metadata.location(),
-            Uuid::new_v4()
+            Uuid::now_v7()
         ))?,
         table_metadata.current_snapshot_id(),
         /*key_metadata=*/ vec![],

--- a/src/moonlink/src/storage/index/persisted_bucket_hash_map.rs
+++ b/src/moonlink/src/storage/index/persisted_bucket_hash_map.rs
@@ -245,7 +245,7 @@ struct IndexBlockBuilder {
 /// TODO(hjiang): Error handle for all IO operations.
 impl IndexBlockBuilder {
     pub async fn new(bucket_start_idx: u32, bucket_end_idx: u32, directory: PathBuf) -> Self {
-        let file_name = format!("index_block_{}.bin", uuid::Uuid::new_v4());
+        let file_name = format!("index_block_{}.bin", uuid::Uuid::now_v7());
         let file_path = directory.join(&file_name);
 
         let file = AsyncFile::create(&file_path).await.unwrap();

--- a/src/moonlink/src/storage/storage_utils.rs
+++ b/src/moonlink/src/storage/storage_utils.rs
@@ -44,7 +44,7 @@ pub fn get_unique_file_id_for_flush(table_auto_incr_id: u64, file_idx: u64) -> u
 
 pub fn get_random_file_name_in_dir(dir_path: &Path) -> String {
     dir_path
-        .join(format!("data-{}.parquet", uuid::Uuid::new_v4()))
+        .join(format!("data-{}.parquet", uuid::Uuid::now_v7()))
         .to_string_lossy()
         .to_string()
 }


### PR DESCRIPTION
## Summary

I'm checking ducklake code, and they're using UUIDv7, instead of UUIDv4, to fill in filenames.
The benefit of which is to provide rough order of file generation.
Discussion reference: https://github.com/duckdb/ducklake/discussions/142#discussioncomment-13370086
Code reference: https://github.com/duckdb/ducklake/blob/d4e144737bc3f88aef1d8768cb2ef162b0db9f09/src/storage/ducklake_insert.cpp#L362-L378

UUID is used here:
- I don't see iceberg spec to require filename format
- Avoid filename duplication
- UUID as prefix to avoid hotspotting on object storage (whose metadata is backed by spanner/dynamo/etc)

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
