### PR TITLE
[storage] Fix index block cache and add assertion

### DIFF
--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -977,6 +977,15 @@ impl SnapshotTableState {
             .await;
         evicted_data_files_to_delete.extend(puffin_evicted_data_files);
 
+        // Import all new file indices, including newly imported ones, merged ones, and compacted ones into cache.
+        // So it should happen before reflecting index merge and data compaction result into mooncake snapshot, and before integrating stream transactions and disk slices.
+        //
+        // TODO(hjiang): double check why we cannot apply disk slice/stream transaction before append unpersisted records.
+        // Import file indices into cache.
+        let file_indices_evicted_files_to_delete =
+            self.import_file_indices_into_cache(&mut task).await;
+        evicted_data_files_to_delete.extend(file_indices_evicted_files_to_delete);
+
         // Update disk files' disk entries and file indices from merged indices.
         let index_merge_evicted_files = self
             .update_file_indices_merge_to_mooncake_snapshot(&task)
@@ -993,12 +1002,6 @@ impl SnapshotTableState {
         // Prune unpersisted records.
         self.prune_committed_deletion_logs(&task);
         self.unpersisted_records.prune_persisted_records(&task);
-
-        // TODO(hjiang): double check why we cannot apply disk slice/stream transaction before append unpersisted records.
-        // Import file indices into cache.
-        let file_indices_evicted_files_to_delete =
-            self.import_file_indices_into_cache(&mut task).await;
-        evicted_data_files_to_delete.extend(file_indices_evicted_files_to_delete);
 
         // Sync buffer snapshot states into unpersisted iceberg content.
         self.unpersisted_records.buffer_unpersisted_records(&task);

--- a/src/moonlink/src/storage/mooncake_table/snapshot_validation.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot_validation.rs
@@ -10,8 +10,28 @@ impl SnapshotTableState {
         self.assert_file_indices_no_duplicate();
         // Check file ids don't have duplicate.
         self.assert_file_ids_no_duplicate();
+        // Check index blocks are all cached.
+        self.assert_index_blocks_cached();
         // Check persistence buffer.
         self.unpersisted_records.validate_invariants();
+    }
+
+    /// Test util function to validate all index block files are cached, and cache handle filepath matches index file path.
+    #[cfg(test)]
+    fn assert_index_blocks_cached(&self) {
+        for cur_file_index in self.current_snapshot.indices.file_indices.iter() {
+            for cur_index_block in cur_file_index.index_blocks.iter() {
+                assert!(cur_index_block.cache_handle.is_some());
+                assert_eq!(
+                    cur_index_block
+                        .cache_handle
+                        .as_ref()
+                        .unwrap()
+                        .get_cache_filepath(),
+                    cur_index_block.index_file.file_path()
+                );
+            }
+        }
     }
 
     /// Test util function to validate one data file is referenced by exactly one file index.


### PR DESCRIPTION
## Summary

The issue is: need to import index blocks into cache before we reflect them into mooncake snapshot.

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
