### PR TITLE
[storage] Use absolute path for statvfs

### DIFF
--- a/src/moonlink_backend/src/lib.rs
+++ b/src/moonlink_backend/src/lib.rs
@@ -69,13 +69,17 @@ fn get_cache_filesystem_size(path: &str) -> u64 {
 }
 
 /// Create default object storage cache.
-fn create_default_object_storage_cache() -> ObjectStorageCache {
-    let filesystem_size = get_cache_filesystem_size(DEFAULT_MOONLINK_OBJECT_STORAGE_CACHE_PATH);
+/// Precondition: cache directory has been created beforehand.
+fn create_default_object_storage_cache(
+    cache_directory_pathbuf: std::path::PathBuf,
+) -> ObjectStorageCache {
+    let cache_directory = cache_directory_pathbuf.to_str().unwrap().to_string();
+    let filesystem_size = get_cache_filesystem_size(&cache_directory);
     ma::assert_ge!(filesystem_size, MIN_DISK_SPACE_FOR_CACHE);
 
     let cache_config = ObjectStorageCacheConfig {
         max_bytes: filesystem_size - MIN_DISK_SPACE_FOR_CACHE,
-        cache_directory: DEFAULT_MOONLINK_OBJECT_STORAGE_CACHE_PATH.to_string(),
+        cache_directory,
         optimize_local_filesystem: true,
     };
     ObjectStorageCache::new(cache_config)
@@ -95,7 +99,7 @@ impl<T: Eq + Hash + Clone> MoonlinkBackend<T> {
             replication_manager: RwLock::new(ReplicationManager::new(
                 base_path.clone(),
                 temp_files_dir.to_str().unwrap().to_string(),
-                create_default_object_storage_cache(),
+                create_default_object_storage_cache(cache_files_dir),
             )),
         }
     }


### PR DESCRIPTION
## Summary

Followup for https://github.com/Mooncake-Labs/moonlink/pull/571, need to give the correct cache directory.

Tested with integration test
```sh
running 7 tests
test tests::test_bulk_insert_one_million_rows ... ok
test tests::test_recreate_directory ... ok
test tests::test_moonlink_service ... ok
test tests::test_replication_connection_cleanup ... ok
test tests::test_scan_returns_inserted_rows ... ok
test tests::test_create_iceberg_snapshot ... ok
test tests::test_scan_table_with_lsn ... ok
```

Tested with pg_mooncake:
```sql
pg_mooncake (pid: 159950) =# DROP EXTENSION IF EXISTS pg_mooncake CASCADE;
DROP TABLE IF EXISTS r;
CREATE EXTENSION pg_mooncake;
CREATE TABLE r (a int primary key, b text);
CALL mooncake.create_table('c', 'r');
INSERT INTO r SELECT a, 'val_' || a FROM generate_series(1, 250000) AS a;
SELECT count(*) FROM c;
DELETE FROM r WHERE a % 2 = 0;
SELECT count(*) FROM c;
NOTICE:  drop cascades to table c
DROP EXTENSION
DROP TABLE
CREATE EXTENSION
CREATE TABLE
CALL
INSERT 0 250000
 count  
--------
 250000
(1 row)

DELETE 125000
 count  
--------
 250000
(1 row)
```

Tested with regression test:
```sh
--- beginning regression test run ---
PASS setup 24ms
PASS partitioned_table 630ms
PASS sanity 567ms
passed=3, failed=0
```

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
