### PR TITLE
Logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2146,6 +2146,7 @@ dependencies = [
  "tokio",
  "tokio-bitstream-io",
  "tokio-retry2",
+ "tracing",
  "typed-builder 0.20.1",
  "url",
  "uuid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2165,6 +2165,7 @@ dependencies = [
  "thiserror 2.0.12",
  "tokio",
  "tokio-postgres",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ tokio-bitstream-io = "0.0.7"
 tokio-postgres = { git = "https://github.com/Mooncake-labs/rust-postgres.git" }
 url = "2.5"
 uuid = { version = "1.17", default-features = false, features = ["v4"] }
+tracing = "0.1"
 
 [profile.release-with-debug]
 inherits = "release"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,9 @@ edition = "2021"
 license = "LicenseRef-BSL-1.1"
 
 [workspace.dependencies]
-arrow = { version = "55", default-features = false, features = ["canonical_extension_types"] }
+arrow = { version = "55", default-features = false, features = [
+  "canonical_extension_types",
+] }
 arrow-array = "55"
 arrow-schema = "55"
 async-trait = "0.1"
@@ -28,7 +30,11 @@ num-traits = "0.2"
 opendal = { version = "0.53", default-features = false, features = [
   "services-s3",
 ] }
-parquet = { version = "55", default-features = false, features = ["arrow", "async", "arrow_canonical_extension_types"] }
+parquet = { version = "55", default-features = false, features = [
+  "arrow",
+  "async",
+  "arrow_canonical_extension_types",
+] }
 postgres-replication = { git = "https://github.com/Mooncake-labs/rust-postgres.git" }
 rand = "0.9"
 roaring = "0.10"
@@ -45,6 +51,7 @@ tokio = { version = "1.45", default-features = false, features = [
 tokio-bitstream-io = "0.0.7"
 tokio-postgres = { git = "https://github.com/Mooncake-labs/rust-postgres.git" }
 tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 url = "2.5"
 uuid = { version = "1.17", default-features = false, features = ["v4"] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,9 +44,9 @@ tokio = { version = "1.45", default-features = false, features = [
 ] }
 tokio-bitstream-io = "0.0.7"
 tokio-postgres = { git = "https://github.com/Mooncake-labs/rust-postgres.git" }
+tracing = "0.1"
 url = "2.5"
 uuid = { version = "1.17", default-features = false, features = ["v4"] }
-tracing = "0.1"
 
 [profile.release-with-debug]
 inherits = "release"

--- a/src/moonlink/Cargo.toml
+++ b/src/moonlink/Cargo.toml
@@ -57,6 +57,7 @@ tokio-retry2 = { version = "0.5", default-features = false, features = [
     "jitter",
 ] }
 typed-builder = "0.20"
+tracing = "0.1"
 url = { workspace = true }
 uuid = { workspace = true }
 

--- a/src/moonlink/Cargo.toml
+++ b/src/moonlink/Cargo.toml
@@ -56,8 +56,8 @@ tokio-bitstream-io = { workspace = true }
 tokio-retry2 = { version = "0.5", default-features = false, features = [
     "jitter",
 ] }
-typed-builder = "0.20"
 tracing = "0.1"
+typed-builder = "0.20"
 url = { workspace = true }
 uuid = { workspace = true }
 

--- a/src/moonlink/src/storage/index/persisted_bucket_hash_map.rs
+++ b/src/moonlink/src/storage/index/persisted_bucket_hash_map.rs
@@ -761,6 +761,7 @@ mod tests {
     use std::vec;
 
     use super::*;
+    use tracing::debug;
 
     use crate::storage::storage_utils::{create_data_file, FileId};
 
@@ -803,7 +804,7 @@ mod tests {
         for block in index.index_blocks.iter() {
             let mut index_block_iter = block.create_iterator(&index, &file_id_remap).await;
             while let Some((hash, seg_idx, row_idx)) = index_block_iter.next().await {
-                println!("{} {} {}", hash, seg_idx, row_idx);
+                debug!(?hash, seg_idx, row_idx, "index entry");
                 hash_entry_num += 1;
             }
         }

--- a/src/moonlink/src/union_read/read_state.rs
+++ b/src/moonlink/src/union_read/read_state.rs
@@ -7,6 +7,7 @@ use super::table_metadata::TableMetadata;
 use crate::storage::PuffinDeletionBlobAtRead;
 
 use bincode::config;
+use tracing::warn;
 
 const BINCODE_CONFIG: config::Configuration = config::standard();
 
@@ -26,7 +27,7 @@ impl Drop for ReadState {
         tokio::spawn(async move {
             for file in associated_files.into_iter() {
                 if let Err(e) = tokio::fs::remove_file(&file).await {
-                    println!("Failed to delete file {} because {:?}", file, e);
+                    warn!(%file, error = ?e, "failed to delete associated file");
                 }
             }
         });

--- a/src/moonlink_backend/Cargo.toml
+++ b/src/moonlink_backend/Cargo.toml
@@ -11,6 +11,7 @@ moonlink_connectors = { path = "../moonlink_connectors" }
 parquet = { workspace = true, features = ["arrow"] }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
 serial_test = "3.0"

--- a/src/moonlink_backend/src/lib.rs
+++ b/src/moonlink_backend/src/lib.rs
@@ -1,4 +1,5 @@
 mod error;
+mod logging;
 
 pub use error::{Error, Result};
 pub use moonlink::ReadState;
@@ -44,6 +45,8 @@ impl<T: Eq + Hash + Clone> Default for MoonlinkBackend<T> {
 
 impl<T: Eq + Hash + Clone> MoonlinkBackend<T> {
     pub fn new(base_path: String) -> Self {
+        logging::init_logging();
+
         recreate_directory(DEFAULT_MOONLINK_TEMP_FILE_PATH).unwrap();
         Self {
             replication_manager: RwLock::new(ReplicationManager::new(

--- a/src/moonlink_backend/src/logging.rs
+++ b/src/moonlink_backend/src/logging.rs
@@ -1,0 +1,7 @@
+pub fn init_logging() {
+    use tracing_subscriber::EnvFilter;
+
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .try_init(); // prevents double-init panics
+}

--- a/src/moonlink_backend/src/logging.rs
+++ b/src/moonlink_backend/src/logging.rs
@@ -1,7 +1,10 @@
 pub fn init_logging() {
-    use tracing_subscriber::EnvFilter;
+    use std::io;
+    use tracing_subscriber::{fmt, EnvFilter};
 
-    let _ = tracing_subscriber::fmt()
+    let _ = fmt()
+        .with_writer(io::stderr)
         .with_env_filter(EnvFilter::from_default_env())
-        .try_init(); // prevents double-init panics
+        .with_ansi(false)
+        .try_init();
 }

--- a/src/moonlink_connectors/src/pg_replicate/moonlink_sink.rs
+++ b/src/moonlink_connectors/src/pg_replicate/moonlink_sink.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::watch;
 use tokio_postgres::types::PgLsn;
+use tracing::{debug, warn};
 
 #[derive(Default)]
 struct TransactionState {
@@ -61,47 +62,58 @@ impl Sink {
     pub async fn process_cdc_event(&mut self, event: CdcEvent) -> Result<PgLsn, Infallible> {
         match event {
             CdcEvent::Begin(begin_body) => {
+                debug!(final_lsn = begin_body.final_lsn(), "begin transaction");
                 self.transaction_state.final_lsn = begin_body.final_lsn();
             }
             CdcEvent::StreamStart(_stream_start_body) => {}
             CdcEvent::Commit(commit_body) => {
+                debug!(end_lsn = commit_body.end_lsn(), "commit transaction");
                 for table_id in &self.transaction_state.touched_tables {
                     let event_sender = self.event_senders.get(table_id).cloned();
                     if let Some(commit_lsn_tx) = self.commit_lsn_txs.get(table_id).cloned() {
-                        commit_lsn_tx
-                            .send(commit_body.end_lsn())
-                            .expect("failed to send commit lsn");
+                        if let Err(e) = commit_lsn_tx.send(commit_body.end_lsn()) {
+                            warn!(error = ?e, "failed to send commit lsn");
+                        }
                     }
                     if let Some(event_sender) = event_sender {
-                        event_sender
+                        if let Err(e) = event_sender
                             .send(TableEvent::Commit {
                                 lsn: commit_body.end_lsn(),
                                 xact_id: None,
                             })
                             .await
-                            .unwrap();
+                        {
+                            warn!(error = ?e, "failed to send commit event");
+                        }
                     }
                 }
                 self.transaction_state.touched_tables.clear();
             }
             CdcEvent::StreamCommit(stream_commit_body) => {
                 let xact_id = stream_commit_body.xid();
+                debug!(
+                    xact_id,
+                    end_lsn = stream_commit_body.end_lsn(),
+                    "stream commit"
+                );
                 if let Some(tables_in_txn) = self.streaming_transactions_state.get(&xact_id) {
                     for table_id in &tables_in_txn.touched_tables {
                         let event_sender = self.event_senders.get(table_id).cloned();
                         if let Some(commit_lsn_tx) = self.commit_lsn_txs.get(table_id).cloned() {
-                            commit_lsn_tx
-                                .send(stream_commit_body.end_lsn())
-                                .expect("failed to send commit lsn");
+                            if let Err(e) = commit_lsn_tx.send(stream_commit_body.end_lsn()) {
+                                warn!(error = ?e, "failed to send stream commit lsn");
+                            }
                         }
                         if let Some(event_sender) = event_sender {
-                            event_sender
+                            if let Err(e) = event_sender
                                 .send(TableEvent::Commit {
                                     lsn: stream_commit_body.end_lsn(),
                                     xact_id: Some(xact_id),
                                 })
                                 .await
-                                .unwrap();
+                            {
+                                warn!(error = ?e, "failed to send stream commit event");
+                            }
                         }
                     }
                     self.streaming_transactions_state.remove(&xact_id);
@@ -110,13 +122,15 @@ impl Sink {
             CdcEvent::Insert((table_id, table_row, xact_id)) => {
                 let event_sender = self.event_senders.get(&table_id).cloned();
                 if let Some(event_sender) = event_sender {
-                    event_sender
+                    if let Err(e) = event_sender
                         .send(TableEvent::Append {
                             row: PostgresTableRow(table_row).into(),
                             xact_id,
                         })
                         .await
-                        .unwrap();
+                    {
+                        warn!(error = ?e, "failed to send append event");
+                    }
                     if let Some(xid) = xact_id {
                         self.streaming_transactions_state
                             .entry(xid)
@@ -146,21 +160,25 @@ impl Sink {
 
                 let event_sender = self.event_senders.get(&table_id).cloned();
                 if let Some(event_sender) = event_sender {
-                    event_sender
+                    if let Err(e) = event_sender
                         .send(TableEvent::Delete {
                             row: PostgresTableRow(old_table_row.unwrap()).into(),
                             lsn: final_lsn,
                             xact_id,
                         })
                         .await
-                        .unwrap();
-                    event_sender
+                    {
+                        warn!(error = ?e, "failed to send delete event");
+                    }
+                    if let Err(e) = event_sender
                         .send(TableEvent::Append {
                             row: PostgresTableRow(new_table_row).into(),
                             xact_id,
                         })
                         .await
-                        .unwrap();
+                    {
+                        warn!(error = ?e, "failed to send append event");
+                    }
                 }
             }
             CdcEvent::Delete((table_id, table_row, xact_id)) => {
@@ -181,18 +199,20 @@ impl Sink {
 
                 let event_sender = self.event_senders.get(&table_id).cloned();
                 if let Some(event_sender) = event_sender {
-                    event_sender
+                    if let Err(e) = event_sender
                         .send(TableEvent::Delete {
                             row: PostgresTableRow(table_row).into(),
                             lsn: final_lsn,
                             xact_id,
                         })
                         .await
-                        .unwrap();
+                    {
+                        warn!(error = ?e, "failed to send delete event");
+                    }
                 }
             }
-            CdcEvent::Relation(relation_body) => println!("Relation {relation_body:?}"),
-            CdcEvent::Type(type_body) => println!("Type {type_body:?}"),
+            CdcEvent::Relation(relation_body) => debug!("Relation {relation_body:?}"),
+            CdcEvent::Type(type_body) => debug!("Type {type_body:?}"),
             CdcEvent::PrimaryKeepAlive(primary_keepalive_body) => {
                 self.replication_state
                     .mark(PgLsn::from(primary_keepalive_body.wal_end()));
@@ -201,14 +221,16 @@ impl Sink {
             CdcEvent::StreamStop(_stream_stop_body) => {}
             CdcEvent::StreamAbort(stream_abort_body) => {
                 let xact_id = stream_abort_body.xid();
+                warn!(xact_id, "stream transaction aborted");
                 if let Some(tables_in_txn) = self.streaming_transactions_state.get(&xact_id) {
                     for table_id in &tables_in_txn.touched_tables {
                         let event_sender = self.event_senders.get(table_id).cloned();
                         if let Some(event_sender) = event_sender {
-                            event_sender
-                                .send(TableEvent::StreamAbort { xact_id })
-                                .await
-                                .unwrap();
+                            if let Err(e) =
+                                event_sender.send(TableEvent::StreamAbort { xact_id }).await
+                            {
+                                warn!(error = ?e, "failed to send stream abort event");
+                            }
                         }
                     }
                 }

--- a/src/moonlink_connectors/src/pg_replicate/moonlink_sink.rs
+++ b/src/moonlink_connectors/src/pg_replicate/moonlink_sink.rs
@@ -229,10 +229,6 @@ impl Sink {
                 );
             }
             CdcEvent::PrimaryKeepAlive(primary_keepalive_body) => {
-                debug!(
-                    wal_end = primary_keepalive_body.wal_end(),
-                    "Primary keep alive"
-                );
                 self.replication_state
                     .mark(PgLsn::from(primary_keepalive_body.wal_end()));
                 self.last_lsn = primary_keepalive_body.wal_end();

--- a/src/moonlink_connectors/src/pg_replicate/postgres_source.rs
+++ b/src/moonlink_connectors/src/pg_replicate/postgres_source.rs
@@ -10,7 +10,7 @@ use pin_project_lite::pin_project;
 use postgres_replication::LogicalReplicationStream;
 use thiserror::Error;
 use tokio_postgres::{types::PgLsn, CopyOutStream};
-use tracing::info;
+use tracing::{debug, error, info};
 
 use crate::pg_replicate::{
     clients::postgres::{ReplicationClient, ReplicationClientError},
@@ -139,6 +139,7 @@ impl PostgresSource {
         // Add the table schema to the source so that we can use it to convert cdc events.
         self.table_schemas
             .insert(table_schema.table_id, table_schema.clone());
+        debug!(table_name, "fetched table schema");
         Ok(table_schema)
     }
 
@@ -239,10 +240,14 @@ impl Stream for TableCopyStream {
                 Ok(row) => Poll::Ready(Some(Ok(row))),
                 Err(e) => {
                     let e = TableCopyStreamError::ConversionError(e);
+                    error!(error = ?e, "failed to convert table row");
                     Poll::Ready(Some(Err(e)))
                 }
             },
-            Some(Err(e)) => Poll::Ready(Some(Err(e.into()))),
+            Some(Err(e)) => {
+                error!(error = ?e, "table copy stream error");
+                Poll::Ready(Some(Err(e.into())))
+            }
             None => Poll::Ready(None),
         }
     }

--- a/src/moonlink_connectors/src/pg_replicate/postgres_source.rs
+++ b/src/moonlink_connectors/src/pg_replicate/postgres_source.rs
@@ -286,6 +286,7 @@ impl CdcStream {
         self: Pin<&mut Self>,
         lsn: PgLsn,
     ) -> Result<(), StatusUpdateError> {
+        debug!(lsn = ?lsn, "sending status update");
         let this = self.project();
         let ts = this.postgres_epoch.elapsed()?.as_micros() as i64;
         this.stream

--- a/src/moonlink_connectors/src/pg_replicate/postgres_source.rs
+++ b/src/moonlink_connectors/src/pg_replicate/postgres_source.rs
@@ -286,7 +286,7 @@ impl CdcStream {
         self: Pin<&mut Self>,
         lsn: PgLsn,
     ) -> Result<(), StatusUpdateError> {
-        debug!(lsn = ?lsn, "sending status update");
+        debug!(lsn = u64::from(lsn), "sending status update");
         let this = self.project();
         let ts = this.postgres_epoch.elapsed()?.as_micros() as i64;
         this.stream

--- a/src/moonlink_connectors/src/pg_replicate/util.rs
+++ b/src/moonlink_connectors/src/pg_replicate/util.rs
@@ -12,6 +12,7 @@ use num_traits::cast::ToPrimitive;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio_postgres::types::{Kind, Type};
+use tracing::warn;
 
 fn numeric_precision_scale(modifier: i32) -> Option<(u8, i8)> {
     const VARHDRSZ: i32 = 4;
@@ -371,9 +372,7 @@ impl From<PostgresTableRow> for MoonlinkRow {
                                 values.push(RowValue::Decimal(scaled_integer));
                             } else {
                                 values.push(RowValue::Null); // handle overflow safely
-                                eprintln!(
-                                    "Decimal value too large to fit in i128 — storing as NULL"
-                                );
+                                warn!("Decimal value too large to fit in i128; storing as NULL");
                             }
                         }
                         _ => {

--- a/src/moonlink_connectors/src/replication_connection.rs
+++ b/src/moonlink_connectors/src/replication_connection.rs
@@ -280,6 +280,7 @@ impl ReplicationConnection {
 
     /// Clean up iceberg table in a blocking manner.
     async fn drop_iceberg_table(&mut self, table_id: u32) -> Result<()> {
+        info!(table_id, "dropping iceberg table");
         let iceberg_state_manager = self
             .iceberg_table_event_managers
             .get_mut(&table_id)

--- a/src/moonlink_connectors/src/replication_connection.rs
+++ b/src/moonlink_connectors/src/replication_connection.rs
@@ -21,7 +21,7 @@ use std::path::Path;
 use tokio::sync::{mpsc, watch};
 use tokio::task::JoinHandle;
 use tokio_postgres::{connect, Client, Config, NoTls};
-use tracing::warn;
+use tracing::{debug, error, info, warn};
 
 pub enum Command {
     AddTable {
@@ -57,6 +57,8 @@ impl ReplicationConnection {
         table_base_path: String,
         table_temp_files_directory: String,
     ) -> Result<Self> {
+        info!(%uri, "initializing replication connection");
+
         let (postgres_client, connection) = connect(&uri, NoTls)
             .await
             .map_err(PostgresSourceError::from)?;
@@ -92,6 +94,8 @@ impl ReplicationConnection {
         .unwrap();
 
         let (cmd_tx, cmd_rx) = mpsc::channel(8);
+
+        info!("replication connection ready");
 
         Ok(Self {
             uri,
@@ -205,24 +209,28 @@ impl ReplicationConnection {
         sink: Sink,
         cmd_rx: mpsc::Receiver<Command>,
     ) -> JoinHandle<Result<()>> {
-        self.source
-            .commit_transaction()
-            .await
-            .expect("failed to commit transaction");
+        debug!("spawning replication task");
+        if let Err(e) = self.source.commit_transaction().await {
+            error!(error = ?e, "failed to commit transaction");
+            return tokio::spawn(async { Err(e.into()) });
+        }
 
         // TODO: track tables copied in replication state and recover these before starting the event loop.
         let last_lsn = self.source.confirmed_flush_lsn();
-        let stream = self
-            .source
-            .get_cdc_stream(last_lsn)
-            .await
-            .expect("failed to get cdc stream");
+        let stream = match self.source.get_cdc_stream(last_lsn).await {
+            Ok(s) => s,
+            Err(e) => {
+                error!(error = ?e, "failed to get cdc stream");
+                return tokio::spawn(async { Err(e.into()) });
+            }
+        };
 
         tokio::spawn(async move { run_event_loop(stream, sink, cmd_rx).await })
     }
 
     async fn add_table_to_replication(&mut self, schema: &TableSchema) -> Result<()> {
         let table_id = schema.table_id;
+        debug!(table_id, "adding table to replication");
         let resources = build_table_components(
             schema,
             Path::new(&self.table_base_path),
@@ -235,7 +243,8 @@ impl ReplicationConnection {
             .insert(table_id, resources.read_state_manager);
         self.iceberg_table_event_managers
             .insert(table_id, resources.iceberg_table_event_manager);
-        self.cmd_tx
+        if let Err(e) = self
+            .cmd_tx
             .send(Command::AddTable {
                 table_id,
                 schema: schema.clone(),
@@ -243,22 +252,28 @@ impl ReplicationConnection {
                 commit_lsn_tx: resources.commit_lsn_tx,
             })
             .await
-            .unwrap();
+        {
+            error!(error = ?e, "failed to enqueue AddTable command");
+        }
+
+        debug!(table_id, "table added to replication");
 
         Ok(())
     }
 
     async fn remove_table_from_replication(&mut self, table_id: u32) -> Result<()> {
+        debug!(table_id, "removing table from replication");
         self.drop_iceberg_table(table_id).await?;
 
         self.table_readers.remove_entry(&table_id).unwrap();
         self.iceberg_table_event_managers
             .remove_entry(&table_id)
             .unwrap();
-        self.cmd_tx
-            .send(Command::DropTable { table_id })
-            .await
-            .unwrap();
+        if let Err(e) = self.cmd_tx.send(Command::DropTable { table_id }).await {
+            error!(error = ?e, "failed to enqueue DropTable command");
+        }
+
+        debug!(table_id, "table removed from replication");
 
         Ok(())
     }
@@ -274,6 +289,7 @@ impl ReplicationConnection {
     }
 
     pub async fn start_replication(&mut self) -> Result<()> {
+        info!("starting replication");
         let table_schemas = self.source.get_table_schemas().await;
 
         let (tx, rx) = mpsc::channel(8);
@@ -290,10 +306,13 @@ impl ReplicationConnection {
 
         self.replication_started = true;
 
+        info!("replication started");
+
         Ok(())
     }
 
     pub async fn add_table(&mut self, table_name: &str) -> Result<TableId> {
+        info!(table_name, "adding table");
         // TODO: We should not naively alter the replica identity of a table. We should only do this if we are sure that the table does not already have a FULL replica identity. [https://github.com/Mooncake-Labs/moonlink/issues/104]
         self.alter_table_replica_identity(table_name).await?;
         let table_schema = self.source.fetch_table_schema(table_name, None).await?;
@@ -302,16 +321,21 @@ impl ReplicationConnection {
 
         self.add_table_to_publication(table_name).await?;
 
+        info!(table_id = table_schema.table_id, "table added");
+
         Ok(table_schema.table_id)
     }
 
     /// Remove the given table from connection.
     pub async fn drop_table(&mut self, table_id: u32) -> Result<()> {
+        info!(table_id, "dropping table");
         let table_name = self.source.get_table_name_from_id(table_id);
         // Remove table from publication as the first step, to prevent further events.
         self.remove_table_from_publication(&table_name).await?;
         self.source.remove_table_schema(table_id);
         self.remove_table_from_replication(table_id).await?;
+
+        info!(table_id, "table dropped");
         Ok(())
     }
 
@@ -327,17 +351,21 @@ async fn run_event_loop(
 ) -> Result<()> {
     pin!(stream);
 
+    debug!("replication event loop started");
+
     let mut status_interval = tokio::time::interval(Duration::from_secs(10));
     let mut last_lsn = PgLsn::from(0);
 
     loop {
         tokio::select! {
                         _ = status_interval.tick() => {
-                            stream
+                            if let Err(e) = stream
                                 .as_mut()
                                 .send_status_update(last_lsn)
                                 .await
-                                .expect("failed to send status update");
+                            {
+                                error!(error = ?e, "failed to send status update");
+                            }
                         },
                         Some(cmd) = cmd_rx.recv() => match cmd {
                             Command::AddTable { table_id, schema, event_sender, commit_lsn_tx } => {
@@ -351,7 +379,8 @@ async fn run_event_loop(
                         },
                         event = StreamExt::next(&mut stream) => {
                 let Some(event_result) = event else {
-                    panic!("replication stream ended unexpectedly");
+                    error!("replication stream ended unexpectedly");
+                    break;
                 };
 
                 match event_result {
@@ -360,7 +389,8 @@ async fn run_event_loop(
                         continue;
                     }
                     Err(e) => {
-                        panic!("cdc stream error: {:?}", e);
+                        error!(error = ?e, "cdc stream error");
+                        break;
                     }
                     Ok(event) => {
                         last_lsn = sink.process_cdc_event(event).await.unwrap();
@@ -369,4 +399,7 @@ async fn run_event_loop(
             }
         }
     }
+
+    info!("replication event loop stopped");
+    Ok(())
 }


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

Remove print statements and panics and replace with logging. We can refine this and improve with actual error propagation but we need more support when debugging issues without the verbosity of print statements in production builds. Keeps most of the logs higher level to avoid logging at every layer. This will likely be refined as we introduce proper error propagation. 

Logs are sent to `stderr` so we are able to see them along with the postgres logs. `pg_mooncake` (or `devcontainer`) will need to set log level with `RUST_LOG`.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/79

## Changes

- 
- 
- 

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
