### PR TITLE
[storage] Fix drop table with opendal remove directory

### DIFF
--- a/src/moonlink/src/storage/iceberg/file_catalog.rs
+++ b/src/moonlink/src/storage/iceberg/file_catalog.rs
@@ -598,7 +598,7 @@ impl Catalog for FileCatalog {
         let directory = format!("{}/{}", table.namespace().to_url_string(), table.name());
         self.remove_directory(&directory)
             .await
-            .map_err(|err| to_iceberg_error(err))?;
+            .map_err(to_iceberg_error)?;
         Ok(())
     }
 
@@ -612,7 +612,7 @@ impl Catalog for FileCatalog {
         let exists = self
             .object_exists(version_hint_filepath.to_str().unwrap())
             .await
-            .map_err(|e| to_iceberg_error(e))?;
+            .map_err(to_iceberg_error)?;
         Ok(exists)
     }
 


### PR DESCRIPTION
## Summary

I met error sometimes when dropping iceberg table, see the linked issue for error details (which seems non-deterministic to me... not sure why)
In this PR, I rewrite directory deletion logic from "list + delete" to "delete the whole directory", which should be more efficient.

I tested with `DROP TABLE` for multiple times, and confirm it works without issues stably.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/606

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
