### PR TITLE
[storage] Fill in table retry properties

### DIFF
--- a/src/moonlink/src/storage/iceberg/table_property.rs
+++ b/src/moonlink/src/storage/iceberg/table_property.rs
@@ -1,6 +1,7 @@
 /// This module defines a few iceberg table property related constants and utils.
 /// Reference: https://iceberg.apache.org/docs/latest/configuration/#table-properties
-///
+use std::collections::HashMap;
+
 /// Compression codec for parquet files.
 pub(crate) const PARQUET_COMPRESSION: &str = "write.parquet.compression-codec";
 pub(crate) const PARQUET_COMPRESSION_DEFAULT: &str = "snappy";
@@ -8,3 +9,48 @@ pub(crate) const PARQUET_COMPRESSION_DEFAULT: &str = "snappy";
 /// Compression codec for metadata.
 pub(crate) const METADATA_COMPRESSION: &str = "write.metadata.compression-codec";
 pub(crate) const METADATA_COMPRESSION_DEFAULT: &str = "none";
+
+/// Retry properties.
+pub(crate) const TABLE_COMMIT_RETRY_NUM: &str = "commit.retry.num-retries";
+pub(crate) const TABLE_COMMIT_RETRY_NUM_DEFAULT: u64 = 0;
+
+pub(crate) const TABLE_COMMIT_RETRY_MIN_MS: &str = "commit.retry.min-wait-ms";
+pub(crate) const TABLE_COMMIT_RETRY_MIN_MS_DEFAULT: u64 = 0;
+
+pub(crate) const TABLE_COMMIT_RETRY_MAX_MS: &str = "commit.retry.max-wait-ms";
+pub(crate) const TABLE_COMMIT_RETRY_MAX_MS_DEFAULT: u64 = 0;
+
+pub(crate) const TABLE_COMMIT_RETRY_TIMEOUT_MS: &str = "commit.retry.total-timeout-ms";
+pub(crate) const TABLE_COMMIT_RETRY_TIMEOUT_MS_DEFAULT: u64 = 0;
+
+// Create iceberg table properties from table config.
+pub(crate) fn create_iceberg_table_properties() -> HashMap<String, String> {
+    let mut props = HashMap::with_capacity(6);
+    // Compression properties.
+    props.insert(
+        PARQUET_COMPRESSION.to_string(),
+        PARQUET_COMPRESSION_DEFAULT.to_string(),
+    );
+    props.insert(
+        METADATA_COMPRESSION.to_string(),
+        METADATA_COMPRESSION_DEFAULT.to_string(),
+    );
+    // Commit retry properties.
+    props.insert(
+        TABLE_COMMIT_RETRY_NUM.to_string(),
+        TABLE_COMMIT_RETRY_NUM_DEFAULT.to_string(),
+    );
+    props.insert(
+        TABLE_COMMIT_RETRY_MIN_MS.to_string(),
+        TABLE_COMMIT_RETRY_MIN_MS_DEFAULT.to_string(),
+    );
+    props.insert(
+        TABLE_COMMIT_RETRY_MAX_MS.to_string(),
+        TABLE_COMMIT_RETRY_MAX_MS_DEFAULT.to_string(),
+    );
+    props.insert(
+        TABLE_COMMIT_RETRY_TIMEOUT_MS.to_string(),
+        TABLE_COMMIT_RETRY_TIMEOUT_MS_DEFAULT.to_string(),
+    );
+    props
+}

--- a/src/moonlink/src/storage/iceberg/utils.rs
+++ b/src/moonlink/src/storage/iceberg/utils.rs
@@ -103,20 +103,6 @@ pub fn create_catalog(warehouse_uri: &str) -> IcebergResult<Box<dyn MoonlinkCata
     todo!("Need to take secrets from client side and create object storage catalog.")
 }
 
-// Create iceberg table properties from table config.
-fn create_iceberg_table_properties() -> HashMap<String, String> {
-    let mut props = HashMap::with_capacity(3);
-    props.insert(
-        table_property::PARQUET_COMPRESSION.to_string(),
-        table_property::PARQUET_COMPRESSION_DEFAULT.to_string(),
-    );
-    props.insert(
-        table_property::METADATA_COMPRESSION.to_string(),
-        table_property::METADATA_COMPRESSION_DEFAULT.to_string(),
-    );
-    props
-}
-
 /// Create an iceberg table in the given catalog from the given namespace and table name.
 /// Precondition: table doesn't exist in the given catalog.
 async fn create_iceberg_table<C: MoonlinkCatalog + ?Sized>(
@@ -143,7 +129,7 @@ async fn create_iceberg_table<C: MoonlinkCatalog + ?Sized>(
             table_name
         ))
         .schema(iceberg_schema)
-        .properties(create_iceberg_table_properties())
+        .properties(table_property::create_iceberg_table_properties())
         .build();
     let table = catalog.create_table(&namespace_ident, tbl_creation).await?;
     Ok(table)


### PR DESCRIPTION
## Summary

Fill in table commit properties, which is not the same as iceberg default.
Reference: https://iceberg.apache.org/docs/latest/configuration/#table-behavior-properties

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
