### PR TITLE
[storage] Combine cache handle unreference and delete

### DIFF
--- a/src/moonlink/src/storage/cache/object_storage/base_cache.rs
+++ b/src/moonlink/src/storage/cache/object_storage/base_cache.rs
@@ -35,13 +35,6 @@ pub trait CacheTrait {
         cache_entry: CacheEntry,
     ) -> (NonEvictableHandle, Vec<String>);
 
-    /// Delete cache entry from the cache, which will be evicted immediately at next cache access.
-    /// It's required requested file id exists in cache, otherwise panic.
-    /// Return evicted files to delete.
-    #[must_use]
-    #[allow(async_fn_in_trait)]
-    async fn delete_cache_entry(&mut self, file_id: TableUniqueFileId) -> Vec<String>;
-
     /// Similar to [`delete_cache_entry`], but doesn't panic if requested entry doesn't exist.
     #[must_use]
     #[allow(async_fn_in_trait)]

--- a/src/moonlink/src/storage/cache/object_storage/cache_handle.rs
+++ b/src/moonlink/src/storage/cache/object_storage/cache_handle.rs
@@ -50,4 +50,17 @@ impl NonEvictableHandle {
         let mut guard = self.cache.write().await;
         guard.unreference(self.file_id)
     }
+
+    /// Unreference and pinned cache file and mark it as deleted.
+    #[must_use]
+    pub(crate) async fn unreference_and_delete(&mut self) -> Vec<String> {
+        let mut guard = self.cache.write().await;
+
+        // Total bytes within cache doesn't change, so current cache entry not evicted.
+        let cur_evicted_files = guard.unreference(self.file_id);
+        assert!(cur_evicted_files.is_empty());
+
+        // The cache entry could be held elsewhere.
+        guard.delete_cache_entry(self.file_id, /*panic_if_non_existent=*/ true)
+    }
 }

--- a/src/moonlink/src/storage/cache/object_storage/object_storage_cache.rs
+++ b/src/moonlink/src/storage/cache/object_storage/object_storage_cache.rs
@@ -103,7 +103,7 @@ impl ObjectStorageCacheInternal {
     }
 
     /// Mark the requested cache entry as deleted, and return evicted files.
-    fn delete_cache_entry(
+    pub(super) fn delete_cache_entry(
         &mut self,
         file_id: TableUniqueFileId,
         panic_if_non_existent: bool,
@@ -375,11 +375,6 @@ impl CacheTrait for ObjectStorageCache {
 
             Ok((None, files_to_delete))
         }
-    }
-
-    async fn delete_cache_entry(&mut self, file_id: TableUniqueFileId) -> Vec<String> {
-        let mut guard = self.cache.write().await;
-        guard.delete_cache_entry(file_id, /*panic_if_non_existent=*/ true)
     }
 
     async fn try_delete_cache_entry(&mut self, file_id: TableUniqueFileId) -> Vec<String> {

--- a/src/moonlink/src/storage/cache/object_storage/state_tests.rs
+++ b/src/moonlink/src/storage/cache/object_storage/state_tests.rs
@@ -515,12 +515,8 @@ async fn test_cache_2_requested_to_delete_4() {
     .await;
     assert!(files_to_evict.is_empty());
 
-    // Unreference cache handle, so requested cache handle is not referenced.
-    let files_to_evict = cache_handle.unreference().await;
-    assert!(files_to_evict.is_empty());
-
-    // Request to delete.
-    let evicted_files = cache.delete_cache_entry(get_table_unique_file_id(0)).await;
+    // Unreference and delete cache handle, so requested cache handle is not referenced.
+    let evicted_files = cache_handle.unreference_and_delete().await;
     assert_eq!(evicted_files, vec![test_file.to_str().unwrap().to_string()]);
 
     // Check cache status.
@@ -560,7 +556,9 @@ async fn test_cache_3_requested_to_delete_5() {
     assert!(files_to_evict.is_empty());
 
     // Request to delete.
-    let evicted_files = cache.delete_cache_entry(get_table_unique_file_id(0)).await;
+    let evicted_files = cache
+        .try_delete_cache_entry(get_table_unique_file_id(0))
+        .await;
     assert!(evicted_files.is_empty());
 
     // Check cache status.
@@ -600,7 +598,9 @@ async fn test_cache_5_usage_finish_and_still_referenced_5() {
     assert!(files_to_evict.is_empty());
 
     // Request to delete.
-    let evicted_files = cache.delete_cache_entry(get_table_unique_file_id(0)).await;
+    let evicted_files = cache
+        .try_delete_cache_entry(get_table_unique_file_id(0))
+        .await;
     assert!(evicted_files.is_empty());
 
     // Reference one more time, which leads to two reference count.
@@ -653,7 +653,9 @@ async fn test_cache_5_usage_finish_and_not_referenced_4() {
     assert!(files_to_evict.is_empty());
 
     // Request to delete.
-    let evicted_files = cache.delete_cache_entry(get_table_unique_file_id(0)).await;
+    let evicted_files = cache
+        .try_delete_cache_entry(get_table_unique_file_id(0))
+        .await;
     assert!(evicted_files.is_empty());
 
     // Reference one more time, which leads to two reference count.


### PR DESCRIPTION
## Summary

When I'm working on cache integration, I found most of the deletion cases are unreference + delete, so simply provide an extra unreference interface to save a function call and mutex acquisition/release.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/537

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
