### PR TITLE
[storage] Use oneshot channel for drop table synchronization

### DIFF
--- a/src/moonlink/src/table_handler/tests.rs
+++ b/src/moonlink/src/table_handler/tests.rs
@@ -433,7 +433,7 @@ async fn test_streaming_transaction_periodic_flush_then_abort() {
 async fn test_drop_empty_table() {
     let temp_dir = tempdir().unwrap();
     let mooncake_table_directory = temp_dir.path().to_str().unwrap().to_string();
-    let mut env = TestEnvironment::new(temp_dir, MooncakeTableConfig::default()).await; // No temp files created.
+    let env = TestEnvironment::new(temp_dir, MooncakeTableConfig::default()).await; // No temp files created.
     env.drop_table().await.unwrap();
 
     // As of now, the whole mooncake table directory should be deleted.
@@ -447,7 +447,7 @@ async fn test_drop_empty_table() {
 async fn test_drop_table_with_data() {
     let temp_dir = tempdir().unwrap();
     let mooncake_table_directory = temp_dir.path().to_str().unwrap().to_string();
-    let mut env = TestEnvironment::new(temp_dir, MooncakeTableConfig::default()).await;
+    let env = TestEnvironment::new(temp_dir, MooncakeTableConfig::default()).await;
 
     // Write a few records to trigger mooncake and iceberg snapshot.
     env.append_row(
@@ -1248,7 +1248,7 @@ async fn test_iceberg_drop_table_failure_mock_test() {
     )
     .await
     .unwrap();
-    let mut env = TestEnvironment::new_with_mooncake_table(temp_dir, mooncake_table).await;
+    let env = TestEnvironment::new_with_mooncake_table(temp_dir, mooncake_table).await;
 
     // Drop table and block wait its completion, check whether error status is correctly propagated.
     let res = env.drop_table().await;

--- a/src/moonlink_connectors/src/pg_replicate/table_init.rs
+++ b/src/moonlink_connectors/src/pg_replicate/table_init.rs
@@ -9,7 +9,7 @@ use moonlink::{
 };
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use tokio::sync::{mpsc, mpsc::Sender, watch};
+use tokio::sync::{mpsc, mpsc::Sender, oneshot, watch};
 
 /// Components required to replicate a single table.
 /// Components that the [`Sink`] needs for processing CDC events.
@@ -28,7 +28,7 @@ pub struct TableResources {
 
 /// Create iceberg table event manager sender and receiver.
 fn create_iceberg_event_syncer() -> (IcebergEventSyncSender, IcebergEventSyncReceiver) {
-    let (iceberg_drop_table_completion_tx, iceberg_drop_table_completion_rx) = mpsc::channel(1);
+    let (iceberg_drop_table_completion_tx, iceberg_drop_table_completion_rx) = oneshot::channel();
     let (flush_lsn_tx, flush_lsn_rx) = watch::channel(0u64);
     let iceberg_event_sync_sender = IcebergEventSyncSender {
         iceberg_drop_table_completion_tx,


### PR DESCRIPTION
## Summary

This PR uses oneshot channel for drop table synchronization, instead of mpsc of size 1

Test statements with pg_mooncake
```sql
pg_mooncake (pid: 5932) =# DROP TABLE IF EXISTS r;                                                         
DROP EXTENSION pg_mooncake CASCADE;
CREATE EXTENSION pg_mooncake;
CREATE TABLE r (a int primary key, b text);
CALL mooncake.create_table('c', 'r');
NOTICE:  table "r" does not exist, skipping
DROP TABLE
DROP EXTENSION
CREATE EXTENSION
CREATE TABLE
CALL
pg_mooncake (pid: 5932) =# INSERT INTO r VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd'), (5, 'e'), (6, 'f');
CALL mooncake.create_snapshot('c');
UPDATE r SET b = a + 1 WHERE a = 3 or a = 5;
CALL mooncake.create_snapshot('c');
SELECT * FROM c;
INSERT 0 6
CALL
UPDATE 2
CALL
 a | b 
---+---
 3 | 4
 5 | 6
 1 | a
 2 | b
 4 | d
 6 | f
(6 rows)

pg_mooncake (pid: 5932) =# DROP TABLE r, c;
DROP TABLE
```

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/633

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
