### PR TITLE
[minor] Rename data file cache to object storage cache

### DIFF
--- a/src/moonlink/src/storage/cache/object_storage/object_storage_cache.rs
+++ b/src/moonlink/src/storage/cache/object_storage/object_storage_cache.rs
@@ -32,9 +32,9 @@ pub(crate) struct ObjectStorageCacheInternal {
     pub(crate) cur_bytes: u64,
     /// Deleted entries, which should be evicted right away, and should never be referenced again.
     pub(crate) evicted_entries: HashSet<TableUniqueFileId>,
-    /// Evictable data file cache entries.
+    /// Evictable object storage cache entries.
     pub(crate) evictable_cache: LruCache<TableUniqueFileId, CacheEntryWrapper>,
-    /// Non-evictable data file cache entries.
+    /// Non-evictable object storage cache entries.
     pub(crate) non_evictable_cache: HashMap<TableUniqueFileId, CacheEntryWrapper>,
 }
 
@@ -185,7 +185,7 @@ impl ObjectStorageCacheInternal {
 pub struct ObjectStorageCache {
     /// Cache configs.
     config: ObjectStorageCacheConfig,
-    /// Data file caches.
+    /// Object storage caches.
     pub(crate) cache: Arc<RwLock<ObjectStorageCacheInternal>>,
 }
 
@@ -399,7 +399,7 @@ mod tests {
     use tempfile::tempdir;
 
     #[tokio::test]
-    async fn test_concurrent_data_file_cache() {
+    async fn test_concurrent_object_storage_cache() {
         const PARALLEL_TASK_NUM: usize = 10;
         let mut handle_futures = Vec::with_capacity(PARALLEL_TASK_NUM);
 

--- a/src/moonlink/src/storage/cache/object_storage/state_tests.rs
+++ b/src/moonlink/src/storage/cache/object_storage/state_tests.rs
@@ -1,4 +1,4 @@
-/// Possible states for data file cache entries:
+/// Possible states for object storage cache entries:
 /// (1) Not managed by cache
 /// (2) Imported into cache, no reference count, not requested to delete => can be evicted
 /// (3) Imported into cache, has reference count, not requested to delete => cannot be evicted
@@ -12,7 +12,7 @@
 /// - Usage finishes, thus release pinned cache files
 /// - Request to delete
 ///
-/// State transfer to data file cache entries:
+/// State transfer to object storage cache entries:
 /// (1) + create mooncake snapshot => (2)
 /// (1) + requested to read + sufficient space => (3)
 /// (2) + requested to read + sufficient space => (3)

--- a/src/moonlink/src/storage/compaction/compactor.rs
+++ b/src/moonlink/src/storage/compaction/compactor.rs
@@ -146,7 +146,7 @@ impl CompactionBuilder {
 
         let (cache_handle, evicted_files) = self
             .compaction_payload
-            .data_file_cache
+            .object_storage_cache
             .get_cache_entry(data_file_to_compact.file_id, &data_file_to_compact.filepath)
             .await?;
         evicted_files_to_delete.extend(evicted_files);

--- a/src/moonlink/src/storage/compaction/table_compaction.rs
+++ b/src/moonlink/src/storage/compaction/table_compaction.rs
@@ -11,7 +11,7 @@ use std::collections::HashSet;
 /// Single disk file and its deletion vector to apply.
 #[derive(Clone, Debug)]
 pub struct SingleFileToCompact {
-    /// Unique file id to lookup in the data file cache.
+    /// Unique file id to lookup in the object storage cache.
     pub(crate) file_id: TableUniqueFileId,
     /// Remote data file; only persisted data files will be compacted.
     pub(crate) filepath: String,
@@ -22,8 +22,8 @@ pub struct SingleFileToCompact {
 /// Payload to trigger a compaction operation.
 #[derive(Clone, Debug)]
 pub struct DataCompactionPayload {
-    /// Data file cache.
-    pub(crate) data_file_cache: ObjectStorageCache,
+    /// Object storage cache.
+    pub(crate) object_storage_cache: ObjectStorageCache,
     /// Disk files to compact, including their deletion vector to apply.
     pub(crate) disk_files: Vec<SingleFileToCompact>,
     /// File indices to compact and rewrite.
@@ -59,7 +59,7 @@ pub struct DataCompactionResult {
     pub(crate) old_file_indices: HashSet<FileIndex>,
     /// New compacted file indices.
     pub(crate) new_file_indices: Vec<FileIndex>,
-    /// Compaction interacts with data file cache, this field records evicted files to delete.
+    /// Compaction interacts with object storage cache, this field records evicted files to delete.
     pub(crate) evicted_files_to_delete: Vec<String>,
 }
 

--- a/src/moonlink/src/storage/compaction/tests.rs
+++ b/src/moonlink/src/storage/compaction/tests.rs
@@ -54,7 +54,7 @@ async fn test_data_file_compaction_1() {
 
     // Prepare compaction payload.
     let payload = DataCompactionPayload {
-        data_file_cache: ObjectStorageCache::default_for_test(&temp_dir),
+        object_storage_cache: ObjectStorageCache::default_for_test(&temp_dir),
         disk_files: vec![get_single_file_to_compact(
             &data_file, /*deletion_vector=*/ None,
         )],
@@ -131,7 +131,7 @@ async fn test_data_file_compaction_2() {
 
     // Prepare compaction payload.
     let payload = DataCompactionPayload {
-        data_file_cache: ObjectStorageCache::default_for_test(&temp_dir),
+        object_storage_cache: ObjectStorageCache::default_for_test(&temp_dir),
         disk_files: vec![get_single_file_to_compact(
             &data_file,
             Some(puffin_blob_ref),
@@ -212,7 +212,7 @@ async fn test_data_file_compaction_3() {
 
     // Prepare compaction payload.
     let payload = DataCompactionPayload {
-        data_file_cache: ObjectStorageCache::default_for_test(&temp_dir),
+        object_storage_cache: ObjectStorageCache::default_for_test(&temp_dir),
         disk_files: vec![get_single_file_to_compact(
             &data_file,
             Some(puffin_blob_ref),
@@ -283,7 +283,7 @@ async fn test_data_file_compaction_4() {
 
     // Prepare compaction payload.
     let payload = DataCompactionPayload {
-        data_file_cache: ObjectStorageCache::default_for_test(&temp_dir),
+        object_storage_cache: ObjectStorageCache::default_for_test(&temp_dir),
         disk_files: vec![
             get_single_file_to_compact(&data_file_1, /*deletion_vector=*/ None),
             get_single_file_to_compact(&data_file_2, /*deletion_vector=*/ None),
@@ -385,7 +385,7 @@ async fn test_data_file_compaction_5() {
 
     // Prepare compaction payload.
     let payload = DataCompactionPayload {
-        data_file_cache: ObjectStorageCache::default_for_test(&temp_dir),
+        object_storage_cache: ObjectStorageCache::default_for_test(&temp_dir),
         disk_files: vec![
             get_single_file_to_compact(&data_file_1, Some(puffin_blob_ref_1)),
             get_single_file_to_compact(&data_file_2, Some(puffin_blob_ref_2)),
@@ -494,7 +494,7 @@ async fn test_data_file_compaction_6() {
 
     // Prepare compaction payload.
     let payload = DataCompactionPayload {
-        data_file_cache: ObjectStorageCache::default_for_test(&temp_dir),
+        object_storage_cache: ObjectStorageCache::default_for_test(&temp_dir),
         disk_files: vec![
             get_single_file_to_compact(&data_file_1, Some(puffin_blob_ref_1)),
             get_single_file_to_compact(&data_file_2, Some(puffin_blob_ref_2)),
@@ -591,7 +591,7 @@ async fn test_multiple_compacted_data_files_1() {
 
     // Prepare compaction payload.
     let payload = DataCompactionPayload {
-        data_file_cache: ObjectStorageCache::default_for_test(&temp_dir),
+        object_storage_cache: ObjectStorageCache::default_for_test(&temp_dir),
         disk_files: vec![
             get_single_file_to_compact(&data_file_1, Some(puffin_blob_ref_1)),
             get_single_file_to_compact(&data_file_2, Some(puffin_blob_ref_2)),
@@ -713,7 +713,7 @@ async fn test_multiple_compacted_data_files_2() {
 
     // Prepare compaction payload.
     let payload = DataCompactionPayload {
-        data_file_cache: ObjectStorageCache::default_for_test(&temp_dir),
+        object_storage_cache: ObjectStorageCache::default_for_test(&temp_dir),
         disk_files: vec![
             get_single_file_to_compact(&data_file_1, Some(puffin_blob_ref_1)),
             get_single_file_to_compact(&data_file_2, Some(puffin_blob_ref_2)),

--- a/src/moonlink/src/storage/mooncake_table/snapshot_read_output.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot_read_output.rs
@@ -47,8 +47,8 @@ pub struct ReadOutput {
     pub associated_files: Vec<String>,
     /// Table notifier for query completion; could be none for empty read output.
     pub table_notifier: Option<Sender<TableNotify>>,
-    /// Data file cache, to pin local file cache, could be none for empty read output.
-    pub data_file_cache: Option<ObjectStorageCache>,
+    /// Object storage cache, to pin local file cache, could be none for empty read output.
+    pub object_storage_cache: Option<ObjectStorageCache>,
 }
 
 impl ReadOutput {
@@ -65,7 +65,7 @@ impl ReadOutput {
                 DataFileForRead::RemoteFilePath((file_id, remote_filepath)) => {
                     // TODO(hjiang): Better error propagation.
                     let (cache_handle, files_to_delete) = self
-                        .data_file_cache
+                        .object_storage_cache
                         .as_mut()
                         .unwrap()
                         .get_cache_entry(file_id, &remote_filepath)

--- a/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
+++ b/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
@@ -256,7 +256,7 @@ impl MooncakeTable {
 }
 
 impl SnapshotTableState {
-    /// Return files evicted from data file cache.
+    /// Return files evicted from object storage cache.
     pub(super) async fn apply_transaction_stream(
         &mut self,
         task: &mut SnapshotTask,
@@ -268,7 +268,7 @@ impl SnapshotTableState {
         for output in new_streaming_xact {
             match output {
                 TransactionStreamOutput::Commit(commit) => {
-                    // Integrate files into current snapshot and import into data file cache.
+                    // Integrate files into current snapshot and import into object storage cache.
                     for (file, mut disk_file_entry) in commit.flushed_files.into_iter() {
                         task.disk_file_lsn_map
                             .insert(file.file_id(), commit.commit_lsn);
@@ -277,7 +277,7 @@ impl SnapshotTableState {
                             file_id: file.file_id(),
                         };
                         let (cache_handle, cur_evicted_files) = self
-                            .data_file_cache
+                            .object_storage_cache
                             .import_cache_entry(
                                 file_id,
                                 CacheEntry {

--- a/src/moonlink/src/table_handler.rs
+++ b/src/moonlink/src/table_handler.rs
@@ -172,7 +172,7 @@ impl TableHandler {
             tokio::task::spawn(async move {
                 for cur_data_file in evicted_file_to_delete.into_iter() {
                     if let Err(e) = tokio::fs::remove_file(&cur_data_file).await {
-                        error!("Failed to delete data file cache: {:?}", e);
+                        error!("Failed to delete object storage cache: {:?}", e);
                     }
                 }
             });
@@ -292,7 +292,7 @@ impl TableHandler {
                                 force_snapshot_lsns.entry(lsn).or_default().push(tx);
                             }
                         }
-                        // Branch to drop the iceberg table and clear pinned data files from the global data file cache, only used when the whole table requested to drop.
+                        // Branch to drop the iceberg table and clear pinned data files from the global object storage cache, only used when the whole table requested to drop.
                         // So we block wait for asynchronous request completion.
                         TableEvent::DropTable => {
                             if let Err(e) = table.shutdown().await {
@@ -307,7 +307,7 @@ impl TableHandler {
                 Some(event) = table_notify_rx.recv() => {
                     match event {
                         TableNotify::MooncakeTableSnapshot { lsn, iceberg_snapshot_payload, data_compaction_payload, file_indice_merge_payload, evicted_data_files_to_delete } => {
-                            // Spawn a detached best-effort task to delete evicted data file cache.
+                            // Spawn a detached best-effort task to delete evicted object storage cache.
                             start_task_to_delete_evicted(evicted_data_files_to_delete);
 
                             // Notify read the mooncake table commit of LSN.

--- a/src/moonlink/src/table_notify.rs
+++ b/src/moonlink/src/table_notify.rs
@@ -23,7 +23,7 @@ pub enum TableNotify {
         data_compaction_payload: Option<DataCompactionPayload>,
         /// Payload used to trigger an index merge.
         file_indice_merge_payload: Option<FileIndiceMergePayload>,
-        /// Evicted data file cache to delete.
+        /// Evicted object storage cache to delete.
         evicted_data_files_to_delete: Vec<String>,
     },
     /// Iceberg snapshot completes.
@@ -48,7 +48,7 @@ pub enum TableNotify {
     },
     /// Evicted data files to delete.
     EvictedDataFilesToDelete {
-        /// Evicted data files by data file cache.
+        /// Evicted data files by object storage cache.
         evicted_data_files: Vec<String>,
     },
 }

--- a/src/moonlink/src/union_read/read_state.rs
+++ b/src/moonlink/src/union_read/read_state.rs
@@ -29,7 +29,7 @@ pub struct ReadState {
 
 impl Drop for ReadState {
     fn drop(&mut self) {
-        // Notify query completion for data file cache unreference.
+        // Notify query completion for object storage cache unreference.
         // Since we cannot rely on async function at `Drop` function, start a detech task immediately here.
         let cache_handles = std::mem::take(&mut self.cache_handles);
 

--- a/src/moonlink_backend/src/lib.rs
+++ b/src/moonlink_backend/src/lib.rs
@@ -18,9 +18,9 @@ const DEFAULT_MOONLINK_TABLE_BASE_PATH: &str = "./mooncake/";
 // Default local filesystem directory where all temporary files (used for union read) will be stored under.
 // The whole directory is cleaned up at moonlink backend start, to prevent file leak.
 pub const DEFAULT_MOONLINK_TEMP_FILE_PATH: &str = "/tmp/moonlink_temp_file";
-// Default data file cache directory.
+// Default object storage cache directory.
 // The whole directory is cleaned up at moonlink backend start, to prevent file leak.
-pub const DEFAULT_MOONLINK_DATA_FILE_CACHE_PATH: &str = "/tmp/moonlink_cache_file";
+pub const DEFAULT_MOONLINK_OBJECT_STORAGE_CACHE_PATH: &str = "/tmp/moonlink_cache_file";
 // Min left disk space for on-disk cache of the filesystem which cache directory is mounted on.
 const MIN_DISK_SPACE_FOR_CACHE: u64 = 1 << 30; // 1GiB
 
@@ -59,14 +59,14 @@ fn get_cache_filesystem_size(path: &str) -> u64 {
     (block_size as u64).checked_mul(avai_blocks as u64).unwrap()
 }
 
-/// Create default data file cache.
-fn create_default_data_file_cache() -> ObjectStorageCache {
-    let filesystem_size = get_cache_filesystem_size(DEFAULT_MOONLINK_DATA_FILE_CACHE_PATH);
+/// Create default object storage cache.
+fn create_default_object_storage_cache() -> ObjectStorageCache {
+    let filesystem_size = get_cache_filesystem_size(DEFAULT_MOONLINK_OBJECT_STORAGE_CACHE_PATH);
     ma::assert_ge!(filesystem_size, MIN_DISK_SPACE_FOR_CACHE);
 
     let cache_config = ObjectStorageCacheConfig {
         max_bytes: filesystem_size - MIN_DISK_SPACE_FOR_CACHE,
-        cache_directory: DEFAULT_MOONLINK_DATA_FILE_CACHE_PATH.to_string(),
+        cache_directory: DEFAULT_MOONLINK_OBJECT_STORAGE_CACHE_PATH.to_string(),
     };
     ObjectStorageCache::new(cache_config)
 }
@@ -76,13 +76,13 @@ impl<T: Eq + Hash + Clone> MoonlinkBackend<T> {
         logging::init_logging();
 
         recreate_directory(DEFAULT_MOONLINK_TEMP_FILE_PATH).unwrap();
-        recreate_directory(DEFAULT_MOONLINK_DATA_FILE_CACHE_PATH).unwrap();
+        recreate_directory(DEFAULT_MOONLINK_OBJECT_STORAGE_CACHE_PATH).unwrap();
 
         Self {
             replication_manager: RwLock::new(ReplicationManager::new(
                 base_path.clone(),
                 DEFAULT_MOONLINK_TEMP_FILE_PATH.to_string(),
-                create_default_data_file_cache(),
+                create_default_object_storage_cache(),
             )),
         }
     }

--- a/src/moonlink_connectors/src/pg_replicate/table_init.rs
+++ b/src/moonlink_connectors/src/pg_replicate/table_init.rs
@@ -43,7 +43,7 @@ pub async fn build_table_components(
     base_path: &Path,
     table_temp_files_directory: String,
     replication_state: &ReplicationState,
-    data_file_cache: ObjectStorageCache,
+    object_storage_cache: ObjectStorageCache,
 ) -> Result<TableResources> {
     let table_path = PathBuf::from(base_path).join(table_schema.table_name.to_string());
     tokio::fs::create_dir_all(&table_path).await.unwrap();
@@ -62,7 +62,7 @@ pub async fn build_table_components(
         identity,
         iceberg_table_config,
         mooncake_table_config,
-        data_file_cache,
+        object_storage_cache,
     )
     .await?;
 

--- a/src/moonlink_connectors/src/replication_connection.rs
+++ b/src/moonlink_connectors/src/replication_connection.rs
@@ -51,8 +51,8 @@ pub struct ReplicationConnection {
     source: PostgresSource,
     replication_started: bool,
     slot_name: String,
-    /// Data file cache.
-    data_file_cache: ObjectStorageCache,
+    /// Object storage cache.
+    object_storage_cache: ObjectStorageCache,
 }
 
 impl ReplicationConnection {
@@ -60,7 +60,7 @@ impl ReplicationConnection {
         uri: String,
         table_base_path: String,
         table_temp_files_directory: String,
-        data_file_cache: ObjectStorageCache,
+        object_storage_cache: ObjectStorageCache,
     ) -> Result<Self> {
         info!(%uri, "initializing replication connection");
 
@@ -119,7 +119,7 @@ impl ReplicationConnection {
             source: postgres_source,
             replication_started: false,
             slot_name,
-            data_file_cache,
+            object_storage_cache,
         })
     }
 
@@ -252,7 +252,7 @@ impl ReplicationConnection {
             Path::new(&self.table_base_path),
             self.table_temp_files_directory.clone(),
             &self.replication_state,
-            self.data_file_cache.clone(),
+            self.object_storage_cache.clone(),
         )
         .await?;
 

--- a/src/moonlink_connectors/src/replication_manager.rs
+++ b/src/moonlink_connectors/src/replication_manager.rs
@@ -21,22 +21,22 @@ pub struct ReplicationManager<T: Eq + Hash> {
     table_base_path: String,
     /// Base directory for temporary files used in union read.
     table_temp_files_directory: String,
-    /// Data file cache.
-    data_file_cache: ObjectStorageCache,
+    /// Object storage cache.
+    object_storage_cache: ObjectStorageCache,
 }
 
 impl<T: Eq + Hash> ReplicationManager<T> {
     pub fn new(
         table_base_path: String,
         table_temp_files_directory: String,
-        data_file_cache: ObjectStorageCache,
+        object_storage_cache: ObjectStorageCache,
     ) -> Self {
         Self {
             connections: HashMap::new(),
             table_info: HashMap::new(),
             table_base_path,
             table_temp_files_directory,
-            data_file_cache,
+            object_storage_cache,
         }
     }
 
@@ -65,7 +65,7 @@ impl<T: Eq + Hash> ReplicationManager<T> {
                 uri.to_owned(),
                 base_path.to_str().unwrap().to_string(),
                 self.table_temp_files_directory.clone(),
-                self.data_file_cache.clone(),
+                self.object_storage_cache.clone(),
             )
             .await?;
             self.connections


### PR DESCRIPTION
## Summary

This PR does a no-op rename globally, to update naming `data_file_cache` to `object_storage_cache`;
I plan to leverage the same infra for all object storage files, including data files, puffin blobs, and file indices.

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
