### PR TITLE
Fix psql command at devcontainer startup

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -2,7 +2,7 @@
 git config devcontainers-theme.show-dirty 1
 
 # pg access.
-echo alias psql=\'psql -h localhost -U postgres\' >> ~/.bashrc
+echo "alias psql='PGPASSWORD=postgres psql -h postgres -p 5432 -U postgres -d postgres'" >> ~/.bashrc
 
 # precommit hook requirement.
 pre-commit install -t pre-push


### PR DESCRIPTION
## Summary

Somehow our current `psql` command is broken.
I don't have concern to bake password in setup script as it's only for devcontainer.

Manual check:
```sh
[/workspaces/moonlink] (hjiang/fix-psql) 
vscode@0b962e1e6dd9$ psql
psql (17.5 (Debian 17.5-1.pgdg120+1))
Type "help" for help.

postgres=# 
```

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
