### PR TITLE
Improve handling of async drop events

### DIFF
--- a/src/moonlink_backend/src/lib.rs
+++ b/src/moonlink_backend/src/lib.rs
@@ -108,10 +108,9 @@ impl<T: Eq + Hash + Clone> MoonlinkBackend<T> {
     }
 
     /// Gracefully shutdown a replication connection identified by its URI.
-    pub async fn shutdown_connection(&self, uri: &str) -> Result<()> {
+    pub async fn shutdown_connection(&self, uri: &str) {
         let mut manager = self.replication_manager.write().await;
-        manager.shutdown_connection(uri).await?;
-        Ok(())
+        manager.shutdown_connection(uri);
     }
 
     /// Create an iceberg snapshot with the given LSN, return when the a snapshot is successfully created.

--- a/src/moonlink_connectors/src/replication_connection.rs
+++ b/src/moonlink_connectors/src/replication_connection.rs
@@ -161,6 +161,7 @@ impl ReplicationConnection {
     }
 
     fn retry_drop(uri: &str, drop_query: &str) -> JoinHandle<Result<()>> {
+        debug!("spawning retry drop");
         let uri = uri.to_string();
         let drop_query = drop_query.to_string();
         tokio::spawn(async move {
@@ -177,6 +178,7 @@ impl ReplicationConnection {
 
     /// Clean up completed retry handles.
     fn cleanup_completed_retries(&mut self) {
+        debug!("cleaning up completed retry handles");
         self.retry_handles.retain(|handle| !handle.is_finished());
     }
 

--- a/src/moonlink_connectors/src/replication_connection.rs
+++ b/src/moonlink_connectors/src/replication_connection.rs
@@ -193,6 +193,7 @@ impl ReplicationConnection {
             .await
             .or_else(|e| match e.code() {
                 Some(&SqlState::LOCK_NOT_AVAILABLE) => {
+                    warn!("lock not available, retrying");
                     // Store the handle so we can track its completion
                     let handle = Self::retry_drop(&self.uri, drop_query);
                     self.retry_handles.push(handle);

--- a/src/moonlink_connectors/src/replication_connection.rs
+++ b/src/moonlink_connectors/src/replication_connection.rs
@@ -157,13 +157,16 @@ impl ReplicationConnection {
     }
 
     async fn remove_table_from_publication(&self, table_name: &str) -> Result<()> {
-        self.postgres_client
+        if let Err(e) = self
+            .postgres_client
             .simple_query(&format!(
                 "ALTER PUBLICATION moonlink_pub DROP TABLE {};",
                 table_name
             ))
             .await
-            .unwrap();
+        {
+            warn!(table_name, error = ?e, "failed to remove table from publication, table may already be deleted");
+        }
         Ok(())
     }
 

--- a/src/moonlink_connectors/src/replication_connection.rs
+++ b/src/moonlink_connectors/src/replication_connection.rs
@@ -196,6 +196,10 @@ impl ReplicationConnection {
                     self.retry_handles.push(handle);
                     Ok(vec![])
                 }
+                Some(&SqlState::UNDEFINED_TABLE) => {
+                    warn!("table already dropped, skipping");
+                    Ok(vec![])
+                }
                 _ => Err(PostgresSourceError::from(e)),
             })?;
         Ok(())

--- a/src/moonlink_connectors/src/replication_connection.rs
+++ b/src/moonlink_connectors/src/replication_connection.rs
@@ -186,8 +186,10 @@ impl ReplicationConnection {
         // Clean up any completed retry handles first
         self.cleanup_completed_retries();
 
+        let timed_drop_query = format!("SET LOCAL lock_timeout = '100ms'; {}", drop_query);
+
         self.postgres_client
-            .simple_query(drop_query)
+            .simple_query(&timed_drop_query)
             .await
             .or_else(|e| match e.code() {
                 Some(&SqlState::LOCK_NOT_AVAILABLE) => {

--- a/src/moonlink_connectors/src/replication_manager.rs
+++ b/src/moonlink_connectors/src/replication_manager.rs
@@ -5,7 +5,7 @@ use moonlink::{IcebergTableEventManager, ObjectStorageCache, ReadStateManager};
 use std::collections::HashMap;
 use std::hash::Hash;
 use tokio::task::JoinHandle;
-use tracing::{debug, info};
+use tracing::{debug, info, warn};
 
 /// Manage replication sources keyed by their connection URI.
 ///
@@ -96,7 +96,7 @@ impl<T: Eq + Hash> ReplicationManager<T> {
         let (table_uri, table_id) = match self.table_info.get(&external_table_id) {
             Some(info) => info.clone(),
             None => {
-                info!("attempted to drop table that is not tracked by moonlink - table may already be dropped");
+                warn!("attempted to drop table that is not tracked by moonlink - table may already be dropped");
                 return Ok(());
             }
         };


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

This PR does two things
1) It avoids crashing when unsubscribing from a table that has already been dropped
2) It avoids the deadlock when we drop the rowstore and columnstore tables together e.g (`DROP r, c;`)

In order to avoid the deadlock, we first attempt the drop with a lock timeout. In the even that we can't obtain a lock within the specified timeout, we spawn the same query as its own task with its own pg client and store the handle in the replication connection. 

In the event that the replication connection needs to shutdown and has pending `retry_handles`, we await the pending handles in another task and store a handle in the replication manager. 

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/547

## Changes

- Continue on drop for non-existent table
- Add timeout and retry logic for drop queries
- Await pending drops on shutdown

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
