### PR TITLE
[storage] Use stringified table id as mooncake table path

### DIFF
--- a/src/moonlink_backend/src/lib.rs
+++ b/src/moonlink_backend/src/lib.rs
@@ -53,7 +53,7 @@ pub struct MoonlinkBackend<T: Eq + Hash> {
     replication_manager: RwLock<ReplicationManager<T>>,
 }
 
-impl<T: Eq + Hash + Clone> Default for MoonlinkBackend<T> {
+impl<T: Eq + Hash + Clone + std::fmt::Display> Default for MoonlinkBackend<T> {
     fn default() -> Self {
         Self::new(DEFAULT_MOONLINK_TABLE_BASE_PATH.to_string())
     }
@@ -85,7 +85,7 @@ fn create_default_object_storage_cache(
     ObjectStorageCache::new(cache_config)
 }
 
-impl<T: Eq + Hash + Clone> MoonlinkBackend<T> {
+impl<T: Eq + Hash + Clone + std::fmt::Display> MoonlinkBackend<T> {
     pub fn new(base_path: String) -> Self {
         logging::init_logging();
 

--- a/src/moonlink_connectors/src/pg_replicate/table_init.rs
+++ b/src/moonlink_connectors/src/pg_replicate/table_init.rs
@@ -39,13 +39,14 @@ fn create_iceberg_event_syncer() -> (IcebergEventSyncSender, IcebergEventSyncRec
 
 /// Build all components needed to replicate `table_schema`.
 pub async fn build_table_components(
+    table_id: String,
     table_schema: &TableSchema,
     base_path: &Path,
     table_temp_files_directory: String,
     replication_state: &ReplicationState,
     object_storage_cache: ObjectStorageCache,
 ) -> Result<TableResources> {
-    let table_path = PathBuf::from(base_path).join(table_schema.table_name.to_string());
+    let table_path = PathBuf::from(base_path).join(table_id);
     tokio::fs::create_dir_all(&table_path).await.unwrap();
     let (arrow_schema, identity) = postgres_schema_to_moonlink_schema(table_schema);
     let iceberg_table_config = IcebergTableConfig {

--- a/src/moonlink_connectors/src/replication_manager.rs
+++ b/src/moonlink_connectors/src/replication_manager.rs
@@ -28,7 +28,7 @@ pub struct ReplicationManager<T: Eq + Hash> {
     shutdown_handles: Vec<JoinHandle<Result<()>>>,
 }
 
-impl<T: Eq + Hash> ReplicationManager<T> {
+impl<T: Eq + Hash + Clone + std::fmt::Display> ReplicationManager<T> {
     pub fn new(
         table_base_path: String,
         table_temp_files_directory: String,
@@ -81,7 +81,9 @@ impl<T: Eq + Hash> ReplicationManager<T> {
             replication_connection.start_replication().await?;
         }
 
-        let table_id = replication_connection.add_table(table_name).await?;
+        let table_id = replication_connection
+            .add_table(table_name, &external_table_id)
+            .await?;
         self.table_info
             .insert(external_table_id, (uri.to_string(), table_id));
 


### PR DESCRIPTION
## Summary

Use fully-qualified column storage table id as mooncake table path.

How I tested:
- I update pg_mooncake `TableId` to implement the format trait
- Mooncake table files do create under the correct directory

diff:
```sh
diff --git a/moonlink b/moonlink
index 940e57b..77670ab 160000
--- a/moonlink
+++ b/moonlink
@@ -1 +1 @@
-Subproject commit 940e57b7411680baa9e02aa45e18e2f75c8cd76d
+Subproject commit 77670ab37fae4aa437111c00a2ecb21068f82afd-dirty
diff --git a/pg_duckdb b/pg_duckdb
index bd3c5a0..90ef7eb 160000
--- a/pg_duckdb
+++ b/pg_duckdb
@@ -1 +1 @@
-Subproject commit bd3c5a0fffe187358a7d66c888bf0ea2e5afb8a1
+Subproject commit 90ef7ebc820cb0ca9c085a26b73553c607aaf04e
diff --git a/src/pgmoonlink/common.rs b/src/pgmoonlink/common.rs
index e22e3a4..28bbf01 100644
--- a/src/pgmoonlink/common.rs
+++ b/src/pgmoonlink/common.rs
@@ -10,6 +10,12 @@ pub(super) struct TableId {
     pub(super) table_id: u32,
 }
 
+impl std::fmt::Display for TableId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "hey-{}-{}", self.database_id, self.table_id)
+    }
+}
+
```
file hierarchy:
```sh
vscode ➜ /workspaces/pg_mooncake/moonlink (hjiang/use-tableid-as-path) $ ls -l /home/vscode/.pgrx/data-17/mooncake/
total 20
drwx------ 2 vscode vscode 4096 Jun 24 18:53 hey-16384-99279
drwx------ 2 vscode vscode 4096 Jun 24 18:52 moonlink_cache_file
drwx------ 2 vscode vscode 4096 Jun 24 18:53 moonlink_temp_file
drwx------ 3 vscode vscode 4096 Jun 24 06:16 public
drwx------ 2 vscode vscode 4096 Jun 24 10:46 public.r
vscode ➜ /workspaces/pg_mooncake/moonlink (hjiang/use-tableid-as-path) $ ls -l /home/vscode/.pgrx/data-17/mooncake/hey-16384-99279/
total 8
-rw------- 1 vscode vscode 992 Jun 24 18:53 data-0197a349-e7a7-78c2-9de3-95ea3be455b8.parquet
-rw------- 1 vscode vscode 160 Jun 24 18:53 index_block_0197a349-e7ab-7e81-8015-f03ca99ada35.bin
```
Test SQL:
```sql
pg_mooncake (pid: 222674) =# DROP EXTENSION IF EXISTS pg_mooncake CASCADE;
DROP TABLE IF EXISTS r;
CREATE EXTENSION pg_mooncake;
CREATE TABLE r (a int primary key, b text);
CALL mooncake.create_table('c', 'r');
INSERT INTO r SELECT a, 'val_' || a FROM generate_series(1, 10) AS a;
SELECT count(*) FROM c;
NOTICE:  drop cascades to table c
DROP EXTENSION
DROP TABLE
CREATE EXTENSION
CREATE TABLE
CALL
INSERT 0 10
 count 
-------
    10
(1 row)

pg_mooncake (pid: 222674) =# CALL mooncake.create_snapshot('c');
CALL
```

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/578

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
