### PR TITLE
fix streaming update perf

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1173,6 +1173,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
+name = "fastbloom"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33f26ab05af2bdfeeb680ec3002f1bfb8065f3d486b9b3db354103c80bd71866"
+dependencies = [
+ "getrandom 0.3.3",
+ "rand 0.9.1",
+ "siphasher",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2383,6 +2394,7 @@ dependencies = [
  "chrono",
  "crc32fast",
  "criterion",
+ "fastbloom",
  "futures",
  "hashbrown 0.15.4",
  "hmac",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ bincode = "2"
 chrono = { version = "0.4", default-features = false }
 console-subscriber = "0.2"
 crc32fast = "1"
+fastbloom = "0.12.0"
 futures = { version = "0.3", default-features = false }
 hashbrown = "0.15.3"
 iceberg = { git = "https://github.com/apache/iceberg-rust.git", rev = "bcd1033ba5c67982b7359a6330defeade9f82526", default-features = false, features = [

--- a/src/moonlink/Cargo.toml
+++ b/src/moonlink/Cargo.toml
@@ -31,6 +31,7 @@ base64 = { version = "0.22", optional = true }
 bincode = { workspace = true }
 chrono = { workspace = true, optional = true }
 crc32fast = { workspace = true }
+fastbloom = { workspace = true }
 futures = { workspace = true }
 hashbrown = { workspace = true }
 hmac = { version = "0.12", optional = true }


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

In streaming xact, when processing deletion,
we need to do a index lookup in foreground on everything in current transaction, both in-memory and flushed rows (since they are not visible to snapshot thread yet).
Index lookup is async function that may involve file IO, so it is relatively costly.
But it is very unlikely a row in current transaction is deleted, so most of the check is indeed wasted.

Fix it by adding a bloomfliter.


## Related Issues

Closes #<issue-number> or links to related issues.

## Changes

- 
- 
- 

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
