### PR TITLE
Upgrade yanked dependency lz4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2253,9 +2253,9 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "lz4_flex"
-version = "0.11.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c592ad9fbc1b7838633b3ae55ce69b17d01150c72fcef229fbb819d39ee51ee"
+checksum = "08ab2867e3eeeca90e844d1940eab391c9dc5228783db2ed999acbc0a9ed375a"
 dependencies = [
  "twox-hash",
 ]


### PR DESCRIPTION
## Summary

Met a warning message:
```sh
warning[yanked]: detected yanked crate (try `cargo update -p lz4_flex`)
    ┌─ /workspaces/moonlink/Cargo.lock:207:1
    │
207 │ lz4_flex 0.11.4 registry+https://github.com/rust-lang/crates.io-index
    │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ yanked version
    │
    ├ lz4_flex v0.11.4
      └── parquet v55.1.0
          ├── iceberg v0.5.1
          │   ├── moonlink v0.0.1
          │   │   ├── moonlink_backend v0.0.1
          │   │   └── moonlink_connectors v0.0.1
          │   │       └── moonlink_backend v0.0.1 (*)
          │   └── (dev) moonlink_connectors v0.0.1 (*)
          ├── moonlink v0.0.1 (*)
          └── moonlink_backend v0.0.1 (*)
```

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
