### PR TITLE
[storage] Rework data file <-> file index mapping

### DIFF
--- a/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
@@ -13,7 +13,6 @@ use crate::storage::iceberg::table_manager::{
 };
 use crate::storage::iceberg::utils;
 use crate::storage::iceberg::validation as IcebergValidation;
-use crate::storage::index::persisted_bucket_hash_map::GlobalIndex;
 use crate::storage::index::{FileIndex as MooncakeFileIndex, MooncakeIndex};
 use crate::storage::io_utils;
 use crate::storage::mooncake_table::delete_vector::BatchDeletionVector;
@@ -826,10 +825,7 @@ impl TableManager for IcebergTableManager {
             }
         }
 
-        let mooncake_snapshot = self.transform_to_mooncake_snapshot(
-            loaded_file_indices,
-            flush_lsn,
-        );
+        let mooncake_snapshot = self.transform_to_mooncake_snapshot(loaded_file_indices, flush_lsn);
         Ok(mooncake_snapshot)
     }
 

--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -167,9 +167,6 @@ pub(crate) struct DiskFileEntry {
     pub(crate) cache_handle: Option<NonEvictableHandle>,
     /// File size.
     pub(crate) file_size: usize,
-    /// File indices.
-    /// Invariant: in a consistent snapshot, disk file entry has its file indice assigned.
-    pub(crate) file_indice: Option<FileIndex>,
     /// In-memory deletion vector, used for new deletion records in-memory processing.
     pub(crate) batch_deletion_vector: BatchDeletionVector,
     /// Persisted iceberg deletion vector puffin blob.

--- a/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
+++ b/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
@@ -199,7 +199,6 @@ impl MooncakeTable {
                 let disk_file_entry = DiskFileEntry {
                     file_size: file_attrs.file_size,
                     cache_handle: None,
-                    file_indice: Some(disk_slice.get_file_indice().as_ref().unwrap().clone()),
                     batch_deletion_vector: BatchDeletionVector::new(file_attrs.row_num),
                     puffin_deletion_blob: None,
                 };


### PR DESCRIPTION
## Summary

I made a bad decision in compaction, which is to store bimap between data file and file index.
Data compaction decides which data files to compact based on their file size, then file indices based on the data files to compact.
The motivation at that time is to get file indices to compact in O(1); but seems one extra O(N) iteration is enough.

Bimap is bad:
- It makes code messy, every time a data file / file index updates, two places will be updated in-sync;
- It makes file index reference count harder, see attached issue. 

There's no behavior change, so no unit test or state machine change;
extra assertion is added to assert mooncake snapshot consistent.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/524

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
