### PR TITLE
[storage] Recode data file to file indice mapping

### DIFF
--- a/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
@@ -342,7 +342,7 @@ impl IcebergTableManager {
                 data_file,
                 DiskFileEntry {
                     file_size: data_file_entry.data_file.file_size_in_bytes() as usize,
-                    file_indice,
+                    file_indice: Some(file_indice),
                     puffin_deletion_blob: data_file_entry.persisted_deletion_vector.clone(),
                     batch_deletion_vector: data_file_entry.deletion_vector.clone(),
                 },

--- a/src/moonlink/src/storage/index/persisted_bucket_hash_map.rs
+++ b/src/moonlink/src/storage/index/persisted_bucket_hash_map.rs
@@ -63,6 +63,7 @@ impl PartialEq for GlobalIndex {
 
 impl Eq for GlobalIndex {}
 
+/// It's guaranteed every file indice references to different set of data files.
 impl Hash for GlobalIndex {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.files.hash(state);

--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -159,8 +159,9 @@ pub struct TableMetadata {
 #[derive(Clone, Debug)]
 pub(crate) struct DiskFileEntry {
     /// File size.
-    #[allow(dead_code)]
     pub(crate) file_size: usize,
+    /// File indices.
+    pub(crate) file_indice: FileIndex, 
     /// In-memory deletion vector, used for new deletion records in-memory processing.
     pub(crate) batch_deletion_vector: BatchDeletionVector,
     /// Persisted iceberg deletion vector puffin blob.

--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -161,7 +161,8 @@ pub(crate) struct DiskFileEntry {
     /// File size.
     pub(crate) file_size: usize,
     /// File indices.
-    pub(crate) file_indice: FileIndex,
+    /// Invariant: in a consistent snapshot, disk file entry has its file indice assigned.
+    pub(crate) file_indice: Option<FileIndex>,
     /// In-memory deletion vector, used for new deletion records in-memory processing.
     pub(crate) batch_deletion_vector: BatchDeletionVector,
     /// Persisted iceberg deletion vector puffin blob.

--- a/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
+++ b/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
@@ -198,6 +198,7 @@ impl MooncakeTable {
                 ma::assert_gt!(file_attrs.file_size, 0);
                 let disk_file_entry = DiskFileEntry {
                     file_size: file_attrs.file_size,
+                    file_indice: disk_slice.get_file_indice().as_ref().unwrap().clone(),
                     batch_deletion_vector: BatchDeletionVector::new(file_attrs.row_num),
                     puffin_deletion_blob: None,
                 };

--- a/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
+++ b/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
@@ -198,7 +198,7 @@ impl MooncakeTable {
                 ma::assert_gt!(file_attrs.file_size, 0);
                 let disk_file_entry = DiskFileEntry {
                     file_size: file_attrs.file_size,
-                    file_indice: disk_slice.get_file_indice().as_ref().unwrap().clone(),
+                    file_indice: Some(disk_slice.get_file_indice().as_ref().unwrap().clone()),
                     batch_deletion_vector: BatchDeletionVector::new(file_attrs.row_num),
                     puffin_deletion_blob: None,
                 };


### PR DESCRIPTION
## Summary

Currently, when deciding which file indices to compact, we use a sequential scan on all file indices, which correlates to data files to compact.
In this PR, I record the <data file, file index> mapping, so we could get file index in O(1).

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/429

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
