### PR TITLE
[storage] Fix iceberg directory

### DIFF
--- a/src/moonlink/src/storage/iceberg/file_catalog.rs
+++ b/src/moonlink/src/storage/iceberg/file_catalog.rs
@@ -805,11 +805,13 @@ mod tests {
     /// TODO(hjiang): Add the same hierarchy test for S3 catalog.
     #[tokio::test]
     async fn test_local_iceberg_table_creation() {
+        const NAMESPACE: &str = "default";
+
         let temp_dir = TempDir::new().unwrap();
         let warehouse_path = temp_dir.path().to_str().unwrap();
         let catalog =
             FileCatalog::new(warehouse_path.to_string(), CatalogConfig::FileSystem {}).unwrap();
-        let namespace_ident = NamespaceIdent::from_strs(["default"]).unwrap();
+        let namespace_ident = NamespaceIdent::from_strs([NAMESPACE]).unwrap();
         let _ = catalog
             .create_namespace(&namespace_ident, /*properties=*/ HashMap::new())
             .await
@@ -817,7 +819,7 @@ mod tests {
 
         // Expected directory for iceberg namespace.
         let mut namespace_dir_pathbuf = temp_dir.path().to_path_buf();
-        namespace_dir_pathbuf.push("default");
+        namespace_dir_pathbuf.push(NAMESPACE);
         let namespace_filepath = namespace_dir_pathbuf.to_str().unwrap().to_string();
 
         // Expected indicator file which marks an iceberg namespace.


### PR DESCRIPTION
## Summary

This PR fixes a bug, which iceberg table manager creates an empty directory under pg table directory.

Manual testing with pg_mooncake (running some sql statements), before this change:
```sql
vscode ➜ /workspaces/pg_mooncake/moonlink (main) $ ls -l /home/vscode/.pgrx/data-17/mooncake
total 12
drwx------ 3 vscode vscode 4096 Jun 24 04:36 home
drwx------ 3 vscode vscode 4096 Jun 24 06:13 public
drwx------ 2 vscode vscode 4096 Jun 24 06:13 public.r
```
it's worth noting `home` directory is an empty one.

After this change:
```sql
vscode ➜ /workspaces/pg_mooncake/moonlink (hjiang/fix-iceberg-directory) $ ls -l /home/vscode/.pgrx/data-17/mooncake
total 8
drwx------ 3 vscode vscode 4096 Jun 24 06:16 public
drwx------ 2 vscode vscode 4096 Jun 24 06:16 public.r
```

Also add a unit test for check against local filesystem hierarchy.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/570

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
