### PR TITLE
[storage] Fix unique file id assignment at iceberg persistence

### DIFF
--- a/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
@@ -41,7 +41,6 @@ use iceberg::transaction::{ApplyTransactionAction, Transaction};
 use iceberg::writer::file_writer::location_generator::DefaultLocationGenerator;
 use iceberg::writer::file_writer::location_generator::LocationGenerator;
 use iceberg::{NamespaceIdent, Result as IcebergResult, TableIdent};
-use more_asserts as ma;
 use typed_builder::TypedBuilder;
 use uuid::Uuid;
 
@@ -381,10 +380,9 @@ impl IcebergTableManager {
         let unique_table_auto_incre_id_offset = puffin_index / storage_utils::NUM_FILES_PER_FLUSH;
         let cur_table_auto_incr_id =
             file_params.table_auto_incr_ids.start as u64 + unique_table_auto_incre_id_offset;
-        ma::assert_lt!(
-            cur_table_auto_incr_id,
-            file_params.table_auto_incr_ids.end as u64
-        );
+        assert!(file_params
+            .table_auto_incr_ids
+            .contains(&(cur_table_auto_incr_id as u32)));
         let cur_file_idx =
             puffin_index - storage_utils::NUM_FILES_PER_FLUSH * unique_table_auto_incre_id_offset;
         TableUniqueFileId {

--- a/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
@@ -371,7 +371,7 @@ impl IcebergTableManager {
     /// ---------- store snapshot ----------
     ///
     /// Util function to get unique table file id for the deletion vector puffin file.
-    /// 
+    ///
     /// Notice: only deletion vector puffin generates new file ids.
     fn get_unique_table_id_for_deletion_vector_puffin(
         &self,

--- a/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
@@ -14,7 +14,6 @@ use crate::storage::iceberg::table_manager::{
 use crate::storage::iceberg::utils;
 use crate::storage::iceberg::validation as IcebergValidation;
 use crate::storage::index::{FileIndex as MooncakeFileIndex, MooncakeIndex};
-use crate::storage::io_utils;
 use crate::storage::mooncake_table::delete_vector::BatchDeletionVector;
 use crate::storage::mooncake_table::IcebergSnapshotPayload;
 use crate::storage::mooncake_table::Snapshot as MooncakeSnapshot;
@@ -27,6 +26,7 @@ use crate::storage::storage_utils::{
     create_data_file, get_unique_file_id_for_flush, FileId, MooncakeDataFileRef, TableId,
     TableUniqueFileId,
 };
+use crate::storage::{io_utils, storage_utils};
 use crate::ObjectStorageCache;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -41,6 +41,7 @@ use iceberg::transaction::{ApplyTransactionAction, Transaction};
 use iceberg::writer::file_writer::location_generator::DefaultLocationGenerator;
 use iceberg::writer::file_writer::location_generator::LocationGenerator;
 use iceberg::{NamespaceIdent, Result as IcebergResult, TableIdent};
+use more_asserts as ma;
 use typed_builder::TypedBuilder;
 use uuid::Uuid;
 
@@ -369,6 +370,32 @@ impl IcebergTableManager {
 
     /// ---------- store snapshot ----------
     ///
+    /// Util function to get unique table file id for the deletion vector puffin file.
+    /// 
+    /// Notice: only deletion vector puffin generates new file ids.
+    fn get_unique_table_id_for_deletion_vector_puffin(
+        &self,
+        file_params: &PersistenceFileParams,
+        puffin_index: u64,
+    ) -> TableUniqueFileId {
+        let unique_table_auto_incre_id_offset = puffin_index / storage_utils::NUM_FILES_PER_FLUSH;
+        let cur_table_auto_incr_id =
+            file_params.table_auto_incr_ids.start as u64 + unique_table_auto_incre_id_offset;
+        ma::assert_lt!(
+            cur_table_auto_incr_id,
+            file_params.table_auto_incr_ids.end as u64
+        );
+        let cur_file_idx =
+            puffin_index - storage_utils::NUM_FILES_PER_FLUSH * unique_table_auto_incre_id_offset;
+        TableUniqueFileId {
+            table_id: TableId(self.mooncake_table_metadata.id),
+            file_id: FileId(get_unique_file_id_for_flush(
+                cur_table_auto_incr_id,
+                cur_file_idx,
+            )),
+        }
+    }
+
     /// Write deletion vector to puffin file.
     /// Precondition: batch deletion vector is not empty.
     ///
@@ -414,13 +441,8 @@ impl IcebergTableManager {
             .await?;
 
         // Import the puffin file in object storage cache.
-        let unique_file_id = TableUniqueFileId {
-            table_id: TableId(self.mooncake_table_metadata.id),
-            file_id: FileId(get_unique_file_id_for_flush(
-                file_params.table_auto_incr_id as u64,
-                puffin_index,
-            )),
-        };
+        let unique_file_id =
+            self.get_unique_table_id_for_deletion_vector_puffin(file_params, puffin_index);
         let (cache_handle, evicted_files_to_delete) = self
             .object_storage_cache
             .get_cache_entry(unique_file_id, &puffin_filepath)

--- a/src/moonlink/src/storage/iceberg/table_manager.rs
+++ b/src/moonlink/src/storage/iceberg/table_manager.rs
@@ -17,7 +17,7 @@ use mockall::*;
 /// File parameters required for snapshot persistence.
 pub struct PersistenceFileParams {
     /// Used to generate unique file id.
-    pub(crate) table_auto_incr_id: u32,
+    pub(crate) table_auto_incr_ids: std::ops::Range<u32>,
 }
 
 /// Iceberg persistence results.

--- a/src/moonlink/src/storage/iceberg/test_utils.rs
+++ b/src/moonlink/src/storage/iceberg/test_utils.rs
@@ -137,11 +137,20 @@ pub(crate) fn create_test_arrow_schema() -> Arc<ArrowSchema> {
 pub(crate) fn create_test_table_metadata(
     local_table_directory: String,
 ) -> Arc<MooncakeTableMetadata> {
+    let config = MooncakeTableConfig::new(local_table_directory.clone());
+    create_test_table_metadata_with_config(local_table_directory, config)
+}
+
+/// Test util function to create mooncake table metadata with mooncake table config.
+pub(crate) fn create_test_table_metadata_with_config(
+    local_table_directory: String,
+    mooncake_table_config: MooncakeTableConfig,
+) -> Arc<MooncakeTableMetadata> {
     Arc::new(MooncakeTableMetadata {
         name: "test_table".to_string(),
         id: 0,
         schema: create_test_arrow_schema(),
-        config: MooncakeTableConfig::new(local_table_directory.clone()),
+        config: mooncake_table_config,
         path: std::path::PathBuf::from(local_table_directory),
         identity: RowIdentity::FullRow,
     })

--- a/src/moonlink/src/storage/iceberg/tests.rs
+++ b/src/moonlink/src/storage/iceberg/tests.rs
@@ -221,7 +221,7 @@ async fn test_store_and_load_snapshot_impl(
     };
 
     let peristence_file_params = PersistenceFileParams {
-        table_auto_incr_id: 1,
+        table_auto_incr_ids: 1..2,
     };
     iceberg_table_manager
         .sync_snapshot(iceberg_snapshot_payload, peristence_file_params)
@@ -271,7 +271,7 @@ async fn test_store_and_load_snapshot_impl(
     };
 
     let peristence_file_params = PersistenceFileParams {
-        table_auto_incr_id: 3,
+        table_auto_incr_ids: 3..4,
     };
     iceberg_table_manager
         .sync_snapshot(iceberg_snapshot_payload, peristence_file_params)
@@ -344,7 +344,7 @@ async fn test_store_and_load_snapshot_impl(
         },
     };
     let peristence_file_params = PersistenceFileParams {
-        table_auto_incr_id: 4,
+        table_auto_incr_ids: 4..5,
     };
     iceberg_table_manager
         .sync_snapshot(iceberg_snapshot_payload, peristence_file_params)
@@ -416,7 +416,7 @@ async fn test_store_and_load_snapshot_impl(
         },
     };
     let peristence_file_params = PersistenceFileParams {
-        table_auto_incr_id: 6,
+        table_auto_incr_ids: 6..7,
     };
     iceberg_table_manager
         .sync_snapshot(iceberg_snapshot_payload, peristence_file_params)
@@ -477,7 +477,7 @@ async fn test_store_and_load_snapshot_impl(
         },
     };
     let peristence_file_params = PersistenceFileParams {
-        table_auto_incr_id: 7,
+        table_auto_incr_ids: 7..8,
     };
     iceberg_table_manager
         .sync_snapshot(iceberg_snapshot_payload, peristence_file_params)
@@ -753,7 +753,7 @@ async fn test_empty_content_snapshot_creation() {
     };
 
     let persistence_file_params = PersistenceFileParams {
-        table_auto_incr_id: 0,
+        table_auto_incr_ids: 0..1,
     };
     iceberg_table_manager
         .sync_snapshot(iceberg_snapshot_payload, persistence_file_params)

--- a/src/moonlink/src/storage/iceberg/tests.rs
+++ b/src/moonlink/src/storage/iceberg/tests.rs
@@ -1557,7 +1557,7 @@ async fn test_drop_table_at_creation() {
     assert!(snapshot.data_file_flush_lsn.is_none());
 }
 
-/// Testint scenario: a large number of deletion records are requested to persist to iceberg, thus multiple table auto increment ids are needed.
+/// Testing scenario: a large number of deletion records are requested to persist to iceberg, thus multiple table auto increment ids are needed.
 /// For more details, please refer to https://github.com/Mooncake-Labs/moonlink/issues/640
 #[tokio::test]
 async fn test_multiple_table_ids_for_deletion_vector() {

--- a/src/moonlink/src/storage/iceberg/tests.rs
+++ b/src/moonlink/src/storage/iceberg/tests.rs
@@ -23,6 +23,7 @@ use crate::storage::mooncake_table::{
     IcebergSnapshotIndexMergePayload,
 };
 use crate::storage::mooncake_table::{MooncakeTableConfig, TableMetadata as MooncakeTableMetadata};
+use crate::storage::storage_utils;
 use crate::storage::storage_utils::create_data_file;
 use crate::storage::storage_utils::FileId;
 use crate::storage::storage_utils::MooncakeDataFileRef;
@@ -1554,4 +1555,88 @@ async fn test_drop_table_at_creation() {
     assert!(snapshot.disk_files.is_empty());
     assert!(snapshot.indices.file_indices.is_empty());
     assert!(snapshot.data_file_flush_lsn.is_none());
+}
+
+/// Testint scenario: a large number of deletion records are requested to persist to iceberg, thus multiple table auto increment ids are needed.
+/// For more details, please refer to https://github.com/Mooncake-Labs/moonlink/issues/640
+#[tokio::test]
+async fn test_multiple_table_ids_for_deletion_vector() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let path = temp_dir.path().to_path_buf();
+    let warehouse_uri = path.clone().to_str().unwrap().to_string();
+    let mooncake_table_config = MooncakeTableConfig {
+        // Flush as long as there's new rows appended at commit.
+        mem_slice_size: 1,
+        // At flush, place each row in a separate parquet file.
+        disk_slice_parquet_file_size: 1,
+        ..Default::default()
+    };
+    let mooncake_table_metadata = create_test_table_metadata_with_config(
+        temp_dir.path().to_str().unwrap().to_string(),
+        mooncake_table_config,
+    );
+    let identity_property = mooncake_table_metadata.identity.clone();
+
+    let iceberg_table_config = create_iceberg_table_config(warehouse_uri);
+    let schema = create_test_arrow_schema();
+    let mut table = MooncakeTable::new(
+        schema.as_ref().clone(),
+        "test_table".to_string(),
+        /*version=*/ 1,
+        path,
+        identity_property,
+        iceberg_table_config.clone(),
+        MooncakeTableConfig::default(),
+        ObjectStorageCache::default_for_test(&temp_dir),
+    )
+    .await
+    .unwrap();
+    let (notify_tx, mut notify_rx) = mpsc::channel(100);
+    table.register_table_notify(notify_tx).await;
+
+    // Create a large number of data files, which is larger than [`NUM_FILES_PER_FLUSH`].
+    let target_data_files_num = storage_utils::NUM_FILES_PER_FLUSH + 1;
+    let mut all_rows = Vec::with_capacity(target_data_files_num as usize);
+    for idx in 0..target_data_files_num {
+        let cur_row = MoonlinkRow::new(vec![
+            RowValue::Int32(idx as i32),
+            RowValue::ByteArray(idx.to_be_bytes().to_vec()),
+            RowValue::Int32(idx as i32),
+        ]);
+        all_rows.push(cur_row.clone());
+        table.append(cur_row).unwrap();
+        table.commit(/*lsn=*/ idx);
+        table.flush(/*lsn=*/ idx).await.unwrap();
+    }
+
+    // Create the first mooncake and iceberg snapshot, which include [`target_data_files_num`] number of files.
+    create_mooncake_and_persist_for_test(&mut table, &mut notify_rx).await;
+
+    // Delete all rows, which corresponds to large number of deletion vector puffin files.
+    for cur_row in all_rows.into_iter() {
+        table.delete(cur_row, /*lsn=*/ target_data_files_num).await;
+    }
+    table.commit(/*lsn=*/ target_data_files_num + 1);
+    table
+        .flush(/*lsn=*/ target_data_files_num + 1)
+        .await
+        .unwrap();
+
+    // Create the second mooncake and iceberg snapshot, which include [`target_data_files_num`] number of deletion vector puffin files.
+    create_mooncake_and_persist_for_test(&mut table, &mut notify_rx).await;
+
+    // Load snaphot from iceberg table to validate.
+    let (_, mut iceberg_table_manager_for_recovery, _) =
+        create_table_and_iceberg_manager(&temp_dir).await;
+    let (next_file_id, snapshot) = iceberg_table_manager_for_recovery
+        .load_snapshot_from_table()
+        .await
+        .unwrap();
+    assert_eq!(next_file_id as u64, target_data_files_num * 3); // one for data file, one for deletion vector puffin, one for file indices.
+
+    // Check deletion vector puffin files' file id.
+    assert_eq!(snapshot.disk_files.len() as u64, target_data_files_num);
+    for (_, cur_disk_file_entry) in snapshot.disk_files.iter() {
+        assert!(cur_disk_file_entry.puffin_deletion_blob.is_some());
+    }
 }

--- a/src/moonlink/src/storage/mooncake_table/state_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/state_test_utils.rs
@@ -631,7 +631,7 @@ pub(crate) async fn perform_data_compaction_for_test(
 /// ===================================
 ///
 /// Test util function to block wait and get iceberg / file indices merge payload.
-pub(crate) async fn sync_mooncake_snapshot(
+async fn sync_mooncake_snapshot(
     receiver: &mut Receiver<TableEvent>,
 ) -> (
     Option<IcebergSnapshotPayload>,

--- a/src/moonlink/src/storage/mooncake_table/state_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/state_test_utils.rs
@@ -631,7 +631,7 @@ pub(crate) async fn perform_data_compaction_for_test(
 /// ===================================
 ///
 /// Test util function to block wait and get iceberg / file indices merge payload.
-async fn sync_mooncake_snapshot(
+pub(crate) async fn sync_mooncake_snapshot(
     receiver: &mut Receiver<TableEvent>,
 ) -> (
     Option<IcebergSnapshotPayload>,
@@ -692,6 +692,7 @@ async fn sync_data_compaction(receiver: &mut Receiver<TableEvent>) -> DataCompac
 /// ===================================
 /// Composite util functions
 /// ===================================
+///
 // Test util function, which creates mooncake snapshot for testing.
 pub(crate) async fn create_mooncake_snapshot_for_test(
     table: &mut MooncakeTable,

--- a/src/moonlink/src/storage/mooncake_table/table_snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_snapshot.rs
@@ -58,6 +58,14 @@ pub struct IcebergSnapshotPayload {
     pub(crate) data_compaction_payload: IcebergSnapshotDataCompactionPayload,
 }
 
+impl IcebergSnapshotPayload {
+    /// Get the number of new files created in iceberg table.
+    pub fn get_new_file_ids_num(&self) -> u32 {
+        // Only deletion vector puffin blobs create files with new file ids.
+        self.import_payload.new_deletion_vector.len() as u32
+    }
+}
+
 ////////////////////////////
 /// Iceberg snapshot result
 ////////////////////////////

--- a/src/moonlink/src/storage/storage_utils.rs
+++ b/src/moonlink/src/storage/storage_utils.rs
@@ -36,7 +36,7 @@ impl Hash for MooncakeDataFile {
 pub type MooncakeDataFileRef = Arc<MooncakeDataFile>;
 
 const LOCAL_FILE_ID_BASE: u64 = 10000000000000000;
-const NUM_FILES_PER_FLUSH: u64 = 100;
+pub const NUM_FILES_PER_FLUSH: u64 = 100;
 
 pub fn get_unique_file_id_for_flush(table_auto_incr_id: u64, file_idx: u64) -> u64 {
     ma::assert_lt!(file_idx, NUM_FILES_PER_FLUSH);


### PR DESCRIPTION
## Summary

This PR fixes unique file id assignment at iceberg persistence.
Current buggy implementation uses the same table auto increment id for all deletion vector files, which limits max file number  to be 100.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/642

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
