### PR TITLE
[storage] ZSTD compress parquet data file

### DIFF
--- a/src/moonlink/src/storage/iceberg/table_property.rs
+++ b/src/moonlink/src/storage/iceberg/table_property.rs
@@ -3,7 +3,7 @@
 ///
 /// Compression codec for parquet files.
 pub(crate) const PARQUET_COMPRESSION: &str = "write.parquet.compression-codec";
-pub(crate) const PARQUET_COMPRESSION_DEFAULT: &str = "none";
+pub(crate) const PARQUET_COMPRESSION_DEFAULT: &str = "zstd";
 
 /// Compression codec for metadata.
 pub(crate) const METADATA_COMPRESSION: &str = "write.metadata.compression-codec";


### PR DESCRIPTION
## Summary

This PR enables ZSTD level 5 to compress data files inline.
The consideration for compression level is 
(1) overhead for small files, not a big concern here, since we only have small files for last streaming writes
(2) tradeoff between IO/storage and CPU overhead
I used ZSTD for a few years, and level 5 is the default I used.

I tested by writing a few parquet files, and confirm file size does change.
Also checked with pg_mooncake, and confirm zstd compression is already handled (by duckdb parquet reader).
```sql
pg_mooncake (pid: 5837) =# DROP EXTENSION IF EXISTS pg_mooncake CASCADE;
DROP TABLE IF EXISTS r;
CREATE EXTENSION pg_mooncake;
CREATE TABLE r (a int primary key, b text);
CALL mooncake.create_table('c', 'r');
INSERT INTO r SELECT a, 'val_' || a FROM generate_series(1, 250000) AS a;
SELECT count(*) FROM c;
DELETE FROM r WHERE a % 2 = 0;
SELECT count(*) FROM c;
NOTICE:  drop cascades to table c
DROP EXTENSION
DROP TABLE
CREATE EXTENSION
CREATE TABLE
CALL
INSERT 0 250000
 count  
--------
 250000
(1 row)

DELETE 125000
 count  
--------
 125000
(1 row)
```

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/457

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
