### PR TITLE
[storage] [1/N] Object storage cache support local filesystem optimization

### DIFF
--- a/src/moonlink/src/storage.rs
+++ b/src/moonlink/src/storage.rs
@@ -5,6 +5,7 @@ pub(crate) mod index;
 pub(crate) mod io_utils;
 pub(crate) mod mooncake_table;
 pub(crate) mod parquet_utils;
+pub(crate) mod path_utils;
 pub(crate) mod storage_utils;
 
 pub use cache::object_storage::cache_config::ObjectStorageCacheConfig;

--- a/src/moonlink/src/storage/cache/object_storage.rs
+++ b/src/moonlink/src/storage/cache/object_storage.rs
@@ -7,4 +7,7 @@ pub mod object_storage_cache;
 mod state_tests;
 
 #[cfg(test)]
+mod local_file_optimization_state_tests;
+
+#[cfg(test)]
 mod test_utils;

--- a/src/moonlink/src/storage/cache/object_storage/cache_config.rs
+++ b/src/moonlink/src/storage/cache/object_storage/cache_config.rs
@@ -8,13 +8,16 @@ pub struct ObjectStorageCacheConfig {
     pub max_bytes: u64,
     /// Directory to store local cache files.
     pub cache_directory: String,
+    // Option to optimize cases where persistent table also sits at local filesystem cases, so only one copy will be stored.
+    pub optimize_local_filesystem: bool,
 }
 
 impl ObjectStorageCacheConfig {
-    pub fn new(max_bytes: u64, cache_directory: String) -> Self {
+    pub fn new(max_bytes: u64, cache_directory: String, optimize_local_filesystem: bool) -> Self {
         Self {
             max_bytes,
             cache_directory,
+            optimize_local_filesystem,
         }
     }
 
@@ -26,6 +29,8 @@ impl ObjectStorageCacheConfig {
         Self {
             max_bytes: DEFAULT_MAX_BYTES_FOR_TEST,
             cache_directory: temp_dir.path().to_str().unwrap().to_string(),
+            // By default disable local filesystem optimization, to mimic production use case where there's remote storage.
+            optimize_local_filesystem: false,
         }
     }
 
@@ -49,6 +54,7 @@ impl ObjectStorageCacheConfig {
         Self {
             max_bytes: DEFAULT_MAX_BYTES_FOR_TEST,
             cache_directory: DEFAULT_CACHE_DIRECTORY.to_string(),
+            optimize_local_filesystem: true,
         }
     }
 }

--- a/src/moonlink/src/storage/cache/object_storage/cache_handle.rs
+++ b/src/moonlink/src/storage/cache/object_storage/cache_handle.rs
@@ -75,7 +75,7 @@ impl NonEvictableHandle {
     /// - Moonlink process restarts and recreates the cache directory.
     #[must_use]
     #[allow(dead_code)]
-    pub(crate) async fn unreference_and_replace_remote(
+    pub(crate) async fn unreference_and_replace_with_remote(
         &mut self,
         remote_filepath: &str,
     ) -> Vec<String> {

--- a/src/moonlink/src/storage/cache/object_storage/cache_handle.rs
+++ b/src/moonlink/src/storage/cache/object_storage/cache_handle.rs
@@ -62,4 +62,37 @@ impl NonEvictableHandle {
         // The cache entry could be held elsewhere.
         guard.delete_cache_entry(self.file_id, /*panic_if_non_existent=*/ true)
     }
+
+    /// Unreference and try import remote files, could be optimized if local filesystem optimization enabled.
+    ///
+    /// This is an optimization for cases where both cache files and persisted files live on local filesystem, so we don't need to store the same files twice.
+    /// The idea way, from users's perspective, is to switch from local filepath to remote if possible, but that leads to state machine being over-complicated.
+    /// For example, we need to keep another pending state in cache, to record file paths requested to replace with remote, when they're (1) in use, or (2) in use and requested to delete.
+    /// To make implementation easy, the implementation here only attempt once at unreference; if it fails, the replacement will never happen.
+    /// But local cache files are still subject to eviction and deletion, for example, when
+    /// - Object storage cache goes out of space;
+    /// - Maintainance job like compaction kicks in and requests to delete old compacted files;
+    /// - Moonlink process restarts and recreates the cache directory.
+    #[must_use]
+    #[allow(dead_code)]
+    pub(crate) async fn unreference_and_replace_remote(
+        &mut self,
+        remote_filepath: &str,
+    ) -> Vec<String> {
+        // Aggregate evicted files to delete.
+        let mut evicted_files_to_delete = vec![];
+
+        let mut guard = self.cache.write().await;
+
+        // First unreference the cache handle as usual.
+        let cur_evicted_files = guard.unreference(self.file_id);
+        assert!(cur_evicted_files.is_empty());
+
+        // Then try to replace cache filepath with remote file, if applicable.
+        let cur_evicted_files =
+            guard.try_replace_evictable_with_remote(&self.file_id, remote_filepath);
+        evicted_files_to_delete.extend(cur_evicted_files);
+
+        evicted_files_to_delete
+    }
 }

--- a/src/moonlink/src/storage/cache/object_storage/local_file_optimization_state_tests.rs
+++ b/src/moonlink/src/storage/cache/object_storage/local_file_optimization_state_tests.rs
@@ -14,6 +14,7 @@ use crate::{ObjectStorageCache, ObjectStorageCacheConfig};
 /// Test state transfer (which displays different behavior as normal one):
 /// (3) + persist + still reference count => (3)
 /// (3) + persist + no reference count => (2)
+/// (1) + requested to read + sufficient space => (3)
 ///
 /// For more details, please refer to
 /// - remote object storage state tests: https://github.com/Mooncake-Labs/moonlink/blob/main/src/moonlink/src/storage/cache/object_storage/state_tests.rs
@@ -30,6 +31,7 @@ fn create_object_storage_cache_with_local_optimization(tmp_dir: &TempDir) -> Obj
     ObjectStorageCache::new(config)
 }
 
+// (3) + persist + still reference count => (3)
 #[tokio::test]
 async fn test_cache_state_3_persist_and_unreferenced_2() {
     let cache_file_directory = tempdir().unwrap();
@@ -47,6 +49,10 @@ async fn test_cache_state_3_persist_and_unreferenced_2() {
     let file_id = get_table_unique_file_id(0);
     let (mut cache_handle, evicted_files_to_delete) =
         cache.import_cache_entry(file_id, cache_entry.clone()).await;
+    assert_eq!(
+        cache_handle.cache_entry.cache_filepath,
+        test_cache_file.to_str().unwrap().to_string()
+    );
     assert!(evicted_files_to_delete.is_empty());
 
     let evicted_files_to_delete = cache_handle
@@ -63,6 +69,7 @@ async fn test_cache_state_3_persist_and_unreferenced_2() {
     assert_evictable_cache_size(&mut cache, /*expected_count=*/ 1).await;
 }
 
+// (3) + persist + no reference count => (2)
 #[tokio::test]
 async fn test_cache_state_3_persist_and_referenced_3() {
     let cache_file_directory = tempdir().unwrap();
@@ -80,6 +87,10 @@ async fn test_cache_state_3_persist_and_referenced_3() {
     let file_id = get_table_unique_file_id(0);
     let (mut cache_handle_1, evicted_files_to_delete) =
         cache.import_cache_entry(file_id, cache_entry.clone()).await;
+    assert_eq!(
+        cache_handle_1.cache_entry.cache_filepath,
+        test_cache_file.to_str().unwrap().to_string()
+    );
     assert!(evicted_files_to_delete.is_empty());
 
     // Get the second reference.
@@ -87,6 +98,10 @@ async fn test_cache_state_3_persist_and_referenced_3() {
         .get_cache_entry(file_id, test_remote_file.to_str().unwrap())
         .await
         .unwrap();
+    assert_eq!(
+        cache_handle_2.as_ref().unwrap().cache_entry.cache_filepath,
+        test_cache_file.to_str().unwrap().to_string()
+    );
     assert!(evicted_files_to_delete.is_empty());
 
     // Unreference and try import with remote doesn't work, since there're other references.
@@ -103,4 +118,28 @@ async fn test_cache_state_3_persist_and_referenced_3() {
     assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 0).await;
     assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 0).await;
     assert_evictable_cache_size(&mut cache, /*expected_count=*/ 1).await;
+}
+
+// (1) + requested to read + sufficient space => (3)
+#[tokio::test]
+async fn test_cache_state_1_request_read_with_sufficient_space_3() {
+    let cache_file_directory = tempdir().unwrap();
+    let test_remote_file =
+        create_test_file(cache_file_directory.path(), TEST_REMOTE_FILENAME_1).await;
+    let mut cache = create_object_storage_cache_with_local_optimization(&cache_file_directory);
+    let file_id = get_table_unique_file_id(0);
+    let (cache_handle, evicted_files_to_delete) = cache
+        .get_cache_entry(file_id, test_remote_file.to_str().unwrap())
+        .await
+        .unwrap();
+    assert!(evicted_files_to_delete.is_empty());
+    assert_eq!(
+        cache_handle.as_ref().unwrap().cache_entry.cache_filepath,
+        test_remote_file.to_str().unwrap().to_string()
+    );
+
+    assert_cache_bytes_size(&mut cache, /*expected_bytes=*/ CONTENT.len() as u64).await;
+    assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 1).await;
+    assert_evictable_cache_size(&mut cache, /*expected_count=*/ 0).await;
 }

--- a/src/moonlink/src/storage/cache/object_storage/local_file_optimization_state_tests.rs
+++ b/src/moonlink/src/storage/cache/object_storage/local_file_optimization_state_tests.rs
@@ -1,0 +1,64 @@
+use tempfile::tempdir;
+use tempfile::TempDir;
+
+use crate::storage::cache::object_storage::base_cache::CacheEntry;
+use crate::storage::cache::object_storage::base_cache::CacheTrait;
+use crate::storage::cache::object_storage::base_cache::FileMetadata;
+use crate::storage::cache::object_storage::test_utils::*;
+use crate::{ObjectStorageCache, ObjectStorageCacheConfig};
+
+/// This module check state machine when local filesystem optimization enabled.
+/// The state transfer is the same as usual, but different at eviction / deletion logic.
+/// This test suite only check different parts.
+///
+/// Test state transfer (which displays different behavior as normal one):
+/// (3) + persist + still reference count => (3)
+/// (3) + persist + no reference count => (2)
+///
+/// For more details, please refer to
+/// - remote object storage state tests: https://github.com/Mooncake-Labs/moonlink/blob/main/src/moonlink/src/storage/cache/object_storage/state_tests.rs
+/// - state machine: https://docs.google.com/document/d/1kwXIl4VPzhgzV4KP8yT42M35PfvMJW9PdjNTF7VNEfA/edit?usp=sharing
+///
+/// Test util function to create object storage cache, with local filesystem optimization enabled.
+fn create_object_storage_cache_with_local_optimization(tmp_dir: &TempDir) -> ObjectStorageCache {
+    let config = ObjectStorageCacheConfig {
+        // Set max bytes larger than one file, but less than two files.
+        max_bytes: 15,
+        cache_directory: tmp_dir.path().to_str().unwrap().to_string(),
+        optimize_local_filesystem: true,
+    };
+    ObjectStorageCache::new(config)
+}
+
+#[tokio::test]
+async fn test_cache_state_3_persist_and_unreferenced_2() {
+    let cache_file_directory = tempdir().unwrap();
+    let test_cache_file =
+        create_test_file(cache_file_directory.path(), TEST_CACHE_FILENAME_1).await;
+    let test_remote_file =
+        create_test_file(cache_file_directory.path(), TEST_REMOTE_FILENAME_1).await;
+    let cache_entry = CacheEntry {
+        cache_filepath: test_cache_file.to_str().unwrap().to_string(),
+        file_metadata: FileMetadata {
+            file_size: CONTENT.len() as u64,
+        },
+    };
+    let mut cache = create_object_storage_cache_with_local_optimization(&cache_file_directory);
+    let file_id = get_table_unique_file_id(0);
+    let (mut cache_handle, evicted_files_to_delete) =
+        cache.import_cache_entry(file_id, cache_entry.clone()).await;
+    assert!(evicted_files_to_delete.is_empty());
+
+    let evicted_files_to_delete = cache_handle
+        .unreference_and_replace_with_remote(test_remote_file.to_str().unwrap())
+        .await;
+    assert_eq!(
+        evicted_files_to_delete,
+        vec![test_cache_file.to_str().unwrap().to_string()]
+    );
+
+    assert_cache_bytes_size(&mut cache, /*expected_bytes=*/ CONTENT.len() as u64).await;
+    assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_evictable_cache_size(&mut cache, /*expected_count=*/ 1).await;
+}

--- a/src/moonlink/src/storage/cache/object_storage/object_storage_cache.rs
+++ b/src/moonlink/src/storage/cache/object_storage/object_storage_cache.rs
@@ -152,7 +152,7 @@ impl ObjectStorageCacheInternal {
         cache_entry_wrapper.reference_count -= 1;
 
         // Aggregate cache entries to delete.
-        let mut entries_to_delete = vec![];
+        let mut evicted_files_to_delete = vec![];
 
         // Down-level to evictable if reference count goes away.
         if cache_entry_wrapper.reference_count == 0 {
@@ -167,7 +167,7 @@ impl ObjectStorageCacheInternal {
                 self.cur_bytes -= cache_entry_wrapper.cache_entry.file_metadata.file_size;
 
                 if cache_entry_wrapper.deletable {
-                    entries_to_delete.push(cache_entry_wrapper.cache_entry.cache_filepath);
+                    evicted_files_to_delete.push(cache_entry_wrapper.cache_entry.cache_filepath);
                 }
             }
             // The cache entry is not requested to delete.
@@ -176,7 +176,7 @@ impl ObjectStorageCacheInternal {
             }
         }
 
-        entries_to_delete
+        evicted_files_to_delete
     }
 
     /// Attempt to replace an evictable cache entry with remote path, if the filepath lives on local filesystem.

--- a/src/moonlink/src/storage/cache/object_storage/object_storage_cache.rs
+++ b/src/moonlink/src/storage/cache/object_storage/object_storage_cache.rs
@@ -196,7 +196,7 @@ impl ObjectStorageCacheInternal {
         }
 
         // Only replace with remote filepath when requested file lives at evictable cache.
-        if let Some(cache_entry_wrapper) = self.evictable_cache.get_mut(&file_id) {
+        if let Some(cache_entry_wrapper) = self.evictable_cache.get_mut(file_id) {
             let old_cache_filepath = cache_entry_wrapper.cache_entry.cache_filepath.clone();
             cache_entry_wrapper.cache_entry.cache_filepath = remote_path.to_string();
             cache_entry_wrapper.deletable = false;

--- a/src/moonlink/src/storage/cache/object_storage/object_storage_cache.rs
+++ b/src/moonlink/src/storage/cache/object_storage/object_storage_cache.rs
@@ -194,12 +194,16 @@ impl ObjectStorageCacheInternal {
         }
 
         // Only replace with remote filepath when requested file lives at evictable cache.
-        let cache_entry_wrapper = self.evictable_cache.get_mut(&file_id).unwrap();
-        let old_cache_filepath = cache_entry_wrapper.cache_entry.cache_filepath.clone();
-        cache_entry_wrapper.cache_entry.cache_filepath = remote_path.to_string();
-        cache_entry_wrapper.deletable = true;
+        if let Some(cache_entry_wrapper) = self.evictable_cache.get_mut(&file_id) {
+            let old_cache_filepath = cache_entry_wrapper.cache_entry.cache_filepath.clone();
+            cache_entry_wrapper.cache_entry.cache_filepath = remote_path.to_string();
+            cache_entry_wrapper.deletable = true;
 
-        vec![old_cache_filepath]
+            return vec![old_cache_filepath];
+        }
+
+        // Otherwise, do nothing.
+        vec![]
     }
 
     /// ================================

--- a/src/moonlink/src/storage/cache/object_storage/state_tests.rs
+++ b/src/moonlink/src/storage/cache/object_storage/state_tests.rs
@@ -118,6 +118,7 @@ async fn test_cache_2_requested_to_read_with_sufficient_space() {
     let mut cache = ObjectStorageCache::new(ObjectStorageCacheConfig {
         max_bytes: CONTENT.len() as u64,
         cache_directory: cache_file_directory.path().to_str().unwrap().to_string(),
+        optimize_local_filesystem: false,
     });
 
     // Import into cache first.
@@ -268,6 +269,7 @@ async fn test_cache_2_new_entry_with_sufficient_space() {
     let mut cache = ObjectStorageCache::new(ObjectStorageCacheConfig {
         max_bytes: (CONTENT.len() * 2) as u64,
         cache_directory: cache_file_directory.path().to_str().unwrap().to_string(),
+        optimize_local_filesystem: false,
     });
 
     // Import the first cache file.
@@ -331,6 +333,7 @@ async fn test_cache_2_new_entry_with_insufficient_space() {
     let mut cache = ObjectStorageCache::new(ObjectStorageCacheConfig {
         max_bytes: CONTENT.len() as u64,
         cache_directory: cache_file_directory.path().to_str().unwrap().to_string(),
+        optimize_local_filesystem: false,
     });
 
     // Import the first cache file.
@@ -495,6 +498,7 @@ async fn test_cache_2_requested_to_delete_4() {
     let mut cache = ObjectStorageCache::new(ObjectStorageCacheConfig {
         max_bytes: CONTENT.len() as u64,
         cache_directory: cache_file_directory.path().to_str().unwrap().to_string(),
+        optimize_local_filesystem: false,
     });
 
     // Import into cache first.
@@ -535,6 +539,7 @@ async fn test_cache_3_requested_to_delete_5() {
     let mut cache = ObjectStorageCache::new(ObjectStorageCacheConfig {
         max_bytes: CONTENT.len() as u64,
         cache_directory: cache_file_directory.path().to_str().unwrap().to_string(),
+        optimize_local_filesystem: false,
     });
 
     // Import into cache first.
@@ -577,6 +582,7 @@ async fn test_cache_5_usage_finish_and_still_referenced_5() {
     let mut cache = ObjectStorageCache::new(ObjectStorageCacheConfig {
         max_bytes: CONTENT.len() as u64,
         cache_directory: cache_file_directory.path().to_str().unwrap().to_string(),
+        optimize_local_filesystem: false,
     });
 
     // Import into cache first.
@@ -632,6 +638,7 @@ async fn test_cache_5_usage_finish_and_not_referenced_4() {
     let mut cache = ObjectStorageCache::new(ObjectStorageCacheConfig {
         max_bytes: CONTENT.len() as u64,
         cache_directory: cache_file_directory.path().to_str().unwrap().to_string(),
+        optimize_local_filesystem: false,
     });
 
     // Import into cache first.

--- a/src/moonlink/src/storage/cache/object_storage/test_utils.rs
+++ b/src/moonlink/src/storage/cache/object_storage/test_utils.rs
@@ -60,8 +60,8 @@ pub(crate) fn get_test_object_storage_cache(tmp_dir: &TempDir) -> ObjectStorageC
     ObjectStorageCache::new(config)
 }
 
-/// Test util function to get cache file number.
-pub(crate) async fn check_cache_file_count(tmp_dir: &TempDir, expected_count: usize) {
+/// Test util function to get file number under the given directory.
+pub(crate) async fn check_directory_file_count(tmp_dir: &TempDir, expected_count: usize) {
     let mut actual_count = 0;
     let mut entries = tokio::fs::read_dir(tmp_dir.path()).await.unwrap();
     while let Some(entry) = entries.next_entry().await.unwrap() {

--- a/src/moonlink/src/storage/cache/object_storage/test_utils.rs
+++ b/src/moonlink/src/storage/cache/object_storage/test_utils.rs
@@ -38,6 +38,7 @@ pub(crate) fn get_test_cache_config(tmp_dir: &TempDir) -> ObjectStorageCacheConf
         // Set max bytes larger than one file, but less than two files.
         max_bytes: 15,
         cache_directory: tmp_dir.path().to_str().unwrap().to_string(),
+        optimize_local_filesystem: false,
     }
 }
 

--- a/src/moonlink/src/storage/cache/object_storage/test_utils.rs
+++ b/src/moonlink/src/storage/cache/object_storage/test_utils.rs
@@ -4,13 +4,25 @@ use tokio::io::AsyncWriteExt;
 
 use crate::storage::cache::object_storage::cache_config::ObjectStorageCacheConfig;
 use crate::storage::cache::object_storage::object_storage_cache::ObjectStorageCache;
+use crate::storage::storage_utils::FileId;
+use crate::storage::storage_utils::TableId;
 use crate::storage::storage_utils::TableUniqueFileId;
 
 /// Content for test files.
 pub(crate) const CONTENT: &[u8; 10] = b"0123456789";
-/// File path for two test files.
-pub(crate) const TEST_FILENAME_1: &str = "remote-1.parquet";
-pub(crate) const TEST_FILENAME_2: &str = "remote-2.parquet";
+/// File path for two test cache files.
+pub(crate) const TEST_CACHE_FILENAME_1: &str = "cache-1.parquet";
+pub(crate) const TEST_CACHE_FILENAME_2: &str = "cache-2.parquet";
+/// File path for two test remote files.
+pub(crate) const TEST_REMOTE_FILENAME_1: &str = "remote-1.parquet";
+
+/// Test util function to return table unique id, with table id hard-coded to 0.
+pub(crate) fn get_table_unique_file_id(file_id: u64) -> TableUniqueFileId {
+    TableUniqueFileId {
+        table_id: TableId(0),
+        file_id: FileId(file_id),
+    }
+}
 
 /// Util function to prepare a test file.
 pub(crate) async fn create_test_file(
@@ -42,7 +54,7 @@ pub(crate) fn get_test_cache_config(tmp_dir: &TempDir) -> ObjectStorageCacheConf
     }
 }
 
-/// Test util function to create object storage cache.
+/// Test util function to create object storage cache, with local filesystem optimization disabled.
 pub(crate) fn get_test_object_storage_cache(tmp_dir: &TempDir) -> ObjectStorageCache {
     let config = get_test_cache_config(tmp_dir);
     ObjectStorageCache::new(config)

--- a/src/moonlink/src/storage/mooncake_table/data_file_state_tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/data_file_state_tests.rs
@@ -128,6 +128,7 @@ async fn test_shutdown_table() {
     let cache_config = ObjectStorageCacheConfig::new(
         INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE,
         temp_dir.path().to_str().unwrap().to_string(),
+        /*optimize_local_filesystem=*/ false,
     );
     let object_storage_cache = ObjectStorageCache::new(cache_config);
 
@@ -181,6 +182,7 @@ async fn test_5_read_4_by_batch_write() {
     let cache_config = ObjectStorageCacheConfig::new(
         INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE,
         temp_dir.path().to_str().unwrap().to_string(),
+        /*optimize_local_filesystem=*/ false,
     );
     let object_storage_cache = ObjectStorageCache::new(cache_config);
 
@@ -310,6 +312,7 @@ async fn test_5_read_4_by_stream_write() {
     let cache_config = ObjectStorageCacheConfig::new(
         INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE,
         temp_dir.path().to_str().unwrap().to_string(),
+        /*optimize_local_filesystem=*/ false,
     );
     let object_storage_cache = ObjectStorageCache::new(cache_config);
 
@@ -438,6 +441,7 @@ async fn test_5_1() {
     let cache_config = ObjectStorageCacheConfig::new(
         INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE,
         temp_dir.path().to_str().unwrap().to_string(),
+        /*optimize_local_filesystem=*/ false,
     );
     let object_storage_cache = ObjectStorageCache::new(cache_config);
 
@@ -502,6 +506,7 @@ async fn test_4_3() {
     let cache_config = ObjectStorageCacheConfig::new(
         INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE,
         temp_dir.path().to_str().unwrap().to_string(),
+        /*optimize_local_filesystem=*/ false,
     );
     let object_storage_cache = ObjectStorageCache::new(cache_config);
 
@@ -622,6 +627,7 @@ async fn test_4_read_4() {
     let cache_config = ObjectStorageCacheConfig::new(
         INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE,
         temp_dir.path().to_str().unwrap().to_string(),
+        /*optimize_local_filesystem=*/ false,
     );
     let object_storage_cache = ObjectStorageCache::new(cache_config);
 
@@ -735,6 +741,7 @@ async fn test_4_read_and_read_over_4() {
     let cache_config = ObjectStorageCacheConfig::new(
         INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE,
         temp_dir.path().to_str().unwrap().to_string(),
+        /*optimize_local_filesystem=*/ false,
     );
     let object_storage_cache = ObjectStorageCache::new(cache_config);
 
@@ -814,6 +821,7 @@ async fn test_3_read_3() {
     let cache_config = ObjectStorageCacheConfig::new(
         INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE,
         temp_dir.path().to_str().unwrap().to_string(),
+        /*optimize_local_filesystem=*/ false,
     );
     let object_storage_cache = ObjectStorageCache::new(cache_config);
 
@@ -938,6 +946,7 @@ async fn test_3_read_and_read_over_and_pinned_3() {
     let cache_config = ObjectStorageCacheConfig::new(
         INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE,
         temp_dir.path().to_str().unwrap().to_string(),
+        /*optimize_local_filesystem=*/ false,
     );
     let object_storage_cache = ObjectStorageCache::new(cache_config);
 
@@ -1069,6 +1078,7 @@ async fn test_3_read_and_read_over_and_unpinned_1() {
     let cache_config = ObjectStorageCacheConfig::new(
         INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE,
         temp_dir.path().to_str().unwrap().to_string(),
+        /*optimize_local_filesystem=*/ false,
     );
     let object_storage_cache = ObjectStorageCache::new(cache_config);
 
@@ -1148,6 +1158,7 @@ async fn test_1_read_and_pinned_3() {
     let cache_config = ObjectStorageCacheConfig::new(
         INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE,
         temp_dir.path().to_str().unwrap().to_string(),
+        /*optimize_local_filesystem=*/ false,
     );
     let object_storage_cache = ObjectStorageCache::new(cache_config);
 
@@ -1268,6 +1279,7 @@ async fn test_1_read_and_unpinned_3() {
     let cache_config = ObjectStorageCacheConfig::new(
         ONE_FILE_CACHE_SIZE,
         temp_dir.path().to_str().unwrap().to_string(),
+        /*optimize_local_filesystem=*/ false,
     );
     let mut object_storage_cache = ObjectStorageCache::new(cache_config);
 
@@ -1317,6 +1329,7 @@ async fn test_2_read_and_pinned_3() {
     let cache_config = ObjectStorageCacheConfig::new(
         ONE_FILE_CACHE_SIZE,
         temp_dir.path().to_str().unwrap().to_string(),
+        /*optimize_local_filesystem=*/ false,
     );
     let mut object_storage_cache = ObjectStorageCache::new(cache_config);
 
@@ -1456,6 +1469,7 @@ async fn test_2_read_and_unpinned_2() {
     let cache_config = ObjectStorageCacheConfig::new(
         ONE_FILE_CACHE_SIZE,
         temp_dir.path().to_str().unwrap().to_string(),
+        /*optimize_local_filesystem=*/ false,
     );
     let mut object_storage_cache = ObjectStorageCache::new(cache_config);
 
@@ -1516,6 +1530,7 @@ async fn test_2_read_over_1() {
     let cache_config = ObjectStorageCacheConfig::new(
         ONE_FILE_CACHE_SIZE,
         temp_dir.path().to_str().unwrap().to_string(),
+        /*optimize_local_filesystem=*/ false,
     );
     let mut object_storage_cache = ObjectStorageCache::new(cache_config);
 
@@ -1611,6 +1626,7 @@ async fn test_3_compact_3_5() {
     let cache_config = ObjectStorageCacheConfig::new(
         INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE,
         temp_dir.path().to_str().unwrap().to_string(),
+        /*optimize_local_filesystem=*/ false,
     );
     let object_storage_cache = ObjectStorageCache::new(cache_config);
 
@@ -1780,6 +1796,7 @@ async fn test_3_compact_1_5() {
     let cache_config = ObjectStorageCacheConfig::new(
         INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE,
         temp_dir.path().to_str().unwrap().to_string(),
+        /*optimize_local_filesystem=*/ false,
     );
     let object_storage_cache = ObjectStorageCache::new(cache_config);
 
@@ -1902,6 +1919,7 @@ async fn test_1_compact_1_5() {
     let cache_config = ObjectStorageCacheConfig::new(
         ONE_FILE_CACHE_SIZE,
         temp_dir.path().to_str().unwrap().to_string(),
+        /*optimize_local_filesystem=*/ false,
     );
     let mut object_storage_cache = ObjectStorageCache::new(cache_config);
 

--- a/src/moonlink/src/storage/mooncake_table/deletion_vector_puffin_state_tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/deletion_vector_puffin_state_tests.rs
@@ -86,6 +86,7 @@ async fn test_1_persist_2() {
     let cache_config = ObjectStorageCacheConfig::new(
         INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE,
         temp_dir.path().to_str().unwrap().to_string(),
+        /*optimize_local_filesystem=*/ false,
     );
     let object_storage_cache = ObjectStorageCache::new(cache_config);
 
@@ -145,6 +146,7 @@ async fn test_1_recover_2() {
     let cache_config = ObjectStorageCacheConfig::new(
         INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE,
         temp_dir.path().to_str().unwrap().to_string(),
+        /*optimize_local_filesystem=*/ false,
     );
 
     let (mut table, mut table_notify) =
@@ -219,6 +221,7 @@ async fn test_2_read() {
     let cache_config = ObjectStorageCacheConfig::new(
         INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE,
         temp_dir.path().to_str().unwrap().to_string(),
+        /*optimize_local_filesystem=*/ false,
     );
     let object_storage_cache = ObjectStorageCache::new(cache_config);
 
@@ -366,6 +369,7 @@ async fn test_2_compact() {
     let cache_config = ObjectStorageCacheConfig::new(
         INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE,
         temp_dir.path().to_str().unwrap().to_string(),
+        /*optimize_local_filesystem=*/ false,
     );
     let object_storage_cache = ObjectStorageCache::new(cache_config);
 

--- a/src/moonlink/src/storage/mooncake_table/file_index_state_tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/file_index_state_tests.rs
@@ -85,6 +85,7 @@ async fn test_1_recover_3() {
     let cache_config = ObjectStorageCacheConfig::new(
         INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE,
         temp_dir.path().to_str().unwrap().to_string(),
+        /*optimize_local_filesystem=*/ false,
     );
 
     let (mut table, mut table_notify) =
@@ -256,6 +257,7 @@ async fn test_3_index_merge() {
     let cache_config = ObjectStorageCacheConfig::new(
         INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE,
         temp_dir.path().to_str().unwrap().to_string(),
+        /*optimize_local_filesystem=*/ false,
     );
     let object_storage_cache = ObjectStorageCache::new(cache_config);
 

--- a/src/moonlink/src/storage/path_utils.rs
+++ b/src/moonlink/src/storage/path_utils.rs
@@ -1,0 +1,22 @@
+use url::Url;
+
+/// Util function to decide whether the given filepath is a local filepath.
+/// It's worth noting only absolute path is acceptable.
+/// No IO operation is involved.
+#[allow(dead_code)]
+pub(crate) fn is_local_filepath(filepath: &str) -> bool {
+    Url::from_file_path(filepath).is_ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_local_filepath() {
+        // Absolute local path.
+        assert!(is_local_filepath("/tmp/non_existent_folder/random_file"));
+        // S3 object path.
+        assert!(!is_local_filepath("s3://bucket/object"));
+    }
+}

--- a/src/moonlink_backend/src/lib.rs
+++ b/src/moonlink_backend/src/lib.rs
@@ -65,6 +65,7 @@ fn create_default_object_storage_cache() -> ObjectStorageCache {
     let cache_config = ObjectStorageCacheConfig {
         max_bytes: filesystem_size - MIN_DISK_SPACE_FOR_CACHE,
         cache_directory: DEFAULT_MOONLINK_OBJECT_STORAGE_CACHE_PATH.to_string(),
+        optimize_local_filesystem: true,
     };
     ObjectStorageCache::new(cache_config)
 }


### PR DESCRIPTION
## Summary

This PR is the first one to implement local filesystem file storage/cache optimization, to avoid double storage.
The overall design is:
- Optimization lies in caching layer, to avoid "check and optimize" logic scattered everywhere
- Optimization happens at import and fetch cache entries

One design design decision I made is:
- The ideal scenario is to add another pending state to replace local file cache with remote one, but that complicates state machine a lot, for example, we need to handle concurrent deletion and usage
- So for simplicity, the replacement only attempts once
- Extra local files could be deleted via compaction and cache eviction, so local filesystem is still shrinkable

I tested with pg_mooncake regression test:
```sh
--- beginning regression test run ---
PASS setup 28ms
PASS partitioned_table 651ms
PASS sanity 566ms
passed=3, failed=0
```

I tested with pg_mooncake SQL statements:
```sql
pg_mooncake (pid: 53328) =# DROP EXTENSION pg_mooncake CASCADE;
DROP TABLE r;                                                                                                                                       
CREATE EXTENSION pg_mooncake; 
CREATE TABLE r (a int primary key, b text); 
CALL mooncake.create_table('c', 'r'); 
INSERT INTO r (a, b) 
SELECT gs AS a, 'val_' || gs AS b FROM generate_series( (SELECT COALESCE(MAX(a), 0) + 1 FROM r), (SELECT COALESCE(MAX(a), 0) + 500000 FROM r) ) AS gs; 
SELECT count(*) AS total_rows FROM c;
NOTICE:  drop cascades to table c
DROP EXTENSION
DROP TABLE
CREATE EXTENSION
CREATE TABLE
CALL
INSERT 0 500000
 total_rows 
------------
     500000
(1 row)

pg_mooncake (pid: 53328) =# DROP EXTENSION IF EXISTS pg_mooncake CASCADE;
DROP TABLE IF EXISTS r;
CREATE EXTENSION pg_mooncake;
CREATE TABLE r (a int primary key, b text);
CALL mooncake.create_table('c', 'r');
INSERT INTO r SELECT a, 'val_' || a FROM generate_series(1, 250000) AS a;
SELECT count(*) FROM c;
DELETE FROM r WHERE a % 2 = 0;
SELECT count(*) FROM c;
DROP EXTENSION
DROP TABLE
CREATE EXTENSION
CREATE TABLE
CALL
INSERT 0 250000
 count  
--------
 250000
(1 row)

DELETE 125000
 count  
--------
 125000
(1 row)
```

## Related Issues

Related to https://github.com/Mooncake-Labs/moonlink/issues/516

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [x] Documentation updated if necessary
- [x] I have reviewed my own changes
