### PR TITLE
[storage] Use temporary directory for test default cache

### DIFF
--- a/src/moonlink/src/storage/cache/object_storage/cache_config.rs
+++ b/src/moonlink/src/storage/cache/object_storage/cache_config.rs
@@ -1,3 +1,6 @@
+#[cfg(test)]
+use tempfile::TempDir;
+
 /// Configuration for object storage cache.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ObjectStorageCacheConfig {
@@ -16,25 +19,13 @@ impl ObjectStorageCacheConfig {
     }
 
     /// Provide a default option for ease of testing.
+    /// It requires to take a testcase-unique temporary directory.
     #[cfg(test)]
-    pub fn default_for_test() -> Self {
+    pub fn default_for_test(temp_dir: &TempDir) -> Self {
         const DEFAULT_MAX_BYTES_FOR_TEST: u64 = 1 << 30; // 1GiB
-        const DEFAULT_CACHE_DIRECTORY: &str = "/tmp/moonlink_test_cache";
-
-        // Re-create default cache directory for testing.
-        match std::fs::remove_dir_all(DEFAULT_CACHE_DIRECTORY) {
-            Ok(()) => {}
-            Err(e) => {
-                if e.kind() != std::io::ErrorKind::NotFound {
-                    panic!("Failed to remove directory: {:?}", e);
-                }
-            }
-        }
-        std::fs::create_dir_all(DEFAULT_CACHE_DIRECTORY).unwrap();
-
         Self {
             max_bytes: DEFAULT_MAX_BYTES_FOR_TEST,
-            cache_directory: DEFAULT_CACHE_DIRECTORY.to_string(),
+            cache_directory: temp_dir.path().to_str().unwrap().to_string(),
         }
     }
 

--- a/src/moonlink/src/storage/cache/object_storage/object_storage_cache.rs
+++ b/src/moonlink/src/storage/cache/object_storage/object_storage_cache.rs
@@ -10,6 +10,8 @@ use crate::Result;
 
 use lru::LruCache;
 use more_asserts as ma;
+#[cfg(test)]
+use tempfile::TempDir;
 use tokio::sync::RwLock;
 use uuid::Uuid;
 
@@ -183,8 +185,8 @@ impl ObjectStorageCache {
     /// ================================
     ///
     #[cfg(test)]
-    pub fn default_for_test() -> Self {
-        let config = ObjectStorageCacheConfig::default_for_test();
+    pub fn default_for_test(temp_dir: &TempDir) -> Self {
+        let config = ObjectStorageCacheConfig::default_for_test(temp_dir);
         Self::new(config)
     }
 

--- a/src/moonlink/src/storage/iceberg/test_utils.rs
+++ b/src/moonlink/src/storage/iceberg/test_utils.rs
@@ -209,7 +209,7 @@ pub(crate) async fn create_table_and_iceberg_manager_with_data_compaction_config
         identity_property,
         iceberg_table_config.clone(),
         mooncake_table_config,
-        ObjectStorageCache::default_for_test(),
+        ObjectStorageCache::default_for_test(temp_dir),
     )
     .await
     .unwrap();

--- a/src/moonlink/src/storage/iceberg/tests.rs
+++ b/src/moonlink/src/storage/iceberg/tests.rs
@@ -603,7 +603,7 @@ async fn test_index_merge_and_create_snapshot() {
     let mut mooncake_table = MooncakeTable::new_with_table_manager(
         mooncake_table_metadata.clone(),
         Box::new(iceberg_table_manager),
-        ObjectStorageCache::default_for_test(),
+        ObjectStorageCache::default_for_test(&tmp_dir),
     )
     .await
     .unwrap();
@@ -714,7 +714,7 @@ async fn test_create_snapshot_when_no_committed_deletion_log_to_flush() {
         identity_property,
         iceberg_table_config.clone(),
         MooncakeTableConfig::default(),
-        ObjectStorageCache::default_for_test(),
+        ObjectStorageCache::default_for_test(&temp_dir),
     )
     .await
     .unwrap();
@@ -759,7 +759,7 @@ async fn test_skip_iceberg_snapshot() {
         identity_property,
         iceberg_table_config.clone(),
         MooncakeTableConfig::default(),
-        ObjectStorageCache::default_for_test(),
+        ObjectStorageCache::default_for_test(&temp_dir),
     )
     .await
     .unwrap();
@@ -813,7 +813,7 @@ async fn test_small_batch_size_and_large_parquet_size() {
         identity_property,
         iceberg_table_config.clone(),
         mooncake_table_config,
-        ObjectStorageCache::default_for_test(),
+        ObjectStorageCache::default_for_test(&temp_dir),
     )
     .await
     .unwrap();
@@ -1090,7 +1090,7 @@ async fn mooncake_table_snapshot_persist_impl(warehouse_uri: String) -> IcebergR
         identity_property.clone(),
         iceberg_table_config.clone(),
         mooncake_table_config,
-        ObjectStorageCache::default_for_test(),
+        ObjectStorageCache::default_for_test(&temp_dir),
     )
     .await
     .unwrap();
@@ -1473,7 +1473,7 @@ async fn test_drop_table_at_creation() -> IcebergResult<()> {
         mooncake_table_metadata.identity.clone(),
         iceberg_table_config.clone(),
         mooncake_table_config,
-        ObjectStorageCache::default_for_test(),
+        ObjectStorageCache::default_for_test(&temp_dir),
     )
     .await
     .unwrap();

--- a/src/moonlink/src/storage/mooncake_table/test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/test_utils.rs
@@ -78,7 +78,7 @@ pub async fn test_table(
         identity,
         iceberg_table_config,
         table_config,
-        ObjectStorageCache::default_for_test(),
+        ObjectStorageCache::default_for_test(&context.temp_dir),
     )
     .await
     .unwrap()

--- a/src/moonlink/src/storage/mooncake_table/tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/tests.rs
@@ -439,7 +439,7 @@ async fn test_snapshot_store_failure() {
     let mut table = MooncakeTable::new_with_table_manager(
         table_metadata,
         Box::new(mock_table_manager),
-        ObjectStorageCache::default_for_test(),
+        ObjectStorageCache::default_for_test(&temp_dir),
     )
     .await
     .unwrap();

--- a/src/moonlink/src/table_handler/test_utils.rs
+++ b/src/moonlink/src/table_handler/test_utils.rs
@@ -127,7 +127,7 @@ impl TestEnvironment {
             IdentityProp::Keys(vec![0]),
             iceberg_table_config,
             mooncake_table_config,
-            ObjectStorageCache::default_for_test(),
+            ObjectStorageCache::default_for_test(&temp_dir),
         )
         .await
         .unwrap();

--- a/src/moonlink/src/table_handler/tests.rs
+++ b/src/moonlink/src/table_handler/tests.rs
@@ -1003,7 +1003,7 @@ async fn test_iceberg_snapshot_failure_mock_test() {
     let mooncake_table = MooncakeTable::new_with_table_manager(
         mooncake_table_metadata,
         Box::new(mock_table_manager),
-        ObjectStorageCache::default_for_test(),
+        ObjectStorageCache::default_for_test(&temp_dir),
     )
     .await
     .unwrap();
@@ -1054,7 +1054,7 @@ async fn test_iceberg_drop_table_failure_mock_test() {
     let mooncake_table = MooncakeTable::new_with_table_manager(
         mooncake_table_metadata,
         Box::new(mock_table_manager),
-        ObjectStorageCache::default_for_test(),
+        ObjectStorageCache::default_for_test(&temp_dir),
     )
     .await
     .unwrap();


### PR DESCRIPTION
## Summary

This PR uses test-specific temporary directory to construct data file cache, instead of hard-coded fixed directory;
considering the fact that the hard-coded dir is re-created every construction, it's possible to suffer data race.

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
