### PR TITLE
fix multi column key

### DIFF
--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -63,7 +63,7 @@ pub struct TableConfig {
     pub mem_slice_size: usize,
     /// Number of new deletion records which decides whether to create a new mooncake table snapshot.
     pub snapshot_deletion_record_count: usize,
-    /// Max number of rows in MemSlice.
+    /// Max number of rows in each record batch within MemSlice.
     pub batch_size: usize,
     /// Disk slice parquet file flush threshold.
     pub disk_slice_parquet_file_size: usize,

--- a/src/moonlink/src/storage/mooncake_table/data_batches.rs
+++ b/src/moonlink/src/storage/mooncake_table/data_batches.rs
@@ -158,7 +158,7 @@ impl ColumnStoreBuffer {
         offset: usize,
         identity: &IdentityProp,
     ) -> bool {
-        if record.row_identity.is_some() {
+        if record.row_identity.is_some() && identity.requires_identity_check_in_mem_slice() {
             if let Some(batch) = &batch.data {
                 record
                     .row_identity
@@ -170,7 +170,7 @@ impl ColumnStoreBuffer {
                     .row_identity
                     .as_ref()
                     .unwrap()
-                    .equals_full_row(self.current_rows.get_row(offset), identity)
+                    .equals_moonlink_row(self.current_rows.get_row(offset), identity)
             }
         } else {
             true

--- a/src/moonlink/src/storage/mooncake_table/test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/test_utils.rs
@@ -69,7 +69,8 @@ pub async fn test_table(
         namespace: vec!["default".to_string()],
         table_name: table_name.to_string(),
     };
-    let table_config = TableConfig::new(context.temp_dir.path().to_str().unwrap().to_string());
+    let mut table_config = TableConfig::new(context.temp_dir.path().to_str().unwrap().to_string());
+    table_config.batch_size = 2;
     MooncakeTable::new(
         test_schema(),
         table_name.to_string(),


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary
The code was calling equals_record_batch_at_offset with a different input 
(the function is expecting full row and caller calls with extracted values).

Fix the mismatch.
Also fix a small perf inefficiency (we don't need to read record batch when the key is stored in memory)
Also modified test config so we will hit the case.

## Related Issues

Closes #<issue-number> or links to related issues.

## Changes

- 
- 
- 

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
