### PR TITLE
[storage] Unreference cache handles at shutdown

### DIFF
--- a/src/moonlink/src/storage/iceberg/iceberg_table_event_manager.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_event_manager.rs
@@ -42,7 +42,7 @@ impl IcebergTableEventManager {
     /// Drop an iceberg table.
     pub async fn drop_table(&mut self) -> Result<()> {
         self.table_event_tx
-            .send(TableEvent::DropIcebergTable)
+            .send(TableEvent::DropTable)
             .await
             .unwrap();
         self.drop_table_completion_rx.recv().await.unwrap()

--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -705,6 +705,12 @@ impl MooncakeTable {
         self.next_snapshot_task.new_commit_point = Some(self.mem_slice.get_commit_check_point());
     }
 
+    /// Shutdown the current table, which unpins all referenced data files in the global data file.
+    pub async fn shutdown(&mut self) {
+        let mut guard = self.snapshot.write().await;
+        guard.unreference_all_cache_handles().await;
+    }
+
     pub fn should_flush(&self) -> bool {
         self.mem_slice.get_num_rows() >= self.metadata.config.mem_slice_size
     }

--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -952,6 +952,16 @@ impl SnapshotTableState {
         self.unreference_read_cache_handles(task).await;
     }
 
+    /// Unreference all pinned data files.
+    pub(crate) async fn unreference_all_cache_handles(&mut self) {
+        for (_, disk_file_entry) in self.current_snapshot.disk_files.iter_mut() {
+            let cache_handle = &mut disk_file_entry.cache_handle;
+            if let Some(cache_handle) = cache_handle {
+                cache_handle.unreference().await;
+            }
+        }
+    }
+
     pub(super) async fn update_snapshot(
         &mut self,
         mut task: SnapshotTask,

--- a/src/moonlink/src/table_handler/test_utils.rs
+++ b/src/moonlink/src/table_handler/test_utils.rs
@@ -247,7 +247,7 @@ impl TestEnvironment {
 
     // --- Lifecycle Helper ---
     pub async fn shutdown(&mut self) {
-        self.send_event(TableEvent::_Shutdown).await;
+        self.send_event(TableEvent::Shutdown).await;
         if let Some(handle) = self.handler._event_handle.take() {
             handle.await.expect("TableHandler task panicked");
         }


### PR DESCRIPTION
## Summary

On mooncake table drop and shutdown, we need to unpin all cache handle references, otherwise it lives in data file cache forever.
Also add missing unit tests left from a prev PR.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/475

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
