### PR TITLE
[storage] Fix iceberg import invariant check

### DIFF
--- a/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
@@ -520,12 +520,7 @@ impl IcebergTableManager {
         file_indices_to_remove: &[MooncakeFileIndex],
         local_data_file_to_remote: HashMap<String, String>,
     ) -> IcebergResult<()> {
-        // Invariant assertion: file indices to remove should only come from compaction, so there must be new file indices to import.
-        if !file_indices_to_remove.is_empty() {
-            assert!(!file_indices_to_import.is_empty());
-        }
-
-        if file_indices_to_import.is_empty() {
+        if file_indices_to_import.is_empty() && file_indices_to_remove.is_empty() {
             return Ok(());
         }
 

--- a/src/moonlink/src/storage/mooncake_table/test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/test_utils.rs
@@ -123,7 +123,6 @@ pub fn verify_file_contents(
     }
 
     assert_eq!(actual, expected, "File contents don't match expected IDs");
-    println!("File contains {} rows with IDs: {:?}", actual.len(), actual);
 }
 
 pub fn append_rows(table: &mut MooncakeTable, rows: Vec<MoonlinkRow>) -> Result<()> {


### PR DESCRIPTION
## Summary

The invariant check is wrong: it's possible to remove all data files and file indices when nothing left after compaction (aka, all rows found deleted).

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
