### PR TITLE
[storage] Reduce flakiness for table hander test

### DIFF
--- a/src/moonlink/src/table_handler/tests.rs
+++ b/src/moonlink/src/table_handler/tests.rs
@@ -433,7 +433,7 @@ async fn test_streaming_transaction_periodic_flush_then_abort() {
 async fn test_drop_empty_table() {
     let temp_dir = tempdir().unwrap();
     let mooncake_table_directory = temp_dir.path().to_str().unwrap().to_string();
-    let env = TestEnvironment::new(temp_dir, MooncakeTableConfig::default()).await; // No temp files created.
+    let mut env = TestEnvironment::new(temp_dir, MooncakeTableConfig::default()).await; // No temp files created.
     env.drop_table().await.unwrap();
 
     // As of now, the whole mooncake table directory should be deleted.
@@ -447,7 +447,7 @@ async fn test_drop_empty_table() {
 async fn test_drop_table_with_data() {
     let temp_dir = tempdir().unwrap();
     let mooncake_table_directory = temp_dir.path().to_str().unwrap().to_string();
-    let env = TestEnvironment::new(temp_dir, MooncakeTableConfig::default()).await;
+    let mut env = TestEnvironment::new(temp_dir, MooncakeTableConfig::default()).await;
 
     // Write a few records to trigger mooncake and iceberg snapshot.
     env.append_row(
@@ -1248,7 +1248,7 @@ async fn test_iceberg_drop_table_failure_mock_test() {
     )
     .await
     .unwrap();
-    let env = TestEnvironment::new_with_mooncake_table(temp_dir, mooncake_table).await;
+    let mut env = TestEnvironment::new_with_mooncake_table(temp_dir, mooncake_table).await;
 
     // Drop table and block wait its completion, check whether error status is correctly propagated.
     let res = env.drop_table().await;

--- a/src/moonlink_connectors/src/replication_connection.rs
+++ b/src/moonlink_connectors/src/replication_connection.rs
@@ -335,7 +335,8 @@ impl ReplicationConnection {
     /// Clean up iceberg table in a blocking manner.
     async fn drop_iceberg_table(&mut self, table_id: u32) -> Result<()> {
         info!(table_id, "dropping iceberg table");
-        let iceberg_state_manager = self.iceberg_table_event_managers.remove(&table_id).unwrap();
+        let mut iceberg_state_manager =
+            self.iceberg_table_event_managers.remove(&table_id).unwrap();
         iceberg_state_manager.drop_table().await?;
         Ok(())
     }


### PR DESCRIPTION
## Summary

Current test implementation is intrinsically flaky:
- At test environment destruction, read state manager is destructed before table handler
- At read state manager destruction, it destructs the cached read state, if any, which spawns a task to send notification to table handler
  + This is to workaround the limitation that drop trait has to be sync
- If we're lucky, when send happens table handler is still alive, otherwise sending to a closed channel panics

No real good way except introducing complicated synchronization logic, this PR simply adds sleep in between.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/636

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
