### PR TITLE
index perf improvement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2754,6 +2754,7 @@ dependencies = [
  "aligned-vec",
  "backtrace",
  "cfg-if",
+ "criterion",
  "findshlibs",
  "inferno",
  "libc",

--- a/src/moonlink/Cargo.toml
+++ b/src/moonlink/Cargo.toml
@@ -64,7 +64,7 @@ uuid = { workspace = true }
 [dev-dependencies]
 criterion = "0.5.1"
 mockall = "0.13"
-pprof = { version = "0.14", features = ["flamegraph"] }
+pprof = { version = "0.14", features = ["flamegraph", "criterion"] }
 rand = "0.9.1"
 rstest = "0.25.0"
 rstest_reuse = "0.7.0"

--- a/src/moonlink/benches/bench_write.rs
+++ b/src/moonlink/benches/bench_write.rs
@@ -2,6 +2,7 @@ use arrow::datatypes::{DataType, Field, Schema};
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use moonlink::row::{IdentityProp, MoonlinkRow, RowValue};
 use moonlink::{IcebergTableConfig, MooncakeTable, TableConfig};
+use pprof::criterion::{Output, PProfProfiler};
 use std::collections::HashMap;
 use tempfile::tempdir;
 use tokio::runtime::Runtime;
@@ -170,7 +171,7 @@ fn bench_write(c: &mut Criterion) {
 
 criterion_group! {
     name = benches;
-    config = Criterion::default();
+    config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
     targets = bench_write
 }
 criterion_main!(benches);

--- a/src/moonlink/benches/microbench_index_stress.rs
+++ b/src/moonlink/benches/microbench_index_stress.rs
@@ -1,6 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use moonlink::create_data_file;
-use moonlink::GlobalIndexBuilder;
+use moonlink::{GlobalIndex, GlobalIndexBuilder};
 use rand::Rng;
 use tokio::runtime::Runtime;
 
@@ -23,9 +23,10 @@ fn bench_index_stress(c: &mut Criterion) {
     group.bench_function("search_10m_entries", |b| {
         b.iter(|| {
             let mut rng = rand::rng();
-            let result = black_box(
-                rt.block_on(index.search_values(&[(rng.random_range(0..10000000) as u64)])),
+            let hashes = GlobalIndex::prepare_hashes_for_lookup(
+                (vec![rng.random_range(0..10000000) as u64]).into_iter(),
             );
+            let result = black_box(rt.block_on(index.search_values(&hashes)));
             black_box(result);
         })
     });

--- a/src/moonlink/src/lib.rs
+++ b/src/moonlink/src/lib.rs
@@ -18,4 +18,6 @@ pub use union_read::{ReadState, ReadStateManager};
 pub use union_read::decode_read_state_for_testing;
 
 #[cfg(feature = "bench")]
+pub use storage::GlobalIndex;
+#[cfg(feature = "bench")]
 pub use storage::GlobalIndexBuilder;

--- a/src/moonlink/src/storage.rs
+++ b/src/moonlink/src/storage.rs
@@ -22,4 +22,6 @@ pub(crate) use iceberg::puffin_utils::*;
 pub(crate) use mooncake_table::test_utils::*;
 
 #[cfg(feature = "bench")]
+pub use index::persisted_bucket_hash_map::GlobalIndex;
+#[cfg(feature = "bench")]
 pub use index::persisted_bucket_hash_map::GlobalIndexBuilder;

--- a/src/moonlink/src/storage/compaction/test_utils.rs
+++ b/src/moonlink/src/storage/compaction/test_utils.rs
@@ -13,7 +13,9 @@ use crate::storage::iceberg::puffin_utils;
 use crate::storage::iceberg::puffin_writer_proxy;
 use crate::storage::iceberg::test_utils as iceberg_test_utils;
 use crate::storage::iceberg::test_utils::load_arrow_batch;
-use crate::storage::index::persisted_bucket_hash_map::GlobalIndexBuilder;
+use crate::storage::index::persisted_bucket_hash_map::{
+    test_get_hashes_for_index, GlobalIndexBuilder,
+};
 use crate::storage::index::FileIndex;
 use crate::storage::mooncake_table::delete_vector::BatchDeletionVector;
 use crate::storage::storage_utils::FileId;
@@ -433,7 +435,9 @@ pub(crate) async fn check_file_indices_compaction_for_multiple_compacted_files(
             NAME_VALUES[*old_row_idx],
             AGE_VALUES[*old_row_idx],
         );
-        let locs = compacted_file_indice.search_values(&[hash_value]).await;
+        let locs = compacted_file_indice
+            .search_values(&test_get_hashes_for_index(&[hash_value]))
+            .await;
         assert_eq!(locs.len(), 1);
         let (_, RecordLocation::DiskFile(actual_file_id, actual_new_row_idx)) = locs[0] else {
             panic!("Failed to get record location for {}", hash_value);
@@ -479,7 +483,9 @@ pub(crate) async fn check_file_indices_compaction(
             NAME_VALUES[*old_row_idx],
             AGE_VALUES[*old_row_idx],
         );
-        let locs = compacted_file_indice.search_values(&[hash_value]).await;
+        let locs = compacted_file_indice
+            .search_values(&test_get_hashes_for_index(&[hash_value]))
+            .await;
         assert_eq!(
             locs.len(),
             1,

--- a/src/moonlink/src/storage/mooncake_table/disk_slice.rs
+++ b/src/moonlink/src/storage/mooncake_table/disk_slice.rs
@@ -226,6 +226,7 @@ impl DiskSliceWriter {
 mod tests {
     use super::*;
     use crate::row::{IdentityProp, MoonlinkRow, RowValue};
+    use crate::storage::index::persisted_bucket_hash_map::test_get_hashes_for_index;
     use crate::storage::mooncake_table::mem_slice::MemSlice;
     use crate::storage::mooncake_table::TableConfig as MooncakeTableConfig;
     use crate::storage::storage_utils::RawDeletionRecord;
@@ -406,7 +407,9 @@ mod tests {
         // Get the remapped index and verify it
         let new_index = disk_slice.take_index().unwrap();
 
-        let results = new_index.search_values(&[1, 3, 5]).await;
+        let results = new_index
+            .search_values(&test_get_hashes_for_index(&[1, 3, 5]))
+            .await;
         // Verify each key has been remapped to a disk location
         for (_, location) in results {
             match location {
@@ -425,7 +428,9 @@ mod tests {
         }
 
         // Check that deleted rows are not in the index
-        let results = new_index.search_values(&[2, 4]).await;
+        let results = new_index
+            .search_values(&test_get_hashes_for_index(&[2, 4]))
+            .await;
         assert!(
             results.is_empty(),
             "Deleted keys {results:?} should not exist in the remapped index"


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

Improve index scan to avoid any n^2 lookups.
For each index scan, we will scan each bucket at most once.

## Related Issues

Closes #<issue-number> or links to related issues.

## Changes

- 
- 
- 

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
