### PR TITLE
Fix add order

### DIFF
--- a/src/moonlink_connectors/src/replication_connection.rs
+++ b/src/moonlink_connectors/src/replication_connection.rs
@@ -297,15 +297,10 @@ impl ReplicationConnection {
 
     pub async fn start_replication(&mut self) -> Result<()> {
         info!("starting replication");
-        let table_schemas = self.source.get_table_schemas().await;
 
         let (tx, rx) = mpsc::channel(8);
         self.cmd_tx = tx;
         self.cmd_rx = Some(rx);
-
-        for schema in table_schemas.values() {
-            self.add_table_to_replication(schema).await?;
-        }
 
         let sink = Sink::new(self.replication_state.clone());
         let receiver = self.cmd_rx.take().unwrap();

--- a/src/moonlink_connectors/src/replication_manager.rs
+++ b/src/moonlink_connectors/src/replication_manager.rs
@@ -73,13 +73,13 @@ impl<T: Eq + Hash> ReplicationManager<T> {
         }
         let replication_connection = self.connections.get_mut(uri).unwrap();
 
-        let table_id = replication_connection.add_table(table_name).await?;
-        self.table_info
-            .insert(external_table_id, (uri.to_string(), table_id));
-
         if !replication_connection.replication_started() {
             replication_connection.start_replication().await?;
         }
+
+        let table_id = replication_connection.add_table(table_name).await?;
+        self.table_info
+            .insert(external_table_id, (uri.to_string(), table_id));
 
         info!(table_id, "table added through manager");
 


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

For now we should only support explicitly adding tables via `create_table`, so don't discover any tables on replication start. 

In this case, switch the order so that we start the replication before explicit add. 

## Related Issues

Closes #<issue-number> or links to related issues.

## Changes

- 
- 
- 

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
