### PR TITLE
[storage] Simplify cache output state and consider insufficient disk space

### DIFF
--- a/src/moonlink/src/storage/cache/object_storage/base_cache.rs
+++ b/src/moonlink/src/storage/cache/object_storage/base_cache.rs
@@ -5,7 +5,7 @@
 /// - evictable if a cache entry is unreferenced
 use async_trait::async_trait;
 
-use crate::storage::cache::object_storage::cache_handle::DataCacheHandle;
+use crate::storage::cache::object_storage::cache_handle::NonEvictableHandle;
 use crate::storage::storage_utils::FileId;
 use crate::Result;
 
@@ -37,21 +37,25 @@ pub struct CacheEntry {
 #[allow(dead_code)]
 #[async_trait]
 pub trait CacheTrait {
-    /// Import cache entry to the cache.
+    /// Import cache entry to the cache. If there's no enough disk space, panic directly.
     /// Precondition: the file is not managed by cache.
     #[allow(async_fn_in_trait)]
     async fn _import_cache_entry(
         &mut self,
         file_id: FileId,
         cache_entry: CacheEntry,
-    ) -> (DataCacheHandle, Vec<String>);
+    ) -> (NonEvictableHandle, Vec<String>);
 
     /// Get file entry.
     /// If the requested file entry doesn't exist in cache, an IO operation is performed.
+    /// If there's no sufficient disk space, return [`None`].
     #[allow(async_fn_in_trait)]
     async fn _get_cache_entry(
         &mut self,
         file_id: FileId,
         remote_filepath: &str,
-    ) -> Result<(DataCacheHandle, Vec<String>)>;
+    ) -> Result<(
+        Option<NonEvictableHandle>,
+        Vec<String>, /*files_to_delete*/
+    )>;
 }

--- a/src/moonlink/src/storage/cache/object_storage/cache_handle.rs
+++ b/src/moonlink/src/storage/cache/object_storage/cache_handle.rs
@@ -44,25 +44,3 @@ impl NonEvictableHandle {
         guard._unreference(self.file_id);
     }
 }
-
-/// A unified handle for data file cache entries, which represents different states for a data file cache resource.
-#[allow(dead_code)]
-#[derive(Debug)]
-pub enum DataCacheHandle {
-    /// Cache file is managed by data file already and at evictable state; should pin before use.
-    Evictable,
-    /// Cache file is managed by data file already and pinned, could use at any time.
-    NonEvictable(NonEvictableHandle),
-}
-
-impl DataCacheHandle {
-    /// Unreferenced the pinned cache file.
-    pub async fn _unreference(&mut self) {
-        match self {
-            DataCacheHandle::NonEvictable(handle) => {
-                handle._unreference().await;
-            }
-            _ => panic!("Cannot unreference for an unpinned cache handle"),
-        }
-    }
-}

--- a/src/moonlink/src/storage/cache/object_storage/state_tests.rs
+++ b/src/moonlink/src/storage/cache/object_storage/state_tests.rs
@@ -11,8 +11,9 @@
 ///
 /// State transfer to data file cache entries:
 /// (1) + create mooncake snapshot => (2)
-/// (1) + requested to read => (3)
-/// (2) + requested to read => (3)
+/// (1) + requested to read + sufficient space => (3)
+/// (2) + requested to read + sufficient space => (3)
+/// (2) + requested to read + insufficient space => (2) <---- to test
 /// (3) + requested to read => (3)
 /// (2) + new entry + sufficient space => (2)
 /// (2) + new entry + insufficient space => (1)
@@ -20,11 +21,9 @@
 /// (3) + query finishes + no reference count => (2)
 ///
 /// For more details, please refer to https://docs.google.com/document/d/1kwXIl4VPzhgzV4KP8yT42M35PfvMJW9PdjNTF7VNEfA/edit?usp=sharing
-use crate::create_data_file;
 use crate::storage::cache::object_storage::base_cache::{
     CacheEntry, CacheTrait, FileMetadata, ObjectStorageCacheConfig,
 };
-use crate::storage::cache::object_storage::cache_handle::DataCacheHandle;
 use crate::storage::cache::object_storage::object_storage_cache::ObjectStorageCache;
 use crate::storage::cache::object_storage::test_utils::*;
 use crate::storage::storage_utils::FileId;
@@ -45,10 +44,9 @@ async fn test_cache_state_1_create_snashot() {
     let mut cache = get_test_object_storage_cache(&cache_file_directory);
 
     // Check cache handle status.
-    let (cache_handle, files_to_evict) = cache
+    let (_, files_to_evict) = cache
         ._import_cache_entry(/*file_id=*/ FileId(0), cache_entry)
         .await;
-    assert_non_evictable_cache_handle(&cache_handle).await;
     assert_non_evictable_cache_handle_ref_count(
         &mut cache,
         /*file_id=*/ FileId(0),
@@ -71,14 +69,13 @@ async fn test_cache_1_requested_to_read() {
     let mut cache = get_test_object_storage_cache(&cache_file_directory);
 
     // Check cache handle status.
-    let (cache_handle, files_to_evict) = cache
+    let (_, files_to_evict) = cache
         ._get_cache_entry(
             /*file_id=*/ FileId(0),
             test_file.as_path().to_str().unwrap(),
         )
         .await
         .unwrap();
-    assert_non_evictable_cache_handle(&cache_handle).await;
     assert_non_evictable_cache_handle_ref_count(
         &mut cache,
         /*file_id=*/ FileId(0),
@@ -110,7 +107,6 @@ async fn test_cache_2_requested_to_read() {
     let (mut cache_handle, files_to_evict) = cache
         ._import_cache_entry(/*file_id=*/ FileId(0), cache_entry)
         .await;
-    assert_non_evictable_cache_handle(&cache_handle).await;
     assert_non_evictable_cache_handle_ref_count(
         &mut cache,
         /*file_id=*/ FileId(0),
@@ -123,14 +119,13 @@ async fn test_cache_2_requested_to_read() {
     cache_handle._unreference().await;
 
     // Request to read, thus pinning the cache entry.
-    let (cache_handle, files_to_evict) = cache
+    let (_, files_to_evict) = cache
         ._get_cache_entry(
             /*file_id=*/ FileId(0),
             test_file.as_path().to_str().unwrap(),
         )
         .await
         .unwrap();
-    assert_non_evictable_cache_handle(&cache_handle).await;
     assert_non_evictable_cache_handle_ref_count(
         &mut cache,
         /*file_id=*/ FileId(0),
@@ -159,10 +154,9 @@ async fn test_cache_3_requested_to_read() {
             file_size: CONTENT.len() as u64,
         },
     };
-    let (cache_handle, files_to_evict) = cache
+    let (_, files_to_evict) = cache
         ._import_cache_entry(/*file_id=*/ FileId(0), cache_entry)
         .await;
-    assert_non_evictable_cache_handle(&cache_handle).await;
     assert_non_evictable_cache_handle_ref_count(
         &mut cache,
         /*file_id=*/ FileId(0),
@@ -172,14 +166,13 @@ async fn test_cache_3_requested_to_read() {
     assert!(files_to_evict.is_empty());
 
     // Request to read, thus pinning the cache entry.
-    let (cache_handle, files_to_evict) = cache
+    let (_, files_to_evict) = cache
         ._get_cache_entry(
             /*file_id=*/ FileId(0),
             test_file.as_path().to_str().unwrap(),
         )
         .await
         .unwrap();
-    assert_non_evictable_cache_handle(&cache_handle).await;
     assert_non_evictable_cache_handle_ref_count(
         &mut cache,
         /*file_id=*/ FileId(0),
@@ -214,7 +207,6 @@ async fn test_cache_2_new_entry_with_sufficient_space() {
     let (mut cache_handle, files_to_evict) = cache
         ._import_cache_entry(/*file_id=*/ FileId(0), cache_entry)
         .await;
-    assert_non_evictable_cache_handle(&cache_handle).await;
     assert_non_evictable_cache_handle_ref_count(
         &mut cache,
         /*file_id=*/ FileId(0),
@@ -234,10 +226,9 @@ async fn test_cache_2_new_entry_with_sufficient_space() {
             file_size: CONTENT.len() as u64,
         },
     };
-    let (cache_handle, files_to_evict) = cache
+    let (_, files_to_evict) = cache
         ._import_cache_entry(/*file_id=*/ FileId(1), cache_entry)
         .await;
-    assert_non_evictable_cache_handle(&cache_handle).await;
     assert_non_evictable_cache_handle_ref_count(
         &mut cache,
         /*file_id=*/ FileId(1),
@@ -272,7 +263,6 @@ async fn test_cache_2_new_entry_with_insufficient_space() {
     let (mut cache_handle_1, files_to_evict) = cache
         ._import_cache_entry(/*file_id=*/ FileId(0), cache_entry)
         .await;
-    assert_non_evictable_cache_handle(&cache_handle_1).await;
     assert_non_evictable_cache_handle_ref_count(
         &mut cache,
         /*file_id=*/ FileId(0),
@@ -292,20 +282,16 @@ async fn test_cache_2_new_entry_with_insufficient_space() {
             file_size: CONTENT.len() as u64,
         },
     };
-    let (cache_handle_2, files_to_evict) = cache
+    let (_, files_to_evict) = cache
         ._import_cache_entry(/*file_id=*/ FileId(1), cache_entry)
         .await;
-    assert_non_evictable_cache_handle(&cache_handle_2).await;
     assert_non_evictable_cache_handle_ref_count(
         &mut cache,
         /*file_id=*/ FileId(1),
         /*expected_ref_count=*/ 1,
     )
     .await;
-    let cache_file_1 = get_non_evictable_cache_handle(&cache_handle_1)
-        .cache_entry
-        .cache_filepath
-        .clone();
+    let cache_file_1 = cache_handle_1.cache_entry.cache_filepath.clone();
     assert_eq!(files_to_evict, vec![cache_file_1]);
 
     // Check cache status.
@@ -322,14 +308,13 @@ async fn test_cache_3_unpin_still_referenced() {
     let mut cache = get_test_object_storage_cache(&cache_file_directory);
 
     // Check cache handle status.
-    let (cache_handle, files_to_evict) = cache
+    let (_, files_to_evict) = cache
         ._get_cache_entry(
             /*file_id=*/ FileId(0),
             test_file.as_path().to_str().unwrap(),
         )
         .await
         .unwrap();
-    assert_non_evictable_cache_handle(&cache_handle).await;
     assert_non_evictable_cache_handle_ref_count(
         &mut cache,
         /*file_id=*/ FileId(0),
@@ -339,14 +324,13 @@ async fn test_cache_3_unpin_still_referenced() {
     assert!(files_to_evict.is_empty());
 
     // Get the same cache entry again to increase its reference count.
-    let (mut cache_handle, files_to_evict) = cache
+    let (cache_handle, files_to_evict) = cache
         ._get_cache_entry(
             /*file_id=*/ FileId(0),
             test_file.as_path().to_str().unwrap(),
         )
         .await
         .unwrap();
-    assert_non_evictable_cache_handle(&cache_handle).await;
     assert_non_evictable_cache_handle_ref_count(
         &mut cache,
         /*file_id=*/ FileId(0),
@@ -356,7 +340,7 @@ async fn test_cache_3_unpin_still_referenced() {
     assert!(files_to_evict.is_empty());
 
     // Unreference one of the cache handles.
-    cache_handle._unreference().await;
+    cache_handle.unwrap()._unreference().await;
 
     // Check cache status.
     assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 1).await;
@@ -372,14 +356,13 @@ async fn test_cache_3_unpin_not_referenced() {
     let mut cache = get_test_object_storage_cache(&cache_file_directory);
 
     // Check cache handle status.
-    let (mut cache_handle_1, files_to_evict) = cache
+    let (cache_handle_1, files_to_evict) = cache
         ._get_cache_entry(
             /*file_id=*/ FileId(0),
             test_file.as_path().to_str().unwrap(),
         )
         .await
         .unwrap();
-    assert_non_evictable_cache_handle(&cache_handle_1).await;
     assert_non_evictable_cache_handle_ref_count(
         &mut cache,
         /*file_id=*/ FileId(0),
@@ -389,14 +372,13 @@ async fn test_cache_3_unpin_not_referenced() {
     assert!(files_to_evict.is_empty());
 
     // Get the same cache entry again to increase its reference count.
-    let (mut cache_handle_2, files_to_evict) = cache
+    let (cache_handle_2, files_to_evict) = cache
         ._get_cache_entry(
             /*file_id=*/ FileId(0),
             test_file.as_path().to_str().unwrap(),
         )
         .await
         .unwrap();
-    assert_non_evictable_cache_handle(&cache_handle_2).await;
     assert_non_evictable_cache_handle_ref_count(
         &mut cache,
         /*file_id=*/ FileId(0),
@@ -406,64 +388,10 @@ async fn test_cache_3_unpin_not_referenced() {
     assert!(files_to_evict.is_empty());
 
     // Unreference all cache handles.
-    cache_handle_1._unreference().await;
-    cache_handle_2._unreference().await;
+    cache_handle_1.unwrap()._unreference().await;
+    cache_handle_2.unwrap()._unreference().await;
 
     // Check cache status.
     assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 0).await;
     assert_evictable_cache_size(&mut cache, /*expected_count=*/ 1).await;
-}
-
-#[tokio::test]
-async fn test_concurrent_data_file_cache() {
-    const PARALLEL_TASK_NUM: usize = 10;
-    let mut handle_futures = Vec::with_capacity(PARALLEL_TASK_NUM);
-
-    let cache_file_directory = tempdir().unwrap();
-    let remote_file_directory = tempdir().unwrap();
-
-    let config = ObjectStorageCacheConfig {
-        // Set max bytes larger than one file, but less than two files.
-        max_bytes: (CONTENT.len() * PARALLEL_TASK_NUM) as u64,
-        cache_directory: cache_file_directory.path().to_str().unwrap().to_string(),
-    };
-    let cache = ObjectStorageCache::_new(config);
-
-    for idx in 0..PARALLEL_TASK_NUM {
-        let mut temp_cache = cache.clone();
-        let remote_file_directory = remote_file_directory.path().to_path_buf();
-
-        let handle = tokio::task::spawn_blocking(async move || -> DataCacheHandle {
-            let filename = format!("{}.parquet", idx);
-            let test_file = create_test_file(remote_file_directory.as_path(), &filename).await;
-            let data_file = create_data_file(
-                /*file_id=*/ idx as u64,
-                test_file.to_str().unwrap().to_string(),
-            );
-            let (cache_handle, cache_to_delete) = temp_cache
-                ._get_cache_entry(data_file.file_id(), data_file.file_path())
-                .await
-                .unwrap();
-            assert!(cache_to_delete.is_empty());
-            cache_handle
-        });
-        handle_futures.push(handle);
-    }
-
-    let results = futures::future::join_all(handle_futures).await;
-    for cur_handle_future in results.into_iter() {
-        let cur_cache_handle = cur_handle_future.unwrap().await;
-        let non_evictable_handle = get_non_evictable_cache_handle(&cur_cache_handle);
-        check_file_content(&non_evictable_handle.cache_entry.cache_filepath).await;
-        assert_eq!(
-            non_evictable_handle.cache_entry.file_metadata.file_size as usize,
-            CONTENT.len()
-        );
-    }
-    assert_eq!(cache.cache.read().await.evictable_cache.len(), 0);
-    assert_eq!(
-        cache.cache.read().await.non_evictable_cache.len(),
-        PARALLEL_TASK_NUM
-    );
-    check_cache_file_count(&cache_file_directory, PARALLEL_TASK_NUM).await;
 }

--- a/src/moonlink/src/storage/cache/object_storage/test_utils.rs
+++ b/src/moonlink/src/storage/cache/object_storage/test_utils.rs
@@ -3,9 +3,7 @@ use tokio::io::AsyncReadExt;
 use tokio::io::AsyncWriteExt;
 
 use crate::storage::cache::object_storage::{
-    base_cache::ObjectStorageCacheConfig,
-    cache_handle::{DataCacheHandle, NonEvictableHandle},
-    object_storage_cache::ObjectStorageCache,
+    base_cache::ObjectStorageCacheConfig, object_storage_cache::ObjectStorageCache,
 };
 use crate::storage::storage_utils::FileId;
 
@@ -61,34 +59,6 @@ pub(crate) async fn check_cache_file_count(tmp_dir: &TempDir, expected_count: us
         }
     }
     assert_eq!(actual_count, expected_count);
-}
-
-/// Test util function to assert returned cache handle is non-evictable.
-pub(crate) async fn assert_non_evictable_cache_handle(data_cache_handle: &DataCacheHandle) {
-    let non_evictable_handle = match data_cache_handle {
-        DataCacheHandle::NonEvictable(non_evictable_handle) => non_evictable_handle,
-        _ => {
-            panic!("Expects to get non-evictable cache handle, but get unimported or evictable one")
-        }
-    };
-    // Check cache file existence.
-    assert!(
-        tokio::fs::try_exists(&non_evictable_handle.cache_entry.cache_filepath)
-            .await
-            .unwrap()
-    );
-}
-
-/// Test util function to assert and get non-evictable cache handle.
-pub(crate) fn get_non_evictable_cache_handle(
-    data_cache_handle: &DataCacheHandle,
-) -> &NonEvictableHandle {
-    match data_cache_handle {
-        DataCacheHandle::NonEvictable(handle) => handle,
-        _ => {
-            panic!("Expects to get non-evictable cache handle, but get unimported or evictable one")
-        }
-    }
 }
 
 /// Test util function to check evictable cache size.


### PR DESCRIPTION
## Summary

This PR does two things:
- Simplify cache handle state to only two: (1) has pinned cache handle, and (2) no pinned cache handle, including no cache
  + from mooncake table's perspective, "no cache" vs "no pinned cache" has no difference
- Add a new state into cache, which is "attempt cache but not sufficient space"
  + I planned to handle it as a special case, but found it an important state from mooncake table disk file's perspective.  


## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [x] Documentation updated if necessary
- [x] I have reviewed my own changes