### PR TITLE
[storage] [1/N] Implement cache integration with iceberg persistence and snapshot read

### DIFF
--- a/src/moonlink/benches/bench_write.rs
+++ b/src/moonlink/benches/bench_write.rs
@@ -1,7 +1,7 @@
 use arrow::datatypes::{DataType, Field, Schema};
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use moonlink::row::{IdentityProp, MoonlinkRow, RowValue};
-use moonlink::{IcebergTableConfig, MooncakeTable, TableConfig};
+use moonlink::{IcebergTableConfig, MooncakeTable, ObjectStorageCache, TableConfig};
 use pprof::criterion::{Output, PProfProfiler};
 use std::collections::HashMap;
 use tempfile::tempdir;
@@ -62,6 +62,7 @@ fn bench_write(c: &mut Criterion) {
                     IdentityProp::SinglePrimitiveKey(0),
                     iceberg_table_config,
                     table_config,
+                    ObjectStorageCache::default_for_bench(),
                 )
                 .await
                 .unwrap();
@@ -94,6 +95,7 @@ fn bench_write(c: &mut Criterion) {
                     IdentityProp::SinglePrimitiveKey(0),
                     iceberg_table_config,
                     table_config,
+                    ObjectStorageCache::default_for_bench(),
                 )
                 .await
                 .unwrap();
@@ -130,6 +132,7 @@ fn bench_write(c: &mut Criterion) {
                         IdentityProp::SinglePrimitiveKey(0),
                         iceberg_table_config,
                         table_config,
+                        ObjectStorageCache::default_for_bench(),
                     ))
                     .unwrap();
                 rt.block_on(async {

--- a/src/moonlink/benches/microbench_write_mooncake_table.rs
+++ b/src/moonlink/benches/microbench_write_mooncake_table.rs
@@ -1,7 +1,7 @@
 use arrow::datatypes::{DataType, Field, Schema};
 use criterion::{criterion_group, criterion_main, Criterion};
 use moonlink::row::{IdentityProp, MoonlinkRow, RowValue};
-use moonlink::IcebergTableConfig;
+use moonlink::{IcebergTableConfig, ObjectStorageCache};
 use moonlink::{MooncakeTable, TableConfig};
 use std::collections::HashMap;
 use std::time::Duration;
@@ -63,6 +63,7 @@ fn bench_write_mooncake_table(c: &mut Criterion) {
             IdentityProp::SinglePrimitiveKey(0),
             iceberg_table_config,
             table_config,
+            ObjectStorageCache::default_for_bench(),
         ))
         .unwrap();
 

--- a/src/moonlink/src/lib.rs
+++ b/src/moonlink/src/lib.rs
@@ -7,10 +7,13 @@ mod union_read;
 
 pub use error::*;
 pub use storage::storage_utils::create_data_file;
+pub(crate) use storage::NonEvictableHandle;
+pub use storage::SnapshotReadOutput;
 pub use storage::{
     IcebergEventSyncReceiver, IcebergTableConfig, IcebergTableEventManager, IcebergTableManager,
     MooncakeTable, TableConfig, TableManager,
 };
+pub use storage::{ObjectStorageCache, ObjectStorageCacheConfig};
 pub use table_handler::{IcebergEventSyncSender, TableEvent, TableHandler};
 pub use union_read::{ReadState, ReadStateManager};
 

--- a/src/moonlink/src/storage.rs
+++ b/src/moonlink/src/storage.rs
@@ -5,11 +5,15 @@ pub(crate) mod index;
 pub(crate) mod mooncake_table;
 pub(crate) mod storage_utils;
 
+pub use cache::object_storage::cache_config::ObjectStorageCacheConfig;
+pub(crate) use cache::object_storage::cache_handle::NonEvictableHandle;
+pub use cache::object_storage::object_storage_cache::ObjectStorageCache;
 pub use iceberg::iceberg_table_event_manager::{
     IcebergEventSyncReceiver, IcebergTableEventManager,
 };
 pub use iceberg::iceberg_table_manager::{IcebergTableConfig, IcebergTableManager};
 pub use iceberg::table_manager::TableManager;
+pub use mooncake_table::SnapshotReadOutput;
 pub use mooncake_table::{MooncakeTable, TableConfig};
 pub(crate) use mooncake_table::{PuffinDeletionBlobAtRead, SnapshotTableState};
 

--- a/src/moonlink/src/storage/cache/object_storage.rs
+++ b/src/moonlink/src/storage/cache/object_storage.rs
@@ -1,6 +1,7 @@
 pub(crate) mod base_cache;
+pub mod cache_config;
 pub(crate) mod cache_handle;
-pub(crate) mod object_storage_cache;
+pub mod object_storage_cache;
 
 #[cfg(test)]
 mod state_tests;

--- a/src/moonlink/src/storage/cache/object_storage/base_cache.rs
+++ b/src/moonlink/src/storage/cache/object_storage/base_cache.rs
@@ -6,7 +6,7 @@
 use async_trait::async_trait;
 
 use crate::storage::cache::object_storage::cache_handle::NonEvictableHandle;
-use crate::storage::storage_utils::FileId;
+use crate::storage::storage_utils::TableUniqueFileId;
 use crate::Result;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -30,7 +30,7 @@ pub trait CacheTrait {
     #[allow(async_fn_in_trait)]
     async fn import_cache_entry(
         &mut self,
-        file_id: FileId,
+        file_id: TableUniqueFileId,
         cache_entry: CacheEntry,
     ) -> (NonEvictableHandle, Vec<String>);
 
@@ -42,7 +42,7 @@ pub trait CacheTrait {
     #[allow(async_fn_in_trait)]
     async fn get_cache_entry(
         &mut self,
-        file_id: FileId,
+        file_id: TableUniqueFileId,
         remote_filepath: &str,
     ) -> Result<(
         Option<NonEvictableHandle>,

--- a/src/moonlink/src/storage/cache/object_storage/base_cache.rs
+++ b/src/moonlink/src/storage/cache/object_storage/base_cache.rs
@@ -18,15 +18,6 @@ pub struct FileMetadata {
 
 #[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub(crate) struct ObjectStorageCacheConfig {
-    /// Max number of bytes for cache entries at local filesystem.
-    pub(crate) max_bytes: u64,
-    /// Directory to store local cache files.
-    pub(crate) cache_directory: String,
-}
-
-#[allow(dead_code)]
-#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CacheEntry {
     /// Cache data file at local filesystem.
     pub(crate) cache_filepath: String,
@@ -40,17 +31,19 @@ pub trait CacheTrait {
     /// Import cache entry to the cache. If there's no enough disk space, panic directly.
     /// Precondition: the file is not managed by cache.
     #[allow(async_fn_in_trait)]
-    async fn _import_cache_entry(
+    async fn import_cache_entry(
         &mut self,
         file_id: FileId,
         cache_entry: CacheEntry,
     ) -> (NonEvictableHandle, Vec<String>);
 
-    /// Get file entry.
-    /// If the requested file entry doesn't exist in cache, an IO operation is performed.
+    /// Get a pinned cache file entry.
+    ///
+    /// If the requested file is already pinned, it will return immediately without any IO operations.
+    /// Otherwise, an IO operation might be performed, depending on whether the corresponding cache entry happens to be alive.
     /// If there's no sufficient disk space, return [`None`].
     #[allow(async_fn_in_trait)]
-    async fn _get_cache_entry(
+    async fn get_cache_entry(
         &mut self,
         file_id: FileId,
         remote_filepath: &str,

--- a/src/moonlink/src/storage/cache/object_storage/base_cache.rs
+++ b/src/moonlink/src/storage/cache/object_storage/base_cache.rs
@@ -9,14 +9,12 @@ use crate::storage::cache::object_storage::cache_handle::NonEvictableHandle;
 use crate::storage::storage_utils::FileId;
 use crate::Result;
 
-#[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct FileMetadata {
     /// Size of the current file.
     pub(crate) file_size: u64,
 }
 
-#[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct CacheEntry {
     /// Cache data file at local filesystem.
@@ -25,7 +23,6 @@ pub struct CacheEntry {
     pub(crate) file_metadata: FileMetadata,
 }
 
-#[allow(dead_code)]
 #[async_trait]
 pub trait CacheTrait {
     /// Import cache entry to the cache. If there's no enough disk space, panic directly.
@@ -37,9 +34,9 @@ pub trait CacheTrait {
         cache_entry: CacheEntry,
     ) -> (NonEvictableHandle, Vec<String>);
 
-    /// Get a pinned cache file entry.
+    /// Attempt to get a pinned cache file entry.
     ///
-    /// If the requested file is already pinned, it will return immediately without any IO operations.
+    /// If the requested file is already pinned, cache handle will returned immediately without any IO operations.
     /// Otherwise, an IO operation might be performed, depending on whether the corresponding cache entry happens to be alive.
     /// If there's no sufficient disk space, return [`None`].
     #[allow(async_fn_in_trait)]

--- a/src/moonlink/src/storage/cache/object_storage/cache_config.rs
+++ b/src/moonlink/src/storage/cache/object_storage/cache_config.rs
@@ -1,0 +1,66 @@
+/// Configuration for object storage cache.
+#[allow(dead_code)]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ObjectStorageCacheConfig {
+    /// Max number of bytes for cache entries at local filesystem.
+    pub max_bytes: u64,
+    /// Directory to store local cache files.
+    pub cache_directory: String,
+}
+
+impl ObjectStorageCacheConfig {
+    pub fn new(max_bytes: u64, cache_directory: String) -> Self {
+        Self {
+            max_bytes,
+            cache_directory,
+        }
+    }
+
+    /// Provide a default option for ease of testing.
+    #[cfg(test)]
+    pub fn default_for_test() -> Self {
+        const DEFAULT_MAX_BYTES_FOR_TEST: u64 = 1 << 30; // 1GiB
+        const DEFAULT_CACHE_DIRECTORY: &str = "/tmp/moonlink_test_cache";
+
+        // Re-create default cache directory for testing.
+        match std::fs::remove_dir_all(DEFAULT_CACHE_DIRECTORY) {
+            Ok(()) => {}
+            Err(e) => {
+                if e.kind() != std::io::ErrorKind::NotFound {
+                    panic!("Failed to remove directory: {:?}", e);
+                }
+            }
+        }
+        std::fs::create_dir_all(DEFAULT_CACHE_DIRECTORY).unwrap();
+
+        Self {
+            max_bytes: DEFAULT_MAX_BYTES_FOR_TEST,
+            cache_directory: DEFAULT_CACHE_DIRECTORY.to_string(),
+        }
+    }
+
+    /// Provide a default option for ease of benchmark.
+    /// For unit test, by default disable on-disk caching so it provides reproducibility in all cases,
+    /// and useful to check write-through cache is not accessed and store after iceberg snapshot persistence.
+    #[cfg(feature = "bench")]
+    pub fn default_for_bench() -> Self {
+        const DEFAULT_MAX_BYTES_FOR_TEST: u64 = 1 << 30; // 1GiB
+        const DEFAULT_CACHE_DIRECTORY: &str = "/tmp/moonlink_test_cache";
+
+        // Re-create default cache directory for testing.
+        match std::fs::remove_dir_all(DEFAULT_CACHE_DIRECTORY) {
+            Ok(()) => {}
+            Err(e) => {
+                if e.kind() != std::io::ErrorKind::NotFound {
+                    panic!("Failed to remove directory: {:?}", e);
+                }
+            }
+        }
+        std::fs::create_dir_all(DEFAULT_CACHE_DIRECTORY).unwrap();
+
+        Self {
+            max_bytes: DEFAULT_MAX_BYTES_FOR_TEST,
+            cache_directory: DEFAULT_CACHE_DIRECTORY.to_string(),
+        }
+    }
+}

--- a/src/moonlink/src/storage/cache/object_storage/cache_config.rs
+++ b/src/moonlink/src/storage/cache/object_storage/cache_config.rs
@@ -1,5 +1,4 @@
 /// Configuration for object storage cache.
-#[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ObjectStorageCacheConfig {
     /// Max number of bytes for cache entries at local filesystem.
@@ -45,7 +44,7 @@ impl ObjectStorageCacheConfig {
     #[cfg(feature = "bench")]
     pub fn default_for_bench() -> Self {
         const DEFAULT_MAX_BYTES_FOR_TEST: u64 = 1 << 30; // 1GiB
-        const DEFAULT_CACHE_DIRECTORY: &str = "/tmp/moonlink_test_cache";
+        const DEFAULT_CACHE_DIRECTORY: &str = "/tmp/moonlink_test_bench";
 
         // Re-create default cache directory for testing.
         match std::fs::remove_dir_all(DEFAULT_CACHE_DIRECTORY) {

--- a/src/moonlink/src/storage/cache/object_storage/cache_config.rs
+++ b/src/moonlink/src/storage/cache/object_storage/cache_config.rs
@@ -39,8 +39,6 @@ impl ObjectStorageCacheConfig {
     }
 
     /// Provide a default option for ease of benchmark.
-    /// For unit test, by default disable on-disk caching so it provides reproducibility in all cases,
-    /// and useful to check write-through cache is not accessed and store after iceberg snapshot persistence.
     #[cfg(feature = "bench")]
     pub fn default_for_bench() -> Self {
         const DEFAULT_MAX_BYTES_FOR_TEST: u64 = 1 << 30; // 1GiB

--- a/src/moonlink/src/storage/cache/object_storage/cache_handle.rs
+++ b/src/moonlink/src/storage/cache/object_storage/cache_handle.rs
@@ -7,6 +7,7 @@ use crate::storage::storage_utils::FileId;
 use tokio::sync::RwLock;
 
 #[allow(dead_code)]
+#[derive(Clone)]
 pub struct NonEvictableHandle {
     /// File id for the mooncake table data file.
     pub(crate) file_id: FileId,
@@ -26,7 +27,7 @@ impl std::fmt::Debug for NonEvictableHandle {
 }
 
 impl NonEvictableHandle {
-    pub(super) fn _new(
+    pub(super) fn new(
         file_id: FileId,
         cache_entry: CacheEntry,
         cache: Arc<RwLock<ObjectStorageCacheInternal>>,
@@ -38,9 +39,14 @@ impl NonEvictableHandle {
         }
     }
 
+    /// Get cache file path.
+    pub(crate) fn get_cache_filepath(&self) -> &str {
+        &self.cache_entry.cache_filepath
+    }
+
     /// Unreference the pinned cache file.
-    pub(super) async fn _unreference(&mut self) {
+    pub(crate) async fn unreference(&mut self) {
         let mut guard = self.cache.write().await;
-        guard._unreference(self.file_id);
+        guard.unreference(self.file_id);
     }
 }

--- a/src/moonlink/src/storage/cache/object_storage/cache_handle.rs
+++ b/src/moonlink/src/storage/cache/object_storage/cache_handle.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use crate::storage::cache::object_storage::base_cache::CacheEntry;
 use crate::storage::cache::object_storage::object_storage_cache::ObjectStorageCacheInternal;
-use crate::storage::storage_utils::FileId;
+use crate::storage::storage_utils::TableUniqueFileId;
 
 use tokio::sync::RwLock;
 
@@ -10,7 +10,7 @@ use tokio::sync::RwLock;
 #[derive(Clone)]
 pub struct NonEvictableHandle {
     /// File id for the mooncake table data file.
-    pub(crate) file_id: FileId,
+    pub(crate) file_id: TableUniqueFileId,
     /// Non-evictable cache entry.
     pub(crate) cache_entry: CacheEntry,
     /// Access to cache, used to unreference at drop.
@@ -28,7 +28,7 @@ impl std::fmt::Debug for NonEvictableHandle {
 
 impl NonEvictableHandle {
     pub(super) fn new(
-        file_id: FileId,
+        file_id: TableUniqueFileId,
         cache_entry: CacheEntry,
         cache: Arc<RwLock<ObjectStorageCacheInternal>>,
     ) -> Self {

--- a/src/moonlink/src/storage/cache/object_storage/object_storage_cache.rs
+++ b/src/moonlink/src/storage/cache/object_storage/object_storage_cache.rs
@@ -25,7 +25,7 @@ pub(crate) struct CacheEntryWrapper {
 /// A cache entry could be either evictable or non-evictable.
 /// A general lifecycle of a cache entry is to
 /// (1) fetch and mark as non-evictable on access
-/// (2) dereference after usage, down-level to evictable when it's _unreferenced
+/// (2) dereference after usage, down-level to evictable when it's unreferenced
 #[allow(dead_code)]
 pub(crate) struct ObjectStorageCacheInternal {
     /// Current number of bytes of all cache entries.
@@ -112,6 +112,20 @@ impl ObjectStorageCacheInternal {
             self.evictable_cache.push(file_id, cache_entry_wrapper);
         }
     }
+
+    /// ================================
+    /// Test util functions
+    /// ================================
+    ///
+    /// Test util function to get reference count for reference count, return 0 if doesn't exist.
+    #[cfg(test)]
+    pub(crate) fn get_non_evictable_entry_ref_count(&self, file_id: &FileId) -> u32 {
+        let cache_entry = self.non_evictable_cache.get(file_id);
+        if let Some(cache_entry) = cache_entry {
+            return cache_entry.reference_count;
+        }
+        0
+    }
 }
 
 // TODO(hjiang): Add stats for cache, like cache hit/miss rate, cache size, etc.
@@ -134,12 +148,6 @@ impl std::fmt::Debug for ObjectStorageCache {
 }
 
 impl ObjectStorageCache {
-    #[cfg(test)]
-    pub fn default_for_test() -> Self {
-        let config = ObjectStorageCacheConfig::default_for_test();
-        Self::new(config)
-    }
-
     pub fn new(config: ObjectStorageCacheConfig) -> Self {
         let evictable_cache = LruCache::unbounded();
         let non_evictable_cache = HashMap::new();
@@ -170,6 +178,40 @@ impl ObjectStorageCache {
             cache_filepath: dst_filepath,
             file_metadata: FileMetadata { file_size },
         })
+    }
+
+    /// ================================
+    /// Test/bench util functions
+    /// ================================
+    ///
+    #[cfg(test)]
+    pub fn default_for_test() -> Self {
+        let config = ObjectStorageCacheConfig::default_for_test();
+        Self::new(config)
+    }
+
+    #[cfg(feature = "bench")]
+    pub fn default_for_bench() -> Self {
+        let config = ObjectStorageCacheConfig::default_for_bench();
+        Self::new(config)
+    }
+
+    /// Test util function to get reference count for reference count.
+    #[cfg(test)]
+    pub(crate) async fn get_non_evictable_entry_ref_count(&self, file_id: &FileId) -> u32 {
+        let guard = self.cache.read().await;
+        guard.get_non_evictable_entry_ref_count(file_id)
+    }
+
+    /// Test util function to get non-evictable filenames.
+    #[cfg(test)]
+    pub(crate) async fn get_non_evictable_filenames(&self) -> Vec<FileId> {
+        let guard = self.cache.read().await;
+        guard
+            .non_evictable_cache
+            .keys()
+            .copied()
+            .collect::<Vec<_>>()
     }
 }
 

--- a/src/moonlink/src/storage/cache/object_storage/object_storage_cache.rs
+++ b/src/moonlink/src/storage/cache/object_storage/object_storage_cache.rs
@@ -13,7 +13,6 @@ use more_asserts as ma;
 use tokio::sync::RwLock;
 use uuid::Uuid;
 
-#[allow(dead_code)]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct CacheEntryWrapper {
     /// Cache entry.
@@ -26,7 +25,6 @@ pub(crate) struct CacheEntryWrapper {
 /// A general lifecycle of a cache entry is to
 /// (1) fetch and mark as non-evictable on access
 /// (2) dereference after usage, down-level to evictable when it's unreferenced
-#[allow(dead_code)]
 pub(crate) struct ObjectStorageCacheInternal {
     /// Current number of bytes of all cache entries.
     pub(crate) cur_bytes: u64,
@@ -117,7 +115,7 @@ impl ObjectStorageCacheInternal {
     /// Test util functions
     /// ================================
     ///
-    /// Test util function to get reference count for reference count, return 0 if doesn't exist.
+    /// Test util function to get reference count for the given file id, return 0 if doesn't exist.
     #[cfg(test)]
     pub(crate) fn get_non_evictable_entry_ref_count(&self, file_id: &FileId) -> u32 {
         let cache_entry = self.non_evictable_cache.get(file_id);

--- a/src/moonlink/src/storage/cache/object_storage/object_storage_cache.rs
+++ b/src/moonlink/src/storage/cache/object_storage/object_storage_cache.rs
@@ -2,9 +2,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 /// Object storage cache, which caches data file in file granularity at local filesystem.
-use crate::storage::cache::object_storage::base_cache::{
-    CacheEntry, CacheTrait, FileMetadata, ObjectStorageCacheConfig,
-};
+use crate::storage::cache::object_storage::base_cache::{CacheEntry, CacheTrait, FileMetadata};
+use crate::storage::cache::object_storage::cache_config::ObjectStorageCacheConfig;
 use crate::storage::cache::object_storage::cache_handle::NonEvictableHandle;
 use crate::storage::storage_utils::FileId;
 use crate::Result;
@@ -47,7 +46,7 @@ impl ObjectStorageCacheInternal {
     /// Return
     /// - whether cache entries eviction succeeds or not.
     /// - data files which get evicted from LRU cache, and will be deleted locally.
-    fn _evict_cache_entries(
+    fn evict_cache_entries(
         &mut self,
         max_bytes: u64,
         tolerate_insufficiency: bool,
@@ -80,7 +79,7 @@ impl ObjectStorageCacheInternal {
     /// NOTICE:
     /// - cache current bytes won't be updated.
     /// - If insertion fails due to insufficiency, the input cache entry won't be inserted into cache.
-    fn _insert_non_evictable(
+    fn insert_non_evictable(
         &mut self,
         file_id: FileId,
         cache_entry_wrapper: CacheEntryWrapper,
@@ -93,7 +92,7 @@ impl ObjectStorageCacheInternal {
             .insert(file_id, cache_entry_wrapper)
             .is_none());
         let (evict_succ, files_to_delete) =
-            self._evict_cache_entries(max_bytes, tolerate_insufficiency);
+            self.evict_cache_entries(max_bytes, tolerate_insufficiency);
         if !evict_succ {
             assert!(self.non_evictable_cache.remove(&file_id).is_some());
         }
@@ -101,7 +100,7 @@ impl ObjectStorageCacheInternal {
     }
 
     /// Unreference the given cache entry.
-    pub(super) fn _unreference(&mut self, file_id: FileId) {
+    pub(super) fn unreference(&mut self, file_id: FileId) {
         let cache_entry_wrapper = self.non_evictable_cache.get_mut(&file_id);
         assert!(cache_entry_wrapper.is_some());
         let cache_entry_wrapper = cache_entry_wrapper.unwrap();
@@ -125,8 +124,23 @@ pub struct ObjectStorageCache {
     pub(crate) cache: Arc<RwLock<ObjectStorageCacheInternal>>,
 }
 
+// A dummy [`Debug`] trait implementation.
+impl std::fmt::Debug for ObjectStorageCache {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ObjectStorageCache")
+            .field("config", &self.config)
+            .finish()
+    }
+}
+
 impl ObjectStorageCache {
-    pub fn _new(config: ObjectStorageCacheConfig) -> Self {
+    #[cfg(test)]
+    pub fn default_for_test() -> Self {
+        let config = ObjectStorageCacheConfig::default_for_test();
+        Self::new(config)
+    }
+
+    pub fn new(config: ObjectStorageCacheConfig) -> Self {
         let evictable_cache = LruCache::unbounded();
         let non_evictable_cache = HashMap::new();
         Self {
@@ -140,7 +154,7 @@ impl ObjectStorageCache {
     }
 
     /// Read from remote [`src`] and write to local cache file, return cache entries.
-    async fn _load_from_remote(&self, src: &str) -> Result<CacheEntry> {
+    async fn load_from_remote(&self, src: &str) -> Result<CacheEntry> {
         let src_pathbuf = std::path::PathBuf::from(src);
         let suffix = src_pathbuf.extension().unwrap().to_str().unwrap();
         let mut dst_pathbuf = std::path::PathBuf::from(&self.config.cache_directory);
@@ -161,7 +175,7 @@ impl ObjectStorageCache {
 
 #[async_trait::async_trait]
 impl CacheTrait for ObjectStorageCache {
-    async fn _import_cache_entry(
+    async fn import_cache_entry(
         &mut self,
         file_id: FileId,
         cache_entry: CacheEntry,
@@ -175,7 +189,7 @@ impl CacheTrait for ObjectStorageCache {
         guard.cur_bytes += cache_entry.file_metadata.file_size;
 
         let cache_files_to_delete = guard
-            ._insert_non_evictable(
+            .insert_non_evictable(
                 file_id,
                 cache_entry_wrapper,
                 self.config.max_bytes,
@@ -183,11 +197,11 @@ impl CacheTrait for ObjectStorageCache {
             )
             .1;
         let non_evictable_handle =
-            NonEvictableHandle::_new(file_id, cache_entry, self.cache.clone());
+            NonEvictableHandle::new(file_id, cache_entry, self.cache.clone());
         (non_evictable_handle, cache_files_to_delete)
     }
 
-    async fn _get_cache_entry(
+    async fn get_cache_entry(
         &mut self,
         file_id: FileId,
         remote_filepath: &str,
@@ -205,7 +219,7 @@ impl CacheTrait for ObjectStorageCache {
                 value.as_mut().unwrap().reference_count += 1;
                 let cache_entry = value.as_ref().unwrap().cache_entry.clone();
                 let non_evictable_handle =
-                    NonEvictableHandle::_new(file_id, cache_entry, self.cache.clone());
+                    NonEvictableHandle::new(file_id, cache_entry, self.cache.clone());
                 return Ok((Some(non_evictable_handle), /*files_to_delete=*/ vec![]));
             }
 
@@ -216,7 +230,7 @@ impl CacheTrait for ObjectStorageCache {
                 value.as_mut().unwrap().reference_count += 1;
                 let cache_entry = value.as_ref().unwrap().cache_entry.clone();
                 let files_to_delete = guard
-                    ._insert_non_evictable(
+                    .insert_non_evictable(
                         file_id,
                         value.unwrap(),
                         self.config.max_bytes,
@@ -225,7 +239,7 @@ impl CacheTrait for ObjectStorageCache {
                     .1;
                 assert!(files_to_delete.is_empty());
                 let non_evictable_handle =
-                    NonEvictableHandle::_new(file_id, cache_entry, self.cache.clone());
+                    NonEvictableHandle::new(file_id, cache_entry, self.cache.clone());
                 return Ok((Some(non_evictable_handle), /*files_to_delete=*/ vec![]));
             }
         }
@@ -235,18 +249,18 @@ impl CacheTrait for ObjectStorageCache {
         // TODO(hjiang):
         // 1. IO operations should leverage opendal, use tokio::fs as of now to validate cache functionality.
         // 2. We could have different requests for the same remote filepath, should able to avoid wasted repeated IO.
-        let cache_entry = self._load_from_remote(remote_filepath).await?;
+        let cache_entry = self.load_from_remote(remote_filepath).await?;
         let cache_entry_wrapper = CacheEntryWrapper {
             cache_entry: cache_entry.clone(),
             reference_count: 1,
         };
         let non_evictable_handle =
-            NonEvictableHandle::_new(file_id, cache_entry.clone(), self.cache.clone());
+            NonEvictableHandle::new(file_id, cache_entry.clone(), self.cache.clone());
 
         {
             let mut guard = self.cache.write().await;
             guard.cur_bytes += cache_entry.file_metadata.file_size;
-            let (cache_succ, files_to_delete) = guard._insert_non_evictable(
+            let (cache_succ, files_to_delete) = guard.insert_non_evictable(
                 file_id,
                 cache_entry_wrapper,
                 self.config.max_bytes,
@@ -282,7 +296,7 @@ mod tests {
             max_bytes: (CONTENT.len() * PARALLEL_TASK_NUM) as u64,
             cache_directory: cache_file_directory.path().to_str().unwrap().to_string(),
         };
-        let cache = ObjectStorageCache::_new(config);
+        let cache = ObjectStorageCache::new(config);
 
         for idx in 0..PARALLEL_TASK_NUM {
             let mut temp_cache = cache.clone();
@@ -296,7 +310,7 @@ mod tests {
                     test_file.to_str().unwrap().to_string(),
                 );
                 let (cache_handle, cache_to_delete) = temp_cache
-                    ._get_cache_entry(data_file.file_id(), data_file.file_path())
+                    .get_cache_entry(data_file.file_id(), data_file.file_path())
                     .await
                     .unwrap();
                 assert!(cache_to_delete.is_empty());

--- a/src/moonlink/src/storage/cache/object_storage/state_tests.rs
+++ b/src/moonlink/src/storage/cache/object_storage/state_tests.rs
@@ -25,9 +25,19 @@ use crate::storage::cache::object_storage::base_cache::{CacheEntry, CacheTrait, 
 use crate::storage::cache::object_storage::cache_config::ObjectStorageCacheConfig;
 use crate::storage::cache::object_storage::object_storage_cache::ObjectStorageCache;
 use crate::storage::cache::object_storage::test_utils::*;
-use crate::storage::storage_utils::FileId;
+use crate::storage::storage_utils::{FileId, TableId, TableUniqueFileId};
 
 use tempfile::tempdir;
+
+/// Test util function to return table unique id, with table id hard-coded to 0.
+fn get_table_unique_file_id(file_id: u64) -> TableUniqueFileId {
+    TableUniqueFileId {
+        table_id: TableId(0),
+        file_id: FileId(file_id),
+    }
+}
+
+/// Test util function to return table unique id, with file id 1.
 
 // (1) + create mooncake snapshot => (2)
 #[tokio::test]
@@ -44,11 +54,11 @@ async fn test_cache_state_1_create_snashot() {
 
     // Check cache handle status.
     let (_, files_to_evict) = cache
-        .import_cache_entry(/*file_id=*/ FileId(0), cache_entry)
+        .import_cache_entry(/*file_id=*/ get_table_unique_file_id(0), cache_entry)
         .await;
     assert_non_evictable_cache_handle_ref_count(
         &mut cache,
-        /*file_id=*/ FileId(0),
+        /*file_id=*/ get_table_unique_file_id(0),
         /*expected_ref_count=*/ 1,
     )
     .await;
@@ -70,14 +80,14 @@ async fn test_cache_1_requested_to_read() {
     // Check cache handle status.
     let (_, files_to_evict) = cache
         .get_cache_entry(
-            /*file_id=*/ FileId(0),
+            /*file_id=*/ get_table_unique_file_id(0),
             test_file.as_path().to_str().unwrap(),
         )
         .await
         .unwrap();
     assert_non_evictable_cache_handle_ref_count(
         &mut cache,
-        /*file_id=*/ FileId(0),
+        /*file_id=*/ get_table_unique_file_id(0),
         /*expected_ref_count=*/ 1,
     )
     .await;
@@ -107,11 +117,11 @@ async fn test_cache_2_requested_to_read_with_sufficient_space() {
         },
     };
     let (_, files_to_evict) = cache
-        .import_cache_entry(/*file_id=*/ FileId(0), cache_entry)
+        .import_cache_entry(/*file_id=*/ get_table_unique_file_id(0), cache_entry)
         .await;
     assert_non_evictable_cache_handle_ref_count(
         &mut cache,
-        /*file_id=*/ FileId(0),
+        /*file_id=*/ get_table_unique_file_id(0),
         /*expected_ref_count=*/ 1,
     )
     .await;
@@ -121,7 +131,7 @@ async fn test_cache_2_requested_to_read_with_sufficient_space() {
     let test_file_2 = create_test_file(remote_file_directory.path(), TEST_FILENAME_2).await;
     let (cache_handle, files_to_evict) = cache
         .get_cache_entry(
-            /*file_id=*/ FileId(1),
+            /*file_id=*/ get_table_unique_file_id(1),
             test_file_2.as_path().to_str().unwrap(),
         )
         .await
@@ -150,11 +160,11 @@ async fn test_cache_2_requested_to_read_with_insufficient_space() {
         },
     };
     let (mut cache_handle, files_to_evict) = cache
-        .import_cache_entry(/*file_id=*/ FileId(0), cache_entry)
+        .import_cache_entry(/*file_id=*/ get_table_unique_file_id(0), cache_entry)
         .await;
     assert_non_evictable_cache_handle_ref_count(
         &mut cache,
-        /*file_id=*/ FileId(0),
+        /*file_id=*/ get_table_unique_file_id(0),
         /*expected_ref_count=*/ 1,
     )
     .await;
@@ -166,14 +176,14 @@ async fn test_cache_2_requested_to_read_with_insufficient_space() {
     // Request to read, thus pinning the cache entry.
     let (_, files_to_evict) = cache
         .get_cache_entry(
-            /*file_id=*/ FileId(0),
+            /*file_id=*/ get_table_unique_file_id(0),
             test_file.as_path().to_str().unwrap(),
         )
         .await
         .unwrap();
     assert_non_evictable_cache_handle_ref_count(
         &mut cache,
-        /*file_id=*/ FileId(0),
+        /*file_id=*/ get_table_unique_file_id(0),
         /*expected_ref_count=*/ 1,
     )
     .await;
@@ -200,11 +210,11 @@ async fn test_cache_3_requested_to_read() {
         },
     };
     let (_, files_to_evict) = cache
-        .import_cache_entry(/*file_id=*/ FileId(0), cache_entry)
+        .import_cache_entry(/*file_id=*/ get_table_unique_file_id(0), cache_entry)
         .await;
     assert_non_evictable_cache_handle_ref_count(
         &mut cache,
-        /*file_id=*/ FileId(0),
+        /*file_id=*/ get_table_unique_file_id(0),
         /*expected_ref_count=*/ 1,
     )
     .await;
@@ -213,14 +223,14 @@ async fn test_cache_3_requested_to_read() {
     // Request to read, thus pinning the cache entry.
     let (_, files_to_evict) = cache
         .get_cache_entry(
-            /*file_id=*/ FileId(0),
+            /*file_id=*/ get_table_unique_file_id(0),
             test_file.as_path().to_str().unwrap(),
         )
         .await
         .unwrap();
     assert_non_evictable_cache_handle_ref_count(
         &mut cache,
-        /*file_id=*/ FileId(0),
+        /*file_id=*/ get_table_unique_file_id(0),
         /*expected_ref_count=*/ 2,
     )
     .await;
@@ -250,11 +260,11 @@ async fn test_cache_2_new_entry_with_sufficient_space() {
         },
     };
     let (mut cache_handle, files_to_evict) = cache
-        .import_cache_entry(/*file_id=*/ FileId(0), cache_entry)
+        .import_cache_entry(/*file_id=*/ get_table_unique_file_id(0), cache_entry)
         .await;
     assert_non_evictable_cache_handle_ref_count(
         &mut cache,
-        /*file_id=*/ FileId(0),
+        /*file_id=*/ get_table_unique_file_id(0),
         /*expected_ref_count=*/ 1,
     )
     .await;
@@ -272,11 +282,11 @@ async fn test_cache_2_new_entry_with_sufficient_space() {
         },
     };
     let (_, files_to_evict) = cache
-        .import_cache_entry(/*file_id=*/ FileId(1), cache_entry)
+        .import_cache_entry(/*file_id=*/ get_table_unique_file_id(1), cache_entry)
         .await;
     assert_non_evictable_cache_handle_ref_count(
         &mut cache,
-        /*file_id=*/ FileId(1),
+        /*file_id=*/ get_table_unique_file_id(1),
         /*expected_ref_count=*/ 1,
     )
     .await;
@@ -306,11 +316,11 @@ async fn test_cache_2_new_entry_with_insufficient_space() {
         },
     };
     let (mut cache_handle_1, files_to_evict) = cache
-        .import_cache_entry(/*file_id=*/ FileId(0), cache_entry)
+        .import_cache_entry(/*file_id=*/ get_table_unique_file_id(0), cache_entry)
         .await;
     assert_non_evictable_cache_handle_ref_count(
         &mut cache,
-        /*file_id=*/ FileId(0),
+        /*file_id=*/ get_table_unique_file_id(0),
         /*expected_ref_count=*/ 1,
     )
     .await;
@@ -328,11 +338,11 @@ async fn test_cache_2_new_entry_with_insufficient_space() {
         },
     };
     let (_, files_to_evict) = cache
-        .import_cache_entry(/*file_id=*/ FileId(1), cache_entry)
+        .import_cache_entry(/*file_id=*/ get_table_unique_file_id(1), cache_entry)
         .await;
     assert_non_evictable_cache_handle_ref_count(
         &mut cache,
-        /*file_id=*/ FileId(1),
+        /*file_id=*/ get_table_unique_file_id(1),
         /*expected_ref_count=*/ 1,
     )
     .await;
@@ -355,14 +365,14 @@ async fn test_cache_3_unpin_still_referenced() {
     // Check cache handle status.
     let (_, files_to_evict) = cache
         .get_cache_entry(
-            /*file_id=*/ FileId(0),
+            /*file_id=*/ get_table_unique_file_id(0),
             test_file.as_path().to_str().unwrap(),
         )
         .await
         .unwrap();
     assert_non_evictable_cache_handle_ref_count(
         &mut cache,
-        /*file_id=*/ FileId(0),
+        /*file_id=*/ get_table_unique_file_id(0),
         /*expected_ref_count=*/ 1,
     )
     .await;
@@ -371,14 +381,14 @@ async fn test_cache_3_unpin_still_referenced() {
     // Get the same cache entry again to increase its reference count.
     let (cache_handle, files_to_evict) = cache
         .get_cache_entry(
-            /*file_id=*/ FileId(0),
+            /*file_id=*/ get_table_unique_file_id(0),
             test_file.as_path().to_str().unwrap(),
         )
         .await
         .unwrap();
     assert_non_evictable_cache_handle_ref_count(
         &mut cache,
-        /*file_id=*/ FileId(0),
+        /*file_id=*/ get_table_unique_file_id(0),
         /*expected_ref_count=*/ 2,
     )
     .await;
@@ -403,14 +413,14 @@ async fn test_cache_3_unpin_not_referenced() {
     // Check cache handle status.
     let (cache_handle_1, files_to_evict) = cache
         .get_cache_entry(
-            /*file_id=*/ FileId(0),
+            /*file_id=*/ get_table_unique_file_id(0),
             test_file.as_path().to_str().unwrap(),
         )
         .await
         .unwrap();
     assert_non_evictable_cache_handle_ref_count(
         &mut cache,
-        /*file_id=*/ FileId(0),
+        /*file_id=*/ get_table_unique_file_id(0),
         /*expected_ref_count=*/ 1,
     )
     .await;
@@ -419,14 +429,14 @@ async fn test_cache_3_unpin_not_referenced() {
     // Get the same cache entry again to increase its reference count.
     let (cache_handle_2, files_to_evict) = cache
         .get_cache_entry(
-            /*file_id=*/ FileId(0),
+            /*file_id=*/ get_table_unique_file_id(0),
             test_file.as_path().to_str().unwrap(),
         )
         .await
         .unwrap();
     assert_non_evictable_cache_handle_ref_count(
         &mut cache,
-        /*file_id=*/ FileId(0),
+        /*file_id=*/ get_table_unique_file_id(0),
         /*expected_ref_count=*/ 2,
     )
     .await;

--- a/src/moonlink/src/storage/cache/object_storage/state_tests.rs
+++ b/src/moonlink/src/storage/cache/object_storage/state_tests.rs
@@ -21,9 +21,8 @@
 /// (3) + query finishes + no reference count => (2)
 ///
 /// For more details, please refer to https://docs.google.com/document/d/1kwXIl4VPzhgzV4KP8yT42M35PfvMJW9PdjNTF7VNEfA/edit?usp=sharing
-use crate::storage::cache::object_storage::base_cache::{
-    CacheEntry, CacheTrait, FileMetadata, ObjectStorageCacheConfig,
-};
+use crate::storage::cache::object_storage::base_cache::{CacheEntry, CacheTrait, FileMetadata};
+use crate::storage::cache::object_storage::cache_config::ObjectStorageCacheConfig;
 use crate::storage::cache::object_storage::object_storage_cache::ObjectStorageCache;
 use crate::storage::cache::object_storage::test_utils::*;
 use crate::storage::storage_utils::FileId;
@@ -45,7 +44,7 @@ async fn test_cache_state_1_create_snashot() {
 
     // Check cache handle status.
     let (_, files_to_evict) = cache
-        ._import_cache_entry(/*file_id=*/ FileId(0), cache_entry)
+        .import_cache_entry(/*file_id=*/ FileId(0), cache_entry)
         .await;
     assert_non_evictable_cache_handle_ref_count(
         &mut cache,
@@ -70,7 +69,7 @@ async fn test_cache_1_requested_to_read() {
 
     // Check cache handle status.
     let (_, files_to_evict) = cache
-        ._get_cache_entry(
+        .get_cache_entry(
             /*file_id=*/ FileId(0),
             test_file.as_path().to_str().unwrap(),
         )
@@ -95,7 +94,7 @@ async fn test_cache_2_requested_to_read_with_sufficient_space() {
     let remote_file_directory = tempdir().unwrap();
     let cache_file_directory = tempdir().unwrap();
     let test_file_1 = create_test_file(remote_file_directory.path(), TEST_FILENAME_1).await;
-    let mut cache = ObjectStorageCache::_new(ObjectStorageCacheConfig {
+    let mut cache = ObjectStorageCache::new(ObjectStorageCacheConfig {
         max_bytes: CONTENT.len() as u64,
         cache_directory: cache_file_directory.path().to_str().unwrap().to_string(),
     });
@@ -108,7 +107,7 @@ async fn test_cache_2_requested_to_read_with_sufficient_space() {
         },
     };
     let (_, files_to_evict) = cache
-        ._import_cache_entry(/*file_id=*/ FileId(0), cache_entry)
+        .import_cache_entry(/*file_id=*/ FileId(0), cache_entry)
         .await;
     assert_non_evictable_cache_handle_ref_count(
         &mut cache,
@@ -121,7 +120,7 @@ async fn test_cache_2_requested_to_read_with_sufficient_space() {
     // Request to read, but failed to pin due to insufficient disk space.
     let test_file_2 = create_test_file(remote_file_directory.path(), TEST_FILENAME_2).await;
     let (cache_handle, files_to_evict) = cache
-        ._get_cache_entry(
+        .get_cache_entry(
             /*file_id=*/ FileId(1),
             test_file_2.as_path().to_str().unwrap(),
         )
@@ -151,7 +150,7 @@ async fn test_cache_2_requested_to_read_with_insufficient_space() {
         },
     };
     let (mut cache_handle, files_to_evict) = cache
-        ._import_cache_entry(/*file_id=*/ FileId(0), cache_entry)
+        .import_cache_entry(/*file_id=*/ FileId(0), cache_entry)
         .await;
     assert_non_evictable_cache_handle_ref_count(
         &mut cache,
@@ -162,11 +161,11 @@ async fn test_cache_2_requested_to_read_with_insufficient_space() {
     assert!(files_to_evict.is_empty());
 
     // Unreference to make cache entry evictable.
-    cache_handle._unreference().await;
+    cache_handle.unreference().await;
 
     // Request to read, thus pinning the cache entry.
     let (_, files_to_evict) = cache
-        ._get_cache_entry(
+        .get_cache_entry(
             /*file_id=*/ FileId(0),
             test_file.as_path().to_str().unwrap(),
         )
@@ -201,7 +200,7 @@ async fn test_cache_3_requested_to_read() {
         },
     };
     let (_, files_to_evict) = cache
-        ._import_cache_entry(/*file_id=*/ FileId(0), cache_entry)
+        .import_cache_entry(/*file_id=*/ FileId(0), cache_entry)
         .await;
     assert_non_evictable_cache_handle_ref_count(
         &mut cache,
@@ -213,7 +212,7 @@ async fn test_cache_3_requested_to_read() {
 
     // Request to read, thus pinning the cache entry.
     let (_, files_to_evict) = cache
-        ._get_cache_entry(
+        .get_cache_entry(
             /*file_id=*/ FileId(0),
             test_file.as_path().to_str().unwrap(),
         )
@@ -238,7 +237,7 @@ async fn test_cache_2_new_entry_with_sufficient_space() {
     let remote_file_directory = tempdir().unwrap();
     let cache_file_directory = tempdir().unwrap();
     let test_file = create_test_file(remote_file_directory.path(), TEST_FILENAME_1).await;
-    let mut cache = ObjectStorageCache::_new(ObjectStorageCacheConfig {
+    let mut cache = ObjectStorageCache::new(ObjectStorageCacheConfig {
         max_bytes: (CONTENT.len() * 2) as u64,
         cache_directory: cache_file_directory.path().to_str().unwrap().to_string(),
     });
@@ -251,7 +250,7 @@ async fn test_cache_2_new_entry_with_sufficient_space() {
         },
     };
     let (mut cache_handle, files_to_evict) = cache
-        ._import_cache_entry(/*file_id=*/ FileId(0), cache_entry)
+        .import_cache_entry(/*file_id=*/ FileId(0), cache_entry)
         .await;
     assert_non_evictable_cache_handle_ref_count(
         &mut cache,
@@ -262,7 +261,7 @@ async fn test_cache_2_new_entry_with_sufficient_space() {
     assert!(files_to_evict.is_empty());
 
     // Unreference to make cache entry evictable.
-    cache_handle._unreference().await;
+    cache_handle.unreference().await;
 
     // Import the second cache file.
     let test_file = create_test_file(remote_file_directory.path(), TEST_FILENAME_2).await;
@@ -273,7 +272,7 @@ async fn test_cache_2_new_entry_with_sufficient_space() {
         },
     };
     let (_, files_to_evict) = cache
-        ._import_cache_entry(/*file_id=*/ FileId(1), cache_entry)
+        .import_cache_entry(/*file_id=*/ FileId(1), cache_entry)
         .await;
     assert_non_evictable_cache_handle_ref_count(
         &mut cache,
@@ -294,7 +293,7 @@ async fn test_cache_2_new_entry_with_insufficient_space() {
     let remote_file_directory = tempdir().unwrap();
     let cache_file_directory = tempdir().unwrap();
     let test_file = create_test_file(remote_file_directory.path(), TEST_FILENAME_1).await;
-    let mut cache = ObjectStorageCache::_new(ObjectStorageCacheConfig {
+    let mut cache = ObjectStorageCache::new(ObjectStorageCacheConfig {
         max_bytes: CONTENT.len() as u64,
         cache_directory: cache_file_directory.path().to_str().unwrap().to_string(),
     });
@@ -307,7 +306,7 @@ async fn test_cache_2_new_entry_with_insufficient_space() {
         },
     };
     let (mut cache_handle_1, files_to_evict) = cache
-        ._import_cache_entry(/*file_id=*/ FileId(0), cache_entry)
+        .import_cache_entry(/*file_id=*/ FileId(0), cache_entry)
         .await;
     assert_non_evictable_cache_handle_ref_count(
         &mut cache,
@@ -318,7 +317,7 @@ async fn test_cache_2_new_entry_with_insufficient_space() {
     assert!(files_to_evict.is_empty());
 
     // Unreference to make cache entry evictable.
-    cache_handle_1._unreference().await;
+    cache_handle_1.unreference().await;
 
     // Import the second cache file.
     let test_file = create_test_file(remote_file_directory.path(), TEST_FILENAME_2).await;
@@ -329,7 +328,7 @@ async fn test_cache_2_new_entry_with_insufficient_space() {
         },
     };
     let (_, files_to_evict) = cache
-        ._import_cache_entry(/*file_id=*/ FileId(1), cache_entry)
+        .import_cache_entry(/*file_id=*/ FileId(1), cache_entry)
         .await;
     assert_non_evictable_cache_handle_ref_count(
         &mut cache,
@@ -355,7 +354,7 @@ async fn test_cache_3_unpin_still_referenced() {
 
     // Check cache handle status.
     let (_, files_to_evict) = cache
-        ._get_cache_entry(
+        .get_cache_entry(
             /*file_id=*/ FileId(0),
             test_file.as_path().to_str().unwrap(),
         )
@@ -371,7 +370,7 @@ async fn test_cache_3_unpin_still_referenced() {
 
     // Get the same cache entry again to increase its reference count.
     let (cache_handle, files_to_evict) = cache
-        ._get_cache_entry(
+        .get_cache_entry(
             /*file_id=*/ FileId(0),
             test_file.as_path().to_str().unwrap(),
         )
@@ -386,7 +385,7 @@ async fn test_cache_3_unpin_still_referenced() {
     assert!(files_to_evict.is_empty());
 
     // Unreference one of the cache handles.
-    cache_handle.unwrap()._unreference().await;
+    cache_handle.unwrap().unreference().await;
 
     // Check cache status.
     assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 1).await;
@@ -403,7 +402,7 @@ async fn test_cache_3_unpin_not_referenced() {
 
     // Check cache handle status.
     let (cache_handle_1, files_to_evict) = cache
-        ._get_cache_entry(
+        .get_cache_entry(
             /*file_id=*/ FileId(0),
             test_file.as_path().to_str().unwrap(),
         )
@@ -419,7 +418,7 @@ async fn test_cache_3_unpin_not_referenced() {
 
     // Get the same cache entry again to increase its reference count.
     let (cache_handle_2, files_to_evict) = cache
-        ._get_cache_entry(
+        .get_cache_entry(
             /*file_id=*/ FileId(0),
             test_file.as_path().to_str().unwrap(),
         )
@@ -434,8 +433,8 @@ async fn test_cache_3_unpin_not_referenced() {
     assert!(files_to_evict.is_empty());
 
     // Unreference all cache handles.
-    cache_handle_1.unwrap()._unreference().await;
-    cache_handle_2.unwrap()._unreference().await;
+    cache_handle_1.unwrap().unreference().await;
+    cache_handle_2.unwrap().unreference().await;
 
     // Check cache status.
     assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 0).await;

--- a/src/moonlink/src/storage/cache/object_storage/test_utils.rs
+++ b/src/moonlink/src/storage/cache/object_storage/test_utils.rs
@@ -2,9 +2,8 @@ use tempfile::TempDir;
 use tokio::io::AsyncReadExt;
 use tokio::io::AsyncWriteExt;
 
-use crate::storage::cache::object_storage::{
-    base_cache::ObjectStorageCacheConfig, object_storage_cache::ObjectStorageCache,
-};
+use crate::storage::cache::object_storage::cache_config::ObjectStorageCacheConfig;
+use crate::storage::cache::object_storage::object_storage_cache::ObjectStorageCache;
 use crate::storage::storage_utils::FileId;
 
 /// Content for test files.
@@ -45,7 +44,7 @@ pub(crate) fn get_test_cache_config(tmp_dir: &TempDir) -> ObjectStorageCacheConf
 /// Test util function to create object storage cache.
 pub(crate) fn get_test_object_storage_cache(tmp_dir: &TempDir) -> ObjectStorageCache {
     let config = get_test_cache_config(tmp_dir);
-    ObjectStorageCache::_new(config)
+    ObjectStorageCache::new(config)
 }
 
 /// Test util function to get cache file number.

--- a/src/moonlink/src/storage/cache/object_storage/test_utils.rs
+++ b/src/moonlink/src/storage/cache/object_storage/test_utils.rs
@@ -4,7 +4,7 @@ use tokio::io::AsyncWriteExt;
 
 use crate::storage::cache::object_storage::cache_config::ObjectStorageCacheConfig;
 use crate::storage::cache::object_storage::object_storage_cache::ObjectStorageCache;
-use crate::storage::storage_utils::FileId;
+use crate::storage::storage_utils::TableUniqueFileId;
 
 /// Content for test files.
 pub(crate) const CONTENT: &[u8; 10] = b"0123456789";
@@ -81,7 +81,7 @@ pub(crate) async fn assert_non_evictable_cache_size(
 /// Test util function to check non-evictable cache handle reference count.
 pub(crate) async fn assert_non_evictable_cache_handle_ref_count(
     cache: &mut ObjectStorageCache,
-    file_id: FileId,
+    file_id: TableUniqueFileId,
     expected_ref_count: u32,
 ) {
     let guard = cache.cache.read().await;

--- a/src/moonlink/src/storage/compaction/compactor.rs
+++ b/src/moonlink/src/storage/compaction/compactor.rs
@@ -62,7 +62,6 @@ pub(crate) struct CompactionBuilder {
     compacted_file_count: u64,
 }
 
-// TODO(hjiang): CompactionBuilder should take a config to decide how big a compacted file should be, like DiskSliceWriter.
 impl CompactionBuilder {
     pub(crate) fn new(
         compaction_payload: DataCompactionPayload,
@@ -286,6 +285,8 @@ impl CompactionBuilder {
     }
 
     /// Perform a compaction operation, and get the result back.
+    ///
+    /// TODO(hjiang): compaction should leverage read-through/write-through cache.
     pub(crate) async fn build(mut self) -> Result<DataCompactionResult> {
         let old_data_files = self
             .compaction_payload

--- a/src/moonlink/src/storage/compaction/table_compaction.rs
+++ b/src/moonlink/src/storage/compaction/table_compaction.rs
@@ -8,7 +8,7 @@ use std::collections::HashSet;
 
 /// Payload to trigger a compaction operation.
 #[derive(Clone, Debug)]
-pub(crate) struct DataCompactionPayload {
+pub struct DataCompactionPayload {
     /// Maps from data file to their deletion records.
     pub(crate) disk_files: HashMap<MooncakeDataFileRef, Option<PuffinBlobRef>>,
     /// File indices to compact and rewrite.
@@ -33,7 +33,7 @@ pub(crate) struct RemappedRecordLocation {
 
 /// Result for a compaction operation.
 #[derive(Clone, Debug, PartialEq)]
-pub(crate) struct DataCompactionResult {
+pub struct DataCompactionResult {
     /// Data files which get compacted, maps from old record location to new one.
     pub(crate) remapped_data_files: HashMap<RecordLocation, RemappedRecordLocation>,
     /// Old compacted data files, which maps to their corresponding compacted data file.

--- a/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
@@ -316,6 +316,7 @@ impl IcebergTableManager {
                 DiskFileEntry {
                     file_size: data_file_entry.data_file.file_size_in_bytes() as usize,
                     file_indice: Some(file_indice),
+                    cache_handle: None,
                     puffin_deletion_blob: data_file_entry.persisted_deletion_vector.clone(),
                     batch_deletion_vector: data_file_entry.deletion_vector.clone(),
                 },

--- a/src/moonlink/src/storage/iceberg/test_utils.rs
+++ b/src/moonlink/src/storage/iceberg/test_utils.rs
@@ -16,6 +16,7 @@ use crate::storage::mooncake_table::{
 };
 use crate::storage::MooncakeTable;
 use crate::table_notify::TableNotify;
+use crate::ObjectStorageCache;
 use crate::Result;
 
 use arrow::datatypes::Schema as ArrowSchema;
@@ -208,6 +209,7 @@ pub(crate) async fn create_table_and_iceberg_manager_with_data_compaction_config
         identity_property,
         iceberg_table_config.clone(),
         mooncake_table_config,
+        ObjectStorageCache::default_for_test(),
     )
     .await
     .unwrap();
@@ -219,7 +221,7 @@ pub(crate) async fn create_table_and_iceberg_manager_with_data_compaction_config
     .unwrap();
 
     let (notify_tx, notify_rx) = mpsc::channel(100);
-    table.register_table_notify(notify_tx);
+    table.register_table_notify(notify_tx).await;
 
     (table, iceberg_table_manager, notify_rx)
 }
@@ -232,6 +234,7 @@ pub(crate) async fn get_mooncake_snapshot_result(
     Option<IcebergSnapshotPayload>,
     Option<FileIndiceMergePayload>,
     Option<DataCompactionPayload>,
+    Vec<String>,
 ) {
     let notification = notify_rx.recv().await.unwrap();
     match notification {
@@ -240,11 +243,13 @@ pub(crate) async fn get_mooncake_snapshot_result(
             iceberg_snapshot_payload,
             file_indice_merge_payload,
             data_compaction_payload,
+            evicted_data_files_to_delete,
         } => (
             lsn,
             iceberg_snapshot_payload,
             file_indice_merge_payload,
             data_compaction_payload,
+            evicted_data_files_to_delete,
         ),
         _ => {
             panic!("Expects to receive mooncake snapshot completion notification, but receives others.");
@@ -261,6 +266,7 @@ pub(crate) async fn create_mooncake_snapshot(
     Option<IcebergSnapshotPayload>,
     Option<FileIndiceMergePayload>,
     Option<DataCompactionPayload>,
+    Vec<String>,
 ) {
     assert!(table.create_snapshot(SnapshotOption::default()));
     get_mooncake_snapshot_result(notify_rx).await

--- a/src/moonlink/src/storage/iceberg/tests.rs
+++ b/src/moonlink/src/storage/iceberg/tests.rs
@@ -28,6 +28,7 @@ use crate::storage::storage_utils::MooncakeDataFileRef;
 use crate::storage::storage_utils::RawDeletionRecord;
 use crate::storage::storage_utils::RecordLocation;
 use crate::storage::MooncakeTable;
+use crate::ObjectStorageCache;
 
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -603,10 +604,11 @@ async fn test_index_merge_and_create_snapshot() {
         mooncake_table_metadata.clone(),
         Box::new(iceberg_table_manager),
         mooncake_table_config.clone(),
+        ObjectStorageCache::default_for_test(),
     )
     .await
     .unwrap();
-    mooncake_table.register_table_notify(notify_tx);
+    mooncake_table.register_table_notify(notify_tx).await;
 
     // Append one row and commit/flush, so we have one file indice persisted.
     let row_1 = test_row_1();
@@ -713,11 +715,12 @@ async fn test_create_snapshot_when_no_committed_deletion_log_to_flush() {
         identity_property,
         iceberg_table_config.clone(),
         MooncakeTableConfig::default(),
+        ObjectStorageCache::default_for_test(),
     )
     .await
     .unwrap();
     let (notify_tx, mut notify_rx) = mpsc::channel(100);
-    table.register_table_notify(notify_tx);
+    table.register_table_notify(notify_tx).await;
 
     let row = test_row_1();
     table.append(row.clone()).unwrap();
@@ -732,7 +735,7 @@ async fn test_create_snapshot_when_no_committed_deletion_log_to_flush() {
     table.delete(row.clone(), /*lsn=*/ 20).await;
     table.commit(/*lsn=*/ 30);
 
-    let (_, iceberg_snapshot_payload, _, _) =
+    let (_, iceberg_snapshot_payload, _, _, _) =
         create_mooncake_snapshot(&mut table, &mut notify_rx).await;
     assert!(iceberg_snapshot_payload.is_none());
 }
@@ -757,11 +760,12 @@ async fn test_skip_iceberg_snapshot() {
         identity_property,
         iceberg_table_config.clone(),
         MooncakeTableConfig::default(),
+        ObjectStorageCache::default_for_test(),
     )
     .await
     .unwrap();
     let (notify_tx, mut notify_rx) = mpsc::channel(100);
-    table.register_table_notify(notify_tx);
+    table.register_table_notify(notify_tx).await;
 
     // Persist data file to local filesystem, so iceberg snapshot should be created, if skip iceberg not specified.
     let row = test_row_1();
@@ -776,7 +780,7 @@ async fn test_skip_iceberg_snapshot() {
         skip_file_indices_merge: false,
         skip_data_file_compaction: false,
     }));
-    let (_, iceberg_snapshot_payload, _, _) = get_mooncake_snapshot_result(&mut notify_rx).await;
+    let (_, iceberg_snapshot_payload, _, _, _) = get_mooncake_snapshot_result(&mut notify_rx).await;
     assert!(iceberg_snapshot_payload.is_none());
 }
 
@@ -810,11 +814,12 @@ async fn test_small_batch_size_and_large_parquet_size() {
         identity_property,
         iceberg_table_config.clone(),
         mooncake_table_config,
+        ObjectStorageCache::default_for_test(),
     )
     .await
     .unwrap();
     let (notify_tx, mut notify_rx) = mpsc::channel(100);
-    table.register_table_notify(notify_tx);
+    table.register_table_notify(notify_tx).await;
 
     // Append first row.
     let row_1 = test_row_1();
@@ -902,7 +907,7 @@ async fn test_async_iceberg_snapshot() {
     table.append(row_1.clone()).unwrap();
     table.commit(/*lsn=*/ 10);
     table.flush(/*lsn=*/ 10).await.unwrap();
-    let (_, iceberg_snapshot_payload, _, _) =
+    let (_, iceberg_snapshot_payload, _, _, _) =
         create_mooncake_snapshot(&mut table, &mut notify_rx).await;
 
     // Operation group 2: Append new rows and create mooncake snapshot.
@@ -911,7 +916,7 @@ async fn test_async_iceberg_snapshot() {
     table.delete(row_1.clone(), /*lsn=*/ 20).await;
     table.commit(/*lsn=*/ 30);
     table.flush(/*lsn=*/ 30).await.unwrap();
-    let (_, _, _, _) = create_mooncake_snapshot(&mut table, &mut notify_rx).await;
+    let (_, _, _, _, _) = create_mooncake_snapshot(&mut table, &mut notify_rx).await;
 
     // Create iceberg snapshot for the first mooncake snapshot.
     let iceberg_snapshot_result =
@@ -945,7 +950,7 @@ async fn test_async_iceberg_snapshot() {
     table.append(row_3.clone()).unwrap();
     table.commit(/*lsn=*/ 40);
     table.flush(/*lsn=*/ 40).await.unwrap();
-    let (_, iceberg_snapshot_payload, _, _) =
+    let (_, iceberg_snapshot_payload, _, _, _) =
         create_mooncake_snapshot(&mut table, &mut notify_rx).await;
 
     // Create iceberg snapshot for the mooncake snapshot.
@@ -1086,10 +1091,11 @@ async fn mooncake_table_snapshot_persist_impl(warehouse_uri: String) -> IcebergR
         identity_property.clone(),
         iceberg_table_config.clone(),
         mooncake_table_config,
+        ObjectStorageCache::default_for_test(),
     )
     .await
     .unwrap();
-    table.register_table_notify(notify_tx);
+    table.register_table_notify(notify_tx).await;
 
     // Perform a few table write operations.
     //
@@ -1468,6 +1474,7 @@ async fn test_drop_table_at_creation() -> IcebergResult<()> {
         mooncake_table_metadata.identity.clone(),
         iceberg_table_config.clone(),
         mooncake_table_config,
+        ObjectStorageCache::default_for_test(),
     )
     .await
     .unwrap();

--- a/src/moonlink/src/storage/iceberg/tests.rs
+++ b/src/moonlink/src/storage/iceberg/tests.rs
@@ -603,7 +603,6 @@ async fn test_index_merge_and_create_snapshot() {
     let mut mooncake_table = MooncakeTable::new_with_table_manager(
         mooncake_table_metadata.clone(),
         Box::new(iceberg_table_manager),
-        mooncake_table_config.clone(),
         ObjectStorageCache::default_for_test(),
     )
     .await

--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -4,6 +4,7 @@ mod disk_slice;
 mod mem_slice;
 mod shared_array;
 mod snapshot;
+pub mod snapshot_read_output;
 mod table_snapshot;
 mod transaction_stream;
 
@@ -13,6 +14,7 @@ use super::index::{FileIndex, MemIndex, MooncakeIndex};
 use super::storage_utils::{MooncakeDataFileRef, RawDeletionRecord, RecordLocation};
 use crate::error::{Error, Result};
 use crate::row::{IdentityProp, MoonlinkRow};
+use crate::storage::cache::object_storage::object_storage_cache::ObjectStorageCache;
 use crate::storage::compaction::compaction_config::DataCompactionConfig;
 use crate::storage::compaction::compactor::{CompactionBuilder, CompactionFileParams};
 use crate::storage::compaction::table_compaction::{CompactedDataEntry, RemappedRecordLocation};
@@ -22,6 +24,7 @@ pub(crate) use crate::storage::compaction::table_compaction::{
 use crate::storage::iceberg::iceberg_table_manager::{IcebergTableConfig, IcebergTableManager};
 use crate::storage::iceberg::table_manager::TableManager;
 use crate::storage::mooncake_table::shared_array::SharedRowBufferSnapshot;
+pub use crate::storage::mooncake_table::snapshot_read_output::ReadOutput as SnapshotReadOutput;
 #[cfg(test)]
 pub(crate) use crate::storage::mooncake_table::table_snapshot::IcebergSnapshotDataCompactionPayload;
 pub(crate) use crate::storage::mooncake_table::table_snapshot::{
@@ -34,6 +37,7 @@ use crate::storage::storage_utils::FileId;
 #[cfg(test)]
 use crate::storage::storage_utils::ProcessedDeletionRecord;
 use crate::table_notify::TableNotify;
+use crate::NonEvictableHandle;
 use std::collections::{HashMap, HashSet};
 use std::mem::take;
 use std::path::PathBuf;
@@ -157,6 +161,8 @@ pub struct TableMetadata {
 
 #[derive(Clone, Debug)]
 pub(crate) struct DiskFileEntry {
+    /// Cache handle. If assigned, it's pinned in data file cache.
+    pub(crate) cache_handle: Option<NonEvictableHandle>,
     /// File size.
     pub(crate) file_size: usize,
     /// File indices.
@@ -241,6 +247,10 @@ pub struct SnapshotTask {
     /// streaming xact
     new_streaming_xact: Vec<TransactionStreamOutput>,
 
+    /// --- States related to read operation ---
+    read_involved_file_ids: Vec<FileId>,
+    read_cache_handles: Vec<NonEvictableHandle>,
+
     /// --- States related to file indices merge operation ---
     /// These persisted items will be reflected to mooncake snapshot in the next invocation of periodic mooncake snapshot operation.
     ///
@@ -302,6 +312,9 @@ impl SnapshotTask {
             new_flush_lsn: None,
             new_commit_point: None,
             new_streaming_xact: Vec::new(),
+            // Read request related fields.
+            read_involved_file_ids: Vec::new(),
+            read_cache_handles: Vec::new(),
             // Index merge related fields.
             old_merged_file_indices: HashSet::new(),
             new_merged_file_indices: Vec::new(),
@@ -456,6 +469,7 @@ impl MooncakeTable {
         identity: IdentityProp,
         iceberg_table_config: IcebergTableConfig,
         table_config: TableConfig,
+        data_file_cache: ObjectStorageCache,
     ) -> Result<Self> {
         let metadata = Arc::new(TableMetadata {
             name,
@@ -469,13 +483,20 @@ impl MooncakeTable {
             metadata.clone(),
             iceberg_table_config,
         )?);
-        Self::new_with_table_manager(metadata, iceberg_table_manager, table_config).await
+        Self::new_with_table_manager(
+            metadata,
+            iceberg_table_manager,
+            table_config,
+            data_file_cache,
+        )
+        .await
     }
 
     pub(crate) async fn new_with_table_manager(
         table_metadata: Arc<TableMetadata>,
         mut table_manager: Box<dyn TableManager>,
         table_config: TableConfig,
+        data_file_cache: ObjectStorageCache,
     ) -> Result<Self> {
         let (table_snapshot_watch_sender, table_snapshot_watch_receiver) = watch::channel(0);
         Ok(Self {
@@ -486,7 +507,8 @@ impl MooncakeTable {
             ),
             metadata: table_metadata.clone(),
             snapshot: Arc::new(RwLock::new(
-                SnapshotTableState::new(table_metadata, &mut *table_manager).await?,
+                SnapshotTableState::new(table_metadata, data_file_cache, &mut *table_manager)
+                    .await?,
             )),
             next_snapshot_task: SnapshotTask::new(table_config),
             transaction_stream_states: HashMap::new(),
@@ -506,9 +528,13 @@ impl MooncakeTable {
 
     /// Register event completion notifier.
     /// Notice it should be registered only once, which could be used to notify multiple events.
-    pub(crate) fn register_table_notify(&mut self, table_notify: Sender<TableNotify>) {
+    pub(crate) async fn register_table_notify(&mut self, table_notify: Sender<TableNotify>) {
         assert!(self.table_notify.is_none());
-        self.table_notify = Some(table_notify);
+        self.table_notify = Some(table_notify.clone());
+        self.snapshot
+            .write()
+            .await
+            .register_table_notify(table_notify);
     }
 
     /// Set iceberg snapshot flush LSN, called after a snapshot operation.
@@ -589,6 +615,20 @@ impl MooncakeTable {
             .iceberg_persisted_old_merged_file_indices = iceberg_snapshot_res
             .index_merge_result
             .old_file_indices_to_remove;
+    }
+
+    /// Set read request completion result, which will be sync-ed to mooncake table snapshot in the next periodic snapshot iteration.
+    pub(crate) fn set_read_request_res(
+        &mut self,
+        involved_file_ids: Vec<FileId>,
+        cache_handles: Vec<NonEvictableHandle>,
+    ) {
+        self.next_snapshot_task
+            .read_involved_file_ids
+            .extend(involved_file_ids);
+        self.next_snapshot_task
+            .read_cache_handles
+            .extend(cache_handles);
     }
 
     /// Set file indices merge result, which will be sync-ed to mooncake and iceberg snapshot in the next periodic snapshot iteration.
@@ -945,18 +985,18 @@ impl MooncakeTable {
         opt: SnapshotOption,
         table_notify: Sender<TableNotify>,
     ) {
-        let (lsn, iceberg_snapshot_payload, data_compaction_payload, file_indice_merge_payload) =
-            snapshot
-                .write()
-                .await
-                .update_snapshot(next_snapshot_task, opt)
-                .await;
+        let snapshot_result = snapshot
+            .write()
+            .await
+            .update_snapshot(next_snapshot_task, opt)
+            .await;
         table_notify
             .send(TableNotify::MooncakeTableSnapshot {
-                lsn,
-                iceberg_snapshot_payload,
-                data_compaction_payload,
-                file_indice_merge_payload,
+                lsn: snapshot_result.commit_lsn,
+                iceberg_snapshot_payload: snapshot_result.iceberg_snapshot_payload,
+                data_compaction_payload: snapshot_result.data_compaction_payload,
+                file_indice_merge_payload: snapshot_result.file_indices_merge_payload,
+                evicted_data_files_to_delete: snapshot_result.evicted_data_files_to_delete,
             })
             .await
             .unwrap();
@@ -974,12 +1014,14 @@ impl MooncakeTable {
         Option<IcebergSnapshotPayload>,
         Option<FileIndiceMergePayload>,
         Option<DataCompactionPayload>,
+        Vec<String>,
     ) {
         let notification = receiver.recv().await.unwrap();
         if let TableNotify::MooncakeTableSnapshot {
             iceberg_snapshot_payload,
             file_indice_merge_payload,
             data_compaction_payload,
+            evicted_data_files_to_delete,
             ..
         } = notification
         {
@@ -987,6 +1029,7 @@ impl MooncakeTable {
                 iceberg_snapshot_payload,
                 file_indice_merge_payload,
                 data_compaction_payload,
+                evicted_data_files_to_delete,
             )
         } else {
             panic!("Expected mooncake snapshot completion notification, but get others.");
@@ -1034,7 +1077,13 @@ impl MooncakeTable {
         if !mooncake_snapshot_created {
             return Ok(());
         }
-        let (iceberg_snapshot_payload, _, _) = Self::sync_mooncake_snapshot(receiver).await;
+        let (iceberg_snapshot_payload, _, _, evicted_data_files_to_delete) =
+            Self::sync_mooncake_snapshot(receiver).await;
+
+        // Delete evicted data file cache entries immediately to make sure later accesses all happen on persisted files.
+        for cur_data_file in evicted_data_files_to_delete.into_iter() {
+            tokio::fs::remove_file(&cur_data_file).await.unwrap();
+        }
 
         // Create iceberg snapshot if possible.
         if let Some(iceberg_snapshot_payload) = iceberg_snapshot_payload {
@@ -1070,7 +1119,13 @@ impl MooncakeTable {
         assert!(self.create_snapshot(force_snapshot_option.clone()));
 
         // Create iceberg snapshot.
-        let (iceberg_snapshot_payload, _, _) = Self::sync_mooncake_snapshot(receiver).await;
+        let (iceberg_snapshot_payload, _, _, evicted_data_file_cache) =
+            Self::sync_mooncake_snapshot(receiver).await;
+        // Delete evicted data file cache entries immediately to make sure later accesses all happen on persisted files.
+        for cur_data_file in evicted_data_file_cache.into_iter() {
+            tokio::fs::remove_file(&cur_data_file).await.unwrap();
+        }
+
         if let Some(iceberg_snapshot_payload) = iceberg_snapshot_payload {
             self.persist_iceberg_snapshot(iceberg_snapshot_payload);
             let iceberg_snapshot_result = Self::sync_iceberg_snapshot(receiver).await;
@@ -1079,8 +1134,13 @@ impl MooncakeTable {
 
         // Get data compaction payload.
         assert!(self.create_snapshot(force_snapshot_option.clone()));
-        let (iceberg_snapshot_payload, _, data_compaction_payload) =
+        let (iceberg_snapshot_payload, _, data_compaction_payload, evicted_data_file_cache) =
             Self::sync_mooncake_snapshot(receiver).await;
+        // Delete evicted data file cache entries immediately to make sure later accesses all happen on persisted files.
+        for cur_data_file in evicted_data_file_cache.into_iter() {
+            tokio::fs::remove_file(&cur_data_file).await.unwrap();
+        }
+
         assert!(iceberg_snapshot_payload.is_none());
         let data_compaction_payload = data_compaction_payload.unwrap();
 
@@ -1106,7 +1166,13 @@ impl MooncakeTable {
             skip_file_indices_merge: true,
             skip_data_file_compaction: false,
         }));
-        let (iceberg_snapshot_payload, _, _) = Self::sync_mooncake_snapshot(receiver).await;
+        let (iceberg_snapshot_payload, _, _, evicted_data_file_cache) =
+            Self::sync_mooncake_snapshot(receiver).await;
+        // Delete evicted data file cache entries immediately to make sure later accesses all happen on persisted files.
+        for cur_data_file in evicted_data_file_cache.into_iter() {
+            tokio::fs::remove_file(&cur_data_file).await.unwrap();
+        }
+
         let iceberg_snapshot_payload = iceberg_snapshot_payload.unwrap();
         self.persist_iceberg_snapshot(iceberg_snapshot_payload);
         let iceberg_snapshot_result = Self::sync_iceberg_snapshot(receiver).await;
@@ -1142,7 +1208,13 @@ impl MooncakeTable {
         assert!(self.create_snapshot(force_snapshot_option.clone()));
 
         // Create iceberg snapshot.
-        let (iceberg_snapshot_payload, _, _) = Self::sync_mooncake_snapshot(receiver).await;
+        let (iceberg_snapshot_payload, _, _, evicted_data_file_cache) =
+            Self::sync_mooncake_snapshot(receiver).await;
+        // Delete evicted data file cache entries immediately to make sure later accesses all happen on persisted files.
+        for cur_data_file in evicted_data_file_cache.into_iter() {
+            tokio::fs::remove_file(&cur_data_file).await.unwrap();
+        }
+
         if let Some(iceberg_snapshot_payload) = iceberg_snapshot_payload {
             self.persist_iceberg_snapshot(iceberg_snapshot_payload);
             let iceberg_snapshot_result = Self::sync_iceberg_snapshot(receiver).await;
@@ -1151,8 +1223,13 @@ impl MooncakeTable {
 
         // Perform index merge.
         assert!(self.create_snapshot(force_snapshot_option.clone()));
-        let (iceberg_snapshot_payload, file_indice_merge_payload, _) =
+        let (iceberg_snapshot_payload, file_indice_merge_payload, _, evicted_data_file_cache) =
             Self::sync_mooncake_snapshot(receiver).await;
+        // Delete evicted data file cache entries immediately to make sure later accesses all happen on persisted files.
+        for cur_data_file in evicted_data_file_cache.into_iter() {
+            tokio::fs::remove_file(&cur_data_file).await.unwrap();
+        }
+
         assert!(iceberg_snapshot_payload.is_none());
         let file_indice_merge_payload = file_indice_merge_payload.unwrap();
 
@@ -1174,7 +1251,13 @@ impl MooncakeTable {
             skip_file_indices_merge: false,
             skip_data_file_compaction: false,
         }));
-        let (iceberg_snapshot_payload, _, _) = Self::sync_mooncake_snapshot(receiver).await;
+        let (iceberg_snapshot_payload, _, _, evicted_data_file_cache) =
+            Self::sync_mooncake_snapshot(receiver).await;
+        // Delete evicted data file cache entries immediately to make sure later accesses all happen on persisted files.
+        for cur_data_file in evicted_data_file_cache.into_iter() {
+            tokio::fs::remove_file(&cur_data_file).await.unwrap();
+        }
+
         let iceberg_snapshot_payload = iceberg_snapshot_payload.unwrap();
         self.persist_iceberg_snapshot(iceberg_snapshot_payload);
         let iceberg_snapshot_result = Self::sync_iceberg_snapshot(receiver).await;

--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -136,7 +136,7 @@ pub(crate) struct MooncakeSnapshotOutput {
     pub(crate) data_compaction_payload: Option<DataCompactionPayload>,
     /// File indice merge payload.
     pub(crate) file_indices_merge_payload: Option<FileIndiceMergePayload>,
-    /// Evicted local data cache files.
+    /// Evicted local data cache files to delete.
     pub(crate) evicted_data_files_to_delete: Vec<String>,
 }
 
@@ -425,8 +425,6 @@ impl SnapshotTableState {
 
     /// Util function to decide whether and what to compact data files.
     /// To simplify states (aka, avoid data compaction already in iceberg with those not), only merge those already persisted.
-    ///
-    /// TODO(hjiang): Pin data file if possible.
     fn get_payload_to_compact(&self) -> Option<DataCompactionPayload> {
         // Fast-path: not enough data files to trigger compaction.
         let all_disk_files = &self.current_snapshot.disk_files;

--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -4,6 +4,10 @@ use super::{
     DiskFileEntry, IcebergSnapshotPayload, Snapshot, SnapshotTask, TableConfig, TableMetadata,
 };
 use crate::error::Result;
+use crate::storage::cache::object_storage::base_cache::{
+    CacheEntry as DataFileCacheEntry, CacheTrait, FileMetadata,
+};
+use crate::storage::cache::object_storage::object_storage_cache::ObjectStorageCache;
 use crate::storage::compaction::table_compaction::{
     CompactedDataEntry, DataCompactionPayload, RemappedRecordLocation,
 };
@@ -11,6 +15,9 @@ use crate::storage::iceberg::puffin_utils::PuffinBlobRef;
 use crate::storage::iceberg::table_manager::TableManager;
 use crate::storage::index::FileIndex;
 use crate::storage::mooncake_table::shared_array::SharedRowBufferSnapshot;
+use crate::storage::mooncake_table::snapshot_read_output::{
+    DataFileForRead, ReadOutput as SnapshotReadOutput,
+};
 use crate::storage::mooncake_table::table_snapshot::{
     FileIndiceMergePayload, IcebergSnapshotDataCompactionPayload,
 };
@@ -23,6 +30,7 @@ use crate::storage::storage_utils::{
     MooncakeDataFile, MooncakeDataFileRef, ProcessedDeletionRecord, RawDeletionRecord,
     RecordLocation,
 };
+use crate::table_notify::TableNotify;
 use more_asserts as ma;
 use parquet::arrow::AsyncArrowWriter;
 use parquet::basic::{Compression, Encoding};
@@ -31,6 +39,7 @@ use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::mem::take;
 use std::sync::Arc;
+use tokio::sync::mpsc::Sender;
 pub(crate) struct SnapshotTableState {
     /// Mooncake table config.
     mooncake_table_config: TableConfig,
@@ -59,6 +68,12 @@ pub(crate) struct SnapshotTableState {
 
     /// Last commit point
     last_commit: RecordLocation,
+
+    /// Data file cache.
+    pub(super) data_file_cache: ObjectStorageCache,
+
+    /// Table notifier.
+    table_notify: Option<Sender<TableNotify>>,
 
     /// ---- Items not persisted to iceberg snapshot ----
     ///
@@ -112,24 +127,23 @@ struct UnpersistedIcebergSnapshotRecords {
     compacted_file_indices_to_add: Vec<FileIndex>,
 }
 
-pub struct ReadOutput {
-    /// Contains two parts:
-    /// 1. Committed and persisted data files.
-    /// 2. Associated files, which include committed but un-persisted records.
-    pub data_file_paths: Vec<String>,
-    /// Puffin file paths.
-    pub puffin_file_paths: Vec<String>,
-    /// Deletion vectors persisted in puffin files.
-    pub deletion_vectors: Vec<PuffinDeletionBlobAtRead>,
-    /// Committed but un-persisted positional deletion records.
-    pub position_deletes: Vec<(u32 /*file_index*/, u32 /*row_index*/)>,
-    /// Contains committed but non-persisted record batches, which are persisted as temporary data files on local filesystem.
-    pub associated_files: Vec<String>,
+pub(crate) struct MooncakeSnapshotOutput {
+    /// Committed LSN for mooncake snapshot.
+    pub(crate) commit_lsn: u64,
+    /// Iceberg snapshot payload.
+    pub(crate) iceberg_snapshot_payload: Option<IcebergSnapshotPayload>,
+    /// Data compaction payload.
+    pub(crate) data_compaction_payload: Option<DataCompactionPayload>,
+    /// File indice merge payload.
+    pub(crate) file_indices_merge_payload: Option<FileIndiceMergePayload>,
+    /// Evicted local data cache files.
+    pub(crate) evicted_data_files_to_delete: Vec<String>,
 }
 
 impl SnapshotTableState {
     pub(super) async fn new(
         metadata: Arc<TableMetadata>,
+        data_file_cache: ObjectStorageCache,
         // TODO(hjiang): Used when recovery enabled.
         _iceberg_table_manager: &mut dyn TableManager,
     ) -> Result<Self> {
@@ -142,6 +156,8 @@ impl SnapshotTableState {
             batches,
             rows: None,
             last_commit: RecordLocation::MemoryBatch(0, 0),
+            data_file_cache,
+            table_notify: None,
             committed_deletion_log: Vec::new(),
             uncommitted_deletion_log: Vec::new(),
             unpersisted_iceberg_records: UnpersistedIcebergSnapshotRecords {
@@ -155,6 +171,13 @@ impl SnapshotTableState {
                 compacted_file_indices_to_remove: Vec::new(),
             },
         })
+    }
+
+    /// Register event completion notifier.
+    /// Notice it should be registered only once, which could be used to notify multiple events.
+    pub(crate) fn register_table_notify(&mut self, table_notify: Sender<TableNotify>) {
+        assert!(self.table_notify.is_none());
+        self.table_notify = Some(table_notify);
     }
 
     /// Aggregate committed deletion logs, which could be persisted into iceberg snapshot.
@@ -318,8 +341,29 @@ impl SnapshotTableState {
             task.iceberg_persisted_file_indices.clone(),
             affected_file_indices,
         );
+    }
 
-        // TODO(hjiang): import write through cache to cache.
+    /// After successful iceberg snapshot, remote file path is recorded in current snapshot and free to dereference write cache.
+    async fn unreference_persisted_data_files(&mut self, task: &SnapshotTask) {
+        if task.iceberg_persisted_data_files.is_empty() {
+            return;
+        }
+
+        let persisted_data_files = &task.iceberg_persisted_data_files;
+        for cur_data_file in persisted_data_files.iter() {
+            let disk_file_entry = self
+                .current_snapshot
+                .disk_files
+                .get_mut(cur_data_file)
+                .unwrap();
+            disk_file_entry
+                .cache_handle
+                .as_mut()
+                .unwrap()
+                .unreference()
+                .await;
+            disk_file_entry.cache_handle = None;
+        }
     }
 
     /// Update unpersisted data files from successful iceberg snapshot operation.
@@ -668,6 +712,7 @@ impl SnapshotTableState {
                 cur_new_data_file.clone(),
                 DiskFileEntry {
                     file_size: cur_entry.file_size,
+                    cache_handle: None,
                     // Current implementation ensures only one file index for all new compacted data files.
                     file_indice: None,
                     batch_deletion_vector: BatchDeletionVector::new(
@@ -898,16 +943,30 @@ impl SnapshotTableState {
         }
     }
 
+    /// Unreference pinned cache handles used in read operations.
+    async fn unreference_read_cache_handles(&mut self, task: &mut SnapshotTask) {
+        for cur_cache_handle in task.read_cache_handles.iter_mut() {
+            cur_cache_handle.unreference().await;
+        }
+    }
+
+    /// Take read request result and update mooncake snapshot.
+    ///
+    /// TODO(hjiang): Pass local files to delete out for actual deletion.
+    async fn update_snapshot_by_read_request_results(&mut self, task: &mut SnapshotTask) {
+        // Unpin cached files used in the read request.
+        self.unreference_read_cache_handles(task).await;
+    }
+
     pub(super) async fn update_snapshot(
         &mut self,
         mut task: SnapshotTask,
         opt: SnapshotOption,
-    ) -> (
-        u64,
-        Option<IcebergSnapshotPayload>,
-        Option<DataCompactionPayload>,
-        Option<FileIndiceMergePayload>,
-    ) {
+    ) -> MooncakeSnapshotOutput {
+        // Reflect read request result to mooncake snapshot.
+        self.update_snapshot_by_read_request_results(&mut task)
+            .await;
+
         // Reflect iceberg snapshot to mooncake snapshot.
         //
         // There're a few things to do:
@@ -918,6 +977,7 @@ impl SnapshotTableState {
         // Update data files and file indices' local file path to remote file path, it only applies to newly imported data files and file indices,
         // because both index merge and data compaction only apply to those already persisted into iceberg table.
         self.update_local_path_to_persisted_by_imported(&task);
+        self.unreference_persisted_data_files(&task).await;
         self.update_current_snapshot_with_iceberg_snapshot(std::mem::take(
             &mut task.iceberg_persisted_puffin_blob,
         ));
@@ -958,10 +1018,13 @@ impl SnapshotTableState {
         self.buffer_unpersisted_iceberg_compaction_data(&task);
 
         // Apply buffered change to current mooncake snapshot.
-        self.apply_transaction_stream(&mut task);
+        let mut evicted_data_files_to_delete = vec![];
+        let stream_evicted_cache_files = self.apply_transaction_stream(&mut task).await;
         self.merge_mem_indices(&mut task);
         self.finalize_batches(&mut task);
-        self.integrate_disk_slices(&mut task);
+        let batch_evicted_cache_files = self.integrate_disk_slices(&mut task).await;
+        evicted_data_files_to_delete.extend(stream_evicted_cache_files);
+        evicted_data_files_to_delete.extend(batch_evicted_cache_files);
 
         // Apply data compaction to committed deletion logs.
         self.remap_and_prune_deletion_logs_after_compaction(&mut task);
@@ -1047,19 +1110,18 @@ impl SnapshotTableState {
             self.assert_current_snapshot_consistent();
         }
 
-        (
-            self.current_snapshot.snapshot_version,
+        MooncakeSnapshotOutput {
+            commit_lsn: self.current_snapshot.snapshot_version,
             iceberg_snapshot_payload,
             data_compaction_payload,
             file_indices_merge_payload,
-        )
+            evicted_data_files_to_delete,
+        }
     }
 
-    /// Test util functions to assert current snapshot is at a consistent state.
+    /// Test util function to assert the mapping between data files and file indices are consistent.
     #[cfg(test)]
-    fn assert_current_snapshot_consistent(&self) {
-        // Check file indices and disk files are consistent.
-        //
+    fn assert_data_files_and_file_indices_consistent(&self) {
         // (1) Get data file to file indices mapping from [`disk_files`].
         let mut data_file_to_file_indices_1 =
             HashMap::with_capacity(self.current_snapshot.disk_files.len());
@@ -1080,6 +1142,13 @@ impl SnapshotTableState {
         }
         // Assert mapping inferred from disk files and file indices are the same.
         assert_eq!(data_file_to_file_indices_1, data_file_to_file_indices_2);
+    }
+
+    /// Test util functions to assert current snapshot is at a consistent state.
+    #[cfg(test)]
+    fn assert_current_snapshot_consistent(&self) {
+        // Check file indices and disk files are consistent.
+        self.assert_data_files_and_file_indices_consistent();
     }
 
     fn merge_mem_indices(&mut self, task: &mut SnapshotTask) {
@@ -1116,28 +1185,44 @@ impl SnapshotTableState {
             }));
     }
 
-    fn integrate_disk_slices(&mut self, task: &mut SnapshotTask) {
+    /// Return files evicted from data file cache.
+    async fn integrate_disk_slices(&mut self, task: &mut SnapshotTask) -> Vec<String> {
+        // Aggregate evicted data cache files to delete.
+        let mut evicted_files = vec![];
+
         for mut slice in take(&mut task.new_disk_slices) {
-            // register new files
-            self.current_snapshot
-                .disk_files
-                .extend(slice.output_files().iter().map(|(f, file_attrs)| {
-                    ma::assert_gt!(file_attrs.file_size, 0);
-                    (
-                        f.clone(),
-                        DiskFileEntry {
-                            file_size: file_attrs.file_size,
-                            file_indice: Some(slice.get_file_indice().as_ref().unwrap().clone()),
-                            batch_deletion_vector: BatchDeletionVector::new(file_attrs.row_num),
-                            puffin_deletion_blob: None,
-                        },
-                    )
-                }));
             let write_lsn = slice.lsn();
             let lsn = write_lsn.expect("commited datafile should have a valid LSN");
-            for (f, _) in slice.output_files().iter() {
-                task.disk_file_lsn_map.insert(f.file_id(), lsn);
+
+            // Register new files into mooncake snapshot, add it into cache, and record LSN map.
+            for (file, file_attrs) in slice.output_files().iter() {
+                ma::assert_gt!(file_attrs.file_size, 0);
+                task.disk_file_lsn_map.insert(file.file_id(), lsn);
+                let (cache_handle, cur_evicted_files) = self
+                    .data_file_cache
+                    .import_cache_entry(
+                        file.file_id(),
+                        DataFileCacheEntry {
+                            cache_filepath: file.file_path().clone(),
+                            file_metadata: FileMetadata {
+                                file_size: file_attrs.file_size as u64,
+                            },
+                        },
+                    )
+                    .await;
+                evicted_files.extend(cur_evicted_files);
+                self.current_snapshot.disk_files.insert(
+                    file.clone(),
+                    DiskFileEntry {
+                        file_size: file_attrs.file_size,
+                        cache_handle: Some(cache_handle),
+                        file_indice: Some(slice.get_file_indice().as_ref().unwrap().clone()),
+                        batch_deletion_vector: BatchDeletionVector::new(file_attrs.row_num),
+                        puffin_deletion_blob: None,
+                    },
+                );
             }
+
             // remap deletions written *after* this slice’s LSN
             let cut = self.committed_deletion_log.partition_point(|d| {
                 d.lsn
@@ -1169,6 +1254,8 @@ impl SnapshotTableState {
                 self.batches.remove(&b.id);
             });
         }
+
+        evicted_files
     }
 
     async fn match_deletions_with_identical_key_and_lsn(
@@ -1457,30 +1544,61 @@ impl SnapshotTableState {
         (puffin_filepaths, deletion_vector_blob_at_read, ret)
     }
 
-    pub(crate) async fn request_read(&self) -> Result<ReadOutput> {
-        let mut data_file_paths = Vec::with_capacity(self.current_snapshot.disk_files.len());
+    /// Util function to get read state, which returns all current data files information, and increment read reference count.
+    async fn get_read_files_for_read(&mut self) -> (Vec<DataFileForRead>, Vec<FileId>) {
+        let mut data_files_for_read = Vec::with_capacity(self.current_snapshot.disk_files.len());
+        let mut involved_data_files = Vec::with_capacity(self.current_snapshot.disk_files.len());
+
+        for (file, file_disk_entry) in self.current_snapshot.disk_files.iter_mut() {
+            involved_data_files.push(file.file_id());
+
+            // Current file already has pinned local cache file, simply increment the reference count.
+            if file_disk_entry.cache_handle.is_some() {
+                // No IO operation will take place, no need to pass remote filepath.
+                // TODO(hjiang): Handle evicted files to delete.
+                let (cache_handle, _files_to_delete) = self
+                    .data_file_cache
+                    .get_cache_entry(file.file_id(), /*remote_filepath=*/ "")
+                    .await
+                    .unwrap();
+                data_files_for_read.push(DataFileForRead::PinnedLocalWriteCache(
+                    cache_handle.unwrap(),
+                ));
+                continue;
+            }
+            // Otherwise, record the file id and remote file path, so we could fetch out of critical section.
+            data_files_for_read.push(DataFileForRead::RemoteFilePath((
+                file.file_id(),
+                file.file_path().to_string(),
+            )));
+        }
+
+        (data_files_for_read, involved_data_files)
+    }
+
+    pub(crate) async fn request_read(&mut self) -> Result<SnapshotReadOutput> {
+        let (mut data_file_paths, involved_data_files) = self.get_read_files_for_read().await;
         let mut associated_files = Vec::new();
         let (puffin_file_paths, deletion_vectors_at_read, position_deletes) =
             self.get_deletion_records();
-        data_file_paths.extend(
-            self.current_snapshot
-                .disk_files
-                .keys()
-                .map(|path| path.file_path().clone()),
-        );
 
         // For committed but not persisted records, we create a temporary file for them, which gets deleted after query completion.
         let file_path = self.current_snapshot.get_name_for_inmemory_file();
         let filepath_exists = tokio::fs::try_exists(&file_path).await?;
         if filepath_exists {
-            data_file_paths.push(file_path.to_string_lossy().to_string());
+            data_file_paths.push(DataFileForRead::TemporaryDataFile(
+                file_path.to_string_lossy().to_string(),
+            ));
             associated_files.push(file_path.to_string_lossy().to_string());
-            return Ok(ReadOutput {
+            return Ok(SnapshotReadOutput {
                 data_file_paths,
                 puffin_file_paths,
+                involved_data_files,
                 deletion_vectors: deletion_vectors_at_read,
                 position_deletes,
                 associated_files,
+                data_file_cache: Some(self.data_file_cache.clone()),
+                table_notifier: Some(self.table_notify.as_ref().unwrap().clone()),
             });
         }
 
@@ -1517,6 +1635,7 @@ impl SnapshotTableState {
                 }
             }
 
+            // TODO(hjiang): Check whether we could avoid IO operation inside of critical section.
             if !filtered_batches.is_empty() {
                 // Build a parquet file from current record batches
                 let temp_file = tokio::fs::File::create(&file_path).await?;
@@ -1530,16 +1649,24 @@ impl SnapshotTableState {
                     parquet_writer.write(batch).await?;
                 }
                 parquet_writer.close().await?;
-                data_file_paths.push(file_path.to_string_lossy().to_string());
+                data_file_paths.push(DataFileForRead::TemporaryDataFile(
+                    file_path.to_string_lossy().to_string(),
+                ));
                 associated_files.push(file_path.to_string_lossy().to_string());
             }
         }
-        Ok(ReadOutput {
+
+        println!("create one SnapshotReadOutput");
+
+        Ok(SnapshotReadOutput {
             data_file_paths,
             puffin_file_paths,
+            involved_data_files,
             deletion_vectors: deletion_vectors_at_read,
             position_deletes,
             associated_files,
+            data_file_cache: Some(self.data_file_cache.clone()),
+            table_notifier: Some(self.table_notify.as_ref().unwrap().clone()),
         })
     }
 }

--- a/src/moonlink/src/storage/mooncake_table/snapshot_read_output.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot_read_output.rs
@@ -1,0 +1,135 @@
+use crate::storage::cache::object_storage::base_cache::CacheTrait;
+use crate::storage::cache::object_storage::object_storage_cache::ObjectStorageCache;
+use crate::storage::storage_utils::FileId;
+use crate::storage::PuffinDeletionBlobAtRead;
+use crate::table_notify::TableNotify;
+use crate::NonEvictableHandle;
+use crate::ReadState;
+
+use std::sync::Arc;
+
+use tokio::sync::mpsc::Sender;
+
+/// Mooncake snapshot for read.
+
+/// Pass out two types of data files to read.
+#[derive(Clone)]
+pub enum DataFileForRead {
+    /// Temporary data file for in-memory unpersisted data, used for union read.
+    TemporaryDataFile(String),
+    /// If the data file has already been pinned, directly add a reference count, otherwise it could be deferenced later.
+    PinnedLocalWriteCache(NonEvictableHandle),
+    /// If the data file is not pinned, pass out (file id, remote file path) and rely on read-through cache.
+    RemoteFilePath((FileId, String)),
+}
+
+impl DataFileForRead {
+    /// Get a file path to read.
+    #[cfg(test)]
+    pub fn get_file_path(&self) -> String {
+        match self {
+            Self::TemporaryDataFile(file) => file.clone(),
+            Self::PinnedLocalWriteCache(cache_handle) => {
+                cache_handle.cache_entry.cache_filepath.clone()
+            }
+            Self::RemoteFilePath((_, file)) => file.clone(),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct ReadOutput {
+    /// Data files contains two parts:
+    /// 1. Committed and persisted data files, which consists of file id and remote path (if any).
+    /// 2. Associated files, which include committed but un-persisted records.
+    pub data_file_paths: Vec<DataFileForRead>,
+    /// Puffin file paths.
+    pub puffin_file_paths: Vec<String>,
+    /// Deletion vectors persisted in puffin files.
+    pub deletion_vectors: Vec<PuffinDeletionBlobAtRead>,
+    /// Committed but un-persisted positional deletion records.
+    pub position_deletes: Vec<(u32 /*file_index*/, u32 /*row_index*/)>,
+    /// Contains committed but non-persisted record batches, which are persisted as temporary data files on local filesystem.
+    pub associated_files: Vec<String>,
+    /// Data files involved in the current snapshot.
+    pub involved_data_files: Vec<FileId>,
+    /// Table notifier for query completion; could be none for empty read output.
+    pub table_notifier: Option<Sender<TableNotify>>,
+    /// Data file cache, to pin local file cache, could be none for empty read output.
+    pub data_file_cache: Option<ObjectStorageCache>,
+}
+
+impl ReadOutput {
+    pub fn default() -> Self {
+        Self {
+            data_file_paths: vec![],
+            puffin_file_paths: vec![],
+            deletion_vectors: vec![],
+            position_deletes: vec![],
+            associated_files: vec![],
+            involved_data_files: vec![],
+            table_notifier: None,
+            data_file_cache: None,
+        }
+    }
+
+    /// Resolve all remote filepaths and convert into [`ReadState`] for query usage.
+    ///
+    /// TODO(hjiang): Parallelize download and pin.
+    pub async fn take_as_read_state(mut self) -> Arc<ReadState> {
+        // Resolve remote data files.
+        let mut resolved_data_files = Vec::with_capacity(self.data_file_paths.len());
+        let mut cache_handles = vec![];
+        for cur_data_file in self.data_file_paths.into_iter() {
+            match cur_data_file {
+                DataFileForRead::TemporaryDataFile(file) => resolved_data_files.push(file),
+                DataFileForRead::PinnedLocalWriteCache(old_cache_handle) => {
+                    // The cache file has already been pinned, no IO operation will take place, thus no error expected.
+                    let (new_cache_handle, evicted_files_to_delete) = self
+                        .data_file_cache
+                        .as_mut()
+                        .unwrap()
+                        .get_cache_entry(old_cache_handle.file_id, /*remote_filepath=*/ "")
+                        .await
+                        .unwrap();
+                    assert!(evicted_files_to_delete.is_empty());
+                    let new_cache_handle = new_cache_handle.unwrap();
+                    resolved_data_files.push(new_cache_handle.get_cache_filepath().to_string());
+                    cache_handles.push(new_cache_handle);
+                }
+                DataFileForRead::RemoteFilePath((file_id, remote_filepath)) => {
+                    // TODO(hjiang):
+                    // 1. Delete evicted data files.
+                    // 2. Better error propagation.
+                    let (cache_handle, _files_to_delete) = self
+                        .data_file_cache
+                        .as_mut()
+                        .unwrap()
+                        .get_cache_entry(file_id, &remote_filepath)
+                        .await
+                        .unwrap();
+                    if let Some(cache_handle) = cache_handle {
+                        resolved_data_files.push(cache_handle.get_cache_filepath().to_string());
+                        cache_handles.push(cache_handle);
+                    } else {
+                        resolved_data_files.push(remote_filepath);
+                    }
+                }
+            }
+        }
+
+        // Construct read state.
+        Arc::new(ReadState::new(
+            // Data file and positional deletes for query.
+            resolved_data_files,
+            self.puffin_file_paths,
+            self.deletion_vectors,
+            self.position_deletes,
+            // Fields used for read state cleanup after query completion.
+            self.associated_files,
+            self.involved_data_files,
+            cache_handles,
+            self.table_notifier,
+        ))
+    }
+}

--- a/src/moonlink/src/storage/mooncake_table/snapshot_read_output.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot_read_output.rs
@@ -1,6 +1,6 @@
 use crate::storage::cache::object_storage::base_cache::CacheTrait;
 use crate::storage::cache::object_storage::object_storage_cache::ObjectStorageCache;
-use crate::storage::storage_utils::FileId;
+use crate::storage::storage_utils::TableUniqueFileId;
 use crate::storage::PuffinDeletionBlobAtRead;
 use crate::table_notify::TableNotify;
 use crate::ReadState;
@@ -17,7 +17,7 @@ pub enum DataFileForRead {
     /// Temporary data file for in-memory unpersisted data, used for union read.
     TemporaryDataFile(String),
     /// Pass out (file id, remote file path) and rely on read-through cache.
-    RemoteFilePath((FileId, String)),
+    RemoteFilePath((TableUniqueFileId, String)),
 }
 
 impl DataFileForRead {

--- a/src/moonlink/src/storage/mooncake_table/state_tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/state_tests.rs
@@ -69,7 +69,7 @@ use crate::row::{MoonlinkRow, RowValue};
 use crate::storage::cache::object_storage::base_cache::{CacheEntry, CacheTrait, FileMetadata};
 use crate::storage::iceberg::test_utils::*;
 use crate::storage::mooncake_table::TableConfig as MooncakeTableConfig;
-use crate::storage::storage_utils::{FileId, MooncakeDataFileRef};
+use crate::storage::storage_utils::{FileId, MooncakeDataFileRef, TableId, TableUniqueFileId};
 use crate::table_notify::TableNotify;
 use crate::{
     IcebergTableConfig, MooncakeTable, NonEvictableHandle, ObjectStorageCache,
@@ -83,14 +83,27 @@ const ONE_FILE_CACHE_SIZE: u64 = 1 << 20;
 /// Iceberg test namespace and table name.
 const ICEBERG_TEST_NAMESPACE: &str = "namespace";
 const ICEBERG_TEST_TABLE: &str = "test_table";
+/// Test constant for table id.
+const TEST_TABLE_ID: TableId = TableId(0);
 /// File attributes for a fake file.
 ///
 /// File id for the fake file.
-const FAKE_FILE_ID: FileId = FileId(100);
+const FAKE_FILE_ID: TableUniqueFileId = TableUniqueFileId {
+    table_id: TEST_TABLE_ID,
+    file_id: FileId(100),
+};
 /// Fake file size.
 const FAKE_FILE_SIZE: u64 = ONE_FILE_CACHE_SIZE;
 /// Fake filename.
 const FAKE_FILE_NAME: &str = "fake-file-name";
+
+/// Test util function to get unique table file id.
+fn get_unique_table_file_id(file_id: FileId) -> TableUniqueFileId {
+    TableUniqueFileId {
+        table_id: TEST_TABLE_ID,
+        file_id,
+    }
+}
 
 /// Test util function to decide whether a given file is remote file.
 fn is_remote_file(file: &MooncakeDataFileRef, temp_dir: &TempDir) -> bool {
@@ -146,7 +159,7 @@ async fn create_mooncake_table_and_notify(
     let mut table = MooncakeTable::new(
         schema.as_ref().clone(),
         "test_table".to_string(),
-        /*version=*/ 1,
+        /*version=*/ TEST_TABLE_ID.0,
         path,
         identity_property,
         iceberg_table_config.clone(),
@@ -249,7 +262,7 @@ async fn test_5_read_4() {
     );
     assert_eq!(
         data_file_cache
-            .get_non_evictable_entry_ref_count(&file.file_id())
+            .get_non_evictable_entry_ref_count(&get_unique_table_file_id(file.file_id()))
             .await,
         2
     );
@@ -335,7 +348,7 @@ async fn test_4_3() {
     );
     assert_eq!(
         data_file_cache
-            .get_non_evictable_entry_ref_count(&file.file_id())
+            .get_non_evictable_entry_ref_count(&get_unique_table_file_id(file.file_id()))
             .await,
         1
     );
@@ -384,7 +397,7 @@ async fn test_4_read_4() {
     );
     assert_eq!(
         data_file_cache
-            .get_non_evictable_entry_ref_count(&file.file_id())
+            .get_non_evictable_entry_ref_count(&get_unique_table_file_id(file.file_id()))
             .await,
         4,
     );
@@ -406,7 +419,7 @@ async fn test_4_read_4() {
     );
     assert_eq!(
         data_file_cache
-            .get_non_evictable_entry_ref_count(&file.file_id())
+            .get_non_evictable_entry_ref_count(&get_unique_table_file_id(file.file_id()))
             .await,
         1,
     );
@@ -454,7 +467,7 @@ async fn test_4_read_and_read_over_4() {
     );
     assert_eq!(
         data_file_cache
-            .get_non_evictable_entry_ref_count(&file.file_id())
+            .get_non_evictable_entry_ref_count(&get_unique_table_file_id(file.file_id()))
             .await,
         1
     );
@@ -508,7 +521,7 @@ async fn test_3_read_3() {
     );
     assert_eq!(
         data_file_cache
-            .get_non_evictable_entry_ref_count(&file.file_id())
+            .get_non_evictable_entry_ref_count(&get_unique_table_file_id(file.file_id()))
             .await,
         2,
     );
@@ -585,7 +598,7 @@ async fn test_3_read_and_read_over_and_pinned_3() {
     );
     assert_eq!(
         data_file_cache
-            .get_non_evictable_entry_ref_count(&file.file_id())
+            .get_non_evictable_entry_ref_count(&get_unique_table_file_id(file.file_id()))
             .await,
         1,
     );
@@ -686,7 +699,7 @@ async fn test_1_read_and_pinned_3() {
     );
     assert_eq!(
         data_file_cache
-            .get_non_evictable_entry_ref_count(&file.file_id())
+            .get_non_evictable_entry_ref_count(&get_unique_table_file_id(file.file_id()))
             .await,
         1,
     );
@@ -804,7 +817,7 @@ async fn test_2_read_and_pinned_3() {
     );
     assert_eq!(
         data_file_cache
-            .get_non_evictable_entry_ref_count(&file.file_id())
+            .get_non_evictable_entry_ref_count(&get_unique_table_file_id(file.file_id()))
             .await,
         1,
     );

--- a/src/moonlink/src/storage/mooncake_table/state_tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/state_tests.rs
@@ -1,0 +1,849 @@
+use tempfile::TempDir;
+use tokio::sync::mpsc::{self, Receiver};
+
+/// This file contains state-machine based unit test, which checks data file state transfer for a few operations, for example, compaction and request read.
+///
+/// remote storage state:
+/// - Has remote storage
+/// - no remote storage
+///
+/// Local cache state:
+/// - Local cache pinned
+/// - No local cache (including unreferenced)
+///
+/// Use request state (use includes request to read or compact, which adds reference count):
+/// - Requested to use
+/// - Not requested to use
+///
+/// Constraint:
+/// - Impossible to have “no remote storage” and “no local cache”
+/// - Local cache pinned indicates either “no remote storage” or “request to use”
+///
+/// Possible states for disk file entries:
+/// (0) No such entry
+/// (1) Has remote storage, no local cache, not requested to use
+/// (2) Has remote storage, no local cache, requested to use
+/// (3) Has remote storage, local cache pinned, requested to use
+/// (4) no remote storage, local cache pinned, requested to use
+/// (5) no remote storage, local cache pinned, not requested to use
+///
+/// State inputs:
+/// - Iceberg snapshot completion
+/// - Request to use, and pinned in cache
+/// - Request to use, but not pinned in cache
+/// - Use finished, still pinned in cache
+/// - Use finished, but not pinned in cache
+///
+/// State transition for disk file entries:
+/// Initial state: no entry
+/// - No entry + disk write => no remote, local, not used
+///
+/// Initial state: no remote, local, not used
+/// - no remote, local, not used + use => no remote, local, in use
+/// - no remote, local, not used + persist => remote, no local, not used
+///
+/// Initial state: no remote, local, in use
+/// - no remote, local, in use + persist => remote, local, in use
+/// - no remote, local, in use + use => no remote, local, in use
+/// - no remote, local, in use + use over => no remote, local, in use
+///
+/// Initial state: remote, local, in use
+/// - remote, local, in use + use => remote, local, in use
+/// - remote, local, in use + use over & pinned => remote, local, in use
+/// - remote, local, in use + use over & unpinned => remote, no local, not used
+///
+/// Initial state: remote, no local, not used
+/// - remote, no local, not used + use & pinned => remote, local, in use
+/// - remote, no local, not used + use & unpinned => remote, no local, in use
+///
+/// Initial state: remote, no local, in use
+/// - remote, no local, in use + use & pinned => remote, local, in use
+/// - remote, no local, in use + use & unpinned => remote, no local, in use
+/// - remote, no local, in use + use over => remote, no local, not used
+///
+/// For more details, please refer to https://docs.google.com/document/d/1f2d0E_Zi8FbR4QmW_YEhcZwMpua0_pgkaNdrqM1qh2E/edit?usp=sharing
+///
+/// TODO(hjiang): Add test cases for compaction usage.
+use crate::row::{MoonlinkRow, RowValue};
+use crate::storage::cache::object_storage::base_cache::{CacheEntry, CacheTrait, FileMetadata};
+use crate::storage::iceberg::test_utils::*;
+use crate::storage::mooncake_table::TableConfig as MooncakeTableConfig;
+use crate::storage::storage_utils::{FileId, MooncakeDataFileRef};
+use crate::table_notify::TableNotify;
+use crate::{
+    IcebergTableConfig, MooncakeTable, NonEvictableHandle, ObjectStorageCache,
+    ObjectStorageCacheConfig,
+};
+
+/// Test constant to mimic an infinitely large data file cache.
+const INFINITE_LARGE_DATA_FILE_CACHE_SIZE: u64 = u64::MAX;
+/// Test constant to allow only one file in data file cache.
+const ONE_FILE_CACHE_SIZE: u64 = 1 << 20;
+/// Iceberg test namespace and table name.
+const ICEBERG_TEST_NAMESPACE: &str = "namespace";
+const ICEBERG_TEST_TABLE: &str = "test_table";
+/// File attributes for a fake file.
+///
+/// File id for the fake file.
+const FAKE_FILE_ID: FileId = FileId(100);
+/// Fake file size.
+const FAKE_FILE_SIZE: u64 = ONE_FILE_CACHE_SIZE;
+/// Fake filename.
+const FAKE_FILE_NAME: &str = "fake-file-name";
+
+/// Test util function to decide whether a given file is remote file.
+fn is_remote_file(file: &MooncakeDataFileRef, temp_dir: &TempDir) -> bool {
+    // Local filesystem directory for iceberg warehouse.
+    let mut temp_pathbuf = temp_dir.path().to_path_buf();
+    temp_pathbuf.push(ICEBERG_TEST_NAMESPACE); // iceberg namespace
+    temp_pathbuf.push(ICEBERG_TEST_TABLE); // iceberg table name
+
+    file.file_path().starts_with(temp_pathbuf.to_str().unwrap())
+}
+
+/// Test util function to decide whether a given file is local file.
+fn is_local_file(file: &MooncakeDataFileRef, temp_dir: &TempDir) -> bool {
+    !is_remote_file(file, temp_dir)
+}
+
+/// Test util function to create mooncake table and table notify.
+async fn create_mooncake_table_and_notify(
+    temp_dir: &TempDir,
+    data_file_cache: ObjectStorageCache,
+) -> (MooncakeTable, Receiver<TableNotify>) {
+    let path = temp_dir.path().to_path_buf();
+    let warehouse_uri = path.clone().to_str().unwrap().to_string();
+    let mooncake_table_metadata =
+        create_test_table_metadata(temp_dir.path().to_str().unwrap().to_string());
+    let identity_property = mooncake_table_metadata.identity.clone();
+
+    let iceberg_table_config = IcebergTableConfig {
+        warehouse_uri,
+        namespace: vec!["namespace".to_string()],
+        table_name: "test_table".to_string(),
+    };
+    let schema = create_test_arrow_schema();
+
+    // Create iceberg snapshot whenever `create_snapshot` is called.
+    let mooncake_table_config = MooncakeTableConfig {
+        iceberg_snapshot_new_data_file_count: 0,
+        ..Default::default()
+    };
+
+    let mut table = MooncakeTable::new(
+        schema.as_ref().clone(),
+        "test_table".to_string(),
+        /*version=*/ 1,
+        path,
+        identity_property,
+        iceberg_table_config.clone(),
+        mooncake_table_config,
+        data_file_cache,
+    )
+    .await
+    .unwrap();
+
+    let (notify_tx, notify_rx) = mpsc::channel(100);
+    table.register_table_notify(notify_tx).await;
+
+    (table, notify_rx)
+}
+
+/// Prepare persisted data files in mooncake table.
+/// Rows are committed and flushed with LSN 1.
+async fn prepare_test_disk_file(
+    temp_dir: &TempDir,
+    data_file_cache: ObjectStorageCache,
+) -> (MooncakeTable, Receiver<TableNotify>) {
+    let (mut table, table_notify) =
+        create_mooncake_table_and_notify(temp_dir, data_file_cache).await;
+
+    let row = MoonlinkRow::new(vec![
+        RowValue::Int32(1),
+        RowValue::ByteArray("John".as_bytes().to_vec()),
+        RowValue::Int32(30),
+    ]);
+    table.append(row.clone()).unwrap();
+    table.commit(/*lsn=*/ 1);
+    table.flush(/*lsn=*/ 1).await.unwrap();
+
+    (table, table_notify)
+}
+
+/// Test util function to import a second data file cache entry.
+async fn import_fake_cache_entry(cache: &mut ObjectStorageCache) -> NonEvictableHandle {
+    let cache_entry = CacheEntry {
+        cache_filepath: FAKE_FILE_NAME.to_string(),
+        file_metadata: FileMetadata {
+            file_size: FAKE_FILE_SIZE,
+        },
+    };
+    cache.import_cache_entry(FAKE_FILE_ID, cache_entry).await.0
+}
+
+/// Test scenario: no remote, local, not used + use => no remote, local, in use
+#[tokio::test]
+async fn test_5_read_4() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let cache_config = ObjectStorageCacheConfig::new(
+        INFINITE_LARGE_DATA_FILE_CACHE_SIZE,
+        temp_dir.path().to_str().unwrap().to_string(),
+    );
+    let data_file_cache = ObjectStorageCache::new(cache_config);
+
+    let (mut table, mut table_notify) =
+        prepare_test_disk_file(&temp_dir, data_file_cache.clone()).await;
+    let (_, _, _, _) = table
+        .create_mooncake_snapshot_for_test(&mut table_notify)
+        .await;
+    let snapshot_read_output = table.request_read().await.unwrap();
+    let _read_state = snapshot_read_output.take_as_read_state().await;
+
+    // Check data file has been pinned in mooncake table.
+    let disk_files = table.get_disk_files_for_snapshot().await;
+    assert_eq!(disk_files.len(), 1);
+    let (file, disk_file_entry) = disk_files.iter().next().unwrap();
+    assert!(disk_file_entry.cache_handle.is_some());
+    assert_eq!(
+        file.file_path(),
+        &disk_file_entry
+            .cache_handle
+            .as_ref()
+            .unwrap()
+            .cache_entry
+            .cache_filepath
+    );
+    assert!(is_local_file(file, &temp_dir));
+
+    // Check cache state.
+    assert_eq!(data_file_cache.cache.read().await.evictable_cache.len(), 0);
+    assert_eq!(
+        data_file_cache.cache.read().await.non_evictable_cache.len(),
+        1,
+    );
+    assert_eq!(
+        data_file_cache
+            .get_non_evictable_entry_ref_count(&file.file_id())
+            .await,
+        2
+    );
+}
+
+/// Test scenario: no remote, local, not used + persist => remote, no local, not used
+#[tokio::test]
+async fn test_5_1() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let cache_config = ObjectStorageCacheConfig::new(
+        INFINITE_LARGE_DATA_FILE_CACHE_SIZE,
+        temp_dir.path().to_str().unwrap().to_string(),
+    );
+    let data_file_cache = ObjectStorageCache::new(cache_config);
+
+    let (mut table, mut table_notify) =
+        prepare_test_disk_file(&temp_dir, data_file_cache.clone()).await;
+    table
+        .create_mooncake_and_iceberg_snapshot_for_test(&mut table_notify)
+        .await
+        .unwrap();
+    // Till now, iceberg snapshot has been persisted, need an extra mooncake snapshot to reflect persistence result.
+    let (_, _, _, _) = table
+        .create_mooncake_snapshot_for_test(&mut table_notify)
+        .await;
+
+    // Check data file has been pinned in mooncake table.
+    let disk_files = table.get_disk_files_for_snapshot().await;
+    assert_eq!(disk_files.len(), 1);
+    let (file, disk_file_entry) = disk_files.iter().next().unwrap();
+    assert!(disk_file_entry.cache_handle.is_none());
+    assert!(is_remote_file(file, &temp_dir));
+
+    // Check cache state.
+    assert_eq!(data_file_cache.cache.read().await.evictable_cache.len(), 1);
+    assert_eq!(
+        data_file_cache.cache.read().await.non_evictable_cache.len(),
+        0
+    );
+}
+
+/// Test scenario: no remote, local, in use + persist => remote, local, in use
+#[tokio::test]
+async fn test_4_3() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let cache_config = ObjectStorageCacheConfig::new(
+        INFINITE_LARGE_DATA_FILE_CACHE_SIZE,
+        temp_dir.path().to_str().unwrap().to_string(),
+    );
+    let data_file_cache = ObjectStorageCache::new(cache_config);
+
+    let (mut table, mut table_notify) =
+        prepare_test_disk_file(&temp_dir, data_file_cache.clone()).await;
+    let (_, _, _, _) = table
+        .create_mooncake_snapshot_for_test(&mut table_notify)
+        .await;
+
+    // Read and increment reference count.
+    let snapshot_read_output = table.request_read().await.unwrap();
+    let _read_state = snapshot_read_output.take_as_read_state().await;
+
+    // Create iceberg snapshot and reflect persistence result to mooncake snapshot.
+    table
+        .create_mooncake_and_iceberg_snapshot_for_test(&mut table_notify)
+        .await
+        .unwrap();
+    let (_, _, _, _) = table
+        .create_mooncake_snapshot_for_test(&mut table_notify)
+        .await;
+
+    // Check data file has been pinned in mooncake table.
+    let disk_files = table.get_disk_files_for_snapshot().await;
+    assert_eq!(disk_files.len(), 1);
+    let (file, disk_file_entry) = disk_files.iter().next().unwrap();
+    assert!(disk_file_entry.cache_handle.is_none());
+    assert!(is_remote_file(file, &temp_dir));
+
+    // Check cache state.
+    assert_eq!(data_file_cache.cache.read().await.evictable_cache.len(), 0);
+    assert_eq!(
+        data_file_cache.cache.read().await.non_evictable_cache.len(),
+        1,
+    );
+    assert_eq!(
+        data_file_cache
+            .get_non_evictable_entry_ref_count(&file.file_id())
+            .await,
+        1
+    );
+}
+
+/// Test scenario: no remote, local, in use + use => no remote, local, in use
+#[tokio::test]
+async fn test_4_read_4() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let cache_config = ObjectStorageCacheConfig::new(
+        INFINITE_LARGE_DATA_FILE_CACHE_SIZE,
+        temp_dir.path().to_str().unwrap().to_string(),
+    );
+    let data_file_cache = ObjectStorageCache::new(cache_config);
+
+    let (mut table, mut table_notify) =
+        prepare_test_disk_file(&temp_dir, data_file_cache.clone()).await;
+    let (_, _, _, _) = table
+        .create_mooncake_snapshot_for_test(&mut table_notify)
+        .await;
+
+    // Read and increment reference count for the first time.
+    let snapshot_read_output_1 = table.request_read().await.unwrap();
+    let _read_state_1 = snapshot_read_output_1.take_as_read_state().await;
+
+    // Read and increment reference count for the second time.
+    let snapshot_read_output_2 = table.request_read().await.unwrap();
+    let snapshot_read_output_2_clone = snapshot_read_output_2.clone();
+    let _read_state_2 = snapshot_read_output_2.take_as_read_state().await;
+
+    // Read and increment reference count for the third time.
+    let _read_state_3 = snapshot_read_output_2_clone.take_as_read_state().await;
+
+    // Check data file has been pinned in mooncake table.
+    let disk_files = table.get_disk_files_for_snapshot().await;
+    assert_eq!(disk_files.len(), 1);
+    let (file, disk_file_entry) = disk_files.iter().next().unwrap();
+    assert!(disk_file_entry.cache_handle.is_some());
+    assert!(is_local_file(file, &temp_dir));
+
+    // Check cache state.
+    assert_eq!(data_file_cache.cache.read().await.evictable_cache.len(), 0);
+    assert_eq!(
+        data_file_cache.cache.read().await.non_evictable_cache.len(),
+        1,
+    );
+    assert_eq!(
+        data_file_cache
+            .get_non_evictable_entry_ref_count(&file.file_id())
+            .await,
+        3
+    );
+}
+
+/// Test scenario: no remote, local, in use + use over => no remote, local, in use
+#[tokio::test]
+async fn test_4_read_and_read_over_4() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let cache_config = ObjectStorageCacheConfig::new(
+        INFINITE_LARGE_DATA_FILE_CACHE_SIZE,
+        temp_dir.path().to_str().unwrap().to_string(),
+    );
+    let data_file_cache = ObjectStorageCache::new(cache_config);
+
+    let (mut table, mut table_notify) =
+        prepare_test_disk_file(&temp_dir, data_file_cache.clone()).await;
+    let (_, _, _, _) = table
+        .create_mooncake_snapshot_for_test(&mut table_notify)
+        .await;
+
+    // Read, increment reference count and drop to declare finish.
+    let snapshot_read_output = table.request_read().await.unwrap();
+    let read_state = snapshot_read_output.take_as_read_state().await;
+    drop(read_state);
+    table.sync_read_request(&mut table_notify).await;
+
+    // Create a mooncake snapshot to reflect read request completion result.
+    let (_, _, _, _) = table
+        .create_mooncake_snapshot_for_test(&mut table_notify)
+        .await;
+
+    // Check data file has been pinned in mooncake table.
+    let disk_files = table.get_disk_files_for_snapshot().await;
+    assert_eq!(disk_files.len(), 1);
+    let (file, disk_file_entry) = disk_files.iter().next().unwrap();
+    assert!(disk_file_entry.cache_handle.is_some());
+    assert!(is_local_file(file, &temp_dir));
+
+    // Check cache state.
+    assert_eq!(data_file_cache.cache.read().await.evictable_cache.len(), 0);
+    assert_eq!(
+        data_file_cache.cache.read().await.non_evictable_cache.len(),
+        1,
+    );
+    assert_eq!(
+        data_file_cache
+            .get_non_evictable_entry_ref_count(&file.file_id())
+            .await,
+        1
+    );
+}
+
+/// Test scenario: remote, local, in use + use => remote, local, in use
+#[tokio::test]
+async fn test_3_read_3() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let cache_config = ObjectStorageCacheConfig::new(
+        INFINITE_LARGE_DATA_FILE_CACHE_SIZE,
+        temp_dir.path().to_str().unwrap().to_string(),
+    );
+    let data_file_cache = ObjectStorageCache::new(cache_config);
+
+    let (mut table, mut table_notify) =
+        prepare_test_disk_file(&temp_dir, data_file_cache.clone()).await;
+    let (_, _, _, _) = table
+        .create_mooncake_snapshot_for_test(&mut table_notify)
+        .await;
+
+    // Read and increment reference count.
+    let snapshot_read_output_1 = table.request_read().await.unwrap();
+    let _read_state_1 = snapshot_read_output_1.take_as_read_state().await;
+
+    // Create iceberg snapshot and reflect persistence result to mooncake snapshot.
+    table
+        .create_mooncake_and_iceberg_snapshot_for_test(&mut table_notify)
+        .await
+        .unwrap();
+    let (_, _, _, _) = table
+        .create_mooncake_snapshot_for_test(&mut table_notify)
+        .await;
+
+    // Read and increment reference count.
+    let snapshot_read_output_2 = table.request_read().await.unwrap();
+    let _read_state_2 = snapshot_read_output_2.take_as_read_state().await;
+
+    // Check data file has been pinned in mooncake table.
+    let disk_files = table.get_disk_files_for_snapshot().await;
+    assert_eq!(disk_files.len(), 1);
+    let (file, disk_file_entry) = disk_files.iter().next().unwrap();
+    assert!(disk_file_entry.cache_handle.is_none());
+    assert!(is_remote_file(file, &temp_dir));
+
+    // Check cache state.
+    assert_eq!(data_file_cache.cache.read().await.evictable_cache.len(), 0);
+    assert_eq!(
+        data_file_cache.cache.read().await.non_evictable_cache.len(),
+        1,
+    );
+    assert_eq!(
+        data_file_cache
+            .get_non_evictable_entry_ref_count(&file.file_id())
+            .await,
+        2,
+    );
+}
+
+/// Test scenario: remote, local, in use + use over & pinned => remote, local, in use
+#[tokio::test]
+async fn test_3_read_and_read_over_and_pinned_3() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let cache_config = ObjectStorageCacheConfig::new(
+        INFINITE_LARGE_DATA_FILE_CACHE_SIZE,
+        temp_dir.path().to_str().unwrap().to_string(),
+    );
+    let data_file_cache = ObjectStorageCache::new(cache_config);
+
+    let (mut table, mut table_notify) =
+        prepare_test_disk_file(&temp_dir, data_file_cache.clone()).await;
+    let (_, _, _, _) = table
+        .create_mooncake_snapshot_for_test(&mut table_notify)
+        .await;
+
+    // Read and increment reference count.
+    let snapshot_read_output_1 = table.request_read().await.unwrap();
+    let _read_state_1 = snapshot_read_output_1.take_as_read_state().await;
+
+    // Create iceberg snapshot and reflect persistence result to mooncake snapshot.
+    table
+        .create_mooncake_and_iceberg_snapshot_for_test(&mut table_notify)
+        .await
+        .unwrap();
+    let (_, _, _, _) = table
+        .create_mooncake_snapshot_for_test(&mut table_notify)
+        .await;
+
+    // Read and increment reference count.
+    let snapshot_read_output_2 = table.request_read().await.unwrap();
+    let read_state_2 = snapshot_read_output_2.take_as_read_state().await;
+    drop(read_state_2);
+    table.sync_read_request(&mut table_notify).await;
+
+    // Create a mooncake snapshot to reflect read request completion result.
+    let (_, _, _, _) = table
+        .create_mooncake_snapshot_for_test(&mut table_notify)
+        .await;
+
+    // Check data file has been pinned in mooncake table.
+    let disk_files = table.get_disk_files_for_snapshot().await;
+    assert_eq!(disk_files.len(), 1);
+    let (file, disk_file_entry) = disk_files.iter().next().unwrap();
+    assert!(disk_file_entry.cache_handle.is_none());
+    assert!(is_remote_file(file, &temp_dir));
+
+    // Check cache state.
+    assert_eq!(data_file_cache.cache.read().await.evictable_cache.len(), 0);
+    assert_eq!(
+        data_file_cache.cache.read().await.non_evictable_cache.len(),
+        1,
+    );
+    assert_eq!(
+        data_file_cache
+            .get_non_evictable_entry_ref_count(&file.file_id())
+            .await,
+        1,
+    );
+}
+
+/// Test scenario: remote, local, in use + use over & unpinned => remote, no local, not used
+#[tokio::test]
+async fn test_3_read_and_read_over_and_unpinned_1() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let cache_config = ObjectStorageCacheConfig::new(
+        INFINITE_LARGE_DATA_FILE_CACHE_SIZE,
+        temp_dir.path().to_str().unwrap().to_string(),
+    );
+    let data_file_cache = ObjectStorageCache::new(cache_config);
+
+    let (mut table, mut table_notify) =
+        prepare_test_disk_file(&temp_dir, data_file_cache.clone()).await;
+    let (_, _, _, _) = table
+        .create_mooncake_snapshot_for_test(&mut table_notify)
+        .await;
+
+    // Create iceberg snapshot and reflect persistence result to mooncake snapshot.
+    table
+        .create_mooncake_and_iceberg_snapshot_for_test(&mut table_notify)
+        .await
+        .unwrap();
+    let (_, _, _, _) = table
+        .create_mooncake_snapshot_for_test(&mut table_notify)
+        .await;
+
+    // Read and increment reference count.
+    let snapshot_read_output = table.request_read().await.unwrap();
+    let read_state = snapshot_read_output.take_as_read_state().await;
+    drop(read_state);
+    table.sync_read_request(&mut table_notify).await;
+
+    // Create a mooncake snapshot to reflect read request completion result.
+    let (_, _, _, _) = table
+        .create_mooncake_snapshot_for_test(&mut table_notify)
+        .await;
+
+    // Check data file has been pinned in mooncake table.
+    let disk_files = table.get_disk_files_for_snapshot().await;
+    assert_eq!(disk_files.len(), 1);
+    let (file, disk_file_entry) = disk_files.iter().next().unwrap();
+    assert!(disk_file_entry.cache_handle.is_none());
+    assert!(is_remote_file(file, &temp_dir));
+
+    // Check cache state.
+    assert_eq!(data_file_cache.cache.read().await.evictable_cache.len(), 1);
+    assert_eq!(
+        data_file_cache.cache.read().await.non_evictable_cache.len(),
+        0,
+    );
+}
+
+/// Test scenario: remote, no local, not used + use & pinned => remote, local, in use
+#[tokio::test]
+async fn test_1_read_and_pinned_3() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let cache_config = ObjectStorageCacheConfig::new(
+        INFINITE_LARGE_DATA_FILE_CACHE_SIZE,
+        temp_dir.path().to_str().unwrap().to_string(),
+    );
+    let data_file_cache = ObjectStorageCache::new(cache_config);
+
+    let (mut table, mut table_notify) =
+        prepare_test_disk_file(&temp_dir, data_file_cache.clone()).await;
+    let (_, _, _, _) = table
+        .create_mooncake_snapshot_for_test(&mut table_notify)
+        .await;
+
+    // Create iceberg snapshot and reflect persistence result to mooncake snapshot.
+    table
+        .create_mooncake_and_iceberg_snapshot_for_test(&mut table_notify)
+        .await
+        .unwrap();
+    let (_, _, _, _) = table
+        .create_mooncake_snapshot_for_test(&mut table_notify)
+        .await;
+
+    // Read and increment reference count.
+    let snapshot_read_output = table.request_read().await.unwrap();
+    let _read_state = snapshot_read_output.take_as_read_state().await;
+
+    // Check data file has been pinned in mooncake table.
+    let disk_files = table.get_disk_files_for_snapshot().await;
+    assert_eq!(disk_files.len(), 1);
+    let (file, disk_file_entry) = disk_files.iter().next().unwrap();
+    assert!(disk_file_entry.cache_handle.is_none());
+    assert!(is_remote_file(file, &temp_dir));
+
+    // Check cache state.
+    assert_eq!(data_file_cache.cache.read().await.evictable_cache.len(), 0);
+    assert_eq!(
+        data_file_cache.cache.read().await.non_evictable_cache.len(),
+        1,
+    );
+    assert_eq!(
+        data_file_cache
+            .get_non_evictable_entry_ref_count(&file.file_id())
+            .await,
+        1,
+    );
+}
+
+/// Test scenario: remote, no local, not used + use & unpinned => remote, no local, not used
+#[tokio::test]
+async fn test_1_read_and_unpinned_3() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let cache_config = ObjectStorageCacheConfig::new(
+        ONE_FILE_CACHE_SIZE,
+        temp_dir.path().to_str().unwrap().to_string(),
+    );
+    let mut data_file_cache = ObjectStorageCache::new(cache_config);
+
+    let (mut table, mut table_notify) =
+        prepare_test_disk_file(&temp_dir, data_file_cache.clone()).await;
+    let (_, _, _, _) = table
+        .create_mooncake_snapshot_for_test(&mut table_notify)
+        .await;
+
+    // Create iceberg snapshot and reflect persistence result to mooncake snapshot.
+    table
+        .create_mooncake_and_iceberg_snapshot_for_test(&mut table_notify)
+        .await
+        .unwrap();
+    let (_, _, _, _) = table
+        .create_mooncake_snapshot_for_test(&mut table_notify)
+        .await;
+
+    // Import second data file into cache, so the cached entry will be evicted.
+    import_fake_cache_entry(&mut data_file_cache).await;
+
+    // Read and increment reference count.
+    let snapshot_read_output = table.request_read().await.unwrap();
+    let _read_state = snapshot_read_output.take_as_read_state().await;
+
+    // Check data file has been pinned in mooncake table.
+    let disk_files = table.get_disk_files_for_snapshot().await;
+    assert_eq!(disk_files.len(), 1);
+    let (file, disk_file_entry) = disk_files.iter().next().unwrap();
+    assert!(disk_file_entry.cache_handle.is_none());
+    assert!(is_remote_file(file, &temp_dir));
+
+    // Check cache state.
+    assert_eq!(data_file_cache.cache.read().await.evictable_cache.len(), 0);
+    assert_eq!(
+        data_file_cache.cache.read().await.non_evictable_cache.len(),
+        1,
+    );
+    assert_eq!(
+        data_file_cache.get_non_evictable_filenames().await,
+        vec![FAKE_FILE_ID]
+    );
+}
+
+/// Test scenario: remote, no local, in use + use & pinned => remote, local, in use
+#[tokio::test]
+async fn test_2_read_and_pinned_3() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let cache_config = ObjectStorageCacheConfig::new(
+        ONE_FILE_CACHE_SIZE,
+        temp_dir.path().to_str().unwrap().to_string(),
+    );
+    let mut data_file_cache = ObjectStorageCache::new(cache_config);
+
+    let (mut table, mut table_notify) =
+        prepare_test_disk_file(&temp_dir, data_file_cache.clone()).await;
+    let (_, _, _, _) = table
+        .create_mooncake_snapshot_for_test(&mut table_notify)
+        .await;
+
+    // Create iceberg snapshot and reflect persistence result to mooncake snapshot.
+    table
+        .create_mooncake_and_iceberg_snapshot_for_test(&mut table_notify)
+        .await
+        .unwrap();
+    let (_, _, _, _) = table
+        .create_mooncake_snapshot_for_test(&mut table_notify)
+        .await;
+
+    // Import second data file into cache, so the cached entry will be evicted.
+    let mut fake_cache_handle = import_fake_cache_entry(&mut data_file_cache).await;
+
+    // Read and increment reference count.
+    let snapshot_read_output_1 = table.request_read().await.unwrap();
+    let _read_state_1 = snapshot_read_output_1.take_as_read_state().await;
+    // Till now, the state is (remote, no local, in use).
+
+    // Unreference the second cache handle, so we could pin requires files again in cache.
+    fake_cache_handle.unreference().await;
+
+    let snapshot_read_output_2 = table.request_read().await.unwrap();
+    let _read_state_2 = snapshot_read_output_2.take_as_read_state().await;
+
+    // Check data file has been pinned in mooncake table.
+    let disk_files = table.get_disk_files_for_snapshot().await;
+    assert_eq!(disk_files.len(), 1);
+    let (file, disk_file_entry) = disk_files.iter().next().unwrap();
+    assert!(disk_file_entry.cache_handle.is_none());
+    assert!(is_remote_file(file, &temp_dir));
+
+    // Check cache state.
+    assert_eq!(data_file_cache.cache.read().await.evictable_cache.len(), 0);
+    assert_eq!(
+        data_file_cache.cache.read().await.non_evictable_cache.len(),
+        1,
+    );
+    assert_eq!(
+        data_file_cache
+            .get_non_evictable_entry_ref_count(&file.file_id())
+            .await,
+        1,
+    );
+}
+
+/// Test scenario: remote, no local, in use + use & unpinned => remote, no local, in use
+#[tokio::test]
+async fn test_2_read_and_unpinned_2() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let cache_config = ObjectStorageCacheConfig::new(
+        ONE_FILE_CACHE_SIZE,
+        temp_dir.path().to_str().unwrap().to_string(),
+    );
+    let mut data_file_cache = ObjectStorageCache::new(cache_config);
+
+    let (mut table, mut table_notify) =
+        prepare_test_disk_file(&temp_dir, data_file_cache.clone()).await;
+    let (_, _, _, _) = table
+        .create_mooncake_snapshot_for_test(&mut table_notify)
+        .await;
+
+    // Create iceberg snapshot and reflect persistence result to mooncake snapshot.
+    table
+        .create_mooncake_and_iceberg_snapshot_for_test(&mut table_notify)
+        .await
+        .unwrap();
+    let (_, _, _, _) = table
+        .create_mooncake_snapshot_for_test(&mut table_notify)
+        .await;
+
+    // Import second data file into cache, so the cached entry will be evicted.
+    import_fake_cache_entry(&mut data_file_cache).await;
+
+    // Read and increment reference count.
+    let snapshot_read_output_1 = table.request_read().await.unwrap();
+    let _read_state_1 = snapshot_read_output_1.take_as_read_state().await;
+    // Till now, the state is (remote, no local, in use).
+
+    let snapshot_read_output_2 = table.request_read().await.unwrap();
+    let _read_state_2 = snapshot_read_output_2.take_as_read_state().await;
+
+    // Check data file has been pinned in mooncake table.
+    let disk_files = table.get_disk_files_for_snapshot().await;
+    assert_eq!(disk_files.len(), 1);
+    let (file, disk_file_entry) = disk_files.iter().next().unwrap();
+    assert!(disk_file_entry.cache_handle.is_none());
+    assert!(is_remote_file(file, &temp_dir));
+
+    // Check cache state.
+    assert_eq!(data_file_cache.cache.read().await.evictable_cache.len(), 0);
+    assert_eq!(
+        data_file_cache.cache.read().await.non_evictable_cache.len(),
+        1,
+    );
+    assert_eq!(
+        data_file_cache.get_non_evictable_filenames().await,
+        vec![FAKE_FILE_ID]
+    );
+}
+
+/// Test scenario: remote, no local, in use + use over => remote, no local, not used
+#[tokio::test]
+async fn test_2_read_over_1() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let cache_config = ObjectStorageCacheConfig::new(
+        ONE_FILE_CACHE_SIZE,
+        temp_dir.path().to_str().unwrap().to_string(),
+    );
+    let mut data_file_cache = ObjectStorageCache::new(cache_config);
+
+    let (mut table, mut table_notify) =
+        prepare_test_disk_file(&temp_dir, data_file_cache.clone()).await;
+    let (_, _, _, _) = table
+        .create_mooncake_snapshot_for_test(&mut table_notify)
+        .await;
+
+    // Create iceberg snapshot and reflect persistence result to mooncake snapshot.
+    table
+        .create_mooncake_and_iceberg_snapshot_for_test(&mut table_notify)
+        .await
+        .unwrap();
+    let (_, _, _, _) = table
+        .create_mooncake_snapshot_for_test(&mut table_notify)
+        .await;
+
+    // Import second data file into cache, so the cached entry will be evicted.
+    import_fake_cache_entry(&mut data_file_cache).await;
+
+    // Read and increment reference count.
+    let snapshot_read_output = table.request_read().await.unwrap();
+    let read_state = snapshot_read_output.take_as_read_state().await;
+    // Till now, the state is (remote, no local, in use).
+
+    drop(read_state);
+
+    // Check data file has been pinned in mooncake table.
+    let disk_files = table.get_disk_files_for_snapshot().await;
+    assert_eq!(disk_files.len(), 1);
+    let (file, disk_file_entry) = disk_files.iter().next().unwrap();
+    assert!(disk_file_entry.cache_handle.is_none());
+    assert!(is_remote_file(file, &temp_dir));
+
+    // Check cache state.
+    assert_eq!(data_file_cache.cache.read().await.evictable_cache.len(), 0);
+    assert_eq!(
+        data_file_cache.cache.read().await.non_evictable_cache.len(),
+        1,
+    );
+    assert_eq!(
+        data_file_cache.get_non_evictable_filenames().await,
+        vec![FAKE_FILE_ID]
+    );
+}

--- a/src/moonlink/src/storage/mooncake_table/state_tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/state_tests.rs
@@ -360,7 +360,7 @@ async fn test_4_read_4() {
         data_file_cache
             .get_non_evictable_entry_ref_count(&file.file_id())
             .await,
-        3
+        4,
     );
 }
 

--- a/src/moonlink/src/storage/mooncake_table/table_snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_snapshot.rs
@@ -93,7 +93,7 @@ pub struct IcebergSnapshotDataCompactionResult {
     pub(crate) old_file_indices_to_remove: Vec<MooncakeFileIndex>,
 }
 
-pub(crate) struct IcebergSnapshotResult {
+pub struct IcebergSnapshotResult {
     /// Table manager is (1) not `Sync` safe; (2) only used at iceberg snapshot creation, so we `move` it around every snapshot.
     pub(crate) table_manager: Box<dyn TableManager>,
     /// Iceberg flush LSN.

--- a/src/moonlink/src/storage/mooncake_table/tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/tests.rs
@@ -1,7 +1,6 @@
 use super::test_utils::*;
 use super::*;
 use crate::storage::iceberg::table_manager::MockTableManager;
-use crate::storage::mooncake_table::snapshot::ReadOutput;
 use crate::storage::mooncake_table::TableConfig as MooncakeTableConfig;
 use iceberg::{Error as IcebergError, ErrorKind};
 use rstest::*;
@@ -22,16 +21,16 @@ async fn test_append_commit_snapshot(#[case] identity: IdentityProp) -> Result<(
     let context = TestContext::new("append_commit");
     let mut table = test_table(&context, "append_table", identity).await;
     let (event_completion_tx, mut event_completion_rx) = mpsc::channel(100);
-    table.register_table_notify(event_completion_tx);
+    table.register_table_notify(event_completion_tx).await;
 
     append_rows(&mut table, vec![test_row(1, "A", 20), test_row(2, "B", 21)])?;
     table.commit(1);
     snapshot(&mut table, &mut event_completion_rx).await;
-    let snapshot = table.snapshot.read().await;
-    let ReadOutput {
+    let mut snapshot = table.snapshot.write().await;
+    let SnapshotReadOutput {
         data_file_paths, ..
     } = snapshot.request_read().await?;
-    verify_file_contents(&data_file_paths[0], &[1, 2], Some(2));
+    verify_file_contents(&data_file_paths[0].get_file_path(), &[1, 2], Some(2));
     Ok(())
 }
 
@@ -41,15 +40,15 @@ async fn test_flush_basic(#[case] identity: IdentityProp) -> Result<()> {
     let context = TestContext::new("flush_basic");
     let mut table = test_table(&context, "flush_table", identity).await;
     let (event_completion_tx, mut event_completion_rx) = mpsc::channel(100);
-    table.register_table_notify(event_completion_tx);
+    table.register_table_notify(event_completion_tx).await;
 
     let rows = vec![test_row(1, "Alice", 30), test_row(2, "Bob", 25)];
     append_commit_flush_snapshot(&mut table, &mut event_completion_rx, rows, 1).await?;
-    let snapshot = table.snapshot.read().await;
-    let ReadOutput {
+    let mut snapshot = table.snapshot.write().await;
+    let SnapshotReadOutput {
         data_file_paths, ..
     } = snapshot.request_read().await?;
-    verify_file_contents(&data_file_paths[0], &[1, 2], Some(2));
+    verify_file_contents(&data_file_paths[0].get_file_path(), &[1, 2], Some(2));
     Ok(())
 }
 
@@ -59,7 +58,7 @@ async fn test_delete_and_append(#[case] identity: IdentityProp) -> Result<()> {
     let context = TestContext::new("delete_append");
     let mut table = test_table(&context, "del_table", identity).await;
     let (event_completion_tx, mut event_completion_rx) = mpsc::channel(100);
-    table.register_table_notify(event_completion_tx);
+    table.register_table_notify(event_completion_tx).await;
 
     let initial_rows = vec![
         test_row(1, "Row 1", 31),
@@ -76,8 +75,8 @@ async fn test_delete_and_append(#[case] identity: IdentityProp) -> Result<()> {
     table.commit(3);
     snapshot(&mut table, &mut event_completion_rx).await;
 
-    let snapshot = table.snapshot.read().await;
-    let ReadOutput {
+    let mut snapshot = table.snapshot.write().await;
+    let SnapshotReadOutput {
         data_file_paths,
         puffin_file_paths,
         position_deletes,
@@ -85,7 +84,7 @@ async fn test_delete_and_append(#[case] identity: IdentityProp) -> Result<()> {
         ..
     } = snapshot.request_read().await?;
     verify_files_and_deletions(
-        &data_file_paths,
+        get_data_files_for_read(&data_file_paths).as_slice(),
         &puffin_file_paths,
         position_deletes,
         deletion_vectors,
@@ -101,7 +100,7 @@ async fn test_deletion_before_flush(#[case] identity: IdentityProp) -> Result<()
     let context = TestContext::new("delete_pre_flush");
     let mut table = test_table(&context, "table", identity).await;
     let (event_completion_tx, mut event_completion_rx) = mpsc::channel(100);
-    table.register_table_notify(event_completion_tx);
+    table.register_table_notify(event_completion_tx).await;
 
     append_rows(&mut table, batch_rows(1, 4))?;
     table.commit(1);
@@ -112,11 +111,11 @@ async fn test_deletion_before_flush(#[case] identity: IdentityProp) -> Result<()
     table.commit(2);
     snapshot(&mut table, &mut event_completion_rx).await;
 
-    let snapshot = table.snapshot.read().await;
-    let ReadOutput {
+    let mut snapshot = table.snapshot.write().await;
+    let SnapshotReadOutput {
         data_file_paths, ..
     } = snapshot.request_read().await?;
-    verify_file_contents(&data_file_paths[0], &[1, 3], None);
+    verify_file_contents(&data_file_paths[0].get_file_path(), &[1, 3], None);
     Ok(())
 }
 
@@ -126,7 +125,7 @@ async fn test_deletion_after_flush(#[case] identity: IdentityProp) -> Result<()>
     let context = TestContext::new("delete_post_flush");
     let mut table = test_table(&context, "table", identity).await;
     let (event_completion_tx, mut event_completion_rx) = mpsc::channel(100);
-    table.register_table_notify(event_completion_tx);
+    table.register_table_notify(event_completion_tx).await;
     append_commit_flush_snapshot(&mut table, &mut event_completion_rx, batch_rows(1, 4), 1).await?;
 
     table.delete(test_row(2, "Row 2", 32), 2).await;
@@ -134,14 +133,14 @@ async fn test_deletion_after_flush(#[case] identity: IdentityProp) -> Result<()>
     table.commit(2);
     snapshot(&mut table, &mut event_completion_rx).await;
 
-    let snapshot = table.snapshot.read().await;
-    let ReadOutput {
+    let mut snapshot = table.snapshot.write().await;
+    let SnapshotReadOutput {
         data_file_paths,
         position_deletes,
         ..
     } = snapshot.request_read().await?;
     assert_eq!(data_file_paths.len(), 1);
-    let mut ids = read_ids_from_parquet(&data_file_paths[0]);
+    let mut ids = read_ids_from_parquet(&data_file_paths[0].get_file_path());
 
     for deletion in position_deletes {
         ids[deletion.1 as usize] = None;
@@ -167,7 +166,7 @@ async fn test_update_rows(#[case] identity: IdentityProp) -> Result<()> {
     let context = TestContext::new("update_rows");
     let mut table = test_table(&context, "update_table", identity).await;
     let (event_completion_tx, mut event_completion_rx) = mpsc::channel(100);
-    table.register_table_notify(event_completion_tx);
+    table.register_table_notify(event_completion_tx).await;
 
     // Perform and check initial append operation.
     table.append(row1.clone())?;
@@ -179,8 +178,8 @@ async fn test_update_rows(#[case] identity: IdentityProp) -> Result<()> {
         .create_mooncake_and_iceberg_snapshot_for_test(&mut event_completion_rx)
         .await?;
     {
-        let table_snapshot = table.snapshot.read().await;
-        let ReadOutput {
+        let mut table_snapshot = table.snapshot.write().await;
+        let SnapshotReadOutput {
             data_file_paths,
             puffin_file_paths,
             position_deletes,
@@ -188,7 +187,7 @@ async fn test_update_rows(#[case] identity: IdentityProp) -> Result<()> {
             ..
         } = table_snapshot.request_read().await?;
         verify_files_and_deletions(
-            &data_file_paths,
+            get_data_files_for_read(&data_file_paths).as_slice(),
             &puffin_file_paths,
             position_deletes,
             deletion_vectors,
@@ -209,8 +208,8 @@ async fn test_update_rows(#[case] identity: IdentityProp) -> Result<()> {
         .create_mooncake_and_iceberg_snapshot_for_test(&mut event_completion_rx)
         .await?;
     {
-        let table_snapshot = table.snapshot.read().await;
-        let ReadOutput {
+        let mut table_snapshot = table.snapshot.write().await;
+        let SnapshotReadOutput {
             data_file_paths,
             puffin_file_paths,
             position_deletes,
@@ -218,7 +217,7 @@ async fn test_update_rows(#[case] identity: IdentityProp) -> Result<()> {
             ..
         } = table_snapshot.request_read().await?;
         verify_files_and_deletions(
-            &data_file_paths,
+            get_data_files_for_read(&data_file_paths).as_slice(),
             &puffin_file_paths,
             position_deletes,
             deletion_vectors,
@@ -258,7 +257,7 @@ async fn test_full_row_with_duplication_and_identical() -> Result<()> {
     )
     .await;
     let (event_completion_tx, mut event_completion_rx) = mpsc::channel(100);
-    table.register_table_notify(event_completion_tx);
+    table.register_table_notify(event_completion_tx).await;
 
     // Insert duplicate rows (same identity, different values)
     let row1 = test_row(1, "A", 20);
@@ -291,8 +290,8 @@ async fn test_full_row_with_duplication_and_identical() -> Result<()> {
 
     // Verify that row1 is deleted, but row2 (same id) remains
     {
-        let table_snapshot = table.snapshot.read().await;
-        let ReadOutput {
+        let mut table_snapshot = table.snapshot.write().await;
+        let SnapshotReadOutput {
             data_file_paths,
             puffin_file_paths,
             position_deletes,
@@ -300,7 +299,7 @@ async fn test_full_row_with_duplication_and_identical() -> Result<()> {
             ..
         } = table_snapshot.request_read().await?;
         verify_files_and_deletions(
-            &data_file_paths,
+            get_data_files_for_read(&data_file_paths).as_slice(),
             &puffin_file_paths,
             position_deletes,
             deletion_vectors,
@@ -320,8 +319,8 @@ async fn test_full_row_with_duplication_and_identical() -> Result<()> {
 
     // Verify that row3 is deleted, but row4 (same id) remains
     {
-        let table_snapshot = table.snapshot.read().await;
-        let ReadOutput {
+        let mut table_snapshot = table.snapshot.write().await;
+        let SnapshotReadOutput {
             data_file_paths,
             puffin_file_paths,
             position_deletes,
@@ -329,7 +328,7 @@ async fn test_full_row_with_duplication_and_identical() -> Result<()> {
             ..
         } = table_snapshot.request_read().await?;
         verify_files_and_deletions(
-            &data_file_paths,
+            get_data_files_for_read(&data_file_paths).as_slice(),
             &puffin_file_paths,
             position_deletes,
             deletion_vectors,
@@ -344,8 +343,8 @@ async fn test_full_row_with_duplication_and_identical() -> Result<()> {
     snapshot(&mut table, &mut event_completion_rx).await;
 
     {
-        let table_snapshot = table.snapshot.read().await;
-        let ReadOutput {
+        let mut table_snapshot = table.snapshot.write().await;
+        let SnapshotReadOutput {
             data_file_paths,
             puffin_file_paths,
             position_deletes,
@@ -353,7 +352,7 @@ async fn test_full_row_with_duplication_and_identical() -> Result<()> {
             ..
         } = table_snapshot.request_read().await?;
         verify_files_and_deletions(
-            &data_file_paths,
+            get_data_files_for_read(&data_file_paths).as_slice(),
             &puffin_file_paths,
             position_deletes,
             deletion_vectors,
@@ -371,7 +370,7 @@ async fn test_duplicate_deletion() -> Result<()> {
     let context = TestContext::new("duplicate_deletion");
     let mut table = test_table(&context, "duplicate_deletion", IdentityProp::Keys(vec![0])).await;
     let (event_completion_tx, mut event_completion_rx) = mpsc::channel(100);
-    table.register_table_notify(event_completion_tx);
+    table.register_table_notify(event_completion_tx).await;
 
     let old_row = test_row(1, "John", 30);
     table.append(old_row.clone()).unwrap();
@@ -392,8 +391,8 @@ async fn test_duplicate_deletion() -> Result<()> {
         .await?;
 
     {
-        let table_snapshot = table.snapshot.read().await;
-        let ReadOutput {
+        let mut table_snapshot = table.snapshot.write().await;
+        let SnapshotReadOutput {
             data_file_paths,
             puffin_file_paths,
             position_deletes,
@@ -401,7 +400,7 @@ async fn test_duplicate_deletion() -> Result<()> {
             ..
         } = table_snapshot.request_read().await?;
         verify_files_and_deletions(
-            &data_file_paths,
+            get_data_files_for_read(&data_file_paths).as_slice(),
             &puffin_file_paths,
             position_deletes,
             deletion_vectors,
@@ -442,18 +441,24 @@ async fn test_snapshot_store_failure() {
         table_metadata,
         Box::new(mock_table_manager),
         MooncakeTableConfig::default(), // No temp files generated.
+        ObjectStorageCache::default_for_test(),
     )
     .await
     .unwrap();
     let (event_completion_tx, mut event_completion_rx) = mpsc::channel(100);
-    table.register_table_notify(event_completion_tx);
+    table.register_table_notify(event_completion_tx).await;
 
     let row = test_row(1, "A", 20);
     table.append(row).unwrap();
     table.commit(/*lsn=*/ 100);
     table.flush(/*lsn=*/ 100).await.unwrap();
 
-    let (_, iceberg_snapshot_payload, _, _) = snapshot(&mut table, &mut event_completion_rx).await;
+    let (_, iceberg_snapshot_payload, _, _, evicted_data_files_cache) =
+        snapshot(&mut table, &mut event_completion_rx).await;
+    for cur_file in evicted_data_files_cache.into_iter() {
+        tokio::fs::remove_file(&cur_file).await.unwrap();
+    }
+
     let iceberg_snapshot_result = create_iceberg_snapshot(
         &mut table,
         iceberg_snapshot_payload,

--- a/src/moonlink/src/storage/mooncake_table/tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/tests.rs
@@ -1,7 +1,6 @@
 use super::test_utils::*;
 use super::*;
 use crate::storage::iceberg::table_manager::MockTableManager;
-use crate::storage::mooncake_table::TableConfig as MooncakeTableConfig;
 use iceberg::{Error as IcebergError, ErrorKind};
 use rstest::*;
 use rstest_reuse::{self, *};
@@ -440,7 +439,6 @@ async fn test_snapshot_store_failure() {
     let mut table = MooncakeTable::new_with_table_manager(
         table_metadata,
         Box::new(mock_table_manager),
-        MooncakeTableConfig::default(), // No temp files generated.
         ObjectStorageCache::default_for_test(),
     )
     .await

--- a/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
+++ b/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::storage::cache::object_storage::base_cache::{CacheEntry, CacheTrait, FileMetadata};
 use crate::storage::mooncake_table::DiskFileEntry;
-use crate::storage::storage_utils::ProcessedDeletionRecord;
+use crate::storage::storage_utils::{ProcessedDeletionRecord, TableUniqueFileId};
 use more_asserts as ma;
 /// Used to track the state of a streamed transaction
 /// Holds appending rows in memslice and files.
@@ -272,10 +272,14 @@ impl SnapshotTableState {
                     for (file, mut disk_file_entry) in commit.flushed_files.into_iter() {
                         task.disk_file_lsn_map
                             .insert(file.file_id(), commit.commit_lsn);
+                        let file_id = TableUniqueFileId {
+                            table_id: TableId(self.mooncake_table_metadata.id),
+                            file_id: file.file_id(),
+                        };
                         let (cache_handle, cur_evicted_files) = self
                             .data_file_cache
                             .import_cache_entry(
-                                file.file_id(),
+                                file_id,
                                 CacheEntry {
                                     cache_filepath: file.file_path().clone(),
                                     file_metadata: FileMetadata {

--- a/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
+++ b/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::storage::cache::object_storage::base_cache::{CacheEntry, CacheTrait, FileMetadata};
 use crate::storage::mooncake_table::DiskFileEntry;
 use crate::storage::storage_utils::ProcessedDeletionRecord;
 use more_asserts as ma;
@@ -197,6 +198,7 @@ impl MooncakeTable {
                 ma::assert_gt!(file_attrs.file_size, 0);
                 let disk_file_entry = DiskFileEntry {
                     file_size: file_attrs.file_size,
+                    cache_handle: None,
                     file_indice: Some(disk_slice.get_file_indice().as_ref().unwrap().clone()),
                     batch_deletion_vector: BatchDeletionVector::new(file_attrs.row_num),
                     puffin_deletion_blob: None,
@@ -254,22 +256,41 @@ impl MooncakeTable {
 }
 
 impl SnapshotTableState {
-    pub(super) fn apply_transaction_stream(&mut self, task: &mut SnapshotTask) {
+    /// Return files evicted from data file cache.
+    pub(super) async fn apply_transaction_stream(
+        &mut self,
+        task: &mut SnapshotTask,
+    ) -> Vec<String> {
+        // Aggregate evicted data cache files to delete.
+        let mut evicted_files = vec![];
+
         let new_streaming_xact = task.new_streaming_xact.drain(..);
         for output in new_streaming_xact {
             match output {
                 TransactionStreamOutput::Commit(commit) => {
-                    // add files
-                    commit
-                        .flushed_files
-                        .into_iter()
-                        .for_each(|(file, disk_file_entry)| {
-                            task.disk_file_lsn_map
-                                .insert(file.file_id(), commit.commit_lsn);
-                            self.current_snapshot
-                                .disk_files
-                                .insert(file, disk_file_entry);
-                        });
+                    // Integrate files into current snapshot and import into data file cache.
+                    for (file, mut disk_file_entry) in commit.flushed_files.into_iter() {
+                        task.disk_file_lsn_map
+                            .insert(file.file_id(), commit.commit_lsn);
+                        let (cache_handle, cur_evicted_files) = self
+                            .data_file_cache
+                            .import_cache_entry(
+                                file.file_id(),
+                                CacheEntry {
+                                    cache_filepath: file.file_path().clone(),
+                                    file_metadata: FileMetadata {
+                                        file_size: disk_file_entry.file_size as u64,
+                                    },
+                                },
+                            )
+                            .await;
+                        disk_file_entry.cache_handle = Some(cache_handle);
+                        evicted_files.extend(cur_evicted_files);
+                        self.current_snapshot
+                            .disk_files
+                            .insert(file, disk_file_entry);
+                    }
+
                     // add index
                     commit
                         .flushed_file_index
@@ -311,5 +332,7 @@ impl SnapshotTableState {
                 }
             }
         }
+
+        evicted_files
     }
 }

--- a/src/moonlink/src/storage/storage_utils.rs
+++ b/src/moonlink/src/storage/storage_utils.rs
@@ -65,6 +65,23 @@ pub fn create_data_file(file_id: u64, file_path: String) -> MooncakeDataFileRef 
 #[derive(Debug, Clone, PartialEq, Eq, Copy, Hash)]
 pub struct FileId(pub(crate) u64);
 
+/// Unique table id.
+#[derive(Debug, Clone, PartialEq, Eq, Copy, Hash)]
+pub struct TableId(pub(crate) u64);
+
+/// A globally unique id for a file.
+#[derive(Debug, Clone, PartialEq, Eq, Copy)]
+pub struct TableUniqueFileId {
+    pub(crate) table_id: TableId,
+    pub(crate) file_id: FileId,
+}
+impl Hash for TableUniqueFileId {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.table_id.hash(state);
+        self.file_id.hash(state);
+    }
+}
+
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum RecordLocation {
     /// Record is in a memory batch

--- a/src/moonlink/src/table_handler.rs
+++ b/src/moonlink/src/table_handler.rs
@@ -384,9 +384,6 @@ impl TableHandler {
                             data_compaction_ongoing = false;
                         }
                         TableNotify::ReadRequest { file_ids, cache_handles } => {
-
-                            println!("finished read {:?}", file_ids);
-
                             table.set_read_request_res(file_ids, cache_handles);
                         }
                     }

--- a/src/moonlink/src/table_handler.rs
+++ b/src/moonlink/src/table_handler.rs
@@ -383,8 +383,8 @@ impl TableHandler {
                             }
                             data_compaction_ongoing = false;
                         }
-                        TableNotify::ReadRequest { file_ids, cache_handles } => {
-                            table.set_read_request_res(file_ids, cache_handles);
+                        TableNotify::ReadRequest { cache_handles } => {
+                            table.set_read_request_res(cache_handles);
                         }
                     }
                 }

--- a/src/moonlink/src/table_handler.rs
+++ b/src/moonlink/src/table_handler.rs
@@ -59,7 +59,7 @@ pub struct IcebergEventSyncSender {
 
 impl TableHandler {
     /// Create a new TableHandler for the given schema and table name
-    pub fn new(
+    pub async fn new(
         mut table: MooncakeTable,
         iceberg_event_sync_sender: IcebergEventSyncSender,
     ) -> Self {
@@ -68,7 +68,7 @@ impl TableHandler {
 
         // Create channel for internal control events.
         let (table_notify_tx, table_notify_rx) = mpsc::channel(100);
-        table.register_table_notify(table_notify_tx.clone());
+        table.register_table_notify(table_notify_tx.clone()).await;
 
         // Spawn the task with the oneshot receiver
         let event_handle = Some(tokio::spawn(async move {
@@ -281,7 +281,18 @@ impl TableHandler {
                 // Wait for the mooncake table event notification.
                 Some(event) = table_notify_rx.recv() => {
                     match event {
-                        TableNotify::MooncakeTableSnapshot { lsn, iceberg_snapshot_payload, data_compaction_payload, file_indice_merge_payload } => {
+                        TableNotify::MooncakeTableSnapshot { lsn, iceberg_snapshot_payload, data_compaction_payload, file_indice_merge_payload, evicted_data_files_to_delete } => {
+                            // Spawn a detached best-effort task to delete evicted data file cache.
+                            if !evicted_data_files_to_delete.is_empty() {
+                                tokio::task::spawn(async move {
+                                    for cur_data_file in evicted_data_files_to_delete.into_iter() {
+                                        if let Err(e) = tokio::fs::remove_file(&cur_data_file).await {
+                                            error!("Failed to delete data file cache: {:?}", e);
+                                        }
+                                    }
+                                });
+                            }
+
                             // Notify read the mooncake table commit of LSN.
                             table.notify_snapshot_reader(lsn);
 
@@ -371,6 +382,12 @@ impl TableHandler {
                                 }
                             }
                             data_compaction_ongoing = false;
+                        }
+                        TableNotify::ReadRequest { file_ids, cache_handles } => {
+
+                            println!("finished read {:?}", file_ids);
+
+                            table.set_read_request_res(file_ids, cache_handles);
                         }
                     }
                 }

--- a/src/moonlink/src/table_handler/tests.rs
+++ b/src/moonlink/src/table_handler/tests.rs
@@ -1003,7 +1003,6 @@ async fn test_iceberg_snapshot_failure_mock_test() {
     let mooncake_table = MooncakeTable::new_with_table_manager(
         mooncake_table_metadata,
         Box::new(mock_table_manager),
-        mooncake_table_config,
         ObjectStorageCache::default_for_test(),
     )
     .await
@@ -1055,7 +1054,6 @@ async fn test_iceberg_drop_table_failure_mock_test() {
     let mooncake_table = MooncakeTable::new_with_table_manager(
         mooncake_table_metadata,
         Box::new(mock_table_manager),
-        mooncake_table_config,
         ObjectStorageCache::default_for_test(),
     )
     .await

--- a/src/moonlink/src/table_handler/tests.rs
+++ b/src/moonlink/src/table_handler/tests.rs
@@ -10,6 +10,7 @@ use crate::storage::mooncake_table::TableMetadata as MooncakeTableMetadata;
 use crate::storage::MockTableManager;
 use crate::storage::MooncakeTable;
 use crate::storage::TableManager;
+use crate::ObjectStorageCache;
 use crate::TableConfig;
 
 use std::sync::Arc;
@@ -1003,6 +1004,7 @@ async fn test_iceberg_snapshot_failure_mock_test() {
         mooncake_table_metadata,
         Box::new(mock_table_manager),
         mooncake_table_config,
+        ObjectStorageCache::default_for_test(),
     )
     .await
     .unwrap();
@@ -1054,6 +1056,7 @@ async fn test_iceberg_drop_table_failure_mock_test() {
         mooncake_table_metadata,
         Box::new(mock_table_manager),
         mooncake_table_config,
+        ObjectStorageCache::default_for_test(),
     )
     .await
     .unwrap();

--- a/src/moonlink/src/table_notify.rs
+++ b/src/moonlink/src/table_notify.rs
@@ -4,14 +4,16 @@ use crate::storage::mooncake_table::FileIndiceMergePayload;
 use crate::storage::mooncake_table::FileIndiceMergeResult;
 use crate::storage::mooncake_table::IcebergSnapshotPayload;
 use crate::storage::mooncake_table::IcebergSnapshotResult;
+use crate::storage::storage_utils::FileId;
 
+use crate::NonEvictableHandle;
 use crate::Result;
 
 /// Completion notifications for mooncake table, including snapshot creation and compaction, etc.
 ///
 /// TODO(hjiang): Revisit whether we need to place the payload into box.
 #[allow(clippy::large_enum_variant)]
-pub(crate) enum TableNotify {
+pub enum TableNotify {
     /// Mooncake snapshot completes.
     MooncakeTableSnapshot {
         /// Mooncake snapshot LSN.
@@ -22,6 +24,8 @@ pub(crate) enum TableNotify {
         data_compaction_payload: Option<DataCompactionPayload>,
         /// Payload used to trigger an index merge.
         file_indice_merge_payload: Option<FileIndiceMergePayload>,
+        /// Evicted data file cache to delete.
+        evicted_data_files_to_delete: Vec<String>,
     },
     /// Iceberg snapshot completes.
     IcebergSnapshot {
@@ -37,5 +41,12 @@ pub(crate) enum TableNotify {
     DataCompaction {
         /// Result for data compaction.
         data_compaction_result: Result<DataCompactionResult>,
+    },
+    /// Read request completion.
+    ReadRequest {
+        /// File ids involved in the current snapshot read.
+        file_ids: Vec<FileId>,
+        /// Cache handles, which are pinned before query.
+        cache_handles: Vec<NonEvictableHandle>,
     },
 }

--- a/src/moonlink/src/table_notify.rs
+++ b/src/moonlink/src/table_notify.rs
@@ -4,7 +4,6 @@ use crate::storage::mooncake_table::FileIndiceMergePayload;
 use crate::storage::mooncake_table::FileIndiceMergeResult;
 use crate::storage::mooncake_table::IcebergSnapshotPayload;
 use crate::storage::mooncake_table::IcebergSnapshotResult;
-use crate::storage::storage_utils::FileId;
 
 use crate::NonEvictableHandle;
 use crate::Result;
@@ -44,8 +43,6 @@ pub enum TableNotify {
     },
     /// Read request completion.
     ReadRequest {
-        /// File ids involved in the current snapshot read.
-        file_ids: Vec<FileId>,
         /// Cache handles, which are pinned before query.
         cache_handles: Vec<NonEvictableHandle>,
     },

--- a/src/moonlink/src/union_read/read_state.rs
+++ b/src/moonlink/src/union_read/read_state.rs
@@ -4,21 +4,49 @@
 //
 
 use super::table_metadata::TableMetadata;
+use crate::storage::storage_utils::FileId;
 use crate::storage::PuffinDeletionBlobAtRead;
+use crate::table_notify::TableNotify;
+use crate::NonEvictableHandle;
 
 use bincode::config;
 use tracing::warn;
 
 const BINCODE_CONFIG: config::Configuration = config::standard();
 
+// TODO(hjiang): A better solution might be wrap clean up in a functor.
 #[derive(Debug)]
 pub struct ReadState {
+    /// Serialized data files and positional deletes for query.
     pub data: Vec<u8>,
+    /// Fields related to clean up after query completion.
     associated_files: Vec<String>,
+    involved_data_files: Vec<FileId>,
+    cache_handles: Vec<NonEvictableHandle>,
+    // Invariant: [`table_notify`] cannot be `None` if there're involved data files.
+    table_notify: Option<tokio::sync::mpsc::Sender<TableNotify>>,
 }
 
 impl Drop for ReadState {
     fn drop(&mut self) {
+        // Notify query completion for data file cache unreference.
+        // Since we cannot rely on async function at `Drop` function, start a detech task immediately here.
+        let involved_files = std::mem::take(&mut self.involved_data_files);
+        let cache_handles = std::mem::take(&mut self.cache_handles);
+
+        if let Some(table_notify) = self.table_notify.clone() {
+            tokio::spawn(async move {
+                table_notify
+                    .send(TableNotify::ReadRequest {
+                        file_ids: involved_files,
+                        cache_handles,
+                    })
+                    .await
+                    .unwrap();
+            });
+        }
+
+        // Delete temporarily data files.
         if self.associated_files.is_empty() {
             return;
         }
@@ -35,13 +63,23 @@ impl Drop for ReadState {
 }
 
 impl ReadState {
-    pub(super) fn new(
+    pub fn new(
+        // Data file and positional deletes for query.
         data_files: Vec<String>,
         puffin_files: Vec<String>,
         mut deletion_vectors_at_read: Vec<PuffinDeletionBlobAtRead>,
         mut position_deletes: Vec<(u32 /*file_index*/, u32 /*row_index*/)>,
+        // Fields used for read state cleanup after query completion.
         associated_files: Vec<String>,
+        involved_data_files: Vec<FileId>,
+        cache_handles: Vec<NonEvictableHandle>,
+        table_notify: Option<tokio::sync::mpsc::Sender<TableNotify>>,
     ) -> Self {
+        // Check invariants.
+        if table_notify.is_none() {
+            assert!(involved_data_files.is_empty());
+        }
+
         deletion_vectors_at_read.sort_by(|dv_1, dv_2| {
             dv_1.data_file_index
                 .cmp(&dv_2.data_file_index)
@@ -61,6 +99,9 @@ impl ReadState {
         Self {
             data,
             associated_files,
+            involved_data_files,
+            cache_handles,
+            table_notify,
         }
     }
 }

--- a/src/moonlink/src/union_read/read_state.rs
+++ b/src/moonlink/src/union_read/read_state.rs
@@ -63,6 +63,8 @@ impl Drop for ReadState {
 }
 
 impl ReadState {
+    // TODO(hjiang): Provide a struct for parameters.
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         // Data file and positional deletes for query.
         data_files: Vec<String>,

--- a/src/moonlink_backend/src/lib.rs
+++ b/src/moonlink_backend/src/lib.rs
@@ -4,6 +4,8 @@ mod logging;
 pub use error::{Error, Result};
 pub use moonlink::ReadState;
 use moonlink::Result as MoonlinkResult;
+use moonlink::SnapshotReadOutput;
+use moonlink::{ObjectStorageCache, ObjectStorageCacheConfig};
 use moonlink_connectors::ReplicationManager;
 use std::hash::Hash;
 use std::io::ErrorKind;
@@ -16,6 +18,9 @@ const DEFAULT_MOONLINK_TABLE_BASE_PATH: &str = "./mooncake/";
 // Default local filesystem directory where all temporary files (used for union read) will be stored under.
 // The whole directory is cleaned up at moonlink backend start, to prevent file leak.
 pub const DEFAULT_MOONLINK_TEMP_FILE_PATH: &str = "/tmp/moonlink_temp_file";
+// Default data file cache directory.
+// The whole directory is cleaned up at moonlink backend start, to prevent file leak.
+pub const DEFAULT_MOONLINK_DATA_FILE_CACHE_PATH: &str = "/tmp/moonlink_cache_file";
 
 /// Util function to delete and re-create the given directory.
 pub fn recreate_directory(dir: &str) -> Result<()> {
@@ -43,15 +48,28 @@ impl<T: Eq + Hash + Clone> Default for MoonlinkBackend<T> {
     }
 }
 
+/// Create default data file cache.
+/// TODO(hjiang): Re-evaluate hard-coded cache size before official release.
+fn create_default_data_file_cache() -> ObjectStorageCache {
+    let cache_config = ObjectStorageCacheConfig {
+        max_bytes: 10 * 1024 * 1024,
+        cache_directory: DEFAULT_MOONLINK_DATA_FILE_CACHE_PATH.to_string(),
+    };
+    ObjectStorageCache::new(cache_config)
+}
+
 impl<T: Eq + Hash + Clone> MoonlinkBackend<T> {
     pub fn new(base_path: String) -> Self {
         logging::init_logging();
 
         recreate_directory(DEFAULT_MOONLINK_TEMP_FILE_PATH).unwrap();
+        recreate_directory(DEFAULT_MOONLINK_DATA_FILE_CACHE_PATH).unwrap();
+
         Self {
             replication_manager: RwLock::new(ReplicationManager::new(
                 base_path.clone(),
                 DEFAULT_MOONLINK_TEMP_FILE_PATH.to_string(),
+                create_default_data_file_cache(),
             )),
         }
     }
@@ -69,11 +87,16 @@ impl<T: Eq + Hash + Clone> MoonlinkBackend<T> {
     }
 
     pub async fn scan_table(&self, table_id: &T, lsn: Option<u64>) -> Result<Arc<ReadState>> {
-        let manager = self.replication_manager.read().await;
+        #[allow(unused_assignments)]
+        let mut snapshot_read_output: Option<Arc<SnapshotReadOutput>> = None;
+        {
+            let manager = self.replication_manager.read().await;
+            let table_reader = manager.get_table_reader(table_id);
+            snapshot_read_output = Some(table_reader.try_read(lsn).await?);
+        }
 
-        let table_reader = manager.get_table_reader(table_id);
-        let read_state = table_reader.try_read(lsn).await?;
-        Ok(read_state)
+        let snapshot_read_output = (*snapshot_read_output.unwrap().clone()).clone();
+        Ok(snapshot_read_output.take_as_read_state().await)
     }
 
     /// Gracefully shutdown a replication connection identified by its URI.


### PR DESCRIPTION
## Summary

This PR integrate read-through/write-through cache into mooncake table.
- All mooncake tables share one single data file cache;
- Initially when writing local files, they're used as write-through cache;
- When iceberg snapshot persists, write through cache entries are unpinned and ready for eviction;
- On read path, moonlink tries to pin local cache entries at first; then download the whole file and add into cache;
- When read requests completes, all involved cache entries are unpinned and ready for eviction.

TODO items:
- Object cache should handle oversized objects
- Properly handle evicted deleted files
  + This PR has been super large (>2000 LOC), prefer not to add additional features
  + It's not a regression; data files are never deleted at the moment
- Cache should be integrated with compaction
- Unreference all data files at table drop

Test with pg_mooncake:
```sql
pg_mooncake (pid: 48561) =# DROP EXTENSION IF EXISTS pg_mooncake CASCADE;
DROP TABLE IF EXISTS r;
CREATE EXTENSION pg_mooncake;
CREATE TABLE r (a int primary key, b text);
CALL mooncake.create_table('c', 'r');
INSERT INTO r SELECT a, 'val_' || a FROM generate_series(1, 250000) AS a;
SELECT count(*) FROM c;
DELETE FROM r WHERE a % 2 = 0;
SELECT count(*) FROM c;
NOTICE:  drop cascades to table c
DROP EXTENSION
DROP TABLE
CREATE EXTENSION
CREATE TABLE
CALL
INSERT 0 250000
 count  
--------
 250000
(1 row)

DELETE 125000
 count  
--------
 125000
(1 row)
```

## Related Issues

Related to https://github.com/Mooncake-Labs/moonlink/issues/459

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
