### PR TITLE
[storage] Load iceberg snapshot at mooncake table construction

### DIFF
--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -471,6 +471,8 @@ impl MooncakeTable {
         object_storage_cache: ObjectStorageCache,
     ) -> Result<Self> {
         let (table_snapshot_watch_sender, table_snapshot_watch_receiver) = watch::channel(0);
+        let (next_file_id, current_snapshot) = table_manager.load_snapshot_from_table().await?;
+
         Ok(Self {
             mem_slice: MemSlice::new(
                 table_metadata.schema.clone(),
@@ -482,7 +484,7 @@ impl MooncakeTable {
                 SnapshotTableState::new(
                     table_metadata.clone(),
                     object_storage_cache,
-                    &mut *table_manager,
+                    current_snapshot,
                 )
                 .await?,
             )),
@@ -490,7 +492,7 @@ impl MooncakeTable {
             transaction_stream_states: HashMap::new(),
             table_snapshot_watch_sender,
             table_snapshot_watch_receiver,
-            next_file_id: 0,
+            next_file_id,
             iceberg_table_manager: Some(table_manager),
             last_iceberg_snapshot_lsn: None,
             table_notify: None,

--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -13,7 +13,6 @@ use crate::storage::compaction::table_compaction::{
     CompactedDataEntry, DataCompactionPayload, RemappedRecordLocation, SingleFileToCompact,
 };
 use crate::storage::iceberg::puffin_utils::PuffinBlobRef;
-use crate::storage::iceberg::table_manager::TableManager;
 use crate::storage::index::{cache_utils as index_cache_utils, FileIndex};
 use crate::storage::mooncake_table::persistence_buffer::UnpersistedRecords;
 use crate::storage::mooncake_table::shared_array::SharedRowBufferSnapshot;
@@ -112,8 +111,7 @@ impl SnapshotTableState {
     pub(super) async fn new(
         metadata: Arc<MooncakeTableMetadata>,
         object_storage_cache: ObjectStorageCache,
-        // TODO(hjiang): Used when recovery enabled.
-        _iceberg_table_manager: &mut dyn TableManager,
+        current_snapshot: Snapshot,
     ) -> Result<Self> {
         let mut batches = BTreeMap::new();
         batches.insert(0, InMemoryBatch::new(metadata.config.batch_size));
@@ -121,7 +119,7 @@ impl SnapshotTableState {
         let table_config = metadata.config.clone();
         Ok(Self {
             mooncake_table_metadata: metadata.clone(),
-            current_snapshot: Snapshot::new(metadata.clone()),
+            current_snapshot,
             batches,
             rows: None,
             last_commit: RecordLocation::MemoryBatch(0, 0),

--- a/src/moonlink/src/storage/mooncake_table/tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/tests.rs
@@ -2,6 +2,7 @@ use super::test_utils::*;
 use super::*;
 use crate::storage::iceberg::table_manager::MockTableManager;
 use crate::storage::mooncake_table::state_test_utils::*;
+use crate::storage::mooncake_table::Snapshot as MooncakeSnapshot;
 use iceberg::{Error as IcebergError, ErrorKind};
 use rstest::*;
 use rstest_reuse::{self, *};
@@ -405,6 +406,39 @@ async fn test_duplicate_deletion() -> Result<()> {
 
 /// ---- Mock unit test ----
 #[tokio::test]
+async fn test_snapshot_load_failure() {
+    let temp_dir = TempDir::new().unwrap();
+    let table_metadata = Arc::new(TableMetadata {
+        name: "test_table".to_string(),
+        id: 1,
+        schema: Arc::new(test_schema()),
+        config: MooncakeTableConfig::default(), // No temp files generated.
+        path: PathBuf::from(temp_dir.path()),
+        identity: IdentityProp::Keys(vec![0]),
+    });
+    let mut mock_table_manager = MockTableManager::new();
+    mock_table_manager
+        .expect_load_snapshot_from_table()
+        .times(1)
+        .returning(|| {
+            Box::pin(async move {
+                Err(IcebergError::new(
+                    ErrorKind::Unexpected,
+                    "Intended error for unit test",
+                ))
+            })
+        });
+
+    let table = MooncakeTable::new_with_table_manager(
+        table_metadata,
+        Box::new(mock_table_manager),
+        ObjectStorageCache::default_for_test(&temp_dir),
+    )
+    .await;
+    assert!(table.is_err());
+}
+
+#[tokio::test]
 async fn test_snapshot_store_failure() {
     let temp_dir = TempDir::new().unwrap();
     let table_metadata = Arc::new(TableMetadata {
@@ -415,8 +449,21 @@ async fn test_snapshot_store_failure() {
         path: PathBuf::from(temp_dir.path()),
         identity: IdentityProp::Keys(vec![0]),
     });
+    let table_metadata_copy = table_metadata.clone();
 
     let mut mock_table_manager = MockTableManager::new();
+    mock_table_manager
+        .expect_load_snapshot_from_table()
+        .times(1)
+        .returning(move || {
+            let table_metadata_copy = table_metadata_copy.clone();
+            Box::pin(async move {
+                Ok((
+                    /*next_file_id=*/ 0,
+                    MooncakeSnapshot::new(table_metadata_copy),
+                ))
+            })
+        });
     mock_table_manager
         .expect_sync_snapshot()
         .times(1)

--- a/src/moonlink/src/table_handler/tests.rs
+++ b/src/moonlink/src/table_handler/tests.rs
@@ -7,6 +7,7 @@ use crate::storage::compaction::compaction_config::DataCompactionConfig;
 use crate::storage::index::index_merge_config::FileIndexMergeConfig;
 use crate::storage::mooncake_table::IcebergPersistenceConfig;
 use crate::storage::mooncake_table::MooncakeTableConfig;
+use crate::storage::mooncake_table::Snapshot as MooncakeSnapshot;
 use crate::storage::mooncake_table::TableMetadata as MooncakeTableMetadata;
 use crate::storage::MockTableManager;
 use crate::storage::MooncakeTable;
@@ -1149,7 +1150,20 @@ async fn test_iceberg_snapshot_failure_mock_test() {
         identity: crate::row::IdentityProp::Keys(vec![0]),
     });
 
+    let mooncake_table_metadata_copy = mooncake_table_metadata.clone();
     let mut mock_table_manager = MockTableManager::new();
+    mock_table_manager
+        .expect_load_snapshot_from_table()
+        .times(1)
+        .returning(move || {
+            let table_metadata_copy = mooncake_table_metadata_copy.clone();
+            Box::pin(async move {
+                Ok((
+                    /*next_file_id=*/ 0,
+                    MooncakeSnapshot::new(table_metadata_copy),
+                ))
+            })
+        });
     mock_table_manager
         .expect_sync_snapshot()
         .times(1)
@@ -1201,7 +1215,20 @@ async fn test_iceberg_drop_table_failure_mock_test() {
         identity: crate::row::IdentityProp::Keys(vec![0]),
     });
 
+    let mooncake_table_metadata_copy = mooncake_table_metadata.clone();
     let mut mock_table_manager = MockTableManager::new();
+    mock_table_manager
+        .expect_load_snapshot_from_table()
+        .times(1)
+        .returning(move || {
+            let table_metadata_copy = mooncake_table_metadata_copy.clone();
+            Box::pin(async move {
+                Ok((
+                    /*next_file_id=*/ 0,
+                    MooncakeSnapshot::new(table_metadata_copy),
+                ))
+            })
+        });
     mock_table_manager
         .expect_drop_table()
         .times(1)


### PR DESCRIPTION
## Summary

This PR redo-es https://github.com/Mooncake-Labs/moonlink/pull/338, to enable iceberg snapshot recovery when create mooncake table.
The linked hot patch is made to workaround the limitation that we didn't support drop table at that time.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/623

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
