### PR TITLE
Add sleep to reduce snapshot test flakiness

### DIFF
--- a/src/moonlink_backend/tests/test_backend.rs
+++ b/src/moonlink_backend/tests/test_backend.rs
@@ -249,13 +249,13 @@ mod tests {
             .unwrap();
 
         // Look for any file in the Iceberg metadata dir.
-        let _meta_dir = tmp
+        let meta_dir = tmp
             .path()
             .join("default")
             .join("public.snapshot_test")
             .join("metadata");
-        assert!(_meta_dir.exists());
-        assert!(_meta_dir.read_dir().unwrap().next().is_some());
+        assert!(meta_dir.exists());
+        assert!(meta_dir.read_dir().unwrap().next().is_some());
 
         backend.drop_table("snapshot_test").await.unwrap();
         recreate_directory(DEFAULT_MOONLINK_TEMP_FILE_PATH).unwrap();


### PR DESCRIPTION
## Summary

Current integration test is flaky, since it doesn't guarantee the order of table insertion and snapshot creation at eventloop.
No real good way to handle with two sets of interfaces, simply add a sleep to reduce flakiness.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/432

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [x] Documentation updated if necessary
- [x] I have reviewed my own changes
