### PR TITLE
Update lsn on commit

### DIFF
--- a/src/moonlink_connectors/src/pg_replicate/moonlink_sink.rs
+++ b/src/moonlink_connectors/src/pg_replicate/moonlink_sink.rs
@@ -83,6 +83,9 @@ impl Sink {
                     }
                 }
                 self.transaction_state.touched_tables.clear();
+                self.replication_state
+                    .mark(PgLsn::from(commit_body.end_lsn()));
+                self.last_lsn = commit_body.end_lsn();
             }
             CdcEvent::StreamCommit(stream_commit_body) => {
                 let xact_id = stream_commit_body.xid();
@@ -106,6 +109,9 @@ impl Sink {
                     }
                     self.streaming_transactions_state.remove(&xact_id);
                 }
+                self.replication_state
+                    .mark(PgLsn::from(stream_commit_body.end_lsn()));
+                self.last_lsn = stream_commit_body.end_lsn();
             }
             CdcEvent::Insert((table_id, table_row, xact_id)) => {
                 let event_sender = self.event_senders.get(&table_id).cloned();


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

Temporary change to provide most up to date LSN to postgres, mostly in the interest of keeping replication happy. This is temporary and not safe to recover from, but it keeps postgres up to date and allows prompt recycling of WAL and correct stream restart. 

## Related Issues

Closes #<issue-number> or links to related issues.

## Changes

- 
- 
- 

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
