### PR TITLE
[storage] [3/N] Integrate data file storage with local filesystem optimization

### DIFF
--- a/src/moonlink/src/storage/mooncake_table/data_file_state_tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/data_file_state_tests.rs
@@ -71,7 +71,7 @@ use crate::row::{MoonlinkRow, RowValue};
 use crate::storage::cache::object_storage::test_utils::*;
 use crate::storage::mooncake_table::state_test_utils::*;
 use crate::table_notify::TableNotify;
-use crate::{MooncakeTable, ObjectStorageCache, ObjectStorageCacheConfig};
+use crate::{MooncakeTable, ObjectStorageCache};
 
 /// ========================
 /// Test util function for read
@@ -81,10 +81,10 @@ use crate::{MooncakeTable, ObjectStorageCache, ObjectStorageCacheConfig};
 /// Rows are committed and flushed with LSN 1.
 async fn prepare_test_disk_file_for_read(
     temp_dir: &TempDir,
-    object_storage_cache: ObjectStorageCache,
+    cache: ObjectStorageCache,
 ) -> (MooncakeTable, Receiver<TableNotify>) {
     let (mut table, table_notify) =
-        create_mooncake_table_and_notify_for_read(temp_dir, object_storage_cache).await;
+        create_mooncake_table_and_notify_for_read(temp_dir, cache).await;
 
     let row = MoonlinkRow::new(vec![
         RowValue::Int32(1),
@@ -102,10 +102,10 @@ async fn prepare_test_disk_file_for_read(
 /// Rows are committed and flushed with LSN 1.
 async fn prepare_test_disk_file_by_stream_write(
     temp_dir: &TempDir,
-    object_storage_cache: ObjectStorageCache,
+    cache: ObjectStorageCache,
 ) -> (MooncakeTable, Receiver<TableNotify>) {
     let (mut table, table_notify) =
-        create_mooncake_table_and_notify_for_read(temp_dir, object_storage_cache).await;
+        create_mooncake_table_and_notify_for_read(temp_dir, cache).await;
 
     let row = MoonlinkRow::new(vec![
         RowValue::Int32(1),
@@ -127,15 +127,11 @@ async fn prepare_test_disk_file_by_stream_write(
 #[tokio::test]
 async fn test_shutdown_table() {
     let temp_dir = tempfile::tempdir().unwrap();
-    let cache_config = ObjectStorageCacheConfig::new(
-        INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE,
-        temp_dir.path().to_str().unwrap().to_string(),
-        /*optimize_local_filesystem=*/ false,
-    );
-    let mut object_storage_cache = ObjectStorageCache::new(cache_config);
+    let mut cache =
+        create_infinite_object_storage_cache(&temp_dir, /*optimize_local_filesystem=*/ false);
 
     let (mut table, mut table_notify) =
-        prepare_test_disk_file_for_read(&temp_dir, object_storage_cache.clone()).await;
+        prepare_test_disk_file_for_read(&temp_dir, cache.clone()).await;
     let (_, _, _, files_to_delete) =
         create_mooncake_snapshot_for_test(&mut table, &mut table_notify).await;
     assert!(files_to_delete.is_empty());
@@ -144,9 +140,9 @@ async fn test_shutdown_table() {
     table.shutdown().await.unwrap();
 
     // Check cache state.
-    assert_pending_eviction_entries_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_non_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
+    assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_evictable_cache_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 0).await;
 }
 
 /// ========================
@@ -160,15 +156,10 @@ async fn test_shutdown_table() {
 #[case(false)]
 async fn test_5_read_4_by_batch_write(#[case] optimize_local_filesystem: bool) {
     let temp_dir = tempfile::tempdir().unwrap();
-    let cache_config = ObjectStorageCacheConfig::new(
-        INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE,
-        temp_dir.path().to_str().unwrap().to_string(),
-        optimize_local_filesystem,
-    );
-    let mut object_storage_cache = ObjectStorageCache::new(cache_config);
+    let mut cache = create_infinite_object_storage_cache(&temp_dir, optimize_local_filesystem);
 
     let (mut table, mut table_notify) =
-        prepare_test_disk_file_for_read(&temp_dir, object_storage_cache.clone()).await;
+        prepare_test_disk_file_for_read(&temp_dir, cache.clone()).await;
     let (_, _, _, files_to_delete) =
         create_mooncake_snapshot_for_test(&mut table, &mut table_notify).await;
     assert!(files_to_delete.is_empty());
@@ -196,17 +187,17 @@ async fn test_5_read_4_by_batch_write(#[case] optimize_local_filesystem: bool) {
     assert!(is_local_file(file, &temp_dir));
 
     // Check cache state.
-    assert_pending_eviction_entries_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_non_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 2).await; // data file and index block file
+    assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_evictable_cache_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 2).await; // data file and index block file
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&get_unique_table_file_id(file.file_id()))
             .await,
         2
     );
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&get_unique_table_file_id(index_block_file_ids[0]))
             .await,
         1,
@@ -220,17 +211,17 @@ async fn test_5_read_4_by_batch_write(#[case] optimize_local_filesystem: bool) {
     )
     .await;
     assert!(files_to_delete.is_empty());
-    assert_pending_eviction_entries_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_non_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 2).await; // data file and index block file
+    assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_evictable_cache_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 2).await; // data file and index block file
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&get_unique_table_file_id(file.file_id()))
             .await,
         1
     );
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&get_unique_table_file_id(index_block_file_ids[0]))
             .await,
         1,
@@ -245,15 +236,11 @@ async fn test_5_read_4_by_batch_write(#[case] optimize_local_filesystem: bool) {
 #[case(false)]
 async fn test_5_read_4_by_stream_write(#[case] optimize_local_filesystem: bool) {
     let temp_dir = tempfile::tempdir().unwrap();
-    let cache_config = ObjectStorageCacheConfig::new(
-        INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE,
-        temp_dir.path().to_str().unwrap().to_string(),
-        optimize_local_filesystem,
-    );
-    let mut object_storage_cache = ObjectStorageCache::new(cache_config);
+    let mut cache =
+        create_object_storage_cache_with_one_file_size(&temp_dir, optimize_local_filesystem);
 
     let (mut table, mut table_notify) =
-        prepare_test_disk_file_by_stream_write(&temp_dir, object_storage_cache.clone()).await;
+        prepare_test_disk_file_by_stream_write(&temp_dir, cache.clone()).await;
     let (_, _, _, files_to_delete) =
         create_mooncake_snapshot_for_test(&mut table, &mut table_notify).await;
     assert!(files_to_delete.is_empty());
@@ -281,17 +268,17 @@ async fn test_5_read_4_by_stream_write(#[case] optimize_local_filesystem: bool) 
     assert!(is_local_file(file, &temp_dir));
 
     // Check cache state.
-    assert_pending_eviction_entries_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_non_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 2).await; // data file and index block file
+    assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_evictable_cache_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 2).await; // data file and index block file
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&get_unique_table_file_id(file.file_id()))
             .await,
         2
     );
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&get_unique_table_file_id(index_block_file_ids[0]))
             .await,
         1,
@@ -305,17 +292,17 @@ async fn test_5_read_4_by_stream_write(#[case] optimize_local_filesystem: bool) 
     )
     .await;
     assert!(files_to_delete.is_empty());
-    assert_pending_eviction_entries_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_non_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 2).await; // data file and index block file
+    assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_evictable_cache_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 2).await; // data file and index block file
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&get_unique_table_file_id(file.file_id()))
             .await,
         1
     );
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&get_unique_table_file_id(index_block_file_ids[0]))
             .await,
         1,
@@ -324,17 +311,13 @@ async fn test_5_read_4_by_stream_write(#[case] optimize_local_filesystem: bool) 
 
 /// Test scenario: no remote, local, not used + persist => remote, no local, not used
 #[tokio::test]
-async fn test_5_1_without_local_filesystem_optimization() {
+async fn test_5_1_without_local_optimization() {
     let temp_dir = tempfile::tempdir().unwrap();
-    let cache_config = ObjectStorageCacheConfig::new(
-        INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE,
-        temp_dir.path().to_str().unwrap().to_string(),
-        /*optimize_local_filesystem=*/ false,
-    );
-    let mut object_storage_cache = ObjectStorageCache::new(cache_config);
+    let mut cache =
+        create_infinite_object_storage_cache(&temp_dir, /*optimize_local_filesystem=*/ false);
 
     let (mut table, mut table_notify) =
-        prepare_test_disk_file_for_read(&temp_dir, object_storage_cache.clone()).await;
+        prepare_test_disk_file_for_read(&temp_dir, cache.clone()).await;
     create_mooncake_and_iceberg_snapshot_for_test(&mut table, &mut table_notify).await;
     // Till now, iceberg snapshot has been persisted, need an extra mooncake snapshot to reflect persistence result.
     let (_, _, _, files_to_delete) =
@@ -352,31 +335,27 @@ async fn test_5_1_without_local_filesystem_optimization() {
     assert_eq!(index_block_file_ids.len(), 1);
 
     // Check cache state.
-    assert_pending_eviction_entries_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 1).await;
-    assert_non_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 1).await; // index block file
+    assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_evictable_cache_size(&mut cache, /*expected_count=*/ 1).await;
+    assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 1).await; // index block file
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&get_unique_table_file_id(index_block_file_ids[0]))
             .await,
         1,
     );
 }
 
-/// State transfer is the same as [`test_5_1_without_local_filesystem_optimization`].
+/// State transfer is the same as [`test_5_1_without_local_optimization`].
 /// Test scenario: no remote, local, not used + persist => remote, no local, not used
 #[tokio::test]
-async fn test_5_1_with_local_filesystem_optimization() {
+async fn test_5_1_with_local_optimization() {
     let temp_dir = tempfile::tempdir().unwrap();
-    let cache_config = ObjectStorageCacheConfig::new(
-        INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE,
-        temp_dir.path().to_str().unwrap().to_string(),
-        /*optimize_local_filesystem=*/ true,
-    );
-    let mut object_storage_cache = ObjectStorageCache::new(cache_config);
+    let mut cache =
+        create_infinite_object_storage_cache(&temp_dir, /*optimize_local_filesystem=*/ true);
 
     let (mut table, mut table_notify) =
-        prepare_test_disk_file_for_read(&temp_dir, object_storage_cache.clone()).await;
+        prepare_test_disk_file_for_read(&temp_dir, cache.clone()).await;
     create_mooncake_and_iceberg_snapshot_for_test(&mut table, &mut table_notify).await;
     let local_data_file = get_only_data_filepath(&table).await;
 
@@ -396,11 +375,11 @@ async fn test_5_1_with_local_filesystem_optimization() {
     assert_eq!(index_block_file_ids.len(), 1);
 
     // Check cache state.
-    assert_pending_eviction_entries_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 1).await;
-    assert_non_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 1).await; // index block file
+    assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_evictable_cache_size(&mut cache, /*expected_count=*/ 1).await;
+    assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 1).await; // index block file
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&get_unique_table_file_id(index_block_file_ids[0]))
             .await,
         1,
@@ -414,15 +393,11 @@ async fn test_5_1_with_local_filesystem_optimization() {
 #[case(false)]
 async fn test_4_3(#[case] optimize_local_filesystem: bool) {
     let temp_dir = tempfile::tempdir().unwrap();
-    let cache_config = ObjectStorageCacheConfig::new(
-        INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE,
-        temp_dir.path().to_str().unwrap().to_string(),
-        optimize_local_filesystem,
-    );
-    let mut object_storage_cache = ObjectStorageCache::new(cache_config);
+    let mut cache =
+        create_object_storage_cache_with_one_file_size(&temp_dir, optimize_local_filesystem);
 
     let (mut table, mut table_notify) =
-        prepare_test_disk_file_for_read(&temp_dir, object_storage_cache.clone()).await;
+        prepare_test_disk_file_for_read(&temp_dir, cache.clone()).await;
     let (_, _, _, files_to_delete) =
         create_mooncake_snapshot_for_test(&mut table, &mut table_notify).await;
     assert!(files_to_delete.is_empty());
@@ -448,17 +423,17 @@ async fn test_4_3(#[case] optimize_local_filesystem: bool) {
     assert_eq!(index_block_file_ids.len(), 1);
 
     // Check cache state.
-    assert_pending_eviction_entries_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_non_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 2).await; // data file and index block file
+    assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_evictable_cache_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 2).await; // data file and index block file
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&get_unique_table_file_id(file.file_id()))
             .await,
         1
     );
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&get_unique_table_file_id(index_block_file_ids[0]))
             .await,
         1,
@@ -472,11 +447,11 @@ async fn test_4_3(#[case] optimize_local_filesystem: bool) {
     )
     .await;
     assert!(files_to_delete.is_empty());
-    assert_pending_eviction_entries_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 1).await;
-    assert_non_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 1).await; // index block file
+    assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_evictable_cache_size(&mut cache, /*expected_count=*/ 1).await;
+    assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 1).await; // index block file
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&get_unique_table_file_id(index_block_file_ids[0]))
             .await,
         1,
@@ -490,15 +465,11 @@ async fn test_4_3(#[case] optimize_local_filesystem: bool) {
 #[case(false)]
 async fn test_4_read_4(#[case] optimize_local_filesystem: bool) {
     let temp_dir = tempfile::tempdir().unwrap();
-    let cache_config = ObjectStorageCacheConfig::new(
-        INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE,
-        temp_dir.path().to_str().unwrap().to_string(),
-        optimize_local_filesystem,
-    );
-    let mut object_storage_cache = ObjectStorageCache::new(cache_config);
+    let mut cache =
+        create_object_storage_cache_with_one_file_size(&temp_dir, optimize_local_filesystem);
 
     let (mut table, mut table_notify) =
-        prepare_test_disk_file_for_read(&temp_dir, object_storage_cache.clone()).await;
+        prepare_test_disk_file_for_read(&temp_dir, cache.clone()).await;
     let (_, _, _, files_to_delete) =
         create_mooncake_snapshot_for_test(&mut table, &mut table_notify).await;
     assert!(files_to_delete.is_empty());
@@ -526,17 +497,17 @@ async fn test_4_read_4(#[case] optimize_local_filesystem: bool) {
     assert_eq!(index_block_file_ids.len(), 1);
 
     // Check cache state.
-    assert_pending_eviction_entries_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_non_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 2).await; // data file and index block file
+    assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_evictable_cache_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 2).await; // data file and index block file
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&get_unique_table_file_id(file.file_id()))
             .await,
         4,
     );
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&get_unique_table_file_id(index_block_file_ids[0]))
             .await,
         1,
@@ -550,11 +521,11 @@ async fn test_4_read_4(#[case] optimize_local_filesystem: bool) {
     )
     .await;
     assert!(files_to_delete.is_empty());
-    assert_pending_eviction_entries_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_non_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 2).await; // data file and index block file
+    assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_evictable_cache_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 2).await; // data file and index block file
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&get_unique_table_file_id(file.file_id()))
             .await,
         1,
@@ -568,15 +539,11 @@ async fn test_4_read_4(#[case] optimize_local_filesystem: bool) {
 #[case(false)]
 async fn test_4_read_and_read_over_4(#[case] optimize_local_filesystem: bool) {
     let temp_dir = tempfile::tempdir().unwrap();
-    let cache_config = ObjectStorageCacheConfig::new(
-        INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE,
-        temp_dir.path().to_str().unwrap().to_string(),
-        optimize_local_filesystem,
-    );
-    let mut object_storage_cache = ObjectStorageCache::new(cache_config);
+    let mut cache =
+        create_object_storage_cache_with_one_file_size(&temp_dir, optimize_local_filesystem);
 
     let (mut table, mut table_notify) =
-        prepare_test_disk_file_for_read(&temp_dir, object_storage_cache.clone()).await;
+        prepare_test_disk_file_for_read(&temp_dir, cache.clone()).await;
     let (_, _, _, files_to_delete) =
         create_mooncake_snapshot_for_test(&mut table, &mut table_notify).await;
     assert!(files_to_delete.is_empty());
@@ -603,17 +570,17 @@ async fn test_4_read_and_read_over_4(#[case] optimize_local_filesystem: bool) {
     assert_eq!(index_block_file_ids.len(), 1);
 
     // Check cache state.
-    assert_pending_eviction_entries_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_non_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 2).await; // data file and index block file
+    assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_evictable_cache_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 2).await; // data file and index block file
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&get_unique_table_file_id(file.file_id()))
             .await,
         1
     );
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&get_unique_table_file_id(index_block_file_ids[0]))
             .await,
         1,
@@ -627,15 +594,11 @@ async fn test_4_read_and_read_over_4(#[case] optimize_local_filesystem: bool) {
 #[case(false)]
 async fn test_3_read_3(#[case] optimize_local_filesystem: bool) {
     let temp_dir = tempfile::tempdir().unwrap();
-    let cache_config = ObjectStorageCacheConfig::new(
-        INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE,
-        temp_dir.path().to_str().unwrap().to_string(),
-        optimize_local_filesystem,
-    );
-    let mut object_storage_cache = ObjectStorageCache::new(cache_config);
+    let mut cache =
+        create_object_storage_cache_with_one_file_size(&temp_dir, optimize_local_filesystem);
 
     let (mut table, mut table_notify) =
-        prepare_test_disk_file_for_read(&temp_dir, object_storage_cache.clone()).await;
+        prepare_test_disk_file_for_read(&temp_dir, cache.clone()).await;
     let (_, _, _, files_to_delete) =
         create_mooncake_snapshot_for_test(&mut table, &mut table_notify).await;
     assert!(files_to_delete.is_empty());
@@ -665,17 +628,17 @@ async fn test_3_read_3(#[case] optimize_local_filesystem: bool) {
     assert_eq!(index_block_file_ids.len(), 1);
 
     // Check cache state.
-    assert_pending_eviction_entries_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_non_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 2).await; // data file and index block file
+    assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_evictable_cache_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 2).await; // data file and index block file
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&get_unique_table_file_id(file.file_id()))
             .await,
         2,
     );
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&get_unique_table_file_id(index_block_file_ids[0]))
             .await,
         1,
@@ -689,11 +652,11 @@ async fn test_3_read_3(#[case] optimize_local_filesystem: bool) {
     )
     .await;
     assert!(files_to_delete.is_empty());
-    assert_pending_eviction_entries_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 1).await;
-    assert_non_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 1).await; // index block file
+    assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_evictable_cache_size(&mut cache, /*expected_count=*/ 1).await;
+    assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 1).await; // index block file
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&get_unique_table_file_id(index_block_file_ids[0]))
             .await,
         1,
@@ -707,15 +670,11 @@ async fn test_3_read_3(#[case] optimize_local_filesystem: bool) {
 #[case(false)]
 async fn test_3_read_and_read_over_and_pinned_3(#[case] optimize_local_filesystem: bool) {
     let temp_dir = tempfile::tempdir().unwrap();
-    let cache_config = ObjectStorageCacheConfig::new(
-        INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE,
-        temp_dir.path().to_str().unwrap().to_string(),
-        optimize_local_filesystem,
-    );
-    let mut object_storage_cache = ObjectStorageCache::new(cache_config);
+    let mut cache =
+        create_object_storage_cache_with_one_file_size(&temp_dir, optimize_local_filesystem);
 
     let (mut table, mut table_notify) =
-        prepare_test_disk_file_for_read(&temp_dir, object_storage_cache.clone()).await;
+        prepare_test_disk_file_for_read(&temp_dir, cache.clone()).await;
     let (_, _, _, files_to_delete) =
         create_mooncake_snapshot_for_test(&mut table, &mut table_notify).await;
     assert!(files_to_delete.is_empty());
@@ -752,17 +711,17 @@ async fn test_3_read_and_read_over_and_pinned_3(#[case] optimize_local_filesyste
     assert_eq!(index_block_file_ids.len(), 1);
 
     // Check cache state.
-    assert_pending_eviction_entries_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_non_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 2).await; // data file and index block file
+    assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_evictable_cache_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 2).await; // data file and index block file
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&get_unique_table_file_id(file.file_id()))
             .await,
         1,
     );
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&get_unique_table_file_id(index_block_file_ids[0]))
             .await,
         1,
@@ -776,11 +735,11 @@ async fn test_3_read_and_read_over_and_pinned_3(#[case] optimize_local_filesyste
     )
     .await;
     assert!(files_to_delete.is_empty());
-    assert_pending_eviction_entries_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 1).await;
-    assert_non_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 1).await; // index block file
+    assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_evictable_cache_size(&mut cache, /*expected_count=*/ 1).await;
+    assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 1).await; // index block file
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&get_unique_table_file_id(index_block_file_ids[0]))
             .await,
         1,
@@ -789,17 +748,13 @@ async fn test_3_read_and_read_over_and_pinned_3(#[case] optimize_local_filesyste
 
 /// Test scenario: remote, local, in use + use over & unpinned => remote, no local, not used
 #[tokio::test]
-async fn test_3_read_and_read_over_and_unpinned_1_without_local_filesystem_optimization() {
+async fn test_3_read_and_read_over_and_unpinned_1_without_local_optimization() {
     let temp_dir = tempfile::tempdir().unwrap();
-    let cache_config = ObjectStorageCacheConfig::new(
-        INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE,
-        temp_dir.path().to_str().unwrap().to_string(),
-        /*optimize_local_filesystem=*/ false,
-    );
-    let mut object_storage_cache = ObjectStorageCache::new(cache_config);
+    let mut cache =
+        create_infinite_object_storage_cache(&temp_dir, /*optimize_local_filesystem=*/ false);
 
     let (mut table, mut table_notify) =
-        prepare_test_disk_file_for_read(&temp_dir, object_storage_cache.clone()).await;
+        prepare_test_disk_file_for_read(&temp_dir, cache.clone()).await;
     let (_, _, _, files_to_delete) =
         create_mooncake_snapshot_for_test(&mut table, &mut table_notify).await;
     assert!(files_to_delete.is_empty());
@@ -832,31 +787,27 @@ async fn test_3_read_and_read_over_and_unpinned_1_without_local_filesystem_optim
     assert_eq!(index_block_file_ids.len(), 1);
 
     // Check cache state.
-    assert_pending_eviction_entries_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 1).await;
-    assert_non_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 1).await; // index block file
+    assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_evictable_cache_size(&mut cache, /*expected_count=*/ 1).await;
+    assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 1).await; // index block file
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&get_unique_table_file_id(index_block_file_ids[0]))
             .await,
         1,
     );
 }
 
-/// State transfer is the same as [`test_3_read_and_read_over_and_unpinned_1_without_local_filesystem_optimization`].
+/// State transfer is the same as [`test_3_read_and_read_over_and_unpinned_1_without_local_optimization`].
 /// Test scenario: remote, local, in use + use over & unpinned => remote, no local, not used
 #[tokio::test]
-async fn test_3_read_and_read_over_and_unpinned_1_with_local_filesystem_optimization() {
+async fn test_3_read_and_read_over_and_unpinned_1_with_local_optimization() {
     let temp_dir = tempfile::tempdir().unwrap();
-    let cache_config = ObjectStorageCacheConfig::new(
-        INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE,
-        temp_dir.path().to_str().unwrap().to_string(),
-        /*optimize_local_filesystem=*/ true,
-    );
-    let mut object_storage_cache = ObjectStorageCache::new(cache_config);
+    let mut cache =
+        create_infinite_object_storage_cache(&temp_dir, /*optimize_local_filesystem=*/ true);
 
     let (mut table, mut table_notify) =
-        prepare_test_disk_file_for_read(&temp_dir, object_storage_cache.clone()).await;
+        prepare_test_disk_file_for_read(&temp_dir, cache.clone()).await;
     let (_, _, _, files_to_delete) =
         create_mooncake_snapshot_for_test(&mut table, &mut table_notify).await;
     assert!(files_to_delete.is_empty());
@@ -891,11 +842,11 @@ async fn test_3_read_and_read_over_and_unpinned_1_with_local_filesystem_optimiza
     assert_eq!(index_block_file_ids.len(), 1);
 
     // Check cache state.
-    assert_pending_eviction_entries_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 1).await;
-    assert_non_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 1).await; // index block file
+    assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_evictable_cache_size(&mut cache, /*expected_count=*/ 1).await;
+    assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 1).await; // index block file
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&get_unique_table_file_id(index_block_file_ids[0]))
             .await,
         1,
@@ -904,17 +855,13 @@ async fn test_3_read_and_read_over_and_unpinned_1_with_local_filesystem_optimiza
 
 /// Test scenario: remote, no local, not used + use & pinned => remote, local, in use
 #[tokio::test]
-async fn test_1_read_and_pinned_3_without_local_filesystem_optimization() {
+async fn test_1_read_and_pinned_3_without_local_optimization() {
     let temp_dir = tempfile::tempdir().unwrap();
-    let cache_config = ObjectStorageCacheConfig::new(
-        INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE,
-        temp_dir.path().to_str().unwrap().to_string(),
-        /*optimize_local_filesystem=*/ false,
-    );
-    let mut object_storage_cache = ObjectStorageCache::new(cache_config);
+    let mut cache =
+        create_infinite_object_storage_cache(&temp_dir, /*optimize_local_filesystem=*/ false);
 
     let (mut table, mut table_notify) =
-        prepare_test_disk_file_for_read(&temp_dir, object_storage_cache.clone()).await;
+        prepare_test_disk_file_for_read(&temp_dir, cache.clone()).await;
     let (_, _, _, files_to_delete) =
         create_mooncake_snapshot_for_test(&mut table, &mut table_notify).await;
     assert!(files_to_delete.is_empty());
@@ -940,17 +887,17 @@ async fn test_1_read_and_pinned_3_without_local_filesystem_optimization() {
     assert_eq!(index_block_file_ids.len(), 1);
 
     // Check cache state.
-    assert_pending_eviction_entries_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_non_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 2).await; // data file and index block file
+    assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_evictable_cache_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 2).await; // data file and index block file
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&get_unique_table_file_id(file.file_id()))
             .await,
         1,
     );
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&get_unique_table_file_id(index_block_file_ids[0]))
             .await,
         1,
@@ -964,31 +911,27 @@ async fn test_1_read_and_pinned_3_without_local_filesystem_optimization() {
     )
     .await;
     assert!(files_to_delete.is_empty());
-    assert_pending_eviction_entries_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 1).await;
-    assert_non_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 1).await; // index block file
+    assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_evictable_cache_size(&mut cache, /*expected_count=*/ 1).await;
+    assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 1).await; // index block file
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&get_unique_table_file_id(index_block_file_ids[0]))
             .await,
         1,
     );
 }
 
-/// State transfer is the same as [`test_1_read_and_pinned_3_without_local_filesystem_optimization`].
+/// State transfer is the same as [`test_1_read_and_pinned_3_without_local_optimization`].
 /// Test scenario: remote, no local, not used + use & pinned => remote, local, in use
 #[tokio::test]
-async fn test_1_read_and_pinned_3_with_local_filesystem_optimization() {
+async fn test_1_read_and_pinned_3_with_local_optimization() {
     let temp_dir = tempfile::tempdir().unwrap();
-    let cache_config = ObjectStorageCacheConfig::new(
-        INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE,
-        temp_dir.path().to_str().unwrap().to_string(),
-        /*optimize_local_filesystem=*/ true,
-    );
-    let mut object_storage_cache = ObjectStorageCache::new(cache_config);
+    let mut cache =
+        create_infinite_object_storage_cache(&temp_dir, /*optimize_local_filesystem=*/ true);
 
     let (mut table, mut table_notify) =
-        prepare_test_disk_file_for_read(&temp_dir, object_storage_cache.clone()).await;
+        prepare_test_disk_file_for_read(&temp_dir, cache.clone()).await;
     let (_, _, _, files_to_delete) =
         create_mooncake_snapshot_for_test(&mut table, &mut table_notify).await;
     assert!(files_to_delete.is_empty());
@@ -1016,17 +959,17 @@ async fn test_1_read_and_pinned_3_with_local_filesystem_optimization() {
     assert_eq!(index_block_file_ids.len(), 1);
 
     // Check cache state.
-    assert_pending_eviction_entries_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_non_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 2).await; // data file and index block file
+    assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_evictable_cache_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 2).await; // data file and index block file
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&get_unique_table_file_id(file.file_id()))
             .await,
         1,
     );
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&get_unique_table_file_id(index_block_file_ids[0]))
             .await,
         1,
@@ -1040,11 +983,11 @@ async fn test_1_read_and_pinned_3_with_local_filesystem_optimization() {
     )
     .await;
     assert!(files_to_delete.is_empty());
-    assert_pending_eviction_entries_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 1).await;
-    assert_non_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 1).await; // index block file
+    assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_evictable_cache_size(&mut cache, /*expected_count=*/ 1).await;
+    assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 1).await; // index block file
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&get_unique_table_file_id(index_block_file_ids[0]))
             .await,
         1,
@@ -1053,17 +996,14 @@ async fn test_1_read_and_pinned_3_with_local_filesystem_optimization() {
 
 /// Test scenario: remote, no local, not used + use & unpinned => remote, no local, not used
 #[tokio::test]
-async fn test_1_read_and_unpinned_3_without_local_filesystem_optimization() {
+async fn test_1_read_and_unpinned_3_without_local_optimization() {
     let temp_dir = tempfile::tempdir().unwrap();
-    let cache_config = ObjectStorageCacheConfig::new(
-        ONE_FILE_CACHE_SIZE,
-        temp_dir.path().to_str().unwrap().to_string(),
-        /*optimize_local_filesystem=*/ false,
+    let mut cache = create_object_storage_cache_with_one_file_size(
+        &temp_dir, /*optimize_local_filesystem=*/ false,
     );
-    let mut object_storage_cache = ObjectStorageCache::new(cache_config);
 
     let (mut table, mut table_notify) =
-        prepare_test_disk_file_for_read(&temp_dir, object_storage_cache.clone()).await;
+        prepare_test_disk_file_for_read(&temp_dir, cache.clone()).await;
     let (_, _, _, files_to_delete) =
         create_mooncake_snapshot_for_test(&mut table, &mut table_notify).await;
     assert!(files_to_delete.is_empty());
@@ -1075,7 +1015,7 @@ async fn test_1_read_and_unpinned_3_without_local_filesystem_optimization() {
     assert!(files_to_delete.is_empty());
 
     // Import second data file into cache, so the cached entry will be evicted.
-    import_fake_cache_entry(&temp_dir, &mut object_storage_cache).await;
+    import_fake_cache_entry(&temp_dir, &mut cache).await;
 
     // Read and increment reference count.
     let snapshot_read_output = perform_read_request_for_test(&mut table).await;
@@ -1092,29 +1032,26 @@ async fn test_1_read_and_unpinned_3_without_local_filesystem_optimization() {
     assert_eq!(index_block_file_ids.len(), 1);
 
     // Check cache state.
-    check_file_not_pinned(&object_storage_cache, file.file_id()).await;
-    check_file_pinned(&object_storage_cache, FAKE_FILE_ID.file_id).await;
+    check_file_not_pinned(&cache, file.file_id()).await;
+    check_file_pinned(&cache, FAKE_FILE_ID.file_id).await;
 
     // Drop all read states and check reference count.
     drop_read_states(vec![read_state], &mut table, &mut table_notify).await;
-    check_file_not_pinned(&object_storage_cache, file.file_id()).await;
-    check_file_pinned(&object_storage_cache, FAKE_FILE_ID.file_id).await;
+    check_file_not_pinned(&cache, file.file_id()).await;
+    check_file_pinned(&cache, FAKE_FILE_ID.file_id).await;
 }
 
-/// State transfer is the same as [`test_1_read_and_unpinned_3_without_local_filesystem_optimization`].
+/// State transfer is the same as [`test_1_read_and_unpinned_3_without_local_optimization`].
 /// Test scenario: remote, no local, not used + use & unpinned => remote, no local, not used
 #[tokio::test]
-async fn test_1_read_and_unpinned_3_with_local_filesystem_optimization() {
+async fn test_1_read_and_unpinned_3_with_local_optimization() {
     let temp_dir = tempfile::tempdir().unwrap();
-    let cache_config = ObjectStorageCacheConfig::new(
-        ONE_FILE_CACHE_SIZE,
-        temp_dir.path().to_str().unwrap().to_string(),
-        /*optimize_local_filesystem=*/ true,
+    let mut cache = create_object_storage_cache_with_one_file_size(
+        &temp_dir, /*optimize_local_filesystem=*/ true,
     );
-    let mut object_storage_cache = ObjectStorageCache::new(cache_config);
 
     let (mut table, mut table_notify) =
-        prepare_test_disk_file_for_read(&temp_dir, object_storage_cache.clone()).await;
+        prepare_test_disk_file_for_read(&temp_dir, cache.clone()).await;
     let (_, _, _, files_to_delete) =
         create_mooncake_snapshot_for_test(&mut table, &mut table_notify).await;
     assert!(files_to_delete.is_empty());
@@ -1128,7 +1065,7 @@ async fn test_1_read_and_unpinned_3_with_local_filesystem_optimization() {
     assert_eq!(files_to_delete, vec![local_data_file]);
 
     // Import second data file into cache, so the cached entry will be evicted.
-    import_fake_cache_entry(&temp_dir, &mut object_storage_cache).await;
+    import_fake_cache_entry(&temp_dir, &mut cache).await;
 
     // Read and increment reference count.
     let snapshot_read_output = perform_read_request_for_test(&mut table).await;
@@ -1145,28 +1082,25 @@ async fn test_1_read_and_unpinned_3_with_local_filesystem_optimization() {
     assert_eq!(index_block_file_ids.len(), 1);
 
     // Check cache state.
-    check_file_not_pinned(&object_storage_cache, file.file_id()).await;
-    check_file_pinned(&object_storage_cache, FAKE_FILE_ID.file_id).await;
+    check_file_not_pinned(&cache, file.file_id()).await;
+    check_file_pinned(&cache, FAKE_FILE_ID.file_id).await;
 
     // Drop all read states and check reference count.
     drop_read_states(vec![read_state], &mut table, &mut table_notify).await;
-    check_file_not_pinned(&object_storage_cache, file.file_id()).await;
-    check_file_pinned(&object_storage_cache, FAKE_FILE_ID.file_id).await;
+    check_file_not_pinned(&cache, file.file_id()).await;
+    check_file_pinned(&cache, FAKE_FILE_ID.file_id).await;
 }
 
 /// Test scenario: remote, no local, in use + use & pinned => remote, local, in use
 #[tokio::test]
-async fn test_2_read_and_pinned_3_without_local_filesystem_optimization() {
+async fn test_2_read_and_pinned_3_without_local_optimization() {
     let temp_dir = tempfile::tempdir().unwrap();
-    let cache_config = ObjectStorageCacheConfig::new(
-        ONE_FILE_CACHE_SIZE,
-        temp_dir.path().to_str().unwrap().to_string(),
-        /*optimize_local_filesystem=*/ false,
+    let mut cache = create_object_storage_cache_with_one_file_size(
+        &temp_dir, /*optimize_local_filesystem=*/ false,
     );
-    let mut object_storage_cache = ObjectStorageCache::new(cache_config);
 
     let (mut table, mut table_notify) =
-        prepare_test_disk_file_for_read(&temp_dir, object_storage_cache.clone()).await;
+        prepare_test_disk_file_for_read(&temp_dir, cache.clone()).await;
     let (_, _, _, files_to_delete) =
         create_mooncake_snapshot_for_test(&mut table, &mut table_notify).await;
     assert!(files_to_delete.is_empty());
@@ -1178,7 +1112,7 @@ async fn test_2_read_and_pinned_3_without_local_filesystem_optimization() {
     assert!(files_to_delete.is_empty());
 
     // Import second data file into cache, so the cached entry will be evicted.
-    let mut fake_cache_handle = import_fake_cache_entry(&temp_dir, &mut object_storage_cache).await;
+    let mut fake_cache_handle = import_fake_cache_entry(&temp_dir, &mut cache).await;
 
     // Read, but no reference count hold within read state.
     let snapshot_read_output_1 = perform_read_request_for_test(&mut table).await;
@@ -1211,17 +1145,17 @@ async fn test_2_read_and_pinned_3_without_local_filesystem_optimization() {
     assert_eq!(index_block_file_ids.len(), 1);
 
     // Check cache state.
-    assert_pending_eviction_entries_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_non_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 2).await; // data file and index block file
+    assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_evictable_cache_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 2).await; // data file and index block file
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&get_unique_table_file_id(file.file_id()))
             .await,
         1,
     );
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&get_unique_table_file_id(index_block_file_ids[0]))
             .await,
         1,
@@ -1235,31 +1169,28 @@ async fn test_2_read_and_pinned_3_without_local_filesystem_optimization() {
     )
     .await;
     assert!(files_to_delete.is_empty());
-    assert_pending_eviction_entries_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 1).await; // data file
-    assert_non_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 1).await; // index block file
+    assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_evictable_cache_size(&mut cache, /*expected_count=*/ 1).await; // data file
+    assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 1).await; // index block file
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&get_unique_table_file_id(index_block_file_ids[0]))
             .await,
         1,
     );
 }
 
-/// State transfer is the same as [`test_2_read_and_pinned_3_without_local_filesystem_optimization`].
+/// State transfer is the same as [`test_2_read_and_pinned_3_without_local_optimization`].
 /// Test scenario: remote, no local, in use + use & pinned => remote, local, in use
 #[tokio::test]
-async fn test_2_read_and_pinned_3_with_local_filesystem_optimization() {
+async fn test_2_read_and_pinned_3_with_local_optimization() {
     let temp_dir = tempfile::tempdir().unwrap();
-    let cache_config = ObjectStorageCacheConfig::new(
-        ONE_FILE_CACHE_SIZE,
-        temp_dir.path().to_str().unwrap().to_string(),
-        /*optimize_local_filesystem=*/ true,
+    let mut cache = create_object_storage_cache_with_one_file_size(
+        &temp_dir, /*optimize_local_filesystem=*/ true,
     );
-    let mut object_storage_cache = ObjectStorageCache::new(cache_config);
 
     let (mut table, mut table_notify) =
-        prepare_test_disk_file_for_read(&temp_dir, object_storage_cache.clone()).await;
+        prepare_test_disk_file_for_read(&temp_dir, cache.clone()).await;
     let (_, _, _, files_to_delete) =
         create_mooncake_snapshot_for_test(&mut table, &mut table_notify).await;
     assert!(files_to_delete.is_empty());
@@ -1273,7 +1204,7 @@ async fn test_2_read_and_pinned_3_with_local_filesystem_optimization() {
     assert_eq!(files_to_delete, vec![local_data_file]);
 
     // Import second data file into cache, so the cached entry will be evicted.
-    let mut fake_cache_handle = import_fake_cache_entry(&temp_dir, &mut object_storage_cache).await;
+    let mut fake_cache_handle = import_fake_cache_entry(&temp_dir, &mut cache).await;
 
     // Read, but no reference count hold within read state.
     let snapshot_read_output_1 = perform_read_request_for_test(&mut table).await;
@@ -1306,17 +1237,17 @@ async fn test_2_read_and_pinned_3_with_local_filesystem_optimization() {
     assert_eq!(index_block_file_ids.len(), 1);
 
     // Check cache state.
-    assert_pending_eviction_entries_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_non_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 2).await; // data file and index block file
+    assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_evictable_cache_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 2).await; // data file and index block file
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&get_unique_table_file_id(file.file_id()))
             .await,
         1,
     );
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&get_unique_table_file_id(index_block_file_ids[0]))
             .await,
         1,
@@ -1330,11 +1261,11 @@ async fn test_2_read_and_pinned_3_with_local_filesystem_optimization() {
     )
     .await;
     assert!(files_to_delete.is_empty());
-    assert_pending_eviction_entries_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 1).await; // data file
-    assert_non_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 1).await; // index block file
+    assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_evictable_cache_size(&mut cache, /*expected_count=*/ 1).await; // data file
+    assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 1).await; // index block file
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&get_unique_table_file_id(index_block_file_ids[0]))
             .await,
         1,
@@ -1343,17 +1274,14 @@ async fn test_2_read_and_pinned_3_with_local_filesystem_optimization() {
 
 /// Test scenario: remote, no local, in use + use & unpinned => remote, no local, in use
 #[tokio::test]
-async fn test_2_read_and_unpinned_2_without_local_filesystem_optimization() {
+async fn test_2_read_and_unpinned_2_without_local_optimization() {
     let temp_dir = tempfile::tempdir().unwrap();
-    let cache_config = ObjectStorageCacheConfig::new(
-        ONE_FILE_CACHE_SIZE,
-        temp_dir.path().to_str().unwrap().to_string(),
-        /*optimize_local_filesystem=*/ false,
+    let mut cache = create_object_storage_cache_with_one_file_size(
+        &temp_dir, /*optimize_local_filesystem=*/ false,
     );
-    let mut object_storage_cache = ObjectStorageCache::new(cache_config);
 
     let (mut table, mut table_notify) =
-        prepare_test_disk_file_for_read(&temp_dir, object_storage_cache.clone()).await;
+        prepare_test_disk_file_for_read(&temp_dir, cache.clone()).await;
     let (_, _, _, files_to_delete) =
         create_mooncake_snapshot_for_test(&mut table, &mut table_notify).await;
     assert!(files_to_delete.is_empty());
@@ -1365,7 +1293,7 @@ async fn test_2_read_and_unpinned_2_without_local_filesystem_optimization() {
     assert!(files_to_delete.is_empty());
 
     // Import second data file into cache, so the cached entry will be evicted.
-    import_fake_cache_entry(&temp_dir, &mut object_storage_cache).await;
+    import_fake_cache_entry(&temp_dir, &mut cache).await;
 
     // Read, but no reference count hold within read state.
     let snapshot_read_output_1 = perform_read_request_for_test(&mut table).await;
@@ -1387,8 +1315,8 @@ async fn test_2_read_and_unpinned_2_without_local_filesystem_optimization() {
     assert_eq!(index_block_file_ids.len(), 1);
 
     // Check cache state.
-    check_file_not_pinned(&object_storage_cache, file.file_id()).await;
-    check_file_pinned(&object_storage_cache, FAKE_FILE_ID.file_id).await;
+    check_file_not_pinned(&cache, file.file_id()).await;
+    check_file_pinned(&cache, FAKE_FILE_ID.file_id).await;
 
     // Drop all read states and check reference count; cache only manages fake file here.
     let files_to_delete = drop_read_states_and_create_mooncake_snapshot(
@@ -1398,24 +1326,21 @@ async fn test_2_read_and_unpinned_2_without_local_filesystem_optimization() {
     )
     .await;
     assert!(files_to_delete.is_empty());
-    check_file_not_pinned(&object_storage_cache, file.file_id()).await;
-    check_file_pinned(&object_storage_cache, FAKE_FILE_ID.file_id).await;
+    check_file_not_pinned(&cache, file.file_id()).await;
+    check_file_pinned(&cache, FAKE_FILE_ID.file_id).await;
 }
 
-/// State transfer is the same as [`test_2_read_and_unpinned_2_with_local_filesystem_optimization`].
+/// State transfer is the same as [`test_2_read_and_unpinned_2_with_local_optimization`].
 /// Test scenario: remote, no local, in use + use & unpinned => remote, no local, in use
 #[tokio::test]
-async fn test_2_read_and_unpinned_2_with_local_filesystem_optimization() {
+async fn test_2_read_and_unpinned_2_with_local_optimization() {
     let temp_dir = tempfile::tempdir().unwrap();
-    let cache_config = ObjectStorageCacheConfig::new(
-        ONE_FILE_CACHE_SIZE,
-        temp_dir.path().to_str().unwrap().to_string(),
-        /*optimize_local_filesystem=*/ true,
+    let mut cache = create_object_storage_cache_with_one_file_size(
+        &temp_dir, /*optimize_local_filesystem=*/ true,
     );
-    let mut object_storage_cache = ObjectStorageCache::new(cache_config);
 
     let (mut table, mut table_notify) =
-        prepare_test_disk_file_for_read(&temp_dir, object_storage_cache.clone()).await;
+        prepare_test_disk_file_for_read(&temp_dir, cache.clone()).await;
     let (_, _, _, files_to_delete) =
         create_mooncake_snapshot_for_test(&mut table, &mut table_notify).await;
     assert!(files_to_delete.is_empty());
@@ -1429,7 +1354,7 @@ async fn test_2_read_and_unpinned_2_with_local_filesystem_optimization() {
     assert_eq!(files_to_delete, vec![local_data_file]);
 
     // Import second data file into cache, so the cached entry will be evicted.
-    import_fake_cache_entry(&temp_dir, &mut object_storage_cache).await;
+    import_fake_cache_entry(&temp_dir, &mut cache).await;
 
     // Read, but no reference count hold within read state.
     let snapshot_read_output_1 = perform_read_request_for_test(&mut table).await;
@@ -1451,8 +1376,8 @@ async fn test_2_read_and_unpinned_2_with_local_filesystem_optimization() {
     assert_eq!(index_block_file_ids.len(), 1);
 
     // Check cache state.
-    check_file_not_pinned(&object_storage_cache, file.file_id()).await;
-    check_file_pinned(&object_storage_cache, FAKE_FILE_ID.file_id).await;
+    check_file_not_pinned(&cache, file.file_id()).await;
+    check_file_pinned(&cache, FAKE_FILE_ID.file_id).await;
 
     // Drop all read states and check reference count; cache only manages fake file here.
     let files_to_delete = drop_read_states_and_create_mooncake_snapshot(
@@ -1462,23 +1387,20 @@ async fn test_2_read_and_unpinned_2_with_local_filesystem_optimization() {
     )
     .await;
     assert!(files_to_delete.is_empty());
-    check_file_not_pinned(&object_storage_cache, file.file_id()).await;
-    check_file_pinned(&object_storage_cache, FAKE_FILE_ID.file_id).await;
+    check_file_not_pinned(&cache, file.file_id()).await;
+    check_file_pinned(&cache, FAKE_FILE_ID.file_id).await;
 }
 
 /// Test scenario: remote, no local, in use + use over => remote, no local, not used
 #[tokio::test]
-async fn test_2_read_over_1_without_local_filesystem_optimization() {
+async fn test_2_read_over_1_without_local_optimization() {
     let temp_dir = tempfile::tempdir().unwrap();
-    let cache_config = ObjectStorageCacheConfig::new(
-        ONE_FILE_CACHE_SIZE,
-        temp_dir.path().to_str().unwrap().to_string(),
-        /*optimize_local_filesystem=*/ false,
+    let mut cache = create_object_storage_cache_with_one_file_size(
+        &temp_dir, /*optimize_local_filesystem=*/ false,
     );
-    let mut object_storage_cache = ObjectStorageCache::new(cache_config);
 
     let (mut table, mut table_notify) =
-        prepare_test_disk_file_for_read(&temp_dir, object_storage_cache.clone()).await;
+        prepare_test_disk_file_for_read(&temp_dir, cache.clone()).await;
     let (_, _, _, files_to_delete) =
         create_mooncake_snapshot_for_test(&mut table, &mut table_notify).await;
     assert!(files_to_delete.is_empty());
@@ -1490,7 +1412,7 @@ async fn test_2_read_over_1_without_local_filesystem_optimization() {
     assert!(files_to_delete.is_empty());
 
     // Import second data file into cache, so the cached entry will be evicted.
-    import_fake_cache_entry(&temp_dir, &mut object_storage_cache).await;
+    import_fake_cache_entry(&temp_dir, &mut cache).await;
 
     // Read and increment reference count.
     let snapshot_read_output = perform_read_request_for_test(&mut table).await;
@@ -1507,24 +1429,21 @@ async fn test_2_read_over_1_without_local_filesystem_optimization() {
     assert!(is_remote_file(file, &temp_dir));
 
     // Check cache state.
-    check_file_not_pinned(&object_storage_cache, file.file_id()).await;
-    check_file_pinned(&object_storage_cache, FAKE_FILE_ID.file_id).await;
+    check_file_not_pinned(&cache, file.file_id()).await;
+    check_file_pinned(&cache, FAKE_FILE_ID.file_id).await;
 }
 
-/// State transfer is the same as [`test_2_read_over_1_without_local_filesystem_optimization`].
+/// State transfer is the same as [`test_2_read_over_1_without_local_optimization`].
 /// Test scenario: remote, no local, in use + use over => remote, no local, not used
 #[tokio::test]
-async fn test_2_read_over_1_with_local_filesystem_optimization() {
+async fn test_2_read_over_1_with_local_optimization() {
     let temp_dir = tempfile::tempdir().unwrap();
-    let cache_config = ObjectStorageCacheConfig::new(
-        ONE_FILE_CACHE_SIZE,
-        temp_dir.path().to_str().unwrap().to_string(),
-        /*optimize_local_filesystem=*/ true,
+    let mut cache = create_object_storage_cache_with_one_file_size(
+        &temp_dir, /*optimize_local_filesystem=*/ true,
     );
-    let mut object_storage_cache = ObjectStorageCache::new(cache_config);
 
     let (mut table, mut table_notify) =
-        prepare_test_disk_file_for_read(&temp_dir, object_storage_cache.clone()).await;
+        prepare_test_disk_file_for_read(&temp_dir, cache.clone()).await;
     let (_, _, _, files_to_delete) =
         create_mooncake_snapshot_for_test(&mut table, &mut table_notify).await;
     assert!(files_to_delete.is_empty());
@@ -1538,7 +1457,7 @@ async fn test_2_read_over_1_with_local_filesystem_optimization() {
     assert_eq!(files_to_delete, vec![local_data_file]);
 
     // Import second data file into cache, so the cached entry will be evicted.
-    import_fake_cache_entry(&temp_dir, &mut object_storage_cache).await;
+    import_fake_cache_entry(&temp_dir, &mut cache).await;
 
     // Read and increment reference count.
     let snapshot_read_output = perform_read_request_for_test(&mut table).await;
@@ -1555,8 +1474,8 @@ async fn test_2_read_over_1_with_local_filesystem_optimization() {
     assert!(is_remote_file(file, &temp_dir));
 
     // Check cache state.
-    check_file_not_pinned(&object_storage_cache, file.file_id()).await;
-    check_file_pinned(&object_storage_cache, FAKE_FILE_ID.file_id).await;
+    check_file_not_pinned(&cache, file.file_id()).await;
+    check_file_pinned(&cache, FAKE_FILE_ID.file_id).await;
 }
 
 /// There're two things different from use for read:
@@ -1578,10 +1497,10 @@ async fn test_2_read_over_1_with_local_filesystem_optimization() {
 /// Rows are committed and flushed with LSN 1 and 2 respectively.
 async fn prepare_test_disk_files_for_compaction(
     temp_dir: &TempDir,
-    object_storage_cache: ObjectStorageCache,
+    cache: ObjectStorageCache,
 ) -> (MooncakeTable, Receiver<TableNotify>) {
     let (mut table, table_notify) =
-        create_mooncake_table_and_notify_for_compaction(temp_dir, object_storage_cache).await;
+        create_mooncake_table_and_notify_for_compaction(temp_dir, cache).await;
 
     // Append, commit and flush the first row.
     let row = MoonlinkRow::new(vec![
@@ -1617,15 +1536,11 @@ async fn prepare_test_disk_files_for_compaction(
 #[case(false)]
 async fn test_3_compact_3_5(#[case] optimize_local_filesystem: bool) {
     let temp_dir = tempfile::tempdir().unwrap();
-    let cache_config = ObjectStorageCacheConfig::new(
-        INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE,
-        temp_dir.path().to_str().unwrap().to_string(),
-        optimize_local_filesystem,
-    );
-    let mut object_storage_cache = ObjectStorageCache::new(cache_config);
+    let mut cache =
+        create_object_storage_cache_with_one_file_size(&temp_dir, optimize_local_filesystem);
 
     let (mut table, mut table_notify) =
-        prepare_test_disk_files_for_compaction(&temp_dir, object_storage_cache.clone()).await;
+        prepare_test_disk_files_for_compaction(&temp_dir, cache.clone()).await;
     let (_, _, _, files_to_delete) =
         create_mooncake_snapshot_for_test(&mut table, &mut table_notify).await;
     assert!(files_to_delete.is_empty());
@@ -1671,12 +1586,12 @@ async fn test_3_compact_3_5(#[case] optimize_local_filesystem: bool) {
     assert_eq!(new_compacted_index_block_file_ids.len(), 1);
 
     // Check cache state.
-    assert_pending_eviction_entries_size(&mut object_storage_cache, /*expected_count=*/ 2).await; // data files
-    assert_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
+    assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 2).await; // data files
+    assert_evictable_cache_size(&mut cache, /*expected_count=*/ 0).await;
     // Two old compacted data files, one new compacted data file, and one new compacted index block
-    assert_non_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 4).await;
+    assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 4).await;
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&get_unique_table_file_id(
                 new_compacted_file.file_id()
             ))
@@ -1685,7 +1600,7 @@ async fn test_3_compact_3_5(#[case] optimize_local_filesystem: bool) {
     );
     for cur_old_compacted_data_file in old_compacted_data_files.iter() {
         assert_eq!(
-            object_storage_cache
+            cache
                 .get_non_evictable_entry_ref_count(&get_unique_table_file_id(
                     cur_old_compacted_data_file.file_id()
                 ))
@@ -1711,14 +1626,14 @@ async fn test_3_compact_3_5(#[case] optimize_local_filesystem: bool) {
 
     // Check cache status.
     assert_eq!(
-        object_storage_cache.cache.read().await.cur_bytes,
+        cache.cache.read().await.cur_bytes,
         (new_compacted_data_file_size as u64) + new_compacted_index_block_size,
     );
-    assert_pending_eviction_entries_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_non_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 2).await; // compacted data file and compacted index block
+    assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_evictable_cache_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 2).await; // compacted data file and compacted index block
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&get_unique_table_file_id(
                 new_compacted_file.file_id()
             ))
@@ -1726,7 +1641,7 @@ async fn test_3_compact_3_5(#[case] optimize_local_filesystem: bool) {
         1
     );
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&get_unique_table_file_id(
                 new_compacted_index_block_file_ids[0]
             ))
@@ -1742,15 +1657,11 @@ async fn test_3_compact_3_5(#[case] optimize_local_filesystem: bool) {
 #[case(false)]
 async fn test_3_compact_1_5(#[case] optimize_local_filesystem: bool) {
     let temp_dir = tempfile::tempdir().unwrap();
-    let cache_config = ObjectStorageCacheConfig::new(
-        INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE,
-        temp_dir.path().to_str().unwrap().to_string(),
-        optimize_local_filesystem,
-    );
-    let mut object_storage_cache = ObjectStorageCache::new(cache_config);
+    let mut cache =
+        create_object_storage_cache_with_one_file_size(&temp_dir, optimize_local_filesystem);
 
     let (mut table, mut table_notify) =
-        prepare_test_disk_files_for_compaction(&temp_dir, object_storage_cache.clone()).await;
+        prepare_test_disk_files_for_compaction(&temp_dir, cache.clone()).await;
     let (_, _, _, files_to_delete) =
         create_mooncake_snapshot_for_test(&mut table, &mut table_notify).await;
     assert!(files_to_delete.is_empty());
@@ -1813,14 +1724,14 @@ async fn test_3_compact_1_5(#[case] optimize_local_filesystem: bool) {
 
     // Check cache state.
     assert_eq!(
-        object_storage_cache.cache.read().await.cur_bytes,
+        cache.cache.read().await.cur_bytes,
         (new_compacted_data_file_size as u64) + new_compacted_file_index_size,
     );
-    assert_pending_eviction_entries_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_non_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 2).await; // data file and index block file
+    assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_evictable_cache_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 2).await; // data file and index block file
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&get_unique_table_file_id(
                 new_compacted_file.file_id()
             ))
@@ -1828,7 +1739,7 @@ async fn test_3_compact_1_5(#[case] optimize_local_filesystem: bool) {
         1,
     );
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&get_unique_table_file_id(
                 new_compacted_index_block_file_ids[0]
             ))
@@ -1839,17 +1750,14 @@ async fn test_3_compact_1_5(#[case] optimize_local_filesystem: bool) {
 
 /// Test scenario: remote, no local, not used + use & pinned + use over & unpinned => (old) remote, no local, not used, (new) no remote, local, no use
 #[tokio::test]
-async fn test_1_compact_1_5_without_local_filesystem_optimization() {
+async fn test_1_compact_1_5_without_local_optimization() {
     let temp_dir = tempfile::tempdir().unwrap();
-    let cache_config = ObjectStorageCacheConfig::new(
-        ONE_FILE_CACHE_SIZE,
-        temp_dir.path().to_str().unwrap().to_string(),
-        /*optimize_local_filesystem=*/ false,
+    let mut cache = create_object_storage_cache_with_one_file_size(
+        &temp_dir, /*optimize_local_filesystem=*/ false,
     );
-    let mut object_storage_cache = ObjectStorageCache::new(cache_config);
 
     let (mut table, mut table_notify) =
-        prepare_test_disk_files_for_compaction(&temp_dir, object_storage_cache.clone()).await;
+        prepare_test_disk_files_for_compaction(&temp_dir, cache.clone()).await;
     let (_, _, _, files_to_delete) =
         create_mooncake_snapshot_for_test(&mut table, &mut table_notify).await;
     assert!(files_to_delete.is_empty());
@@ -1866,7 +1774,7 @@ async fn test_1_compact_1_5_without_local_filesystem_optimization() {
     assert!(data_compaction_payload.is_some());
 
     // Import second data file into cache, so the cached entry will be evicted.
-    let mut fake_cache_handle = import_fake_cache_entry(&temp_dir, &mut object_storage_cache).await;
+    let mut fake_cache_handle = import_fake_cache_entry(&temp_dir, &mut cache).await;
     let evicted_files_to_delete = fake_cache_handle.unreference().await;
     assert!(evicted_files_to_delete.is_empty());
 
@@ -1895,14 +1803,14 @@ async fn test_1_compact_1_5_without_local_filesystem_optimization() {
 
     // Check cache state.
     assert_eq!(
-        object_storage_cache.cache.read().await.cur_bytes,
+        cache.cache.read().await.cur_bytes,
         (new_compacted_data_file_size as u64) + new_compacted_index_block_size,
     );
-    assert_pending_eviction_entries_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_non_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 2).await; // data file and index block file
+    assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_evictable_cache_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 2).await; // data file and index block file
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&get_unique_table_file_id(
                 new_compacted_file.file_id()
             ))
@@ -1910,7 +1818,7 @@ async fn test_1_compact_1_5_without_local_filesystem_optimization() {
         1,
     );
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&get_unique_table_file_id(
                 new_compacted_index_block_file_ids[0]
             ))
@@ -1919,20 +1827,17 @@ async fn test_1_compact_1_5_without_local_filesystem_optimization() {
     );
 }
 
-/// State transfer is the same as [`test_1_compact_1_5_without_local_filesystem_optimization`].
+/// State transfer is the same as [`test_1_compact_1_5_without_local_optimization`].
 /// Test scenario: remote, no local, not used + use & pinned + use over & unpinned => (old) remote, no local, not used, (new) no remote, local, no use
 #[tokio::test]
-async fn test_1_compact_1_5_with_local_filesystem_optimization() {
+async fn test_1_compact_1_5_with_local_optimization() {
     let temp_dir = tempfile::tempdir().unwrap();
-    let cache_config = ObjectStorageCacheConfig::new(
-        ONE_FILE_CACHE_SIZE,
-        temp_dir.path().to_str().unwrap().to_string(),
-        /*optimize_local_filesystem=*/ true,
+    let mut cache = create_object_storage_cache_with_one_file_size(
+        &temp_dir, /*optimize_local_filesystem=*/ true,
     );
-    let mut object_storage_cache = ObjectStorageCache::new(cache_config);
 
     let (mut table, mut table_notify) =
-        prepare_test_disk_files_for_compaction(&temp_dir, object_storage_cache.clone()).await;
+        prepare_test_disk_files_for_compaction(&temp_dir, cache.clone()).await;
     let (_, _, _, files_to_delete) =
         create_mooncake_snapshot_for_test(&mut table, &mut table_notify).await;
     assert!(files_to_delete.is_empty());
@@ -1950,7 +1855,7 @@ async fn test_1_compact_1_5_with_local_filesystem_optimization() {
     assert!(data_compaction_payload.is_some());
 
     // Import second data file into cache, so the cached entry will be evicted.
-    let mut fake_cache_handle = import_fake_cache_entry(&temp_dir, &mut object_storage_cache).await;
+    let mut fake_cache_handle = import_fake_cache_entry(&temp_dir, &mut cache).await;
     let evicted_files_to_delete = fake_cache_handle.unreference().await;
     assert!(evicted_files_to_delete.is_empty());
 
@@ -1979,14 +1884,14 @@ async fn test_1_compact_1_5_with_local_filesystem_optimization() {
 
     // Check cache state.
     assert_eq!(
-        object_storage_cache.cache.read().await.cur_bytes,
+        cache.cache.read().await.cur_bytes,
         (new_compacted_data_file_size as u64) + new_compacted_index_block_size,
     );
-    assert_pending_eviction_entries_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_non_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 2).await; // data file and index block file
+    assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_evictable_cache_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 2).await; // data file and index block file
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&get_unique_table_file_id(
                 new_compacted_file.file_id()
             ))
@@ -1994,7 +1899,7 @@ async fn test_1_compact_1_5_with_local_filesystem_optimization() {
         1,
     );
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&get_unique_table_file_id(
                 new_compacted_index_block_file_ids[0]
             ))

--- a/src/moonlink/src/storage/mooncake_table/deletion_vector_puffin_state_tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/deletion_vector_puffin_state_tests.rs
@@ -53,10 +53,10 @@ use crate::{
 /// Rows are committed and flushed with LSN 1, and deleted with LSN 3.
 async fn prepare_test_deletion_vector_for_read(
     temp_dir: &TempDir,
-    object_storage_cache: ObjectStorageCache,
+    cache: ObjectStorageCache,
 ) -> (MooncakeTable, Receiver<TableNotify>) {
     let (mut table, table_notify) =
-        create_mooncake_table_and_notify_for_read(temp_dir, object_storage_cache).await;
+        create_mooncake_table_and_notify_for_read(temp_dir, cache).await;
 
     // Append a new row.
     let row = MoonlinkRow::new(vec![
@@ -82,17 +82,13 @@ async fn prepare_test_deletion_vector_for_read(
 ///
 /// Test scenario: no deletion vector + persist => referenced, not requested to delete
 #[tokio::test]
-async fn test_1_persist_2_without_local_filesystem_optimization() {
+async fn test_1_persist_2_without_local_optimization() {
     let temp_dir = tempfile::tempdir().unwrap();
-    let cache_config = ObjectStorageCacheConfig::new(
-        INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE,
-        temp_dir.path().to_str().unwrap().to_string(),
-        /*optimize_local_filesystem=*/ false,
-    );
-    let mut object_storage_cache = ObjectStorageCache::new(cache_config);
+    let mut cache =
+        create_infinite_object_storage_cache(&temp_dir, /*optimize_local_filesystem=*/ false);
 
     let (mut table, mut table_notify) =
-        prepare_test_deletion_vector_for_read(&temp_dir, object_storage_cache.clone()).await;
+        prepare_test_deletion_vector_for_read(&temp_dir, cache.clone()).await;
     create_mooncake_and_iceberg_snapshot_for_test(&mut table, &mut table_notify).await;
     let (_, _, _, files_to_delete) =
         create_mooncake_snapshot_for_test(&mut table, &mut table_notify).await;
@@ -105,31 +101,27 @@ async fn test_1_persist_2_without_local_filesystem_optimization() {
     let puffin_blob_ref = disk_file_entry.puffin_deletion_blob.as_ref().unwrap();
 
     // Check cache state.
-    assert_pending_eviction_entries_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 1).await; // Data file.
-    assert_non_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 2).await; // Puffin file and index block.
+    assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_evictable_cache_size(&mut cache, /*expected_count=*/ 1).await; // Data file.
+    assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 2).await; // Puffin file and index block.
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&puffin_blob_ref.puffin_file_cache_handle.file_id)
             .await,
         1
     );
 }
 
-/// State transfer is the same as [`test_1_persist_2_without_local_filesystem_optimization`].
+/// State transfer is the same as [`test_1_persist_2_without_local_optimization`].
 /// Test scenario: no deletion vector + persist => referenced, not requested to delete
 #[tokio::test]
-async fn test_1_persist_2_with_local_filesystem_optimization() {
+async fn test_1_persist_2_with_local_optimization() {
     let temp_dir = tempfile::tempdir().unwrap();
-    let cache_config = ObjectStorageCacheConfig::new(
-        INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE,
-        temp_dir.path().to_str().unwrap().to_string(),
-        /*optimize_local_filesystem=*/ true,
-    );
-    let mut object_storage_cache = ObjectStorageCache::new(cache_config);
+    let mut cache =
+        create_infinite_object_storage_cache(&temp_dir, /*optimize_local_filesystem=*/ true);
 
     let (mut table, mut table_notify) =
-        prepare_test_deletion_vector_for_read(&temp_dir, object_storage_cache.clone()).await;
+        prepare_test_deletion_vector_for_read(&temp_dir, cache.clone()).await;
     create_mooncake_and_iceberg_snapshot_for_test(&mut table, &mut table_notify).await;
     let disk_files = get_disk_files_for_snapshot(&table).await;
     assert_eq!(disk_files.len(), 1);
@@ -146,11 +138,11 @@ async fn test_1_persist_2_with_local_filesystem_optimization() {
     let puffin_blob_ref = disk_file_entry.puffin_deletion_blob.as_ref().unwrap();
 
     // Check cache state.
-    assert_pending_eviction_entries_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 1).await; // Data file.
-    assert_non_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 2).await; // Puffin file and index block.
+    assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_evictable_cache_size(&mut cache, /*expected_count=*/ 1).await; // Data file.
+    assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 2).await; // Puffin file and index block.
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&puffin_blob_ref.puffin_file_cache_handle.file_id)
             .await,
         1
@@ -159,7 +151,7 @@ async fn test_1_persist_2_with_local_filesystem_optimization() {
 
 /// Test scenario: no deletion vector + recover => referenced, not requested to delete
 #[tokio::test]
-async fn test_1_recover_2_without_local_filesystem_optimization() {
+async fn test_1_recover_2_without_local_optimization() {
     let temp_dir = tempfile::tempdir().unwrap();
     let cache_config = ObjectStorageCacheConfig::new(
         INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE,
@@ -176,10 +168,10 @@ async fn test_1_recover_2_without_local_filesystem_optimization() {
     assert!(files_to_delete.is_empty());
 
     // Now the disk file and deletion vector has been persist into iceberg.
-    let mut object_storage_cache_for_recovery = ObjectStorageCache::default_for_test(&temp_dir);
+    let mut cache_for_recovery = ObjectStorageCache::default_for_test(&temp_dir);
     let mut iceberg_table_manager_to_recover = IcebergTableManager::new(
         table.metadata.clone(),
-        object_storage_cache_for_recovery.clone(),
+        cache_for_recovery.clone(),
         get_iceberg_table_config(&temp_dir),
     )
     .unwrap();
@@ -196,33 +188,21 @@ async fn test_1_recover_2_without_local_filesystem_optimization() {
     let puffin_blob_ref = disk_file_entry.puffin_deletion_blob.as_ref().unwrap();
 
     // Check cache state.
-    assert_pending_eviction_entries_size(
-        &mut object_storage_cache_for_recovery,
-        /*expected_count=*/ 0,
-    )
-    .await;
-    assert_evictable_cache_size(
-        &mut object_storage_cache_for_recovery,
-        /*expected_count=*/ 0,
-    )
-    .await;
-    assert_non_evictable_cache_size(
-        &mut object_storage_cache_for_recovery,
-        /*expected_count=*/ 2,
-    )
-    .await; // Puffin file and index block.
+    assert_pending_eviction_entries_size(&mut cache_for_recovery, /*expected_count=*/ 0).await;
+    assert_evictable_cache_size(&mut cache_for_recovery, /*expected_count=*/ 0).await;
+    assert_non_evictable_cache_size(&mut cache_for_recovery, /*expected_count=*/ 2).await; // Puffin file and index block.
     assert_eq!(
-        object_storage_cache_for_recovery
+        cache_for_recovery
             .get_non_evictable_entry_ref_count(&puffin_blob_ref.puffin_file_cache_handle.file_id)
             .await,
         1,
     );
 }
 
-/// State transfer is the same as [`test_1_recover_2_without_local_filesystem_optimization`].
+/// State transfer is the same as [`test_1_recover_2_without_local_optimization`].
 /// Test scenario: no deletion vector + recover => referenced, not requested to delete
 #[tokio::test]
-async fn test_1_recover_2_with_local_filesystem_optimization() {
+async fn test_1_recover_2_with_local_optimization() {
     let temp_dir = tempfile::tempdir().unwrap();
     let cache_config = ObjectStorageCacheConfig::new(
         INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE,
@@ -243,10 +223,10 @@ async fn test_1_recover_2_with_local_filesystem_optimization() {
     assert_eq!(files_to_delete, vec![local_data_file]);
 
     // Now the disk file and deletion vector has been persist into iceberg.
-    let mut object_storage_cache_for_recovery = ObjectStorageCache::default_for_test(&temp_dir);
+    let mut cache_for_recovery = ObjectStorageCache::default_for_test(&temp_dir);
     let mut iceberg_table_manager_to_recover = IcebergTableManager::new(
         table.metadata.clone(),
-        object_storage_cache_for_recovery.clone(),
+        cache_for_recovery.clone(),
         get_iceberg_table_config(&temp_dir),
     )
     .unwrap();
@@ -263,23 +243,11 @@ async fn test_1_recover_2_with_local_filesystem_optimization() {
     let puffin_blob_ref = disk_file_entry.puffin_deletion_blob.as_ref().unwrap();
 
     // Check cache state.
-    assert_pending_eviction_entries_size(
-        &mut object_storage_cache_for_recovery,
-        /*expected_count=*/ 0,
-    )
-    .await;
-    assert_evictable_cache_size(
-        &mut object_storage_cache_for_recovery,
-        /*expected_count=*/ 0,
-    )
-    .await;
-    assert_non_evictable_cache_size(
-        &mut object_storage_cache_for_recovery,
-        /*expected_count=*/ 2,
-    )
-    .await; // Puffin file and index block.
+    assert_pending_eviction_entries_size(&mut cache_for_recovery, /*expected_count=*/ 0).await;
+    assert_evictable_cache_size(&mut cache_for_recovery, /*expected_count=*/ 0).await;
+    assert_non_evictable_cache_size(&mut cache_for_recovery, /*expected_count=*/ 2).await; // Puffin file and index block.
     assert_eq!(
-        object_storage_cache_for_recovery
+        cache_for_recovery
             .get_non_evictable_entry_ref_count(&puffin_blob_ref.puffin_file_cache_handle.file_id)
             .await,
         1,
@@ -289,17 +257,13 @@ async fn test_1_recover_2_with_local_filesystem_optimization() {
 /// Test scenario: referenced, no delete + use => referenced, no delete
 /// Test scenario: referenced, no delete + use over => referenced, no delete
 #[tokio::test]
-async fn test_2_read_without_local_filesystem_optimization() {
+async fn test_2_read_without_local_optimization() {
     let temp_dir = tempfile::tempdir().unwrap();
-    let cache_config = ObjectStorageCacheConfig::new(
-        INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE,
-        temp_dir.path().to_str().unwrap().to_string(),
-        /*optimize_local_filesystem=*/ false,
-    );
-    let mut object_storage_cache = ObjectStorageCache::new(cache_config);
+    let mut cache =
+        create_infinite_object_storage_cache(&temp_dir, /*optimize_local_filesystem=*/ false);
 
     let (mut table, mut table_notify) =
-        prepare_test_deletion_vector_for_read(&temp_dir, object_storage_cache.clone()).await;
+        prepare_test_deletion_vector_for_read(&temp_dir, cache.clone()).await;
     create_mooncake_and_iceberg_snapshot_for_test(&mut table, &mut table_notify).await;
     let (_, _, _, files_to_delete) =
         create_mooncake_snapshot_for_test(&mut table, &mut table_notify).await;
@@ -316,11 +280,11 @@ async fn test_2_read_without_local_filesystem_optimization() {
     let puffin_blob_ref = disk_file_entry.puffin_deletion_blob.as_ref().unwrap();
 
     // Check cache state.
-    assert_pending_eviction_entries_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_non_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 3).await; // Puffin file, data file, and index block.
+    assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_evictable_cache_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 3).await; // Puffin file, data file, and index block.
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&puffin_blob_ref.puffin_file_cache_handle.file_id)
             .await,
         2,
@@ -334,32 +298,28 @@ async fn test_2_read_without_local_filesystem_optimization() {
     )
     .await;
     assert!(files_to_delete.is_empty());
-    assert_pending_eviction_entries_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 1).await; // data file
-    assert_non_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 2).await; // puffin file and index block.
+    assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_evictable_cache_size(&mut cache, /*expected_count=*/ 1).await; // data file
+    assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 2).await; // puffin file and index block.
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&puffin_blob_ref.puffin_file_cache_handle.file_id)
             .await,
         1
     );
 }
 
-/// State transfer is the same as [`test_2_read_without_local_filesystem_optimization`].
+/// State transfer is the same as [`test_2_read_without_local_optimization`].
 /// Test scenario: referenced, no delete + use => referenced, no delete
 /// Test scenario: referenced, no delete + use over => referenced, no delete
 #[tokio::test]
-async fn test_2_read_with_local_filesystem_optimization() {
+async fn test_2_read_with_local_optimization() {
     let temp_dir = tempfile::tempdir().unwrap();
-    let cache_config = ObjectStorageCacheConfig::new(
-        INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE,
-        temp_dir.path().to_str().unwrap().to_string(),
-        /*optimize_local_filesystem=*/ true,
-    );
-    let mut object_storage_cache = ObjectStorageCache::new(cache_config);
+    let mut cache =
+        create_infinite_object_storage_cache(&temp_dir, /*optimize_local_filesystem=*/ true);
 
     let (mut table, mut table_notify) =
-        prepare_test_deletion_vector_for_read(&temp_dir, object_storage_cache.clone()).await;
+        prepare_test_deletion_vector_for_read(&temp_dir, cache.clone()).await;
     create_mooncake_and_iceberg_snapshot_for_test(&mut table, &mut table_notify).await;
     let disk_files = get_disk_files_for_snapshot(&table).await;
     assert_eq!(disk_files.len(), 1);
@@ -380,11 +340,11 @@ async fn test_2_read_with_local_filesystem_optimization() {
     let puffin_blob_ref = disk_file_entry.puffin_deletion_blob.as_ref().unwrap();
 
     // Check cache state.
-    assert_pending_eviction_entries_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_non_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 3).await; // Puffin file, data file, and index block.
+    assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_evictable_cache_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 3).await; // Puffin file, data file, and index block.
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&puffin_blob_ref.puffin_file_cache_handle.file_id)
             .await,
         2,
@@ -398,11 +358,11 @@ async fn test_2_read_with_local_filesystem_optimization() {
     )
     .await;
     assert!(files_to_delete.is_empty());
-    assert_pending_eviction_entries_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 1).await; // data file
-    assert_non_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 2).await; // puffin file and index block.
+    assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_evictable_cache_size(&mut cache, /*expected_count=*/ 1).await; // data file
+    assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 2).await; // puffin file and index block.
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&puffin_blob_ref.puffin_file_cache_handle.file_id)
             .await,
         1
@@ -417,10 +377,10 @@ async fn test_2_read_with_local_filesystem_optimization() {
 /// Rows are committed and flushed with LSN 1 and 2 respectively.
 async fn prepare_test_disk_files_with_deletion_vector_for_compaction(
     temp_dir: &TempDir,
-    object_storage_cache: ObjectStorageCache,
+    cache: ObjectStorageCache,
 ) -> (MooncakeTable, Receiver<TableNotify>) {
     let (mut table, table_notify) =
-        create_mooncake_table_and_notify_for_compaction(temp_dir, object_storage_cache).await;
+        create_mooncake_table_and_notify_for_compaction(temp_dir, cache).await;
 
     // Append, commit and flush the first row.
     let row = MoonlinkRow::new(vec![
@@ -462,21 +422,13 @@ async fn prepare_test_disk_files_with_deletion_vector_for_compaction(
 /// Test scenario: referenced, no delete + delete & referenced => referenced, requested to delete
 /// Test scenario: referenced, no delete + delete & unreferenced => no entry
 #[tokio::test]
-async fn test_2_compact_without_local_filesystem_optimization() {
+async fn test_2_compact_without_local_optimization() {
     let temp_dir = tempfile::tempdir().unwrap();
-    let cache_config = ObjectStorageCacheConfig::new(
-        INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE,
-        temp_dir.path().to_str().unwrap().to_string(),
-        /*optimize_local_filesystem=*/ false,
-    );
-    let mut object_storage_cache = ObjectStorageCache::new(cache_config);
+    let mut cache =
+        create_infinite_object_storage_cache(&temp_dir, /*optimize_local_filesystem=*/ false);
 
     let (mut table, mut table_notify) =
-        prepare_test_disk_files_with_deletion_vector_for_compaction(
-            &temp_dir,
-            object_storage_cache.clone(),
-        )
-        .await;
+        prepare_test_disk_files_with_deletion_vector_for_compaction(&temp_dir, cache.clone()).await;
     create_mooncake_and_iceberg_snapshot_for_test(&mut table, &mut table_notify).await;
     let (_, _, data_compaction_payload, files_to_delete) =
         create_mooncake_snapshot_for_test(&mut table, &mut table_notify).await;
@@ -511,17 +463,17 @@ async fn test_2_compact_without_local_filesystem_optimization() {
     assert_eq!(old_compacted_index_block_files.len(), 2);
 
     // Check cache state.
-    assert_pending_eviction_entries_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 2).await; // data files
-    assert_non_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 4).await; // Puffin files and index blocks.
+    assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_evictable_cache_size(&mut cache, /*expected_count=*/ 2).await; // data files
+    assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 4).await; // Puffin files and index blocks.
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&old_compacted_puffin_file_ids[0])
             .await,
         1,
     );
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&old_compacted_puffin_file_ids[1])
             .await,
         1,
@@ -546,36 +498,28 @@ async fn test_2_compact_without_local_filesystem_optimization() {
     assert!(disk_files.is_empty());
 
     // Check cache state.
-    assert_pending_eviction_entries_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_non_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
+    assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_evictable_cache_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 0).await;
 }
 
-/// State transfer is the same as [`test_2_compact_without_local_filesystem_optimization`].
+/// State transfer is the same as [`test_2_compact_without_local_optimization`].
 /// Test scenario: referenced, no delete + delete & referenced => referenced, requested to delete
 /// Test scenario: referenced, no delete + delete & unreferenced => no entry
 #[tokio::test]
-async fn test_2_compact_with_local_filesystem_optimization() {
+async fn test_2_compact_with_local_optimization() {
     let temp_dir = tempfile::tempdir().unwrap();
-    let cache_config = ObjectStorageCacheConfig::new(
-        INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE,
-        temp_dir.path().to_str().unwrap().to_string(),
-        /*optimize_local_filesystem=*/ true,
-    );
-    let mut object_storage_cache = ObjectStorageCache::new(cache_config);
+    let mut cache =
+        create_infinite_object_storage_cache(&temp_dir, /*optimize_local_filesystem=*/ true);
 
     let (mut table, mut table_notify) =
-        prepare_test_disk_files_with_deletion_vector_for_compaction(
-            &temp_dir,
-            object_storage_cache.clone(),
-        )
-        .await;
+        prepare_test_disk_files_with_deletion_vector_for_compaction(&temp_dir, cache.clone()).await;
     create_mooncake_and_iceberg_snapshot_for_test(&mut table, &mut table_notify).await;
     let disk_files = get_disk_files_for_snapshot(&table).await;
     assert_eq!(disk_files.len(), 2);
     let mut local_data_files = disk_files
-        .iter()
-        .map(|(f, _)| f.file_path().to_string())
+        .keys()
+        .map(|f| f.file_path().to_string())
         .collect::<Vec<_>>();
     local_data_files.sort();
 
@@ -613,17 +557,17 @@ async fn test_2_compact_with_local_filesystem_optimization() {
     assert_eq!(old_compacted_index_block_files.len(), 2);
 
     // Check cache state.
-    assert_pending_eviction_entries_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 2).await; // data files
-    assert_non_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 4).await; // Puffin files and index blocks.
+    assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_evictable_cache_size(&mut cache, /*expected_count=*/ 2).await; // data files
+    assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 4).await; // Puffin files and index blocks.
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&old_compacted_puffin_file_ids[0])
             .await,
         1,
     );
     assert_eq!(
-        object_storage_cache
+        cache
             .get_non_evictable_entry_ref_count(&old_compacted_puffin_file_ids[1])
             .await,
         1,
@@ -650,7 +594,7 @@ async fn test_2_compact_with_local_filesystem_optimization() {
     assert!(disk_files.is_empty());
 
     // Check cache state.
-    assert_pending_eviction_entries_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
-    assert_non_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
+    assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_evictable_cache_size(&mut cache, /*expected_count=*/ 0).await;
+    assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 0).await;
 }

--- a/src/moonlink/src/storage/mooncake_table/deletion_vector_puffin_state_tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/deletion_vector_puffin_state_tests.rs
@@ -1,4 +1,3 @@
-use rstest::rstest;
 use tempfile::TempDir;
 use tokio::sync::mpsc::Receiver;
 
@@ -83,15 +82,12 @@ async fn prepare_test_deletion_vector_for_read(
 ///
 /// Test scenario: no deletion vector + persist => referenced, not requested to delete
 #[tokio::test]
-#[rstest]
-#[case(true)]
-#[case(false)]
-async fn test_1_persist_2(#[case] optimize_local_filesystem: bool) {
+async fn test_1_persist_2_without_local_filesystem_optimization() {
     let temp_dir = tempfile::tempdir().unwrap();
     let cache_config = ObjectStorageCacheConfig::new(
         INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE,
         temp_dir.path().to_str().unwrap().to_string(),
-        optimize_local_filesystem,
+        /*optimize_local_filesystem=*/ false,
     );
     let mut object_storage_cache = ObjectStorageCache::new(cache_config);
 
@@ -120,17 +116,55 @@ async fn test_1_persist_2(#[case] optimize_local_filesystem: bool) {
     );
 }
 
-/// Test scenario: no deletion vector + recover => referenced, not requested to delete
+/// State transfer is the same as [`test_1_persist_2_without_local_filesystem_optimization`].
+/// Test scenario: no deletion vector + persist => referenced, not requested to delete
 #[tokio::test]
-#[rstest]
-#[case(true)]
-#[case(false)]
-async fn test_1_recover_2(#[case] optimize_local_filesystem: bool) {
+async fn test_1_persist_2_with_local_filesystem_optimization() {
     let temp_dir = tempfile::tempdir().unwrap();
     let cache_config = ObjectStorageCacheConfig::new(
         INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE,
         temp_dir.path().to_str().unwrap().to_string(),
-        optimize_local_filesystem,
+        /*optimize_local_filesystem=*/ true,
+    );
+    let mut object_storage_cache = ObjectStorageCache::new(cache_config);
+
+    let (mut table, mut table_notify) =
+        prepare_test_deletion_vector_for_read(&temp_dir, object_storage_cache.clone()).await;
+    create_mooncake_and_iceberg_snapshot_for_test(&mut table, &mut table_notify).await;
+    let disk_files = get_disk_files_for_snapshot(&table).await;
+    assert_eq!(disk_files.len(), 1);
+    let local_data_file = disk_files.iter().next().unwrap().0.file_path().to_string();
+
+    let (_, _, _, files_to_delete) =
+        create_mooncake_snapshot_for_test(&mut table, &mut table_notify).await;
+    assert_eq!(files_to_delete, vec![local_data_file]);
+
+    // Check data file has been pinned in mooncake table.
+    let disk_files = get_disk_files_for_snapshot(&table).await;
+    assert_eq!(disk_files.len(), 1);
+    let (_, disk_file_entry) = disk_files.iter().next().unwrap();
+    let puffin_blob_ref = disk_file_entry.puffin_deletion_blob.as_ref().unwrap();
+
+    // Check cache state.
+    assert_pending_eviction_entries_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
+    assert_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 1).await; // Data file.
+    assert_non_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 2).await; // Puffin file and index block.
+    assert_eq!(
+        object_storage_cache
+            .get_non_evictable_entry_ref_count(&puffin_blob_ref.puffin_file_cache_handle.file_id)
+            .await,
+        1
+    );
+}
+
+/// Test scenario: no deletion vector + recover => referenced, not requested to delete
+#[tokio::test]
+async fn test_1_recover_2_without_local_filesystem_optimization() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let cache_config = ObjectStorageCacheConfig::new(
+        INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE,
+        temp_dir.path().to_str().unwrap().to_string(),
+        /*optimize_local_filesystem=*/ false,
     );
 
     let (mut table, mut table_notify) =
@@ -185,18 +219,82 @@ async fn test_1_recover_2(#[case] optimize_local_filesystem: bool) {
     );
 }
 
-/// Test scenario: referenced, no delete + use => referenced, no delete
-/// Test scenario: referenced, no delete + use over => referenced, no delete
+/// State transfer is the same as [`test_1_recover_2_without_local_filesystem_optimization`].
+/// Test scenario: no deletion vector + recover => referenced, not requested to delete
 #[tokio::test]
-#[rstest]
-#[case(true)]
-#[case(false)]
-async fn test_2_read(#[case] optimize_local_filesystem: bool) {
+async fn test_1_recover_2_with_local_filesystem_optimization() {
     let temp_dir = tempfile::tempdir().unwrap();
     let cache_config = ObjectStorageCacheConfig::new(
         INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE,
         temp_dir.path().to_str().unwrap().to_string(),
-        optimize_local_filesystem,
+        /*optimize_local_filesystem=*/ true,
+    );
+
+    let (mut table, mut table_notify) =
+        prepare_test_deletion_vector_for_read(&temp_dir, ObjectStorageCache::new(cache_config))
+            .await;
+    create_mooncake_and_iceberg_snapshot_for_test(&mut table, &mut table_notify).await;
+    let disk_files = get_disk_files_for_snapshot(&table).await;
+    assert_eq!(disk_files.len(), 1);
+    let local_data_file = disk_files.iter().next().unwrap().0.file_path().to_string();
+
+    let (_, _, _, files_to_delete) =
+        create_mooncake_snapshot_for_test(&mut table, &mut table_notify).await;
+    assert_eq!(files_to_delete, vec![local_data_file]);
+
+    // Now the disk file and deletion vector has been persist into iceberg.
+    let mut object_storage_cache_for_recovery = ObjectStorageCache::default_for_test(&temp_dir);
+    let mut iceberg_table_manager_to_recover = IcebergTableManager::new(
+        table.metadata.clone(),
+        object_storage_cache_for_recovery.clone(),
+        get_iceberg_table_config(&temp_dir),
+    )
+    .unwrap();
+    let (next_file_id, mooncake_snapshot) = iceberg_table_manager_to_recover
+        .load_snapshot_from_table()
+        .await
+        .unwrap();
+    assert_eq!(next_file_id, 3); // one data file, one index block file, one deletion vector puffin
+
+    // Check data file has been pinned in mooncake table.
+    let disk_files = mooncake_snapshot.disk_files.clone();
+    assert_eq!(disk_files.len(), 1);
+    let (_, disk_file_entry) = disk_files.iter().next().unwrap();
+    let puffin_blob_ref = disk_file_entry.puffin_deletion_blob.as_ref().unwrap();
+
+    // Check cache state.
+    assert_pending_eviction_entries_size(
+        &mut object_storage_cache_for_recovery,
+        /*expected_count=*/ 0,
+    )
+    .await;
+    assert_evictable_cache_size(
+        &mut object_storage_cache_for_recovery,
+        /*expected_count=*/ 0,
+    )
+    .await;
+    assert_non_evictable_cache_size(
+        &mut object_storage_cache_for_recovery,
+        /*expected_count=*/ 2,
+    )
+    .await; // Puffin file and index block.
+    assert_eq!(
+        object_storage_cache_for_recovery
+            .get_non_evictable_entry_ref_count(&puffin_blob_ref.puffin_file_cache_handle.file_id)
+            .await,
+        1,
+    );
+}
+
+/// Test scenario: referenced, no delete + use => referenced, no delete
+/// Test scenario: referenced, no delete + use over => referenced, no delete
+#[tokio::test]
+async fn test_2_read_without_local_filesystem_optimization() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let cache_config = ObjectStorageCacheConfig::new(
+        INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE,
+        temp_dir.path().to_str().unwrap().to_string(),
+        /*optimize_local_filesystem=*/ false,
     );
     let mut object_storage_cache = ObjectStorageCache::new(cache_config);
 
@@ -206,6 +304,70 @@ async fn test_2_read(#[case] optimize_local_filesystem: bool) {
     let (_, _, _, files_to_delete) =
         create_mooncake_snapshot_for_test(&mut table, &mut table_notify).await;
     assert!(files_to_delete.is_empty());
+
+    // Use by read.
+    let snapshot_read_output = perform_read_request_for_test(&mut table).await;
+    let read_state = snapshot_read_output.take_as_read_state().await;
+
+    // Check data file has been pinned in mooncake table.
+    let disk_files = get_disk_files_for_snapshot(&table).await;
+    assert_eq!(disk_files.len(), 1);
+    let (_, disk_file_entry) = disk_files.iter().next().unwrap();
+    let puffin_blob_ref = disk_file_entry.puffin_deletion_blob.as_ref().unwrap();
+
+    // Check cache state.
+    assert_pending_eviction_entries_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
+    assert_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
+    assert_non_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 3).await; // Puffin file, data file, and index block.
+    assert_eq!(
+        object_storage_cache
+            .get_non_evictable_entry_ref_count(&puffin_blob_ref.puffin_file_cache_handle.file_id)
+            .await,
+        2,
+    );
+
+    // Drop all read states and check reference count.
+    let files_to_delete = drop_read_states_and_create_mooncake_snapshot(
+        vec![read_state],
+        &mut table,
+        &mut table_notify,
+    )
+    .await;
+    assert!(files_to_delete.is_empty());
+    assert_pending_eviction_entries_size(&mut object_storage_cache, /*expected_count=*/ 0).await;
+    assert_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 1).await; // data file
+    assert_non_evictable_cache_size(&mut object_storage_cache, /*expected_count=*/ 2).await; // puffin file and index block.
+    assert_eq!(
+        object_storage_cache
+            .get_non_evictable_entry_ref_count(&puffin_blob_ref.puffin_file_cache_handle.file_id)
+            .await,
+        1
+    );
+}
+
+/// State transfer is the same as [`test_2_read_without_local_filesystem_optimization`].
+/// Test scenario: referenced, no delete + use => referenced, no delete
+/// Test scenario: referenced, no delete + use over => referenced, no delete
+#[tokio::test]
+async fn test_2_read_with_local_filesystem_optimization() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let cache_config = ObjectStorageCacheConfig::new(
+        INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE,
+        temp_dir.path().to_str().unwrap().to_string(),
+        /*optimize_local_filesystem=*/ true,
+    );
+    let mut object_storage_cache = ObjectStorageCache::new(cache_config);
+
+    let (mut table, mut table_notify) =
+        prepare_test_deletion_vector_for_read(&temp_dir, object_storage_cache.clone()).await;
+    create_mooncake_and_iceberg_snapshot_for_test(&mut table, &mut table_notify).await;
+    let disk_files = get_disk_files_for_snapshot(&table).await;
+    assert_eq!(disk_files.len(), 1);
+    let local_data_file = disk_files.iter().next().unwrap().0.file_path().to_string();
+
+    let (_, _, _, files_to_delete) =
+        create_mooncake_snapshot_for_test(&mut table, &mut table_notify).await;
+    assert_eq!(files_to_delete, vec![local_data_file]);
 
     // Use by read.
     let snapshot_read_output = perform_read_request_for_test(&mut table).await;
@@ -409,9 +571,18 @@ async fn test_2_compact_with_local_filesystem_optimization() {
         )
         .await;
     create_mooncake_and_iceberg_snapshot_for_test(&mut table, &mut table_notify).await;
-    let (_, _, data_compaction_payload, files_to_delete) =
+    let disk_files = get_disk_files_for_snapshot(&table).await;
+    assert_eq!(disk_files.len(), 2);
+    let mut local_data_files = disk_files
+        .iter()
+        .map(|(f, _)| f.file_path().to_string())
+        .collect::<Vec<_>>();
+    local_data_files.sort();
+
+    let (_, _, data_compaction_payload, mut files_to_delete) =
         create_mooncake_snapshot_for_test(&mut table, &mut table_notify).await;
-    assert!(files_to_delete.is_empty());
+    files_to_delete.sort();
+    assert_eq!(files_to_delete, local_data_files);
 
     // Get old snapshot disk files.
     let disk_files = get_disk_files_for_snapshot(&table).await;
@@ -465,8 +636,10 @@ async fn test_2_compact_with_local_filesystem_optimization() {
         data_compaction_payload.unwrap(),
     )
     .await;
-    // Include both two data files and index blocks.
-    assert_eq!(evicted_files.len(), 4);
+    // Include both two index block files.
+    assert_eq!(evicted_files.len(), 2);
+    assert!(!evicted_files.contains(&local_data_files[0]));
+    assert!(!evicted_files.contains(&local_data_files[1]));
     assert!(!evicted_files.contains(&old_compacted_puffin_files[0]));
     assert!(!evicted_files.contains(&old_compacted_puffin_files[1]));
     assert!(evicted_files.contains(&old_compacted_index_block_files[0]));

--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -265,6 +265,8 @@ impl SnapshotTableState {
         // Update disk file from local write through cache to iceberg persisted remote path.
         let persisted_data_files = &task.iceberg_persisted_records.import_result.new_data_files;
         for cur_data_file in persisted_data_files.iter() {
+            // Removing entry with [`cur_data_file`] and insert with the same key might be confusing, but here we're only using file id as key, but not filepath.
+            // So the real operation is: remove the entry with <old filepath> and insert with <new filepath>.
             let mut disk_file_entry = self
                 .current_snapshot
                 .disk_files
@@ -274,7 +276,7 @@ impl SnapshotTableState {
                 .cache_handle
                 .as_mut()
                 .unwrap()
-                .unreference()
+                .unreference_and_replace_with_remote(&cur_data_file.file_path())
                 .await;
             evicted_files_to_delete.extend(cur_evicted_files);
             disk_file_entry.cache_handle = None;

--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -276,7 +276,7 @@ impl SnapshotTableState {
                 .cache_handle
                 .as_mut()
                 .unwrap()
-                .unreference_and_replace_with_remote(&cur_data_file.file_path())
+                .unreference_and_replace_with_remote(cur_data_file.file_path())
                 .await;
             evicted_files_to_delete.extend(cur_evicted_files);
             disk_file_entry.cache_handle = None;

--- a/src/moonlink/src/storage/mooncake_table/state_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/state_test_utils.rs
@@ -23,8 +23,8 @@ use crate::storage::storage_utils::{
 };
 use crate::table_notify::TableNotify;
 use crate::{
-    IcebergTableConfig, MooncakeTable, NonEvictableHandle, ObjectStorageCache, ReadState,
-    SnapshotReadOutput,
+    IcebergTableConfig, MooncakeTable, NonEvictableHandle, ObjectStorageCache,
+    ObjectStorageCacheConfig, ReadState, SnapshotReadOutput,
 };
 
 /// This module contains util functions for state-based tests.
@@ -73,29 +73,6 @@ pub(super) fn is_remote_file(file: &MooncakeDataFileRef, temp_dir: &TempDir) -> 
 /// Test util function to decide whether a given file is local file.
 pub(super) fn is_local_file(file: &MooncakeDataFileRef, temp_dir: &TempDir) -> bool {
     !is_remote_file(file, temp_dir)
-}
-
-/// Test util function to drop read states, and apply the synchronized response to mooncake table.
-pub(super) async fn drop_read_states(
-    read_states: Vec<Arc<ReadState>>,
-    table: &mut MooncakeTable,
-    receiver: &mut Receiver<TableNotify>,
-) {
-    for cur_read_state in read_states.into_iter() {
-        drop(cur_read_state);
-        sync_read_request_for_test(table, receiver).await;
-    }
-}
-/// Test util function to drop read states and create a mooncake snapshot to reflect.
-/// Return evicted files to delete.
-pub(super) async fn drop_read_states_and_create_mooncake_snapshot(
-    read_states: Vec<Arc<ReadState>>,
-    table: &mut MooncakeTable,
-    receiver: &mut Receiver<TableNotify>,
-) -> Vec<String> {
-    drop_read_states(read_states, table, receiver).await;
-    let (_, _, _, files_to_delete) = create_mooncake_snapshot_for_test(table, receiver).await;
-    files_to_delete
 }
 
 /// Test util function to get fake file path.
@@ -151,44 +128,6 @@ pub(super) fn get_iceberg_table_config(temp_dir: &TempDir) -> IcebergTableConfig
         namespace: vec!["namespace".to_string()],
         table_name: "test_table".to_string(),
     }
-}
-
-/// Test util function to create mooncake table and table notify for read test.
-pub(super) async fn create_mooncake_table_and_notify_for_read(
-    temp_dir: &TempDir,
-    object_storage_cache: ObjectStorageCache,
-) -> (MooncakeTable, Receiver<TableNotify>) {
-    let path = temp_dir.path().to_path_buf();
-    let mooncake_table_metadata =
-        create_test_table_metadata(temp_dir.path().to_str().unwrap().to_string());
-    let identity_property = mooncake_table_metadata.identity.clone();
-
-    let iceberg_table_config = get_iceberg_table_config(temp_dir);
-    let schema = create_test_arrow_schema();
-
-    // Create iceberg snapshot whenever `create_snapshot` is called.
-    let mooncake_table_config = MooncakeTableConfig {
-        iceberg_snapshot_new_data_file_count: 0,
-        ..Default::default()
-    };
-
-    let mut table = MooncakeTable::new(
-        schema.as_ref().clone(),
-        "test_table".to_string(),
-        /*version=*/ TEST_TABLE_ID.0,
-        path,
-        identity_property,
-        iceberg_table_config.clone(),
-        mooncake_table_config,
-        object_storage_cache,
-    )
-    .await
-    .unwrap();
-
-    let (notify_tx, notify_rx) = mpsc::channel(100);
-    table.register_table_notify(notify_tx).await;
-
-    (table, notify_rx)
 }
 
 /// Test util function to create mooncake table and table notify for compaction test.
@@ -252,6 +191,102 @@ pub(super) fn get_index_block_files(
         }
     }
     (index_block_files, overall_file_size)
+}
+
+/// ===================================
+/// Cache utils
+///  ===================================
+///
+/// Test util function to create an infinitely large object storage cache.
+pub(super) fn create_infinite_object_storage_cache(
+    temp_dir: &TempDir,
+    optimize_local_filesystem: bool,
+) -> ObjectStorageCache {
+    let cache_config = ObjectStorageCacheConfig::new(
+        INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE,
+        temp_dir.path().to_str().unwrap().to_string(),
+        optimize_local_filesystem,
+    );
+    ObjectStorageCache::new(cache_config)
+}
+
+/// Test util function to create an object storage cache, with size of only one file.
+pub(super) fn create_object_storage_cache_with_one_file_size(
+    temp_dir: &TempDir,
+    optimize_local_filesystem: bool,
+) -> ObjectStorageCache {
+    let cache_config = ObjectStorageCacheConfig::new(
+        ONE_FILE_CACHE_SIZE,
+        temp_dir.path().to_str().unwrap().to_string(),
+        optimize_local_filesystem,
+    );
+    ObjectStorageCache::new(cache_config)
+}
+
+/// ===================================
+/// Request read
+/// ===================================
+///
+/// Test util function to drop read states, and apply the synchronized response to mooncake table.
+pub(super) async fn drop_read_states(
+    read_states: Vec<Arc<ReadState>>,
+    table: &mut MooncakeTable,
+    receiver: &mut Receiver<TableNotify>,
+) {
+    for cur_read_state in read_states.into_iter() {
+        drop(cur_read_state);
+        sync_read_request_for_test(table, receiver).await;
+    }
+}
+
+/// Test util function to drop read states and create a mooncake snapshot to reflect.
+/// Return evicted files to delete.
+pub(super) async fn drop_read_states_and_create_mooncake_snapshot(
+    read_states: Vec<Arc<ReadState>>,
+    table: &mut MooncakeTable,
+    receiver: &mut Receiver<TableNotify>,
+) -> Vec<String> {
+    drop_read_states(read_states, table, receiver).await;
+    let (_, _, _, files_to_delete) = create_mooncake_snapshot_for_test(table, receiver).await;
+    files_to_delete
+}
+
+/// Test util function to create mooncake table and table notify for read test.
+pub(super) async fn create_mooncake_table_and_notify_for_read(
+    temp_dir: &TempDir,
+    object_storage_cache: ObjectStorageCache,
+) -> (MooncakeTable, Receiver<TableNotify>) {
+    let path = temp_dir.path().to_path_buf();
+    let mooncake_table_metadata =
+        create_test_table_metadata(temp_dir.path().to_str().unwrap().to_string());
+    let identity_property = mooncake_table_metadata.identity.clone();
+
+    let iceberg_table_config = get_iceberg_table_config(temp_dir);
+    let schema = create_test_arrow_schema();
+
+    // Create iceberg snapshot whenever `create_snapshot` is called.
+    let mooncake_table_config = MooncakeTableConfig {
+        iceberg_snapshot_new_data_file_count: 0,
+        ..Default::default()
+    };
+
+    let mut table = MooncakeTable::new(
+        schema.as_ref().clone(),
+        "test_table".to_string(),
+        /*version=*/ TEST_TABLE_ID.0,
+        path,
+        identity_property,
+        iceberg_table_config.clone(),
+        mooncake_table_config,
+        object_storage_cache,
+    )
+    .await
+    .unwrap();
+
+    let (notify_tx, notify_rx) = mpsc::channel(100);
+    table.register_table_notify(notify_tx).await;
+
+    (table, notify_rx)
 }
 
 /// ===================================

--- a/src/moonlink/src/storage/mooncake_table/state_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/state_test_utils.rs
@@ -266,6 +266,31 @@ pub(crate) async fn get_disk_files_for_snapshot(
     guard.current_snapshot.disk_files.clone()
 }
 
+/// Test util function to get sorted data file filepaths for the given mooncake table, and assert on expected disk file number.
+pub(crate) async fn get_disk_files_for_snapshot_and_assert(
+    table: &MooncakeTable,
+    expected_file_num: usize,
+) -> Vec<String> {
+    let guard = table.snapshot.read().await;
+    assert_eq!(guard.current_snapshot.disk_files.len(), expected_file_num);
+    let mut data_files = guard
+        .current_snapshot
+        .disk_files
+        .keys()
+        .map(|f| f.file_path().to_string())
+        .collect::<Vec<_>>();
+    data_files.sort();
+    data_files
+}
+
+/// Test util to get the only data file filepath for the given mooncake table.
+pub(crate) async fn get_only_data_filepath(table: &MooncakeTable) -> String {
+    let guard = table.snapshot.read().await;
+    let disk_files = guard.current_snapshot.disk_files.clone();
+    assert_eq!(disk_files.len(), 1);
+    disk_files.iter().next().unwrap().0.file_path().to_string()
+}
+
 /// Test util function to get committed and uncommitted deletion logs states.
 pub(crate) async fn get_deletion_logs_for_snapshot(
     table: &MooncakeTable,


### PR DESCRIPTION
## Summary

pg_mooncake regression tests pass
```sh
--- beginning regression test run ---
PASS setup 23ms
PASS partitioned_table 605ms
PASS sanity 574ms
passed=3, failed=0
```

pg_mooncake sql:
```sql
pg_mooncake (pid: 33138) =# DROP EXTENSION IF EXISTS pg_mooncake CASCADE;
DROP TABLE IF EXISTS r;
CREATE EXTENSION pg_mooncake;
CREATE TABLE r (a int primary key, b text);
CALL mooncake.create_table('c', 'r');
INSERT INTO r SELECT a, 'val_' || a FROM generate_series(1, 1000000) AS a;
SELECT count(*) FROM c;
DELETE FROM r WHERE a % 2 = 0;
SELECT * FROM c LIMIT 10;
NOTICE:  drop cascades to table c
DROP EXTENSION
DROP TABLE
CREATE EXTENSION
CREATE TABLE
CALL
INSERT 0 1000000
  count  
---------
 1000000
(1 row)

DELETE 500000
   a    |     b      
--------+------------
 267265 | val_267265
 267267 | val_267267
 267269 | val_267269
 267271 | val_267271
 267273 | val_267273
 267275 | val_267275
 267277 | val_267277
 267279 | val_267279
 267281 | val_267281
 267283 | val_267283
(10 rows)
```

Test with the below sql, I confirm data files and puffin files are all coming from iceberg table
```sql
pg_mooncake (pid: 195154) =# DROP EXTENSION IF EXISTS pg_mooncake CASCADE;
DROP TABLE IF EXISTS r;
CREATE EXTENSION pg_mooncake;
CREATE TABLE r (a int primary key, b text);
CALL mooncake.create_table('c', 'r');
INSERT INTO r SELECT a, 'val_' || a FROM generate_series(1, 10) AS a;
SELECT count(*) FROM c;
NOTICE:  drop cascades to table c
DROP EXTENSION
DROP TABLE
CREATE EXTENSION
CREATE TABLE
CALL
INSERT 0 10
count 
-------
    10
(1 row)

pg_mooncake (pid: 195154) =# CALL mooncake.create_snapshot('c');
CALL
pg_mooncake (pid: 195154) =# DELETE FROM r WHERE a % 2 = 0;
DELETE 5
pg_mooncake (pid: 195154) =# CALL mooncake.create_snapshot('c');
CALL
pg_mooncake (pid: 195154) =# SELECT * FROM c;
 a |   b   
---+-------
 1 | val_1
 3 | val_3
 5 | val_5
 7 | val_7
 9 | val_9
(5 rows)
```
Table directory, which stores intermediate disk slice files, is empty.
```sh
vscode ➜ /workspaces/pg_mooncake/moonlink (hjiang/enable-data-file) $ ls /home/vscode/.pgrx/data-17/mooncake/temp/
vscode ➜ /workspaces/pg_mooncake/moonlink (hjiang/enable-data-file) $ 
```

Again, one thing to notice, the way we avoid double storage is not the most ideal from behavior's perspective, but easy to implementation to avoid over-complicated state machine.
https://github.com/Mooncake-Labs/moonlink/blob/ae18a31efd296c71557a5eb8f5323a5dbf0aefb4/src/moonlink/src/storage/cache/object_storage/cache_handle.rs#L68-L75

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/580

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
