### PR TITLE
[storage] [3/N] Delete old cache entries at compaction completion

### DIFF
--- a/src/moonlink/src/storage/cache/object_storage/base_cache.rs
+++ b/src/moonlink/src/storage/cache/object_storage/base_cache.rs
@@ -38,7 +38,6 @@ pub trait CacheTrait {
     /// Delete cache entry from the cache, which will be evicted immediately at next cache access.
     /// It's required requested file id exists in cache, otherwise panic.
     /// Return evicted files to delete.
-    #[allow(dead_code)]
     #[must_use]
     #[allow(async_fn_in_trait)]
     async fn delete_cache_entry(&mut self, file_id: TableUniqueFileId) -> Vec<String>;

--- a/src/moonlink/src/storage/cache/object_storage/base_cache.rs
+++ b/src/moonlink/src/storage/cache/object_storage/base_cache.rs
@@ -42,6 +42,11 @@ pub trait CacheTrait {
     #[allow(async_fn_in_trait)]
     async fn delete_cache_entry(&mut self, file_id: TableUniqueFileId) -> Vec<String>;
 
+    /// Similar to [`delete_cache_entry`], but doesn't panic if requested entry doesn't exist.
+    #[must_use]
+    #[allow(async_fn_in_trait)]
+    async fn try_delete_cache_entry(&mut self, file_id: TableUniqueFileId) -> Vec<String>;
+
     /// Attempt to get a pinned cache file entry.
     ///
     /// If the requested file is already pinned, cache handle will returned immediately without any IO operations.

--- a/src/moonlink/src/storage/cache/object_storage/base_cache.rs
+++ b/src/moonlink/src/storage/cache/object_storage/base_cache.rs
@@ -34,6 +34,12 @@ pub trait CacheTrait {
         cache_entry: CacheEntry,
     ) -> (NonEvictableHandle, Vec<String>);
 
+    /// Delete cache entry from the cache, which will be evicted immediately at next cache access.
+    /// It's required requested file id exists in cache, otherwise panic.
+    /// Return evicted files to delete.
+    #[allow(async_fn_in_trait)]
+    async fn delete_cache_entry(&mut self, file_id: TableUniqueFileId) -> Vec<String>;
+
     /// Attempt to get a pinned cache file entry.
     ///
     /// If the requested file is already pinned, cache handle will returned immediately without any IO operations.

--- a/src/moonlink/src/storage/cache/object_storage/base_cache.rs
+++ b/src/moonlink/src/storage/cache/object_storage/base_cache.rs
@@ -27,6 +27,7 @@ pub struct CacheEntry {
 pub trait CacheTrait {
     /// Import cache entry to the cache. If there's no enough disk space, panic directly.
     /// Precondition: the file is not managed by cache.
+    #[must_use]
     #[allow(async_fn_in_trait)]
     async fn import_cache_entry(
         &mut self,
@@ -38,6 +39,7 @@ pub trait CacheTrait {
     /// It's required requested file id exists in cache, otherwise panic.
     /// Return evicted files to delete.
     #[allow(dead_code)]
+    #[must_use]
     #[allow(async_fn_in_trait)]
     async fn delete_cache_entry(&mut self, file_id: TableUniqueFileId) -> Vec<String>;
 
@@ -46,7 +48,8 @@ pub trait CacheTrait {
     /// If the requested file is already pinned, cache handle will returned immediately without any IO operations.
     /// Otherwise, an IO operation might be performed, depending on whether the corresponding cache entry happens to be alive.
     /// If there's no sufficient disk space, return [`None`].
-    #[allow(async_fn_in_trait)]
+    #[deny(unused_must_use)]
+    #[must_use]
     async fn get_cache_entry(
         &mut self,
         file_id: TableUniqueFileId,

--- a/src/moonlink/src/storage/cache/object_storage/base_cache.rs
+++ b/src/moonlink/src/storage/cache/object_storage/base_cache.rs
@@ -37,6 +37,7 @@ pub trait CacheTrait {
     /// Delete cache entry from the cache, which will be evicted immediately at next cache access.
     /// It's required requested file id exists in cache, otherwise panic.
     /// Return evicted files to delete.
+    #[allow(dead_code)]
     #[allow(async_fn_in_trait)]
     async fn delete_cache_entry(&mut self, file_id: TableUniqueFileId) -> Vec<String>;
 

--- a/src/moonlink/src/storage/cache/object_storage/cache_handle.rs
+++ b/src/moonlink/src/storage/cache/object_storage/cache_handle.rs
@@ -45,6 +45,7 @@ impl NonEvictableHandle {
     }
 
     /// Unreference the pinned cache file.
+    #[must_use]
     pub(crate) async fn unreference(&mut self) -> Vec<String> {
         let mut guard = self.cache.write().await;
         guard.unreference(self.file_id)

--- a/src/moonlink/src/storage/cache/object_storage/cache_handle.rs
+++ b/src/moonlink/src/storage/cache/object_storage/cache_handle.rs
@@ -45,8 +45,8 @@ impl NonEvictableHandle {
     }
 
     /// Unreference the pinned cache file.
-    pub(crate) async fn unreference(&mut self) {
+    pub(crate) async fn unreference(&mut self) -> Vec<String> {
         let mut guard = self.cache.write().await;
-        guard.unreference(self.file_id);
+        guard.unreference(self.file_id)
     }
 }

--- a/src/moonlink/src/storage/cache/object_storage/state_tests.rs
+++ b/src/moonlink/src/storage/cache/object_storage/state_tests.rs
@@ -472,7 +472,7 @@ async fn test_cache_3_unpin_not_referenced() {
 async fn test_cache_2_requested_to_delete_4() {
     let remote_file_directory = tempdir().unwrap();
     let cache_file_directory = tempdir().unwrap();
-    let test_file_1 = create_test_file(remote_file_directory.path(), TEST_FILENAME_1).await;
+    let test_file = create_test_file(remote_file_directory.path(), TEST_FILENAME_1).await;
     let mut cache = ObjectStorageCache::new(ObjectStorageCacheConfig {
         max_bytes: CONTENT.len() as u64,
         cache_directory: cache_file_directory.path().to_str().unwrap().to_string(),
@@ -480,7 +480,7 @@ async fn test_cache_2_requested_to_delete_4() {
 
     // Import into cache first.
     let cache_entry = CacheEntry {
-        cache_filepath: test_file_1.to_str().unwrap().to_string(),
+        cache_filepath: test_file.to_str().unwrap().to_string(),
         file_metadata: FileMetadata {
             file_size: CONTENT.len() as u64,
         },
@@ -502,9 +502,155 @@ async fn test_cache_2_requested_to_delete_4() {
 
     // Request to delete.
     let evicted_files = cache.delete_cache_entry(get_table_unique_file_id(0)).await;
+    assert_eq!(evicted_files, vec![test_file.to_str().unwrap().to_string()]);
+
+    // Check cache status.
+    assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_evictable_cache_size(&mut cache, /*expected_count=*/ 0).await;
+}
+
+// (3) + requested to delete => (5)
+#[tokio::test]
+async fn test_cache_3_requested_to_delete_5() {
+    let remote_file_directory = tempdir().unwrap();
+    let cache_file_directory = tempdir().unwrap();
+    let test_file = create_test_file(remote_file_directory.path(), TEST_FILENAME_1).await;
+    let mut cache = ObjectStorageCache::new(ObjectStorageCacheConfig {
+        max_bytes: CONTENT.len() as u64,
+        cache_directory: cache_file_directory.path().to_str().unwrap().to_string(),
+    });
+
+    // Import into cache first.
+    let cache_entry = CacheEntry {
+        cache_filepath: test_file.to_str().unwrap().to_string(),
+        file_metadata: FileMetadata {
+            file_size: CONTENT.len() as u64,
+        },
+    };
+    let (_, files_to_evict) = cache
+        .import_cache_entry(/*file_id=*/ get_table_unique_file_id(0), cache_entry)
+        .await;
+    assert_non_evictable_cache_handle_ref_count(
+        &mut cache,
+        /*file_id=*/ get_table_unique_file_id(0),
+        /*expected_ref_count=*/ 1,
+    )
+    .await;
+    assert!(files_to_evict.is_empty());
+
+    // Request to delete.
+    let evicted_files = cache.delete_cache_entry(get_table_unique_file_id(0)).await;
+    assert!(evicted_files.is_empty());
+
+    // Check cache status.
+    assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 1).await;
+    assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 1).await;
+    assert_evictable_cache_size(&mut cache, /*expected_count=*/ 0).await;
+}
+
+// (5) + usage finished + still referenced => (5)
+#[tokio::test]
+async fn test_cache_5_usage_finish_and_still_referenced_5() {
+    let remote_file_directory = tempdir().unwrap();
+    let cache_file_directory = tempdir().unwrap();
+    let test_file_1 = create_test_file(remote_file_directory.path(), TEST_FILENAME_1).await;
+    let mut cache = ObjectStorageCache::new(ObjectStorageCacheConfig {
+        max_bytes: CONTENT.len() as u64,
+        cache_directory: cache_file_directory.path().to_str().unwrap().to_string(),
+    });
+
+    // Import into cache first.
+    let cache_entry = CacheEntry {
+        cache_filepath: test_file_1.to_str().unwrap().to_string(),
+        file_metadata: FileMetadata {
+            file_size: CONTENT.len() as u64,
+        },
+    };
+    let (_, files_to_evict) = cache
+        .import_cache_entry(/*file_id=*/ get_table_unique_file_id(0), cache_entry)
+        .await;
+    assert_non_evictable_cache_handle_ref_count(
+        &mut cache,
+        /*file_id=*/ get_table_unique_file_id(0),
+        /*expected_ref_count=*/ 1,
+    )
+    .await;
+    assert!(files_to_evict.is_empty());
+
+    // Request to delete.
+    let evicted_files = cache.delete_cache_entry(get_table_unique_file_id(0)).await;
+    assert!(evicted_files.is_empty());
+
+    // Reference one more time, which leads to two reference count.
+    let (cache_handle, files_to_evict) = cache
+        .get_cache_entry(
+            /*file_id=*/ get_table_unique_file_id(0),
+            /*remote_filepath=*/ "",
+        )
+        .await
+        .unwrap();
+    assert!(files_to_evict.is_empty());
+    // One unreferences still keep the cache entry pinned.
+    let files_to_evict = cache_handle.unwrap().unreference().await;
+    assert!(files_to_evict.is_empty());
+
+    // Check cache status.
+    assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 1).await;
+    assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 1).await;
+    assert_evictable_cache_size(&mut cache, /*expected_count=*/ 0).await;
+}
+
+// (5) + usage finished + not referenced => (4)
+#[tokio::test]
+async fn test_cache_5_usage_finish_and_not_referenced_4() {
+    let remote_file_directory = tempdir().unwrap();
+    let cache_file_directory = tempdir().unwrap();
+    let test_file = create_test_file(remote_file_directory.path(), TEST_FILENAME_1).await;
+    let mut cache = ObjectStorageCache::new(ObjectStorageCacheConfig {
+        max_bytes: CONTENT.len() as u64,
+        cache_directory: cache_file_directory.path().to_str().unwrap().to_string(),
+    });
+
+    // Import into cache first.
+    let cache_entry = CacheEntry {
+        cache_filepath: test_file.to_str().unwrap().to_string(),
+        file_metadata: FileMetadata {
+            file_size: CONTENT.len() as u64,
+        },
+    };
+    let (mut cache_handle_1, files_to_evict) = cache
+        .import_cache_entry(/*file_id=*/ get_table_unique_file_id(0), cache_entry)
+        .await;
+    assert_non_evictable_cache_handle_ref_count(
+        &mut cache,
+        /*file_id=*/ get_table_unique_file_id(0),
+        /*expected_ref_count=*/ 1,
+    )
+    .await;
+    assert!(files_to_evict.is_empty());
+
+    // Request to delete.
+    let evicted_files = cache.delete_cache_entry(get_table_unique_file_id(0)).await;
+    assert!(evicted_files.is_empty());
+
+    // Reference one more time, which leads to two reference count.
+    let (cache_handle_2, files_to_evict) = cache
+        .get_cache_entry(
+            /*file_id=*/ get_table_unique_file_id(0),
+            /*remote_filepath=*/ "",
+        )
+        .await
+        .unwrap();
+    assert!(files_to_evict.is_empty());
+
+    // Unreference for twice, which leads the request-to-delete entry finally evicted.
+    let files_to_evict = cache_handle_1.unreference().await;
+    assert!(files_to_evict.is_empty());
+    let files_to_evict = cache_handle_2.unwrap().unreference().await;
     assert_eq!(
-        evicted_files,
-        vec![test_file_1.to_str().unwrap().to_string()]
+        files_to_evict,
+        vec![test_file.to_str().unwrap().to_string()]
     );
 
     // Check cache status.

--- a/src/moonlink/src/storage/cache/object_storage/state_tests.rs
+++ b/src/moonlink/src/storage/cache/object_storage/state_tests.rs
@@ -181,7 +181,8 @@ async fn test_cache_2_requested_to_read_with_insufficient_space() {
     assert!(files_to_evict.is_empty());
 
     // Unreference to make cache entry evictable.
-    cache_handle.unreference().await;
+    let evicted_files_to_delete = cache_handle.unreference().await;
+    assert!(evicted_files_to_delete.is_empty());
 
     // Request to read, thus pinning the cache entry.
     let (_, files_to_evict) = cache
@@ -283,7 +284,8 @@ async fn test_cache_2_new_entry_with_sufficient_space() {
     assert!(files_to_evict.is_empty());
 
     // Unreference to make cache entry evictable.
-    cache_handle.unreference().await;
+    let evicted_files_to_delete = cache_handle.unreference().await;
+    assert!(evicted_files_to_delete.is_empty());
 
     // Import the second cache file.
     let test_file = create_test_file(remote_file_directory.path(), TEST_FILENAME_2).await;
@@ -340,7 +342,8 @@ async fn test_cache_2_new_entry_with_insufficient_space() {
     assert!(files_to_evict.is_empty());
 
     // Unreference to make cache entry evictable.
-    cache_handle_1.unreference().await;
+    let evicted_files_to_delete = cache_handle_1.unreference().await;
+    assert!(evicted_files_to_delete.is_empty());
 
     // Import the second cache file.
     let test_file = create_test_file(remote_file_directory.path(), TEST_FILENAME_2).await;
@@ -409,7 +412,8 @@ async fn test_cache_3_unpin_still_referenced() {
     assert!(files_to_evict.is_empty());
 
     // Unreference one of the cache handles.
-    cache_handle.unwrap().unreference().await;
+    let evicted_files_to_delete = cache_handle.unwrap().unreference().await;
+    assert!(evicted_files_to_delete.is_empty());
 
     // Check cache status.
     assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 0).await;
@@ -458,8 +462,10 @@ async fn test_cache_3_unpin_not_referenced() {
     assert!(files_to_evict.is_empty());
 
     // Unreference all cache handles.
-    cache_handle_1.unwrap().unreference().await;
-    cache_handle_2.unwrap().unreference().await;
+    let evicted_files_to_delete = cache_handle_1.unwrap().unreference().await;
+    assert!(evicted_files_to_delete.is_empty());
+    let evicted_files_to_delete = cache_handle_2.unwrap().unreference().await;
+    assert!(evicted_files_to_delete.is_empty());
 
     // Check cache status.
     assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 0).await;

--- a/src/moonlink/src/storage/cache/object_storage/test_utils.rs
+++ b/src/moonlink/src/storage/cache/object_storage/test_utils.rs
@@ -69,6 +69,15 @@ pub(crate) async fn assert_evictable_cache_size(
     assert_eq!(guard.evictable_cache.len(), expected_count);
 }
 
+/// Test util function to check the number of entries pending to delete.
+pub(crate) async fn assert_pending_eviction_entries_size(
+    cache: &mut ObjectStorageCache,
+    expected_count: usize,
+) {
+    let guard = cache.cache.read().await;
+    assert_eq!(guard.evicted_entries.len(), expected_count);
+}
+
 /// Test util function to check non-evictable cache size.
 pub(crate) async fn assert_non_evictable_cache_size(
     cache: &mut ObjectStorageCache,

--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -1136,12 +1136,13 @@ impl MooncakeTable {
     }
 
     // Test util function to perform data compaction, block wait its completion and reflect compaction result to mooncake table.
+    // Return evicted files to assertion.
     #[cfg(test)]
     pub(crate) async fn perform_data_compaction_for_test(
         &mut self,
         receiver: &mut Receiver<TableNotify>,
         data_compaction_payload: DataCompactionPayload,
-    ) {
+    ) -> Vec<String> {
         // Perform and block wait data compaction.
         self.perform_data_compaction(data_compaction_payload);
         let data_compaction_result = Self::sync_data_compaction(receiver).await;
@@ -1154,11 +1155,12 @@ impl MooncakeTable {
             skip_file_indices_merge: true,
             skip_data_file_compaction: false,
         }));
-        let (_, _, _, evicted_data_file_cache) = Self::sync_mooncake_snapshot(receiver).await;
+        let (_, _, _, evicted_data_files_to_delete) = Self::sync_mooncake_snapshot(receiver).await;
         // Delete evicted data file cache entries immediately to make sure later accesses all happen on persisted files.
-        for cur_data_file in evicted_data_file_cache.into_iter() {
-            tokio::fs::remove_file(&cur_data_file).await.unwrap();
+        for cur_data_file in evicted_data_files_to_delete.iter() {
+            tokio::fs::remove_file(cur_data_file).await.unwrap();
         }
+        evicted_data_files_to_delete
     }
 
     // Test util function, which does the following things in serial fashion.

--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -258,10 +258,19 @@ impl SnapshotTableState {
 
     /// Update disk files in the current snapshot from local data files to remote ones, meanwile unpin write-through cache file from data file cache.
     /// Return affected file indices, which are caused by data file updates, and will be removed.
-    async fn update_data_files_to_persisted(&mut self, task: &SnapshotTask) -> HashSet<FileIndex> {
+    async fn update_data_files_to_persisted(
+        &mut self,
+        task: &SnapshotTask,
+    ) -> (
+        HashSet<FileIndex>,
+        Vec<String>, /*evicted files to delete*/
+    ) {
         if task.iceberg_persisted_records.data_files.is_empty() {
-            return HashSet::new();
+            return (HashSet::new(), Vec::new());
         }
+
+        // Aggregate evicted files to delete.
+        let mut evicted_files_to_delete = vec![];
 
         // Update disk file from local write through cache to iceberg persisted remote path.
         let mut affected_file_indices =
@@ -273,12 +282,13 @@ impl SnapshotTableState {
                 .disk_files
                 .remove(cur_data_file)
                 .unwrap();
-            disk_file_entry
+            let cur_evicted_files = disk_file_entry
                 .cache_handle
                 .as_mut()
                 .unwrap()
                 .unreference()
                 .await;
+            evicted_files_to_delete.extend(cur_evicted_files);
             disk_file_entry.cache_handle = None;
 
             // One file index corresponds to one or many data files, so it's possible to have duplicates.
@@ -288,7 +298,8 @@ impl SnapshotTableState {
                 .disk_files
                 .insert(cur_data_file.clone(), disk_file_entry);
         }
-        affected_file_indices
+
+        (affected_file_indices, evicted_files_to_delete)
     }
 
     /// Update file indices in the current snapshot from local data files to remote ones.
@@ -334,13 +345,21 @@ impl SnapshotTableState {
     /// Before iceberg snapshot, mooncake snapshot records local write through cache in disk file (which is local filepath).
     /// After a successful iceberg snapshot, update current snapshot's disk files and file indices to reference to remote paths,
     /// also import local write through cache to globally managed data file cache, so they could be pinned and evicted when necessary.
-    async fn update_local_path_to_persisted_by_imported(&mut self, task: &SnapshotTask) {
+    ///
+    /// Return evicted data files to delete when unreference existing disk file entries.
+    async fn update_local_path_to_persisted_by_imported(
+        &mut self,
+        task: &SnapshotTask,
+    ) -> Vec<String> {
         // Handle imported new data files and file indices.
-        let affected_file_indices = self.update_data_files_to_persisted(task).await;
+        let (affected_file_indices, evicted_files_to_delete) =
+            self.update_data_files_to_persisted(task).await;
         self.update_file_indices_to_persisted(
             task.iceberg_persisted_records.file_indices.clone(),
             affected_file_indices,
         );
+
+        evicted_files_to_delete
     }
 
     /// Update unpersisted data files from successful iceberg snapshot operation.
@@ -737,7 +756,8 @@ impl SnapshotTableState {
             // If the old entry is pinned cache handle, unreference.
             let old_entry = old_entry.unwrap();
             if let Some(mut cache_handle) = old_entry.cache_handle {
-                cache_handle.unreference().await;
+                let cur_evicted_files = cache_handle.unreference().await;
+                evicted_data_files.extend(cur_evicted_files);
             }
 
             // If no deletion record for this file, directly remove it, no need to do remapping.
@@ -982,26 +1002,44 @@ impl SnapshotTableState {
     }
 
     /// Unreference pinned cache handles used in read operations.
-    async fn unreference_read_cache_handles(&mut self, task: &mut SnapshotTask) {
+    /// Return evicted data files to delete.
+    async fn unreference_read_cache_handles(&mut self, task: &mut SnapshotTask) -> Vec<String> {
+        // Aggregate evicted data files to delete.
+        let mut evicted_files_to_delete = vec![];
+
         for cur_cache_handle in task.read_cache_handles.iter_mut() {
-            cur_cache_handle.unreference().await;
+            let cur_evicted_files = cur_cache_handle.unreference().await;
+            evicted_files_to_delete.extend(cur_evicted_files);
         }
+
+        evicted_files_to_delete
     }
 
     /// Take read request result and update mooncake snapshot.
-    async fn update_snapshot_by_read_request_results(&mut self, task: &mut SnapshotTask) {
+    /// Return evicted data files to delete.
+    async fn update_snapshot_by_read_request_results(
+        &mut self,
+        task: &mut SnapshotTask,
+    ) -> Vec<String> {
         // Unpin cached files used in the read request.
-        self.unreference_read_cache_handles(task).await;
+        self.unreference_read_cache_handles(task).await
     }
 
     /// Unreference all pinned data files.
-    pub(crate) async fn unreference_all_cache_handles(&mut self) {
+    /// Return all evicted files to evict
+    pub(crate) async fn unreference_all_cache_handles(&mut self) -> Vec<String> {
+        // Aggregate evicted files to delete.
+        let mut evicted_files_to_delete = vec![];
+
         for (_, disk_file_entry) in self.current_snapshot.disk_files.iter_mut() {
             let cache_handle = &mut disk_file_entry.cache_handle;
             if let Some(cache_handle) = cache_handle {
-                cache_handle.unreference().await;
+                let cur_evicted_files = cache_handle.unreference().await;
+                evicted_files_to_delete.extend(cur_evicted_files);
             }
         }
+
+        evicted_files_to_delete
     }
 
     pub(super) async fn update_snapshot(
@@ -1013,8 +1051,10 @@ impl SnapshotTableState {
         let mut evicted_data_files_to_delete = vec![];
 
         // Reflect read request result to mooncake snapshot.
-        self.update_snapshot_by_read_request_results(&mut task)
+        let completed_read_evicted_data_files = self
+            .update_snapshot_by_read_request_results(&mut task)
             .await;
+        evicted_data_files_to_delete.extend(completed_read_evicted_data_files);
 
         // Reflect iceberg snapshot to mooncake snapshot.
         //
@@ -1025,7 +1065,10 @@ impl SnapshotTableState {
         //
         // Update data files and file indices' local file path to remote file path, it only applies to newly imported data files and file indices,
         // because both index merge and data compaction only apply to those already persisted into iceberg table.
-        self.update_local_path_to_persisted_by_imported(&task).await;
+        let persistence_evicted_data_files =
+            self.update_local_path_to_persisted_by_imported(&task).await;
+        evicted_data_files_to_delete.extend(persistence_evicted_data_files);
+
         self.update_current_snapshot_with_iceberg_snapshot(std::mem::take(
             &mut task.iceberg_persisted_records.puffin_blob,
         ));

--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -788,7 +788,7 @@ impl SnapshotTableState {
         task: &SnapshotTask,
     ) -> Vec<String> {
         if task.data_compaction_result.is_empty() {
-            return task.data_compaction_result.evicted_files_to_delete.clone();
+            return vec![];
         }
 
         // NOTICE: Update data files before file indices, so when update file indices, data files for new file indices already exist in disk files map.

--- a/src/moonlink/src/table_handler.rs
+++ b/src/moonlink/src/table_handler.rs
@@ -201,7 +201,7 @@ impl TableHandler {
                                     let res = table.append_in_stream_batch(row, xact_id);
                                     if table.should_transaction_flush(xact_id) {
                                         if let Err(e) = table.flush_transaction_stream(xact_id).await {
-                                            warn!(error = %e, "flush failed in append");
+                                            error!(error = %e, "flush failed in append");
                                         }
                                     }
                                     res
@@ -210,7 +210,7 @@ impl TableHandler {
                             };
 
                             if let Err(e) = result {
-                                warn!(error = %e, "failed to append row");
+                                error!(error = %e, "failed to append row");
                             }
                         }
                         TableEvent::Delete { row, lsn, xact_id } => {
@@ -231,14 +231,14 @@ impl TableHandler {
                             match xact_id {
                                 Some(xact_id) => {
                                     if let Err(e) = table.commit_transaction_stream(xact_id, lsn).await {
-                                        warn!(error = %e, "stream commit flush failed");
+                                        error!(error = %e, "stream commit flush failed");
                                     }
                                 }
                                 None => {
                                     table.commit(lsn);
                                     if table.should_flush() || force_snapshot {
                                         if let Err(e) = table.flush(lsn).await {
-                                            warn!(error = %e, "flush failed in commit");
+                                            error!(error = %e, "flush failed in commit");
                                         }
                                     }
                                 }
@@ -260,16 +260,18 @@ impl TableHandler {
                         }
                         TableEvent::Flush { lsn } => {
                             if let Err(e) = table.flush(lsn).await {
-                                warn!(error = %e, "explicit flush failed");
+                                error!(error = %e, "explicit flush failed");
                             }
                         }
                         TableEvent::StreamFlush { xact_id } => {
                             if let Err(e) = table.flush_transaction_stream(xact_id).await {
-                                warn!(error = %e, "stream flush failed");
+                                error!(error = %e, "stream flush failed");
                             }
                         }
                         TableEvent::Shutdown => {
-                            table.shutdown().await;
+                            if let Err(e) = table.shutdown().await {
+                                error!(error = %e, "failed to shutdown table");
+                            }
                             info!("shutting down table handler");
                             break;
                         }
@@ -293,7 +295,9 @@ impl TableHandler {
                         // Branch to drop the iceberg table and clear pinned data files from the global data file cache, only used when the whole table requested to drop.
                         // So we block wait for asynchronous request completion.
                         TableEvent::DropTable => {
-                            table.shutdown().await;
+                            if let Err(e) = table.shutdown().await {
+                                error!(error = %e, "failed to shutdown table");
+                            }
                             let res = table.drop_iceberg_table().await;
                             iceberg_event_sync_sender.iceberg_drop_table_completion_tx.send(res).await.unwrap();
                         }
@@ -440,7 +444,9 @@ impl TableHandler {
                 }
                 // If all senders have been dropped, exit the loop
                 else => {
-                    table.shutdown().await;
+                    if let Err(e) = table.shutdown().await {
+                        warn!(error = %e, "failed to shutdown table");
+                    }
                     info!("all event senders dropped, shutting down table handler");
                     break;
                 }


### PR DESCRIPTION
## Summary

This PR is the last section for data file / cache integration, which evicts and deletes old cache entries at compaction completion.

- File deletion state is handled in object storage cache
- Usage and persistence state is tracked in mooncake snapshot

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/494
Closes https://github.com/Mooncake-Labs/moonlink/issues/478
Closes https://github.com/Mooncake-Labs/moonlink/issues/491

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
