### PR TITLE
[minor] Fix index merge config default value

### DIFF
--- a/src/moonlink/src/storage/iceberg/tests.rs
+++ b/src/moonlink/src/storage/iceberg/tests.rs
@@ -7,7 +7,7 @@ use crate::storage::iceberg::iceberg_table_manager::TableManager;
 #[cfg(feature = "storage-s3")]
 use crate::storage::iceberg::s3_test_utils;
 use crate::storage::iceberg::test_utils::*;
-use crate::storage::index::persisted_bucket_hash_map::FileIndexMergeConfig;
+use crate::storage::index::index_merge_config::FileIndexMergeConfig;
 use crate::storage::index::persisted_bucket_hash_map::GlobalIndex;
 use crate::storage::index::Index;
 use crate::storage::index::MooncakeIndex;

--- a/src/moonlink/src/storage/index.rs
+++ b/src/moonlink/src/storage/index.rs
@@ -1,4 +1,5 @@
 pub mod hash_index;
+pub mod index_merge_config;
 pub mod mem_index;
 pub mod persisted_bucket_hash_map;
 

--- a/src/moonlink/src/storage/index/index_merge_config.rs
+++ b/src/moonlink/src/storage/index/index_merge_config.rs
@@ -1,0 +1,31 @@
+use typed_builder::TypedBuilder;
+
+/// Configuration for index merge.
+///
+/// TODO(hjiang): To reduce code change before preview release, disable data compaction by default until we do further testing to make sure moonlink fine.
+#[derive(Clone, Default, Debug, TypedBuilder)]
+pub struct FileIndexMergeConfig {
+    /// Number of existing index blocks under final size to trigger a merge operation.
+    pub file_indices_to_merge: u32,
+    /// Number of bytes for a block index to consider it finalized and won't be merged again.
+    pub index_block_final_size: u64,
+}
+
+impl FileIndexMergeConfig {
+    #[cfg(debug_assertions)]
+    pub const DEFAULT_FILE_INDICES_TO_MERGE: u32 = u32::MAX;
+    #[cfg(debug_assertions)]
+    pub const DEFAULT_INDEX_BLOCK_FINAL_SIZE: u64 = u64::MAX;
+
+    #[cfg(not(debug_assertions))]
+    pub const DEFAULT_FILE_INDICES_TO_MERGE: u32 = u32::MAX;
+    #[cfg(not(debug_assertions))]
+    pub const DEFAULT_INDEX_BLOCK_FINAL_SIZE: u64 = u64::MAX;
+
+    pub fn default() -> Self {
+        Self {
+            file_indices_to_merge: Self::DEFAULT_FILE_INDICES_TO_MERGE,
+            index_block_final_size: Self::DEFAULT_INDEX_BLOCK_FINAL_SIZE,
+        }
+    }
+}

--- a/src/moonlink/src/storage/index/persisted_bucket_hash_map.rs
+++ b/src/moonlink/src/storage/index/persisted_bucket_hash_map.rs
@@ -16,7 +16,6 @@ use tokio_bitstream_io::{
     BigEndian as AsyncBigEndian, BitRead as AsyncBitRead, BitReader as AsyncBitReader,
     BitWrite as AsyncBitWrite, BitWriter as AsyncBitWriter,
 };
-use typed_builder::TypedBuilder;
 
 // Constants
 const HASH_BITS: u32 = 64;
@@ -30,28 +29,6 @@ fn splitmix64(mut x: u64) -> u64 {
     z = (z ^ (z >> 30)).wrapping_mul(0xBF58476D1CE4E5B9);
     z = (z ^ (z >> 27)).wrapping_mul(0x94D049BB133111EB);
     z ^ (z >> 31)
-}
-
-/// Configurations for merging file indices.
-///
-/// TODO(hjiang): To reduce code change before preview release, disable index merge by default until we do further testing to make sure moonlink fine.
-#[derive(Clone, Default, Debug, TypedBuilder)]
-pub struct FileIndexMergeConfig {
-    /// Number of existing index blocks under final size to trigger a merge operation.
-    #[cfg(debug_assertions)]
-    #[builder(default = u32::MAX)]
-    pub file_indices_to_merge: u32,
-    /// Number of bytes for a block index to consider it finalized and won't be merged again.
-    #[cfg(debug_assertions)]
-    #[builder(default = u64::MAX)]
-    pub index_block_final_size: u64,
-
-    #[cfg(not(debug_assertions))]
-    #[builder(default = u32::MAX)]
-    pub file_indices_to_merge: u32,
-    #[cfg(not(debug_assertions))]
-    #[builder(default = u64::MAX)]
-    pub index_block_final_size: u64,
 }
 
 /// Hash index

--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -8,7 +8,6 @@ mod table_snapshot;
 mod transaction_stream;
 
 use super::iceberg::puffin_utils::PuffinBlobRef;
-use super::index::persisted_bucket_hash_map::FileIndexMergeConfig;
 use super::index::{FileIndex, MemIndex, MooncakeIndex};
 use super::storage_utils::{MooncakeDataFileRef, RawDeletionRecord, RecordLocation};
 use crate::error::{Error, Result};
@@ -16,6 +15,7 @@ use crate::row::{IdentityProp, MoonlinkRow};
 use crate::storage::iceberg::iceberg_table_manager::{
     IcebergTableConfig, IcebergTableManager, TableManager,
 };
+use crate::storage::index::index_merge_config::FileIndexMergeConfig;
 use crate::storage::mooncake_table::shared_array::SharedRowBufferSnapshot;
 #[cfg(test)]
 pub(crate) use crate::storage::mooncake_table::table_snapshot::IcebergSnapshotDataCompactionPayload;

--- a/src/moonlink/src/table_handler/tests.rs
+++ b/src/moonlink/src/table_handler/tests.rs
@@ -3,7 +3,7 @@ use iceberg::{Error as IcebergError, ErrorKind};
 use tempfile::tempdir;
 
 use super::test_utils::*;
-use crate::storage::index::persisted_bucket_hash_map::FileIndexMergeConfig;
+use crate::storage::index::index_merge_config::FileIndexMergeConfig;
 use crate::storage::mooncake_table::TableConfig as MooncakeTableConfig;
 use crate::storage::mooncake_table::TableMetadata as MooncakeTableMetadata;
 use crate::storage::MockTableManager;


### PR DESCRIPTION
## Summary

I found for the current implementation, if I create mooncake table config fields with `..Default::default()`,
both `file_indices_to_merge` and `index_block_final_size` will be initialized to 0, instead of u32 max and u64 max.

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
