### PR TITLE
[CI] Add timeout to test CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,7 @@ jobs:
 
       # ---------- Run the suite through llvm-cov and nextest ----------
       - name: Run tests via llvm-cov/nextest
+        timeout-minutes: 5
         run: |
           cargo llvm-cov \
             --locked \


### PR DESCRIPTION
## Summary

I have a PR with unit test running ~1 hour and keeps running, which wastes resource and burns our bill.
This PR sets a timeout to testing stage.
Reference CI run: https://github.com/Mooncake-Labs/moonlink/actions/runs/15688369501/job/44197204808?pr=470

Timeout change test PR: https://github.com/Mooncake-Labs/moonlink/actions/runs/15689748769/job/44201810050?pr=474

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
