### PR TITLE
[storage] Rename snapshot state test

### DIFF
--- a/src/moonlink/src/storage/cache/object_storage/state_tests.rs
+++ b/src/moonlink/src/storage/cache/object_storage/state_tests.rs
@@ -48,7 +48,7 @@ fn get_table_unique_file_id(file_id: u64) -> TableUniqueFileId {
 
 // (1) + create mooncake snapshot => (2)
 #[tokio::test]
-async fn test_cache_state_1_create_snashot() {
+async fn test_cache_state_1_create_snapshot() {
     let cache_file_directory = tempdir().unwrap();
     let test_file = create_test_file(cache_file_directory.path(), TEST_FILENAME_1).await;
     let cache_entry = CacheEntry {


### PR DESCRIPTION
## Summary
- rename `test_cache_state_1_create_snashot` to `test_cache_state_1_create_snapshot`

## Testing
- `cargo test -p moonlink --quiet` *(fails: could not download Rust toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_6852504b63508326bd0b4c6c599e349f