### PR TITLE
Drop table bug fix

### DIFF
--- a/src/moonlink_connectors/src/pg_replicate/postgres_source.rs
+++ b/src/moonlink_connectors/src/pg_replicate/postgres_source.rs
@@ -284,6 +284,11 @@ impl CdcStream {
         let this = self.project();
         this.table_schemas.insert(schema.table_id, schema);
     }
+
+    pub fn remove_table_schema(self: Pin<&mut Self>, table_id: TableId) {
+        let this = self.project();
+        this.table_schemas.remove(&table_id);
+    }
 }
 
 impl Stream for CdcStream {

--- a/src/moonlink_connectors/src/replication_connection.rs
+++ b/src/moonlink_connectors/src/replication_connection.rs
@@ -309,6 +309,7 @@ async fn run_event_loop(
                 }
                 Command::DropTable { table_id } => {
                     sink.drop_table(table_id);
+                    stream.as_mut().remove_table_schema(table_id);
                 }
             },
             event = StreamExt::next(&mut stream) => {


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

Currently we never remove the table schemas from the stream. When the table is dropped, we should remove the schema from the stream as well as the sink. This is symmetric to add table. 

## Related Issues

Closes #<issue-number> or links to related issues.

## Changes

- 
- 
- 

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
