### PR TITLE
[storage] Allow excessive number of data files to compact

### DIFF
--- a/src/moonlink/src/storage/compaction/compactor.rs
+++ b/src/moonlink/src/storage/compaction/compactor.rs
@@ -19,11 +19,10 @@ use crate::storage::iceberg::puffin_utils;
 use crate::storage::index::persisted_bucket_hash_map::GlobalIndexBuilder;
 use crate::storage::index::FileIndex;
 use crate::storage::mooncake_table::delete_vector::BatchDeletionVector;
+use crate::storage::storage_utils::RecordLocation;
 use crate::storage::storage_utils::{
-    get_file_idx_from_flush_file_id, get_random_file_name_in_dir, get_unique_file_id_for_flush,
-    MooncakeDataFileRef,
+    get_random_file_name_in_dir, get_unique_file_id_for_flush, MooncakeDataFileRef,
 };
-use crate::storage::storage_utils::{FileId, RecordLocation};
 use crate::storage::{parquet_utils, storage_utils};
 use crate::{create_data_file, Result};
 

--- a/src/moonlink/src/storage/compaction/table_compaction.rs
+++ b/src/moonlink/src/storage/compaction/table_compaction.rs
@@ -31,6 +31,14 @@ pub struct DataCompactionPayload {
     pub(crate) file_indices: Vec<FileIndex>,
 }
 
+impl DataCompactionPayload {
+    /// Get max possible number of new file ids number.
+    pub fn get_new_compacted_data_file_ids_number(&self) -> u32 {
+        // In worst case, we create two new files (one data file, one index block) per data file.
+        self.disk_files.len() as u32 * 2
+    }
+}
+
 /// Entry for compacted data files.
 #[derive(Clone, Debug, PartialEq)]
 pub(crate) struct CompactedDataEntry {

--- a/src/moonlink/src/storage/compaction/tests.rs
+++ b/src/moonlink/src/storage/compaction/tests.rs
@@ -5,7 +5,7 @@ use crate::storage::compaction::test_utils::get_record_location_mapping;
 use crate::storage::iceberg::test_utils as iceberg_test_utils;
 use crate::storage::mooncake_table::delete_vector::BatchDeletionVector;
 use crate::storage::storage_utils::{
-    get_unique_file_id_for_flush, MooncakeDataFileRef, TableId, TableUniqueFileId,
+    self, get_unique_file_id_for_flush, MooncakeDataFileRef, TableId, TableUniqueFileId,
 };
 use crate::storage::storage_utils::{FileId, RecordLocation};
 use crate::storage::PuffinBlobRef;
@@ -674,7 +674,7 @@ async fn test_multiple_compacted_data_files_1() {
     let table_auto_incr_id: u64 = 4;
     let file_params = CompactionFileParams {
         dir_path: std::path::PathBuf::from(temp_dir.path()),
-        table_auto_incr_ids: (table_auto_incr_id as u32)..(table_auto_incr_id as u32 + 1),
+        table_auto_incr_ids: (table_auto_incr_id as u32)..(table_auto_incr_id as u32 + 4),
         data_file_final_size: MULTI_COMPACTED_DATA_FILE_SIZE,
     };
 
@@ -809,7 +809,7 @@ async fn test_multiple_compacted_data_files_2() {
     let table_auto_incr_id: u64 = 4;
     let file_params = CompactionFileParams {
         dir_path: std::path::PathBuf::from(temp_dir.path()),
-        table_auto_incr_ids: (table_auto_incr_id as u32)..(table_auto_incr_id as u32 + 1),
+        table_auto_incr_ids: (table_auto_incr_id as u32)..(table_auto_incr_id as u32 + 4),
         data_file_final_size: MULTI_COMPACTED_DATA_FILE_SIZE,
     };
 
@@ -822,4 +822,82 @@ async fn test_multiple_compacted_data_files_2() {
     let compaction_result = builder.build().await.unwrap();
     assert!(compaction_result.new_data_files.is_empty());
     assert!(compaction_result.remapped_data_files.is_empty());
+}
+
+/// Testing scenario: new compacted data files are larger than max flush count.
+/// For more details, please refer to https://github.com/Mooncake-Labs/moonlink/issues/641
+#[tokio::test]
+async fn test_large_number_of_data_files() {
+    // Create data file.
+    let temp_dir = tempfile::tempdir().unwrap();
+
+    let target_data_files_to_compact = storage_utils::NUM_FILES_PER_FLUSH + 1;
+    let record_batch = test_utils::create_test_batch_1();
+    let row_count_per_file = record_batch.num_rows();
+
+    let mut old_data_files_to_compact = vec![];
+    let mut old_file_indices_to_compact = vec![];
+    for idx in 0..target_data_files_to_compact {
+        let data_file_file_id = idx;
+        let index_block_file_id = target_data_files_to_compact + idx;
+
+        // Prepare data files to compact.
+        let data_file_path = temp_dir.path().join(format!("test-{}.parquet", idx));
+        let data_file = create_data_file(
+            data_file_file_id,
+            data_file_path.to_str().unwrap().to_string(),
+        );
+        test_utils::dump_arrow_record_batches(vec![record_batch.clone()], data_file.clone()).await;
+        old_data_files_to_compact.push(get_single_file_to_compact(
+            &data_file, /*deletion_vector=*/ None,
+        ));
+
+        // Prepare file indices to compact.
+        let file_index = test_utils::create_file_index_1(
+            temp_dir.path().to_path_buf(),
+            data_file.clone(),
+            index_block_file_id,
+        )
+        .await;
+        old_file_indices_to_compact.push(file_index);
+    }
+
+    // Prepare compaction payload.
+    let payload = DataCompactionPayload {
+        object_storage_cache: ObjectStorageCache::default_for_test(&temp_dir),
+        disk_files: old_data_files_to_compact,
+        file_indices: old_file_indices_to_compact,
+    };
+    let start_table_auto_incr_id = target_data_files_to_compact as u32 * 3;
+    let end_table_auto_incr_id = target_data_files_to_compact as u32 * 4;
+    let file_params = CompactionFileParams {
+        dir_path: std::path::PathBuf::from(temp_dir.path()),
+        table_auto_incr_ids: start_table_auto_incr_id..end_table_auto_incr_id,
+        data_file_final_size: 1, // Dump each data file into its own file.
+    };
+
+    // Perform compaction.
+    let builder = CompactionBuilder::new(
+        payload,
+        iceberg_test_utils::create_test_arrow_schema(),
+        file_params,
+    );
+    let compaction_result = builder.build().await.unwrap();
+    assert_eq!(
+        compaction_result.remapped_data_files.len(),
+        target_data_files_to_compact as usize * row_count_per_file
+    );
+    assert_eq!(
+        compaction_result.old_data_files.len(),
+        target_data_files_to_compact as usize
+    );
+    assert_eq!(
+        compaction_result.new_data_files.len(),
+        target_data_files_to_compact as usize
+    );
+    assert_eq!(
+        compaction_result.old_file_indices.len(),
+        target_data_files_to_compact as usize
+    );
+    assert_eq!(compaction_result.new_file_indices.len(), 1);
 }

--- a/src/moonlink/src/storage/compaction/tests.rs
+++ b/src/moonlink/src/storage/compaction/tests.rs
@@ -75,7 +75,7 @@ async fn test_data_file_compaction_1() {
     let table_auto_incr_id: u64 = 2;
     let file_params = CompactionFileParams {
         dir_path: std::path::PathBuf::from(temp_dir.path()),
-        table_auto_incr_id: table_auto_incr_id as u32,
+        table_auto_incr_ids: (table_auto_incr_id as u32)..(table_auto_incr_id as u32 + 1),
         data_file_final_size: SINGLE_COMPACTED_DATA_FILE_SIZE,
     };
 
@@ -160,7 +160,7 @@ async fn test_data_file_compaction_2() {
     let table_auto_incr_id: u64 = 2;
     let file_params = CompactionFileParams {
         dir_path: std::path::PathBuf::from(temp_dir.path()),
-        table_auto_incr_id: table_auto_incr_id as u32,
+        table_auto_incr_ids: (table_auto_incr_id as u32)..(table_auto_incr_id as u32 + 1),
         data_file_final_size: SINGLE_COMPACTED_DATA_FILE_SIZE,
     };
 
@@ -248,7 +248,7 @@ async fn test_data_file_compaction_3() {
     let table_auto_incr_id: u64 = 2;
     let file_params = CompactionFileParams {
         dir_path: std::path::PathBuf::from(temp_dir.path()),
-        table_auto_incr_id: table_auto_incr_id as u32,
+        table_auto_incr_ids: (table_auto_incr_id as u32)..(table_auto_incr_id as u32 + 1),
         data_file_final_size: SINGLE_COMPACTED_DATA_FILE_SIZE,
     };
 
@@ -327,7 +327,7 @@ async fn test_data_file_compaction_4() {
     let table_auto_incr_id: u64 = 4;
     let file_params = CompactionFileParams {
         dir_path: std::path::PathBuf::from(temp_dir.path()),
-        table_auto_incr_id: table_auto_incr_id as u32,
+        table_auto_incr_ids: (table_auto_incr_id as u32)..(table_auto_incr_id as u32 + 1),
         data_file_final_size: SINGLE_COMPACTED_DATA_FILE_SIZE,
     };
 
@@ -442,7 +442,7 @@ async fn test_data_file_compaction_5() {
     let table_auto_incr_id: u64 = 4;
     let file_params = CompactionFileParams {
         dir_path: std::path::PathBuf::from(temp_dir.path()),
-        table_auto_incr_id: table_auto_incr_id as u32,
+        table_auto_incr_ids: (table_auto_incr_id as u32)..(table_auto_incr_id as u32 + 1),
         data_file_final_size: SINGLE_COMPACTED_DATA_FILE_SIZE,
     };
 
@@ -564,7 +564,7 @@ async fn test_data_file_compaction_6() {
     let table_auto_incr_id: u64 = 4;
     let file_params = CompactionFileParams {
         dir_path: std::path::PathBuf::from(temp_dir.path()),
-        table_auto_incr_id: table_auto_incr_id as u32,
+        table_auto_incr_ids: (table_auto_incr_id as u32)..(table_auto_incr_id as u32 + 1),
         data_file_final_size: SINGLE_COMPACTED_DATA_FILE_SIZE,
     };
 
@@ -674,7 +674,7 @@ async fn test_multiple_compacted_data_files_1() {
     let table_auto_incr_id: u64 = 4;
     let file_params = CompactionFileParams {
         dir_path: std::path::PathBuf::from(temp_dir.path()),
-        table_auto_incr_id: table_auto_incr_id as u32,
+        table_auto_incr_ids: (table_auto_incr_id as u32)..(table_auto_incr_id as u32 + 1),
         data_file_final_size: MULTI_COMPACTED_DATA_FILE_SIZE,
     };
 
@@ -809,7 +809,7 @@ async fn test_multiple_compacted_data_files_2() {
     let table_auto_incr_id: u64 = 4;
     let file_params = CompactionFileParams {
         dir_path: std::path::PathBuf::from(temp_dir.path()),
-        table_auto_incr_id: table_auto_incr_id as u32,
+        table_auto_incr_ids: (table_auto_incr_id as u32)..(table_auto_incr_id as u32 + 1),
         data_file_final_size: MULTI_COMPACTED_DATA_FILE_SIZE,
     };
 

--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -811,11 +811,12 @@ impl MooncakeTable {
 
     /// Perform data compaction, whose completion will be notified separately in async style.
     pub(crate) fn perform_data_compaction(&mut self, compaction_payload: DataCompactionPayload) {
-        let next_file_id = self.next_file_id;
-        self.next_file_id += 1;
+        let data_compaction_new_file_ids = compaction_payload.get_new_compacted_data_file_ids_number();
+        let table_auto_incr_ids = self.next_file_id..(self.next_file_id + data_compaction_new_file_ids);
+        self.next_file_id += data_compaction_new_file_ids;
         let file_params = CompactionFileParams {
             dir_path: self.metadata.path.clone(),
-            table_auto_incr_id: next_file_id,
+            table_auto_incr_ids,
             data_file_final_size: self
                 .metadata
                 .config
@@ -966,14 +967,14 @@ impl MooncakeTable {
         let iceberg_table_manager = self.iceberg_table_manager.take().unwrap();
         // Create a detached task, whose completion will be notified separately.
         let new_file_ids_to_create = snapshot_payload.get_new_file_ids_num();
-        let table_auto_incre_ids = self.next_file_id..(self.next_file_id + new_file_ids_to_create);
+        let table_auto_incr_ids = self.next_file_id..(self.next_file_id + new_file_ids_to_create);
         self.next_file_id += new_file_ids_to_create;
         tokio::task::spawn(
             Self::persist_iceberg_snapshot_impl(
                 iceberg_table_manager,
                 snapshot_payload,
                 self.table_notify.as_ref().unwrap().clone(),
-                table_auto_incre_ids,
+                table_auto_incr_ids,
             )
             .instrument(info_span!("persist_iceberg_snapshot")),
         );

--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -811,8 +811,10 @@ impl MooncakeTable {
 
     /// Perform data compaction, whose completion will be notified separately in async style.
     pub(crate) fn perform_data_compaction(&mut self, compaction_payload: DataCompactionPayload) {
-        let data_compaction_new_file_ids = compaction_payload.get_new_compacted_data_file_ids_number();
-        let table_auto_incr_ids = self.next_file_id..(self.next_file_id + data_compaction_new_file_ids);
+        let data_compaction_new_file_ids =
+            compaction_payload.get_new_compacted_data_file_ids_number();
+        let table_auto_incr_ids =
+            self.next_file_id..(self.next_file_id + data_compaction_new_file_ids);
         self.next_file_id += data_compaction_new_file_ids;
         let file_params = CompactionFileParams {
             dir_path: self.metadata.path.clone(),

--- a/src/moonlink/src/storage/storage_utils.rs
+++ b/src/moonlink/src/storage/storage_utils.rs
@@ -43,10 +43,6 @@ pub fn get_unique_file_id_for_flush(table_auto_incr_id: u64, file_idx: u64) -> u
     LOCAL_FILE_ID_BASE + table_auto_incr_id * NUM_FILES_PER_FLUSH + file_idx
 }
 
-pub fn get_file_idx_from_flush_file_id(file_id: u64, table_auto_incr_id: u64) -> u64 {
-    file_id - LOCAL_FILE_ID_BASE - table_auto_incr_id * NUM_FILES_PER_FLUSH
-}
-
 pub fn get_random_file_name_in_dir(dir_path: &Path) -> String {
     dir_path
         .join(format!("data-{}.parquet", uuid::Uuid::now_v7()))


### PR DESCRIPTION
## Summary

Current implementation assigns only one table id to compactor, which limits overall data files to compact 100.
This PR assigns a range of table ids, according to the compaction payload.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/641

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
