### PR TITLE
[minor] Validate persisted iceberg snapshot

### DIFF
--- a/src/moonlink/src/storage/iceberg/compaction_tests.rs
+++ b/src/moonlink/src/storage/iceberg/compaction_tests.rs
@@ -28,7 +28,7 @@ use crate::storage::iceberg::iceberg_table_manager::TableManager;
 use crate::storage::iceberg::test_utils::{
     check_deletion_vector_consistency_for_snapshot,
     create_table_and_iceberg_manager_with_data_compaction_config, create_test_arrow_schema,
-    load_arrow_batch,
+    load_arrow_batch, validate_recovered_snapshot,
 };
 use crate::storage::index::{FileIndex, Index, MooncakeIndex};
 use crate::storage::mooncake_table::Snapshot;
@@ -294,6 +294,11 @@ async fn test_compaction_1_1_1() {
     check_loaded_snapshot(&snapshot, /*row_indices=*/ vec![0, 1, 2, 3]).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager_to_load.config.warehouse_uri,
+    )
+    .await;
 
     // Check disk files for the current mooncake snapshot.
     let disk_files = table.get_disk_files_for_snapshot().await;
@@ -346,6 +351,11 @@ async fn test_compaction_1_1_2() {
     check_loaded_snapshot(&snapshot, /*row_indices=*/ vec![0, 1, 2, 3]).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager_to_load.config.warehouse_uri,
+    )
+    .await;
 
     // Check disk files for the current mooncake snapshot.
     let disk_files = table.get_disk_files_for_snapshot().await;
@@ -419,6 +429,11 @@ async fn test_compaction_1_2_1() {
     check_loaded_snapshot(&snapshot, /*row_indices=*/ vec![0, 1, 2, 3]).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager_to_load.config.warehouse_uri,
+    )
+    .await;
 
     // Check disk files for the current mooncake snapshot.
     let disk_files = table.get_disk_files_for_snapshot().await;
@@ -491,6 +506,11 @@ async fn test_compaction_1_2_2() {
     check_loaded_snapshot(&snapshot, /*row_indices=*/ vec![0, 1, 2, 3]).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager_to_load.config.warehouse_uri,
+    )
+    .await;
 
     // Check disk files for the current mooncake snapshot.
     let disk_files = table.get_disk_files_for_snapshot().await;
@@ -575,6 +595,11 @@ async fn test_compaction_2_2_1() {
     check_loaded_snapshot(&snapshot, /*row_indices=*/ vec![1, 2, 3]).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager_to_load.config.warehouse_uri,
+    )
+    .await;
 
     // Check disk files for the current mooncake snapshot.
     let disk_files = table.get_disk_files_for_snapshot().await;
@@ -648,6 +673,11 @@ async fn test_compaction_2_2_2() {
     check_loaded_snapshot(&snapshot, /*row_indices=*/ vec![1, 2, 3]).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager_to_load.config.warehouse_uri,
+    )
+    .await;
 
     // Check disk files for the current mooncake snapshot.
     let disk_files = table.get_disk_files_for_snapshot().await;
@@ -734,6 +764,11 @@ async fn test_compaction_2_3_1() {
     check_loaded_snapshot(&snapshot, /*row_indices=*/ vec![1, 3]).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager_to_load.config.warehouse_uri,
+    )
+    .await;
 
     // Check disk files for the current mooncake snapshot.
     let disk_files = table.get_disk_files_for_snapshot().await;
@@ -795,6 +830,11 @@ async fn test_compaction_2_3_2() {
     check_loaded_snapshot(&snapshot, /*row_indices=*/ vec![1, 3]).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager_to_load.config.warehouse_uri,
+    )
+    .await;
 
     // Check disk files for the current mooncake snapshot.
     let disk_files = table.get_disk_files_for_snapshot().await;
@@ -884,6 +924,11 @@ async fn test_compaction_3_2_1() {
     check_loaded_snapshot(&snapshot, /*row_indices=*/ vec![0, 1, 2, 3]).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager_to_load.config.warehouse_uri,
+    )
+    .await;
 
     // Check disk files for the current mooncake snapshot.
     let disk_files = table.get_disk_files_for_snapshot().await;
@@ -959,6 +1004,11 @@ async fn test_compaction_3_3_1() {
     assert!(snapshot.disk_files.is_empty());
     assert!(snapshot.indices.file_indices.is_empty());
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager_to_load.config.warehouse_uri,
+    )
+    .await;
 
     // Check disk files for the current mooncake snapshot.
     let disk_files = table.get_disk_files_for_snapshot().await;

--- a/src/moonlink/src/storage/iceberg/state_tests.rs
+++ b/src/moonlink/src/storage/iceberg/state_tests.rs
@@ -34,7 +34,7 @@ use crate::storage::iceberg::iceberg_table_manager::IcebergTableManager;
 use crate::storage::iceberg::iceberg_table_manager::TableManager;
 use crate::storage::iceberg::test_utils::{
     check_deletion_vector_consistency_for_snapshot, create_table_and_iceberg_manager,
-    load_arrow_batch,
+    load_arrow_batch, validate_recovered_snapshot,
 };
 use crate::storage::mooncake_table::delete_vector::BatchDeletionVector;
 use crate::storage::mooncake_table::Snapshot;
@@ -254,6 +254,7 @@ async fn test_state_1_1() -> IcebergResult<()> {
     assert!(snapshot.indices.file_indices.is_empty());
     assert!(snapshot.data_file_flush_lsn.is_none());
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
 
     Ok(())
 }
@@ -284,6 +285,7 @@ async fn test_state_1_2() -> IcebergResult<()> {
     assert!(snapshot.indices.file_indices.is_empty());
     assert!(snapshot.data_file_flush_lsn.is_none());
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
 
     Ok(())
 }
@@ -320,6 +322,7 @@ async fn test_state_1_3() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 100);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
 
     Ok(())
 }
@@ -358,6 +361,7 @@ async fn test_state_1_4() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 100);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
 
     Ok(())
 }
@@ -395,6 +399,7 @@ async fn test_state_1_5() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 300);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
 
     Ok(())
 }
@@ -434,6 +439,7 @@ async fn test_state_1_6() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 300);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
 
     Ok(())
 }
@@ -466,6 +472,7 @@ async fn test_state_2_1() -> IcebergResult<()> {
     assert!(snapshot.indices.file_indices.is_empty());
     assert!(snapshot.data_file_flush_lsn.is_none());
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
 
     Ok(())
 }
@@ -500,6 +507,7 @@ async fn test_state_2_2() -> IcebergResult<()> {
     assert!(snapshot.indices.file_indices.is_empty());
     assert!(snapshot.data_file_flush_lsn.is_none());
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
 
     Ok(())
 }
@@ -537,6 +545,7 @@ async fn test_state_2_3() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 100);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
 
     Ok(())
 }
@@ -576,6 +585,7 @@ async fn test_state_2_4() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 100);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
 
     Ok(())
 }
@@ -614,6 +624,7 @@ async fn test_state_2_5() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 300);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
 
     Ok(())
 }
@@ -654,6 +665,7 @@ async fn test_state_2_6() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 300);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
 
     Ok(())
 }
@@ -687,6 +699,7 @@ async fn test_state_3_1() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 200);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
 
     Ok(())
 }
@@ -722,6 +735,7 @@ async fn test_state_3_2() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 200);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
 
     Ok(())
 }
@@ -765,6 +779,7 @@ async fn test_state_3_3_deletion_before_flush() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 2);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 500);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
 
     Ok(())
 }
@@ -808,6 +823,7 @@ async fn test_state_3_3_deletion_after_flush() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 2);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 300);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
 
     Ok(())
 }
@@ -853,6 +869,7 @@ async fn test_state_3_4_committed_deletion_before_flush() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 2);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 500);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
 
     Ok(())
 }
@@ -898,6 +915,7 @@ async fn test_state_3_4_committed_deletion_after_flush() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 2);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 300);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
 
     Ok(())
 }
@@ -942,6 +960,7 @@ async fn test_state_3_5() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 2);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 400);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
 
     Ok(())
 }
@@ -988,6 +1007,7 @@ async fn test_state_3_6() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 2);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 400);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
 
     Ok(())
 }
@@ -1027,6 +1047,7 @@ async fn test_state_4_1() -> IcebergResult<()> {
     assert!(snapshot.indices.file_indices.is_empty());
     assert!(snapshot.data_file_flush_lsn.is_none());
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
 
     Ok(())
 }
@@ -1068,6 +1089,7 @@ async fn test_state_4_2() -> IcebergResult<()> {
     assert!(snapshot.indices.file_indices.is_empty());
     assert!(snapshot.data_file_flush_lsn.is_none());
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
 
     Ok(())
 }
@@ -1112,6 +1134,7 @@ async fn test_state_4_3() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 100);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
 
     Ok(())
 }
@@ -1158,6 +1181,7 @@ async fn test_state_4_4() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 100);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
 
     Ok(())
 }
@@ -1203,6 +1227,7 @@ async fn test_state_4_5() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 300);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
 
     Ok(())
 }
@@ -1250,6 +1275,7 @@ async fn test_state_4_6() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 300);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
 
     Ok(())
 }
@@ -1291,6 +1317,7 @@ async fn test_state_5_1() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 200);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
 
     Ok(())
 }
@@ -1334,6 +1361,7 @@ async fn test_state_5_2() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 200);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
 
     Ok(())
 }
@@ -1385,6 +1413,7 @@ async fn test_state_5_3_deletion_before_flush() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 2);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 500);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
 
     Ok(())
 }
@@ -1436,6 +1465,7 @@ async fn test_state_5_3_deletion_after_flush() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 2);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 300);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
 
     Ok(())
 }
@@ -1489,6 +1519,7 @@ async fn test_state_5_4_committed_deletion_before_flush() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 2);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 500);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
 
     Ok(())
 }
@@ -1542,6 +1573,7 @@ async fn test_state_5_4_committed_deletion_after_flush() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 2);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 300);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
 
     Ok(())
 }
@@ -1594,6 +1626,7 @@ async fn test_state_5_5() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 2);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 400);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
 
     Ok(())
 }
@@ -1648,6 +1681,7 @@ async fn test_state_5_6() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 2);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 400);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
 
     Ok(())
 }
@@ -1696,6 +1730,7 @@ async fn test_state_6_1() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 200);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
 
     Ok(())
 }
@@ -1746,6 +1781,7 @@ async fn test_state_6_2() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 200);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
 
     Ok(())
 }
@@ -1804,6 +1840,7 @@ async fn test_state_6_3_deletion_before_flush() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 2);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 500);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
 
     Ok(())
 }
@@ -1862,6 +1899,7 @@ async fn test_state_6_3_deletion_after_flush() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 2);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 300);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
 
     Ok(())
 }
@@ -1921,6 +1959,7 @@ async fn test_state_6_4_committed_deletion_before_flush() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 2);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 500);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
 
     Ok(())
 }
@@ -1981,6 +2020,7 @@ async fn test_state_6_4_committed_deletion_after_flush() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 2);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 300);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
 
     Ok(())
 }
@@ -2040,6 +2080,7 @@ async fn test_state_6_5() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 2);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 400);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
 
     Ok(())
 }
@@ -2101,6 +2142,7 @@ async fn test_state_6_6() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 2);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 400);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
 
     Ok(())
 }
@@ -2124,6 +2166,7 @@ async fn test_state_7_1() -> IcebergResult<()> {
     assert!(snapshot.indices.file_indices.is_empty());
     assert!(snapshot.data_file_flush_lsn.is_none());
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
 
     Ok(())
 }
@@ -2152,6 +2195,7 @@ async fn test_state_7_2() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 100);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
 
     Ok(())
 }
@@ -2181,6 +2225,7 @@ async fn test_state_7_3() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 100);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
 
     Ok(())
 }
@@ -2213,6 +2258,7 @@ async fn test_state_7_4() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 100);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
 
     Ok(())
 }
@@ -2243,6 +2289,7 @@ async fn test_state_7_5() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 300);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
 
     Ok(())
 }
@@ -2275,6 +2322,7 @@ async fn test_state_7_6() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 300);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
 
     Ok(())
 }

--- a/src/moonlink/src/storage/iceberg/test_utils.rs
+++ b/src/moonlink/src/storage/iceberg/test_utils.rs
@@ -94,13 +94,18 @@ pub(crate) async fn validate_recovered_snapshot(snapshot: &Snapshot, warehouse_u
     // Check file indices.
     let mut index_referenced_data_filepaths: HashSet<String> = HashSet::new();
     for cur_file_index in snapshot.indices.file_indices.iter() {
+        // Check index blocks are imported into the iceberg table.
         for cur_index_block in cur_file_index.index_blocks.iter() {
             let index_pathbuf = std::path::PathBuf::from(&cur_index_block.file_path);
             assert!(index_pathbuf.starts_with(&warehouse_directory));
             assert!(tokio::fs::try_exists(&index_pathbuf).await.unwrap());
         }
 
+        // Check data files referenced by index blocks are imported into iceberg table.
         for cur_data_filepath in cur_file_index.files.iter() {
+            let data_file_pathbuf = std::path::PathBuf::from(cur_data_filepath.file_path());
+            assert!(data_file_pathbuf.starts_with(&warehouse_directory));
+            assert!(tokio::fs::try_exists(&data_file_pathbuf).await.unwrap());
             index_referenced_data_filepaths.insert(cur_data_filepath.file_path().clone());
         }
     }

--- a/src/moonlink/src/storage/iceberg/tests.rs
+++ b/src/moonlink/src/storage/iceberg/tests.rs
@@ -449,6 +449,7 @@ async fn test_store_and_load_snapshot_impl(
     assert!(snapshot.disk_files.is_empty());
     assert!(snapshot.indices.in_memory_index.is_empty());
     assert!(snapshot.indices.file_indices.is_empty());
+    validate_recovered_snapshot(&snapshot, &iceberg_table_config.warehouse_uri).await;
 
     Ok(())
 }
@@ -520,6 +521,8 @@ async fn test_empty_snapshot_load() -> IcebergResult<()> {
     assert!(snapshot.indices.in_memory_index.is_empty());
     assert!(snapshot.indices.file_indices.is_empty());
     assert!(snapshot.data_file_flush_lsn.is_none());
+    validate_recovered_snapshot(&snapshot, &config.warehouse_uri).await;
+
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

A no-op change, simply add missing validation for persisted iceberg snapshot, to make sure everything in iceberg (data files, deletion vectors, file indices) points to remote filepath instead of local ones.

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
