### PR TITLE
[storage] Cache read state instead of snapshot read output

### DIFF
--- a/src/moonlink/src/table_handler/test_utils.rs
+++ b/src/moonlink/src/table_handler/test_utils.rs
@@ -269,8 +269,7 @@ pub async fn check_read_snapshot(
     target_lsn: u64,
     expected_ids: &[i32],
 ) {
-    let snapshot_read_output = read_manager.try_read(Some(target_lsn)).await.unwrap();
-    let read_state = (*snapshot_read_output).clone().take_as_read_state().await;
+    let read_state = read_manager.try_read(Some(target_lsn)).await.unwrap();
     let (data_files, puffin_files, deletion_vectors, position_deletes) =
         decode_read_state_for_testing(&read_state);
 

--- a/src/moonlink/src/union_read/read_state.rs
+++ b/src/moonlink/src/union_read/read_state.rs
@@ -15,7 +15,7 @@ use tracing::{info_span, warn};
 const BINCODE_CONFIG: config::Configuration = config::standard();
 
 // TODO(hjiang): A better solution might be wrap clean up in a functor.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct ReadState {
     /// Serialized data files and positional deletes for query.
     pub data: Vec<u8>,

--- a/src/moonlink/src/union_read/read_state_manager.rs
+++ b/src/moonlink/src/union_read/read_state_manager.rs
@@ -25,7 +25,15 @@ impl ReadStateManager {
         let (table_snapshot, table_snapshot_watch_receiver) = table.get_state_for_reader();
         ReadStateManager {
             last_read_lsn: AtomicU64::new(0),
-            last_read_state: RwLock::new(Arc::new(ReadState::default())),
+            last_read_state: RwLock::new(Arc::new(ReadState::new(
+                /*data_files=*/ Vec::new(),
+                /*puffin_cache_handles=*/ Vec::new(),
+                /*deletion_vectors_at_read=*/ Vec::new(),
+                /*position_deletes=*/ Vec::new(),
+                /*associated_files=*/ Vec::new(),
+                /*cache_handles=*/ Vec::new(),
+                /*table_notify=*/ None,
+            ))),
             table_snapshot,
             table_snapshot_watch_receiver,
             replication_lsn_rx,


### PR DESCRIPTION
## Summary

The bug is: at `scan_table` every time we create a new `ReadState`, which deletes all temporary files after this particular variable goes out of scope.

Tested by pg_mooncake regression test:
```sql
--- beginning regression test run ---
PASS setup 24ms
PASS partitioned_table 663ms
PASS sanity 566ms
passed=3, failed=0
```

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/546

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
