### PR TITLE
[storage] Update iceberg namespace to pg db schema

### DIFF
--- a/src/moonlink_backend/tests/test_backend.rs
+++ b/src/moonlink_backend/tests/test_backend.rs
@@ -256,8 +256,8 @@ mod tests {
         // Look for any file in the Iceberg metadata dir.
         let meta_dir = tmp
             .path()
-            .join("default")
-            .join("public.snapshot_test")
+            .join("public")
+            .join("snapshot_test")
             .join("metadata");
         assert!(meta_dir.exists());
         assert!(meta_dir.read_dir().unwrap().next().is_some());

--- a/src/moonlink_connectors/src/pg_replicate/table_init.rs
+++ b/src/moonlink_connectors/src/pg_replicate/table_init.rs
@@ -50,8 +50,8 @@ pub async fn build_table_components(
     let (arrow_schema, identity) = postgres_schema_to_moonlink_schema(table_schema);
     let iceberg_table_config = IcebergTableConfig {
         warehouse_uri: base_path.to_str().unwrap().to_string(),
-        namespace: vec!["default".to_string()],
-        table_name: table_schema.table_name.to_string(),
+        namespace: vec![table_schema.table_name.schema.clone()],
+        table_name: table_schema.table_name.name.clone(),
     };
     let mooncake_table_config = TableConfig::new(table_temp_files_directory);
     let table = MooncakeTable::new(


### PR DESCRIPTION
## Summary

Use db schema name as iceberg namespace, instead of hard-coded "default".

## Related Issues

Related to https://github.com/Mooncake-Labs/moonlink/issues/471

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
