### PR TITLE
Add cache invalidation check

### DIFF
--- a/src/moonlink/src/union_read/read_state_manager.rs
+++ b/src/moonlink/src/union_read/read_state_manager.rs
@@ -271,6 +271,22 @@ mod tests {
                 commit: 10,
                 expect: false,
             },
+            // miss: uninitialized cache with all LSNs at 0 (initial state)
+            Case {
+                requested: Some(5),
+                cached: 0,
+                snap: 0,
+                commit: 0,
+                expect: false,
+            },
+            // miss: uninitialized cache with all LSNs at 0 for latest read
+            Case {
+                requested: None,
+                cached: 0,
+                snap: 0,
+                commit: 0,
+                expect: false,
+            },
         ];
 
         for (i, c) in cases.iter().enumerate() {

--- a/src/moonlink/src/union_read/read_state_manager.rs
+++ b/src/moonlink/src/union_read/read_state_manager.rs
@@ -42,7 +42,7 @@ impl ReadStateManager {
     ) -> bool {
         let snapshot_clean = snapshot_lsn == commit_lsn;
         match requested {
-            Some(bound) => cached_lsn == snapshot_lsn && cached_lsn <= bound,
+            Some(bound) => cached_lsn == snapshot_lsn && cached_lsn <= bound && snapshot_clean,
             None => cached_lsn == snapshot_lsn && snapshot_clean,
         }
     }

--- a/src/moonlink/src/union_read/read_state_manager.rs
+++ b/src/moonlink/src/union_read/read_state_manager.rs
@@ -47,8 +47,9 @@ impl ReadStateManager {
         }
     }
 
-    /// Attempts to read state at or after the specified LSN.
-    /// If `lsn` is `None`, it attempts to read the latest available state.
+    /// Returns a snapshot whose commit LSN is:
+    /// • ≤ `requested_lsn` when `requested_lsn` is supplied, or
+    /// • the latest snapshot when `requested_lsn` is `None`.
     #[tracing::instrument(name = "read_state_try_read", skip_all)]
     pub async fn try_read(&self, requested_lsn: Option<u64>) -> Result<Arc<SnapshotReadOutput>> {
         // fast-path: reuse cached snapshot only when its still the tables latest and not newer than the callers LSN


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

Invalidates the cache as soon as the table advances, fixing stale reads for new sessions that have a low LSN while retaining fast-path hits when data is unchanged.

## Related Issues

Closes #<issue-number> or links to related issues.

## Changes

- 
- 
- 

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
