### PR TITLE
[storage] Return next file id on recovery

### DIFF
--- a/src/moonlink/src/storage/iceberg/compaction_tests.rs
+++ b/src/moonlink/src/storage/iceberg/compaction_tests.rs
@@ -285,11 +285,12 @@ async fn test_compaction_1_1_1() {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager_to_load
+    let (next_file_id, snapshot) = iceberg_table_manager_to_load
         .load_snapshot_from_table()
         .await
         .unwrap();
 
+    assert_eq!(next_file_id, 2); // one compacted data file, one compacted index block file
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 1);
     check_loaded_snapshot(&snapshot, /*row_indices=*/ vec![0, 1, 2, 3]).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
@@ -342,11 +343,12 @@ async fn test_compaction_1_1_2() {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager_to_load
+    let (next_file_id, snapshot) = iceberg_table_manager_to_load
         .load_snapshot_from_table()
         .await
         .unwrap();
 
+    assert_eq!(next_file_id, 2); // one compacted data file, one compacted index block file
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 1);
     check_loaded_snapshot(&snapshot, /*row_indices=*/ vec![0, 1, 2, 3]).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
@@ -420,11 +422,12 @@ async fn test_compaction_1_2_1() {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager_to_load
+    let (next_file_id, snapshot) = iceberg_table_manager_to_load
         .load_snapshot_from_table()
         .await
         .unwrap();
 
+    assert_eq!(next_file_id, 2); // one compacted data file, one compacted index block file
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 1);
     check_loaded_snapshot(&snapshot, /*row_indices=*/ vec![0, 1, 2, 3]).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
@@ -497,11 +500,12 @@ async fn test_compaction_1_2_2() {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager_to_load
+    let (next_file_id, snapshot) = iceberg_table_manager_to_load
         .load_snapshot_from_table()
         .await
         .unwrap();
 
+    assert_eq!(next_file_id, 2); // one compacted data file, one compacted index block file
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 1);
     check_loaded_snapshot(&snapshot, /*row_indices=*/ vec![0, 1, 2, 3]).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
@@ -586,11 +590,12 @@ async fn test_compaction_2_2_1() {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager_to_load
+    let (next_file_id, snapshot) = iceberg_table_manager_to_load
         .load_snapshot_from_table()
         .await
         .unwrap();
 
+    assert_eq!(next_file_id, 2); // one compacted data file, one compacted index block file
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 3);
     check_loaded_snapshot(&snapshot, /*row_indices=*/ vec![1, 2, 3]).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
@@ -664,11 +669,12 @@ async fn test_compaction_2_2_2() {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager_to_load
+    let (next_file_id, snapshot) = iceberg_table_manager_to_load
         .load_snapshot_from_table()
         .await
         .unwrap();
 
+    assert_eq!(next_file_id, 2); // one compacted data file, one compacted index block file
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 3);
     check_loaded_snapshot(&snapshot, /*row_indices=*/ vec![1, 2, 3]).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
@@ -755,11 +761,12 @@ async fn test_compaction_2_3_1() {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager_to_load
+    let (next_file_id, snapshot) = iceberg_table_manager_to_load
         .load_snapshot_from_table()
         .await
         .unwrap();
 
+    assert_eq!(next_file_id, 2); // one compacted data file, one compacted index block file
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 5);
     check_loaded_snapshot(&snapshot, /*row_indices=*/ vec![1, 3]).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
@@ -821,11 +828,12 @@ async fn test_compaction_2_3_2() {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager_to_load
+    let (next_file_id, snapshot) = iceberg_table_manager_to_load
         .load_snapshot_from_table()
         .await
         .unwrap();
 
+    assert_eq!(next_file_id, 2); // one compacted data file, one compacted index block file
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 5);
     check_loaded_snapshot(&snapshot, /*row_indices=*/ vec![1, 3]).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
@@ -915,11 +923,12 @@ async fn test_compaction_3_2_1() {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager_to_load
+    let (next_file_id, snapshot) = iceberg_table_manager_to_load
         .load_snapshot_from_table()
         .await
         .unwrap();
 
+    assert_eq!(next_file_id, 2); // one compacted data file, one compacted index block file
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 1);
     check_loaded_snapshot(&snapshot, /*row_indices=*/ vec![0, 1, 2, 3]).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
@@ -995,11 +1004,12 @@ async fn test_compaction_3_3_1() {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager_to_load
+    let (next_file_id, snapshot) = iceberg_table_manager_to_load
         .load_snapshot_from_table()
         .await
         .unwrap();
 
+    assert_eq!(next_file_id, 0);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 7);
     assert!(snapshot.disk_files.is_empty());
     assert!(snapshot.indices.file_indices.is_empty());

--- a/src/moonlink/src/storage/iceberg/index.rs
+++ b/src/moonlink/src/storage/iceberg/index.rs
@@ -36,7 +36,7 @@ pub(crate) struct FileIndex {
     /// Data file paths at iceberg table.
     data_files: Vec<String>,
     /// Corresponds to [storage::index::IndexBlock].
-    index_block_files: Vec<IndexBlock>,
+    pub index_block_files: Vec<IndexBlock>, // TODO
     /// Hash related fields.
     num_rows: u32,
     hash_bits: u32,

--- a/src/moonlink/src/storage/iceberg/state_tests.rs
+++ b/src/moonlink/src/storage/iceberg/state_tests.rs
@@ -249,7 +249,8 @@ async fn test_state_1_1() -> IcebergResult<()> {
     assert!(!table.create_snapshot(SnapshotOption::default()));
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager.load_snapshot_from_table().await?;
+    let (next_file_id, snapshot) = iceberg_table_manager.load_snapshot_from_table().await?;
+    assert_eq!(next_file_id, 0);
     assert!(snapshot.disk_files.is_empty());
     assert!(snapshot.indices.file_indices.is_empty());
     assert!(snapshot.data_file_flush_lsn.is_none());
@@ -280,7 +281,8 @@ async fn test_state_1_2() -> IcebergResult<()> {
     assert!(!table.create_snapshot(SnapshotOption::default()));
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager.load_snapshot_from_table().await?;
+    let (next_file_id, snapshot) = iceberg_table_manager.load_snapshot_from_table().await?;
+    assert_eq!(next_file_id, 0);
     assert!(snapshot.disk_files.is_empty());
     assert!(snapshot.indices.file_indices.is_empty());
     assert!(snapshot.data_file_flush_lsn.is_none());
@@ -317,7 +319,8 @@ async fn test_state_1_3() -> IcebergResult<()> {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager.load_snapshot_from_table().await?;
+    let (next_file_id, snapshot) = iceberg_table_manager.load_snapshot_from_table().await?;
+    assert_eq!(next_file_id, 2); // one data file, one index block file
     check_prev_data_files(&snapshot, &iceberg_table_manager, /*deleted=*/ false).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 100);
@@ -356,7 +359,8 @@ async fn test_state_1_4() -> IcebergResult<()> {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager.load_snapshot_from_table().await?;
+    let (next_file_id, snapshot) = iceberg_table_manager.load_snapshot_from_table().await?;
+    assert_eq!(next_file_id, 2); // one data file, one index block file
     check_prev_data_files(&snapshot, &iceberg_table_manager, /*deleted=*/ false).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 100);
@@ -394,7 +398,8 @@ async fn test_state_1_5() -> IcebergResult<()> {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager.load_snapshot_from_table().await?;
+    let (next_file_id, snapshot) = iceberg_table_manager.load_snapshot_from_table().await?;
+    assert_eq!(next_file_id, 3); // one data file, one index block file, one puffin blob
     check_prev_data_files(&snapshot, &iceberg_table_manager, /*deleted=*/ true).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 300);
@@ -434,7 +439,8 @@ async fn test_state_1_6() -> IcebergResult<()> {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager.load_snapshot_from_table().await?;
+    let (next_file_id, snapshot) = iceberg_table_manager.load_snapshot_from_table().await?;
+    assert_eq!(next_file_id, 3); // one data file, one index block file, one puffin blob
     check_prev_data_files(&snapshot, &iceberg_table_manager, /*deleted=*/ true).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 300);
@@ -467,7 +473,8 @@ async fn test_state_2_1() -> IcebergResult<()> {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager.load_snapshot_from_table().await?;
+    let (next_file_id, snapshot) = iceberg_table_manager.load_snapshot_from_table().await?;
+    assert_eq!(next_file_id, 0);
     assert!(snapshot.disk_files.is_empty());
     assert!(snapshot.indices.file_indices.is_empty());
     assert!(snapshot.data_file_flush_lsn.is_none());
@@ -502,7 +509,8 @@ async fn test_state_2_2() -> IcebergResult<()> {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager.load_snapshot_from_table().await?;
+    let (next_file_id, snapshot) = iceberg_table_manager.load_snapshot_from_table().await?;
+    assert_eq!(next_file_id, 0);
     assert!(snapshot.disk_files.is_empty());
     assert!(snapshot.indices.file_indices.is_empty());
     assert!(snapshot.data_file_flush_lsn.is_none());
@@ -540,7 +548,8 @@ async fn test_state_2_3() -> IcebergResult<()> {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager.load_snapshot_from_table().await?;
+    let (next_file_id, snapshot) = iceberg_table_manager.load_snapshot_from_table().await?;
+    assert_eq!(next_file_id, 2); // one data file, one index block file
     check_prev_data_files(&snapshot, &iceberg_table_manager, /*deleted=*/ false).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 100);
@@ -580,7 +589,8 @@ async fn test_state_2_4() -> IcebergResult<()> {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager.load_snapshot_from_table().await?;
+    let (next_file_id, snapshot) = iceberg_table_manager.load_snapshot_from_table().await?;
+    assert_eq!(next_file_id, 2); // one data file, one index block file
     check_prev_data_files(&snapshot, &iceberg_table_manager, /*deleted=*/ false).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 100);
@@ -619,7 +629,8 @@ async fn test_state_2_5() -> IcebergResult<()> {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager.load_snapshot_from_table().await?;
+    let (next_file_id, snapshot) = iceberg_table_manager.load_snapshot_from_table().await?;
+    assert_eq!(next_file_id, 3); // one data file, one index block file, one deletion vector puffin
     check_prev_data_files(&snapshot, &iceberg_table_manager, /*deleted=*/ true).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 300);
@@ -660,7 +671,8 @@ async fn test_state_2_6() -> IcebergResult<()> {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager.load_snapshot_from_table().await?;
+    let (next_file_id, snapshot) = iceberg_table_manager.load_snapshot_from_table().await?;
+    assert_eq!(next_file_id, 3); // one data file, one index block file, one deletion vector puffin
     check_prev_data_files(&snapshot, &iceberg_table_manager, /*deleted=*/ true).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 300);
@@ -694,7 +706,8 @@ async fn test_state_3_1() -> IcebergResult<()> {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager.load_snapshot_from_table().await?;
+    let (next_file_id, snapshot) = iceberg_table_manager.load_snapshot_from_table().await?;
+    assert_eq!(next_file_id, 2); // one data file, one index block file
     check_new_data_files(&snapshot, &iceberg_table_manager, /*deleted=*/ false).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 200);
@@ -730,7 +743,8 @@ async fn test_state_3_2() -> IcebergResult<()> {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager.load_snapshot_from_table().await?;
+    let (next_file_id, snapshot) = iceberg_table_manager.load_snapshot_from_table().await?;
+    assert_eq!(next_file_id, 2); // one data file, one index block file
     check_new_data_files(&snapshot, &iceberg_table_manager, /*deleted=*/ false).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 200);
@@ -769,7 +783,8 @@ async fn test_state_3_3_deletion_before_flush() -> IcebergResult<()> {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager.load_snapshot_from_table().await?;
+    let (next_file_id, snapshot) = iceberg_table_manager.load_snapshot_from_table().await?;
+    assert_eq!(next_file_id, 5); // two data files, two index block files, one deletion vector puffin
     check_prev_and_new_data_files(
         &snapshot,
         &iceberg_table_manager,
@@ -813,7 +828,8 @@ async fn test_state_3_3_deletion_after_flush() -> IcebergResult<()> {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager.load_snapshot_from_table().await?;
+    let (next_file_id, snapshot) = iceberg_table_manager.load_snapshot_from_table().await?;
+    assert_eq!(next_file_id, 4); // two data files, two index block files
     check_prev_and_new_data_files(
         &snapshot,
         &iceberg_table_manager,
@@ -859,7 +875,8 @@ async fn test_state_3_4_committed_deletion_before_flush() -> IcebergResult<()> {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager.load_snapshot_from_table().await?;
+    let (next_file_id, snapshot) = iceberg_table_manager.load_snapshot_from_table().await?;
+    assert_eq!(next_file_id, 5); // two data files, two index block files, one deletion vector puffin
     check_prev_and_new_data_files(
         &snapshot,
         &iceberg_table_manager,
@@ -905,7 +922,8 @@ async fn test_state_3_4_committed_deletion_after_flush() -> IcebergResult<()> {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager.load_snapshot_from_table().await?;
+    let (next_file_id, snapshot) = iceberg_table_manager.load_snapshot_from_table().await?;
+    assert_eq!(next_file_id, 4); // two data files, two index block files
     check_prev_and_new_data_files(
         &snapshot,
         &iceberg_table_manager,
@@ -950,7 +968,8 @@ async fn test_state_3_5() -> IcebergResult<()> {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager.load_snapshot_from_table().await?;
+    let (next_file_id, snapshot) = iceberg_table_manager.load_snapshot_from_table().await?;
+    assert_eq!(next_file_id, 5); // two data files, two index block files, one deletion vector puffin
     check_prev_and_new_data_files(
         &snapshot,
         &iceberg_table_manager,
@@ -997,7 +1016,8 @@ async fn test_state_3_6() -> IcebergResult<()> {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager.load_snapshot_from_table().await?;
+    let (next_file_id, snapshot) = iceberg_table_manager.load_snapshot_from_table().await?;
+    assert_eq!(next_file_id, 5); // two data files, two index block files, one deletion vector puffin
     check_prev_and_new_data_files(
         &snapshot,
         &iceberg_table_manager,
@@ -1042,7 +1062,8 @@ async fn test_state_4_1() -> IcebergResult<()> {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager.load_snapshot_from_table().await?;
+    let (next_file_id, snapshot) = iceberg_table_manager.load_snapshot_from_table().await?;
+    assert_eq!(next_file_id, 0);
     assert!(snapshot.disk_files.is_empty());
     assert!(snapshot.indices.file_indices.is_empty());
     assert!(snapshot.data_file_flush_lsn.is_none());
@@ -1084,7 +1105,8 @@ async fn test_state_4_2() -> IcebergResult<()> {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager.load_snapshot_from_table().await?;
+    let (next_file_id, snapshot) = iceberg_table_manager.load_snapshot_from_table().await?;
+    assert_eq!(next_file_id, 0);
     assert!(snapshot.disk_files.is_empty());
     assert!(snapshot.indices.file_indices.is_empty());
     assert!(snapshot.data_file_flush_lsn.is_none());
@@ -1129,7 +1151,8 @@ async fn test_state_4_3() -> IcebergResult<()> {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager.load_snapshot_from_table().await?;
+    let (next_file_id, snapshot) = iceberg_table_manager.load_snapshot_from_table().await?;
+    assert_eq!(next_file_id, 2); // one data file, one index block file
     check_prev_data_files(&snapshot, &iceberg_table_manager, /*deleted=*/ false).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 100);
@@ -1176,7 +1199,8 @@ async fn test_state_4_4() -> IcebergResult<()> {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager.load_snapshot_from_table().await?;
+    let (next_file_id, snapshot) = iceberg_table_manager.load_snapshot_from_table().await?;
+    assert_eq!(next_file_id, 2); // one data file, one index block file
     check_prev_data_files(&snapshot, &iceberg_table_manager, /*deleted=*/ false).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 100);
@@ -1222,7 +1246,8 @@ async fn test_state_4_5() -> IcebergResult<()> {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager.load_snapshot_from_table().await?;
+    let (next_file_id, snapshot) = iceberg_table_manager.load_snapshot_from_table().await?;
+    assert_eq!(next_file_id, 3); // one data file, one index block file, one deletion vector puffin
     check_prev_data_files(&snapshot, &iceberg_table_manager, /*deleted=*/ true).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 300);
@@ -1270,7 +1295,8 @@ async fn test_state_4_6() -> IcebergResult<()> {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager.load_snapshot_from_table().await?;
+    let (next_file_id, snapshot) = iceberg_table_manager.load_snapshot_from_table().await?;
+    assert_eq!(next_file_id, 3); // one data file, one index block file, one deletion vector puffin
     check_prev_data_files(&snapshot, &iceberg_table_manager, /*deleted=*/ true).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 300);
@@ -1312,7 +1338,8 @@ async fn test_state_5_1() -> IcebergResult<()> {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager.load_snapshot_from_table().await?;
+    let (next_file_id, snapshot) = iceberg_table_manager.load_snapshot_from_table().await?;
+    assert_eq!(next_file_id, 2); // one data file, one index block file
     check_new_data_files(&snapshot, &iceberg_table_manager, /*deleted=*/ false).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 200);
@@ -1356,7 +1383,8 @@ async fn test_state_5_2() -> IcebergResult<()> {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager.load_snapshot_from_table().await?;
+    let (next_file_id, snapshot) = iceberg_table_manager.load_snapshot_from_table().await?;
+    assert_eq!(next_file_id, 2); // one data file, one index block file
     check_new_data_files(&snapshot, &iceberg_table_manager, /*deleted=*/ false).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 200);
@@ -1403,7 +1431,8 @@ async fn test_state_5_3_deletion_before_flush() -> IcebergResult<()> {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager.load_snapshot_from_table().await?;
+    let (next_file_id, snapshot) = iceberg_table_manager.load_snapshot_from_table().await?;
+    assert_eq!(next_file_id, 5); // two data files, two index block files, one deletion vector puffin
     check_prev_and_new_data_files(
         &snapshot,
         &iceberg_table_manager,
@@ -1455,7 +1484,8 @@ async fn test_state_5_3_deletion_after_flush() -> IcebergResult<()> {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager.load_snapshot_from_table().await?;
+    let (next_file_id, snapshot) = iceberg_table_manager.load_snapshot_from_table().await?;
+    assert_eq!(next_file_id, 4); // two data files, two index block files
     check_prev_and_new_data_files(
         &snapshot,
         &iceberg_table_manager,
@@ -1509,7 +1539,8 @@ async fn test_state_5_4_committed_deletion_before_flush() -> IcebergResult<()> {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager.load_snapshot_from_table().await?;
+    let (next_file_id, snapshot) = iceberg_table_manager.load_snapshot_from_table().await?;
+    assert_eq!(next_file_id, 5); // two data files, two index block files, one deletion vector puffin
     check_prev_and_new_data_files(
         &snapshot,
         &iceberg_table_manager,
@@ -1563,7 +1594,8 @@ async fn test_state_5_4_committed_deletion_after_flush() -> IcebergResult<()> {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager.load_snapshot_from_table().await?;
+    let (next_file_id, snapshot) = iceberg_table_manager.load_snapshot_from_table().await?;
+    assert_eq!(next_file_id, 4); // two data files, two index block files
     check_prev_and_new_data_files(
         &snapshot,
         &iceberg_table_manager,
@@ -1616,7 +1648,8 @@ async fn test_state_5_5() -> IcebergResult<()> {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager.load_snapshot_from_table().await?;
+    let (next_file_id, snapshot) = iceberg_table_manager.load_snapshot_from_table().await?;
+    assert_eq!(next_file_id, 5); // two data files, two index block files, one deletion vector puffin
     check_prev_and_new_data_files(
         &snapshot,
         &iceberg_table_manager,
@@ -1671,7 +1704,8 @@ async fn test_state_5_6() -> IcebergResult<()> {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager.load_snapshot_from_table().await?;
+    let (next_file_id, snapshot) = iceberg_table_manager.load_snapshot_from_table().await?;
+    assert_eq!(next_file_id, 5); // two data files, two index block files, one deletion vector puffin
     check_prev_and_new_data_files(
         &snapshot,
         &iceberg_table_manager,
@@ -1725,7 +1759,8 @@ async fn test_state_6_1() -> IcebergResult<()> {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager.load_snapshot_from_table().await?;
+    let (next_file_id, snapshot) = iceberg_table_manager.load_snapshot_from_table().await?;
+    assert_eq!(next_file_id, 2); // one data file, one index block file
     check_new_data_files(&snapshot, &iceberg_table_manager, /*deleted=*/ false).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 200);
@@ -1776,7 +1811,8 @@ async fn test_state_6_2() -> IcebergResult<()> {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager.load_snapshot_from_table().await?;
+    let (next_file_id, snapshot) = iceberg_table_manager.load_snapshot_from_table().await?;
+    assert_eq!(next_file_id, 2); // one data file, one index block file
     check_new_data_files(&snapshot, &iceberg_table_manager, /*deleted=*/ false).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 200);
@@ -1830,7 +1866,8 @@ async fn test_state_6_3_deletion_before_flush() -> IcebergResult<()> {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager.load_snapshot_from_table().await?;
+    let (next_file_id, snapshot) = iceberg_table_manager.load_snapshot_from_table().await?;
+    assert_eq!(next_file_id, 5); // two data files, two index block files, one deletion vector puffin
     check_prev_and_new_data_files(
         &snapshot,
         &iceberg_table_manager,
@@ -1889,7 +1926,8 @@ async fn test_state_6_3_deletion_after_flush() -> IcebergResult<()> {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager.load_snapshot_from_table().await?;
+    let (next_file_id, snapshot) = iceberg_table_manager.load_snapshot_from_table().await?;
+    assert_eq!(next_file_id, 4); // two data files, two index block files
     check_prev_and_new_data_files(
         &snapshot,
         &iceberg_table_manager,
@@ -1949,7 +1987,8 @@ async fn test_state_6_4_committed_deletion_before_flush() -> IcebergResult<()> {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager.load_snapshot_from_table().await?;
+    let (next_file_id, snapshot) = iceberg_table_manager.load_snapshot_from_table().await?;
+    assert_eq!(next_file_id, 5); // two data files, two index block files, one deletion vector puffin
     check_prev_and_new_data_files(
         &snapshot,
         &iceberg_table_manager,
@@ -2010,7 +2049,8 @@ async fn test_state_6_4_committed_deletion_after_flush() -> IcebergResult<()> {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager.load_snapshot_from_table().await?;
+    let (next_file_id, snapshot) = iceberg_table_manager.load_snapshot_from_table().await?;
+    assert_eq!(next_file_id, 4); // two data files, two index block files
     check_prev_and_new_data_files(
         &snapshot,
         &iceberg_table_manager,
@@ -2070,7 +2110,8 @@ async fn test_state_6_5() -> IcebergResult<()> {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager.load_snapshot_from_table().await?;
+    let (next_file_id, snapshot) = iceberg_table_manager.load_snapshot_from_table().await?;
+    assert_eq!(next_file_id, 5); // two data files, two index block files, one deletion vector puffin
     check_prev_and_new_data_files(
         &snapshot,
         &iceberg_table_manager,
@@ -2132,7 +2173,8 @@ async fn test_state_6_6() -> IcebergResult<()> {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager.load_snapshot_from_table().await?;
+    let (next_file_id, snapshot) = iceberg_table_manager.load_snapshot_from_table().await?;
+    assert_eq!(next_file_id, 5); // two data files, two index block files, one deletion vector puffin
     check_prev_and_new_data_files(
         &snapshot,
         &iceberg_table_manager,
@@ -2161,7 +2203,8 @@ async fn test_state_7_1() -> IcebergResult<()> {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager.load_snapshot_from_table().await?;
+    let (next_file_id, snapshot) = iceberg_table_manager.load_snapshot_from_table().await?;
+    assert_eq!(next_file_id, 0);
     assert!(snapshot.disk_files.is_empty());
     assert!(snapshot.indices.file_indices.is_empty());
     assert!(snapshot.data_file_flush_lsn.is_none());
@@ -2190,7 +2233,8 @@ async fn test_state_7_2() -> IcebergResult<()> {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager.load_snapshot_from_table().await?;
+    let (next_file_id, snapshot) = iceberg_table_manager.load_snapshot_from_table().await?;
+    assert_eq!(next_file_id, 2); // one data file, one index block file
     check_prev_data_files(&snapshot, &iceberg_table_manager, /*deleted=*/ false).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 100);
@@ -2220,7 +2264,8 @@ async fn test_state_7_3() -> IcebergResult<()> {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager.load_snapshot_from_table().await?;
+    let (next_file_id, snapshot) = iceberg_table_manager.load_snapshot_from_table().await?;
+    assert_eq!(next_file_id, 2); // one data file, one index block file
     check_prev_data_files(&snapshot, &iceberg_table_manager, /*deleted=*/ false).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 100);
@@ -2253,7 +2298,8 @@ async fn test_state_7_4() -> IcebergResult<()> {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager.load_snapshot_from_table().await?;
+    let (next_file_id, snapshot) = iceberg_table_manager.load_snapshot_from_table().await?;
+    assert_eq!(next_file_id, 2); // one data file, one index block file
     check_prev_data_files(&snapshot, &iceberg_table_manager, /*deleted=*/ false).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 100);
@@ -2284,7 +2330,8 @@ async fn test_state_7_5() -> IcebergResult<()> {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager.load_snapshot_from_table().await?;
+    let (next_file_id, snapshot) = iceberg_table_manager.load_snapshot_from_table().await?;
+    assert_eq!(next_file_id, 3); // one data file, one index block file, one deletion vector puffin
     check_prev_data_files(&snapshot, &iceberg_table_manager, /*deleted=*/ true).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 300);
@@ -2317,7 +2364,8 @@ async fn test_state_7_6() -> IcebergResult<()> {
         .unwrap();
 
     // Check iceberg snapshot status.
-    let snapshot = iceberg_table_manager.load_snapshot_from_table().await?;
+    let (next_file_id, snapshot) = iceberg_table_manager.load_snapshot_from_table().await?;
+    assert_eq!(next_file_id, 3); // one data file, one index block file, one deletion vector puffin
     check_prev_data_files(&snapshot, &iceberg_table_manager, /*deleted=*/ true).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 300);

--- a/src/moonlink/src/storage/iceberg/table_manager.rs
+++ b/src/moonlink/src/storage/iceberg/table_manager.rs
@@ -50,10 +50,12 @@ pub trait TableManager: Send {
         file_params: PersistenceFileParams,
     ) -> IcebergResult<PersistenceResult>;
 
-    /// Load the latest snapshot from iceberg table. Used for recovery and initialization.
+    /// Load the latest snapshot from iceberg table, and return next file id for the current mooncake table.
     /// Notice this function is supposed to call **only once**.
     #[allow(async_fn_in_trait)]
-    async fn load_snapshot_from_table(&mut self) -> IcebergResult<MooncakeSnapshot>;
+    async fn load_snapshot_from_table(
+        &mut self,
+    ) -> IcebergResult<(u32 /*next file id*/, MooncakeSnapshot)>;
 
     /// Drop the current iceberg table.
     #[allow(async_fn_in_trait)]

--- a/src/moonlink/src/storage/mooncake_table/deletion_vector_puffin_state_tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/deletion_vector_puffin_state_tests.rs
@@ -171,10 +171,11 @@ async fn test_1_recover_2() {
         get_iceberg_table_config(&temp_dir),
     )
     .unwrap();
-    let mooncake_snapshot = iceberg_table_manager_to_recover
+    let (next_file_id, mooncake_snapshot) = iceberg_table_manager_to_recover
         .load_snapshot_from_table()
         .await
         .unwrap();
+    assert_eq!(next_file_id, 3); // one data file, one index block file, one deletion vector puffin
 
     // Check data file has been pinned in mooncake table.
     let disk_files = mooncake_snapshot.disk_files.clone();

--- a/src/moonlink/src/storage/mooncake_table/file_index_state_tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/file_index_state_tests.rs
@@ -106,10 +106,11 @@ async fn test_1_recover_3() {
         get_iceberg_table_config(&temp_dir),
     )
     .unwrap();
-    let mooncake_snapshot = iceberg_table_manager_to_recover
+    let (next_file_id, mooncake_snapshot) = iceberg_table_manager_to_recover
         .load_snapshot_from_table()
         .await
         .unwrap();
+    assert_eq!(next_file_id, 2); // one data file, one index block file
 
     // Check data file has been pinned in mooncake table.
     let file_indices = mooncake_snapshot.indices.file_indices.clone();

--- a/src/moonlink/src/table_handler/tests.rs
+++ b/src/moonlink/src/table_handler/tests.rs
@@ -510,10 +510,11 @@ async fn test_iceberg_snapshot_creation_for_batch_write() {
 
     // Load from iceberg table manager to check snapshot status.
     let mut iceberg_table_manager = env.create_iceberg_table_manager(mooncake_table_config.clone());
-    let snapshot = iceberg_table_manager
+    let (next_file_id, snapshot) = iceberg_table_manager
         .load_snapshot_from_table()
         .await
         .unwrap();
+    assert_eq!(next_file_id, 2); // one for data file, one for index block file
     assert_eq!(snapshot.disk_files.len(), 1);
     let (cur_data_file, cur_deletion_vector) = snapshot.disk_files.into_iter().next().unwrap();
     // Check data file.
@@ -553,10 +554,11 @@ async fn test_iceberg_snapshot_creation_for_batch_write() {
 
     // Load from iceberg table manager to check snapshot status.
     let mut iceberg_table_manager = env.create_iceberg_table_manager(mooncake_table_config.clone());
-    let snapshot = iceberg_table_manager
+    let (next_file_id, snapshot) = iceberg_table_manager
         .load_snapshot_from_table()
         .await
         .unwrap();
+    assert_eq!(next_file_id, 5); // two data files, two index block files, one deletion vector puffin
     assert_eq!(snapshot.disk_files.len(), 2);
     for (cur_data_file, cur_deletion_vector) in snapshot.disk_files.into_iter() {
         // Check the first data file.
@@ -608,10 +610,11 @@ async fn test_iceberg_snapshot_creation_for_batch_write() {
 
     // Load from iceberg table manager to check snapshot status.
     let mut iceberg_table_manager = env.create_iceberg_table_manager(mooncake_table_config.clone());
-    let snapshot = iceberg_table_manager
+    let (next_file_id, snapshot) = iceberg_table_manager
         .load_snapshot_from_table()
         .await
         .unwrap();
+    assert_eq!(next_file_id, 6); // two data files, two index block files, two deletion vector puffin
     assert_eq!(snapshot.disk_files.len(), 2);
     for (cur_data_file, cur_deletion_vector) in snapshot.disk_files.into_iter() {
         // Check the first data file.
@@ -710,10 +713,11 @@ async fn test_iceberg_snapshot_creation_for_streaming_write() {
 
     // Load from iceberg table manager to check snapshot status.
     let mut iceberg_table_manager = env.create_iceberg_table_manager(mooncake_table_config.clone());
-    let snapshot = iceberg_table_manager
+    let (next_file_id, snapshot) = iceberg_table_manager
         .load_snapshot_from_table()
         .await
         .unwrap();
+    assert_eq!(next_file_id, 2); // one data file, one index block file
     assert_eq!(snapshot.disk_files.len(), 1);
     let (cur_data_file, cur_deletion_vector) = snapshot.disk_files.into_iter().next().unwrap();
     // Check data file.
@@ -759,10 +763,11 @@ async fn test_iceberg_snapshot_creation_for_streaming_write() {
 
     // Load from iceberg table manager to check snapshot status.
     let mut iceberg_table_manager = env.create_iceberg_table_manager(mooncake_table_config.clone());
-    let snapshot = iceberg_table_manager
+    let (next_file_id, snapshot) = iceberg_table_manager
         .load_snapshot_from_table()
         .await
         .unwrap();
+    assert_eq!(next_file_id, 5); // two data files, two index block files, one deletion vector puffin
     assert_eq!(snapshot.disk_files.len(), 2);
     for (cur_data_file, cur_deletion_vector) in snapshot.disk_files.into_iter() {
         // Check the first data file.
@@ -817,10 +822,11 @@ async fn test_iceberg_snapshot_creation_for_streaming_write() {
 
     // Load from iceberg table manager to check snapshot status.
     let mut iceberg_table_manager = env.create_iceberg_table_manager(mooncake_table_config.clone());
-    let snapshot = iceberg_table_manager
+    let (next_file_id, snapshot) = iceberg_table_manager
         .load_snapshot_from_table()
         .await
         .unwrap();
+    assert_eq!(next_file_id, 6); // two data files, two index block files, two deletion vector puffins
     assert_eq!(snapshot.disk_files.len(), 2);
     for (cur_data_file, cur_deletion_vector) in snapshot.disk_files.into_iter() {
         // Check the first data file.
@@ -969,10 +975,11 @@ async fn test_multiple_snapshot_requests() {
 
     // Check iceberg snapshot content.
     let mut iceberg_table_manager = env.create_iceberg_table_manager(mooncake_table_config.clone());
-    let snapshot = iceberg_table_manager
+    let (next_file_id, snapshot) = iceberg_table_manager
         .load_snapshot_from_table()
         .await
         .unwrap();
+    assert_eq!(next_file_id, 4); // two data files, two index block files
     assert_eq!(snapshot.disk_files.len(), 2);
 
     let mut visited = [false, false]; // Check both row flushed.


### PR DESCRIPTION
## Summary

When recovery from iceberg snapshot, each file has assign its own file id; which should be passed to mooncake table for continued usage.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/514

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
