### PR TITLE
[storage] Implement replacement semantics for cache handle

### DIFF
--- a/src/moonlink/src/storage/cache/object_storage/cache_handle.rs
+++ b/src/moonlink/src/storage/cache/object_storage/cache_handle.rs
@@ -63,25 +63,22 @@ impl NonEvictableHandle {
         guard.delete_cache_entry(self.file_id, /*panic_if_non_existent=*/ true)
     }
 
-    /// Unreference and try import remote files, could be optimized if local filesystem optimization enabled.
+    /// Unreference and try import remote files, used for local filesystem optimization if enabled.
     ///
     /// This is an optimization for cases where both cache files and persisted files live on local filesystem, so we don't need to store the same files twice.
     /// The idea way, from users's perspective, is to switch from local filepath to remote if possible, but that leads to state machine being over-complicated.
     /// For example, we need to keep another pending state in cache, to record file paths requested to replace with remote, when they're (1) in use, or (2) in use and requested to delete.
     /// To make implementation easy, the implementation here only attempt once at unreference; if it fails, the replacement will never happen.
+    /// 
     /// But local cache files are still subject to eviction and deletion, for example, when
     /// - Object storage cache goes out of space;
     /// - Maintainance job like compaction kicks in and requests to delete old compacted files;
     /// - Moonlink process restarts and recreates the cache directory.
     #[must_use]
-    #[allow(dead_code)]
     pub(crate) async fn unreference_and_replace_with_remote(
         &mut self,
         remote_filepath: &str,
     ) -> Vec<String> {
-        // Aggregate evicted files to delete.
-        let mut evicted_files_to_delete = vec![];
-
         let mut guard = self.cache.write().await;
 
         // First unreference the cache handle as usual.
@@ -89,10 +86,30 @@ impl NonEvictableHandle {
         assert!(cur_evicted_files.is_empty());
 
         // Then try to replace cache filepath with remote file, if applicable.
-        let cur_evicted_files =
+        let evicted_files_to_delete =
             guard.try_replace_evictable_with_remote(&self.file_id, remote_filepath);
-        evicted_files_to_delete.extend(cur_evicted_files);
 
         evicted_files_to_delete
+    }
+
+    /// Replace current cache filepath with remote, used for local filesystem optimization if enabled.
+    /// 
+    /// This is an optimization for cases where both cache files and persisted files live on local filesystem, so we don't need to store the same files twice.
+    /// The idea way, from users's perspective, is to switch from local filepath to remote if possible, but that leads to state machine being over-complicated.
+    /// For example, we need to keep another pending state in cache, to record file paths requested to replace with remote, when they're (1) in use, or (2) in use and requested to delete.
+    /// To make implementation easy, the implementation here only attempt once at invocation, it succeeds if the current cache entry is the only non-evictable reference count, and not requested to delete; 
+    /// if it fails, the replacement will never happen.
+    /// 
+    /// But local cache files are still subject to eviction and deletion, for example, when
+    /// - Object storage cache goes out of space;
+    /// - Maintainance job like compaction kicks in and requests to delete old compacted files;
+    /// - Moonlink process restarts and recreates the cache directory.
+    #[must_use]
+    #[allow(dead_code)]
+    pub(crate) async fn replace_with_remote(&mut self, remote_filepath: &str) -> Vec<String> {
+        let mut guard = self.cache.write().await;
+
+        // Try to replace cache filepath with remote file, if applicable.
+        guard.try_replace_only_reference_count_with_remote(&self.file_id, remote_filepath)
     }
 }

--- a/src/moonlink/src/storage/cache/object_storage/cache_handle.rs
+++ b/src/moonlink/src/storage/cache/object_storage/cache_handle.rs
@@ -69,7 +69,7 @@ impl NonEvictableHandle {
     /// The idea way, from users's perspective, is to switch from local filepath to remote if possible, but that leads to state machine being over-complicated.
     /// For example, we need to keep another pending state in cache, to record file paths requested to replace with remote, when they're (1) in use, or (2) in use and requested to delete.
     /// To make implementation easy, the implementation here only attempt once at unreference; if it fails, the replacement will never happen.
-    /// 
+    ///
     /// But local cache files are still subject to eviction and deletion, for example, when
     /// - Object storage cache goes out of space;
     /// - Maintainance job like compaction kicks in and requests to delete old compacted files;
@@ -86,20 +86,17 @@ impl NonEvictableHandle {
         assert!(cur_evicted_files.is_empty());
 
         // Then try to replace cache filepath with remote file, if applicable.
-        let evicted_files_to_delete =
-            guard.try_replace_evictable_with_remote(&self.file_id, remote_filepath);
-
-        evicted_files_to_delete
+        guard.try_replace_evictable_with_remote(&self.file_id, remote_filepath)
     }
 
     /// Replace current cache filepath with remote, used for local filesystem optimization if enabled.
-    /// 
+    ///
     /// This is an optimization for cases where both cache files and persisted files live on local filesystem, so we don't need to store the same files twice.
     /// The idea way, from users's perspective, is to switch from local filepath to remote if possible, but that leads to state machine being over-complicated.
     /// For example, we need to keep another pending state in cache, to record file paths requested to replace with remote, when they're (1) in use, or (2) in use and requested to delete.
-    /// To make implementation easy, the implementation here only attempt once at invocation, it succeeds if the current cache entry is the only non-evictable reference count, and not requested to delete; 
+    /// To make implementation easy, the implementation here only attempt once at invocation, it succeeds if the current cache entry is the only non-evictable reference count, and not requested to delete;
     /// if it fails, the replacement will never happen.
-    /// 
+    ///
     /// But local cache files are still subject to eviction and deletion, for example, when
     /// - Object storage cache goes out of space;
     /// - Maintainance job like compaction kicks in and requests to delete old compacted files;
@@ -110,6 +107,13 @@ impl NonEvictableHandle {
         let mut guard = self.cache.write().await;
 
         // Try to replace cache filepath with remote file, if applicable.
-        guard.try_replace_only_reference_count_with_remote(&self.file_id, remote_filepath)
+        let evicted_files_to_delete =
+            guard.try_replace_only_reference_count_with_remote(&self.file_id, remote_filepath);
+        // If replacement succeeds, local cache filepath will be returned and to evict.
+        if !evicted_files_to_delete.is_empty() {
+            self.cache_entry.cache_filepath = remote_filepath.to_string();
+        }
+
+        evicted_files_to_delete
     }
 }

--- a/src/moonlink/src/storage/cache/object_storage/object_storage_cache.rs
+++ b/src/moonlink/src/storage/cache/object_storage/object_storage_cache.rs
@@ -209,7 +209,7 @@ impl ObjectStorageCacheInternal {
     }
 
     /// Attempt to replace the cache entry with remote path, if it's the last reference count on local filesystem, and not requested to delete.
-    /// Return evicted files to delete.
+    /// Return evicted files to delete; it's non empty if replacement succeeds.
     pub(super) fn try_replace_only_reference_count_with_remote(
         &mut self,
         file_id: &TableUniqueFileId,

--- a/src/moonlink/src/storage/cache/object_storage/object_storage_cache.rs
+++ b/src/moonlink/src/storage/cache/object_storage/object_storage_cache.rs
@@ -181,7 +181,6 @@ impl ObjectStorageCacheInternal {
 
     /// Attempt to replace an evictable cache entry with remote path, if the filepath lives on local filesystem.
     /// Return evicted files to delete.
-    #[allow(dead_code)]
     pub(super) fn try_replace_evictable_with_remote(
         &mut self,
         file_id: &TableUniqueFileId,
@@ -197,6 +196,45 @@ impl ObjectStorageCacheInternal {
 
         // Only replace with remote filepath when requested file lives at evictable cache.
         if let Some(cache_entry_wrapper) = self.evictable_cache.get_mut(file_id) {
+            let old_cache_filepath =
+                std::mem::take(&mut cache_entry_wrapper.cache_entry.cache_filepath);
+            cache_entry_wrapper.cache_entry.cache_filepath = remote_path.to_string();
+            cache_entry_wrapper.deletable = false;
+
+            return vec![old_cache_filepath];
+        }
+
+        // Otherwise, do nothing.
+        vec![]
+    }
+
+    /// Attempt to replace the cache entry with remote path, if it's the last reference count on local filesystem, and not requested to delete.
+    /// Return evicted files to delete.
+    pub(super) fn try_replace_only_reference_count_with_remote(
+        &mut self,
+        file_id: &TableUniqueFileId,
+        remote_path: &str,
+    ) -> Vec<String> {
+        // Local filesystem optimization doesn't apply here.
+        if !self.config.optimize_local_filesystem {
+            return vec![];
+        }
+        if !path_utils::is_local_filepath(remote_path) {
+            return vec![];
+        }
+
+        // If the cache entry has been requested to delete, skip.
+        if self.evicted_entries.contains(file_id) {
+            return vec![];
+        }
+
+        // Only replace with remote filepath when requested file is the only reference count at the non-evictable cache.
+        if let Some(cache_entry_wrapper) = self.non_evictable_cache.get_mut(file_id) {
+            ma::assert_ge!(cache_entry_wrapper.reference_count, 1);
+            if cache_entry_wrapper.reference_count > 1 {
+                return vec![];
+            }
+
             let old_cache_filepath =
                 std::mem::take(&mut cache_entry_wrapper.cache_entry.cache_filepath);
             cache_entry_wrapper.cache_entry.cache_filepath = remote_path.to_string();


### PR DESCRIPTION
## Summary

For cache handle returned, and to enable local filesystem optimization on index block files, cache needs to support a "try replace" semantics and update local cache filepath to remote filepath, if it's on local fs.

It doesn't affect state transfer.

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
