### PR TITLE
[storage] Update cache and temp file directory

### DIFF
--- a/src/moonlink_backend/src/lib.rs
+++ b/src/moonlink_backend/src/lib.rs
@@ -85,7 +85,7 @@ impl<T: Eq + Hash + Clone> MoonlinkBackend<T> {
     pub fn new(base_path: String) -> Self {
         logging::init_logging();
 
-        // Re-create directory for temporary files directoryand cache files directory under base directory.
+        // Re-create directory for temporary files directory and cache files directory under base directory.
         let temp_files_dir = get_temp_file_directory_under_base();
         let cache_files_dir = get_cache_directory_under_base();
         recreate_directory(temp_files_dir.to_str().unwrap()).unwrap();

--- a/src/moonlink_backend/src/lib.rs
+++ b/src/moonlink_backend/src/lib.rs
@@ -13,14 +13,24 @@ use tokio::sync::RwLock;
 
 // Default local filesystem directory where all tables data will be stored under.
 const DEFAULT_MOONLINK_TABLE_BASE_PATH: &str = "./mooncake/";
-// Default local filesystem directory where all temporary files (used for union read) will be stored under.
+// Default local filesystem directory under the above base directory (which defaults to `PGDATA/mooncake`) where all temporary files (used for union read) will be stored under.
 // The whole directory is cleaned up at moonlink backend start, to prevent file leak.
-pub const DEFAULT_MOONLINK_TEMP_FILE_PATH: &str = "/tmp/moonlink_temp_file";
-// Default object storage cache directory.
+pub const DEFAULT_MOONLINK_TEMP_FILE_PATH: &str = "./moonlink_temp_file/";
+// Default object storage cache directory under the above mooncake directory (which defaults to `PGDATA/mooncake`).
 // The whole directory is cleaned up at moonlink backend start, to prevent file leak.
-pub const DEFAULT_MOONLINK_OBJECT_STORAGE_CACHE_PATH: &str = "/tmp/moonlink_cache_file";
+pub const DEFAULT_MOONLINK_OBJECT_STORAGE_CACHE_PATH: &str = "./moonlink_cache_file/";
 // Min left disk space for on-disk cache of the filesystem which cache directory is mounted on.
 const MIN_DISK_SPACE_FOR_CACHE: u64 = 1 << 30; // 1GiB
+
+/// Get temporary directory under base path.
+fn get_temp_file_directory_under_base() -> std::path::PathBuf {
+    std::path::PathBuf::from(DEFAULT_MOONLINK_TABLE_BASE_PATH).join(DEFAULT_MOONLINK_TEMP_FILE_PATH)
+}
+/// Get cache directory under base path.
+fn get_cache_directory_under_base() -> std::path::PathBuf {
+    std::path::PathBuf::from(DEFAULT_MOONLINK_TABLE_BASE_PATH)
+        .join(DEFAULT_MOONLINK_OBJECT_STORAGE_CACHE_PATH)
+}
 
 /// Util function to delete and re-create the given directory.
 pub fn recreate_directory(dir: &str) -> Result<()> {
@@ -34,6 +44,7 @@ pub fn recreate_directory(dir: &str) -> Result<()> {
         }
     }
     std::fs::create_dir_all(dir)?;
+
     Ok(())
 }
 
@@ -74,13 +85,16 @@ impl<T: Eq + Hash + Clone> MoonlinkBackend<T> {
     pub fn new(base_path: String) -> Self {
         logging::init_logging();
 
-        recreate_directory(DEFAULT_MOONLINK_TEMP_FILE_PATH).unwrap();
-        recreate_directory(DEFAULT_MOONLINK_OBJECT_STORAGE_CACHE_PATH).unwrap();
+        // Re-create directory for temporary files directoryand cache files directory under base directory.
+        let temp_files_dir = get_temp_file_directory_under_base();
+        let cache_files_dir = get_cache_directory_under_base();
+        recreate_directory(temp_files_dir.to_str().unwrap()).unwrap();
+        recreate_directory(cache_files_dir.to_str().unwrap()).unwrap();
 
         Self {
             replication_manager: RwLock::new(ReplicationManager::new(
                 base_path.clone(),
-                DEFAULT_MOONLINK_TEMP_FILE_PATH.to_string(),
+                temp_files_dir.to_str().unwrap().to_string(),
                 create_default_object_storage_cache(),
             )),
         }


### PR DESCRIPTION
## Summary

After this PR, this temporary and cache directory are placed under `PGDATA/mooncake` directory.
```sh
vscode ➜ /workspaces/pg_mooncake/moonlink (main) $ ls -l /home/vscode/.pgrx/data-17/mooncake/
total 16
drwx------ 2 vscode vscode 4096 Jun 24 07:13 moonlink_cache_file
drwx------ 2 vscode vscode 4096 Jun 24 07:13 moonlink_temp_file
drwx------ 3 vscode vscode 4096 Jun 24 06:16 public
drwx------ 2 vscode vscode 4096 Jun 24 06:44 public.r

vscode ➜ /workspaces/pg_mooncake/moonlink (main) $ ls -l /home/vscode/.pgrx/data-17/mooncake/moonlink_temp_file/inmemory_public.r_66125_475506632.parquet 
-rw------- 1 vscode vscode 2121 Jun 24 07:17 /home/vscode/.pgrx/data-17/mooncake/moonlink_temp_file/inmemory_public.r_66125_475506632.parquet
```

Tested with regression test:
```sh
--- beginning regression test run ---
PASS setup 23ms
PASS partitioned_table 619ms
PASS sanity 577ms
passed=3, failed=0
```

Tested with pg_mooncake:
```sql
pg_mooncake (pid: 141413) =# DROP EXTENSION IF EXISTS pg_mooncake CASCADE;
DROP TABLE IF EXISTS r;
CREATE EXTENSION pg_mooncake;
CREATE TABLE r (a int primary key, b text);
CALL mooncake.create_table('c', 'r');
INSERT INTO r SELECT a, 'val_' || a FROM generate_series(1, 250000) AS a;
SELECT count(*) FROM c;
DELETE FROM r WHERE a % 2 = 0;
SELECT count(*) FROM c;
NOTICE:  drop cascades to table c
DROP EXTENSION
DROP TABLE
CREATE EXTENSION
CREATE TABLE
CALL
INSERT 0 250000
 count  
--------
 250000
(1 row)

DELETE 125000
 count  
--------
 250000
(1 row)
```

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/572

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
