### PR TITLE
[storage] Implement retry on iceberg transaction commit

### DIFF
--- a/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
@@ -6,13 +6,16 @@ use crate::storage::iceberg::deletion_vector::{
 };
 use crate::storage::iceberg::index::FileIndexBlob;
 use crate::storage::iceberg::moonlink_catalog::MoonlinkCatalog;
-use crate::storage::iceberg::puffin_utils;
 use crate::storage::iceberg::puffin_utils::PuffinBlobRef;
 use crate::storage::iceberg::table_manager::{
     PersistenceFileParams, PersistenceResult, TableManager,
 };
+use crate::storage::iceberg::table_property::{
+    self, TABLE_COMMIT_RETRY_MAX_MS_DEFAULT, TABLE_COMMIT_RETRY_MIN_MS_DEFAULT,
+};
 use crate::storage::iceberg::utils;
 use crate::storage::iceberg::validation as IcebergValidation;
+use crate::storage::iceberg::{puffin_utils, tokio_retry_utils};
 use crate::storage::index::{FileIndex as MooncakeFileIndex, MooncakeIndex};
 use crate::storage::mooncake_table::delete_vector::BatchDeletionVector;
 use crate::storage::mooncake_table::IcebergSnapshotPayload;
@@ -40,7 +43,9 @@ use iceberg::table::Table as IcebergTable;
 use iceberg::transaction::{ApplyTransactionAction, Transaction};
 use iceberg::writer::file_writer::location_generator::DefaultLocationGenerator;
 use iceberg::writer::file_writer::location_generator::LocationGenerator;
-use iceberg::{NamespaceIdent, Result as IcebergResult, TableIdent};
+use iceberg::{Error as IcebergError, NamespaceIdent, Result as IcebergResult, TableIdent};
+use tokio_retry2::strategy::{jitter, ExponentialBackoff};
+use tokio_retry2::{Retry, RetryError};
 use typed_builder::TypedBuilder;
 use uuid::Uuid;
 
@@ -734,6 +739,33 @@ impl IcebergTableManager {
 
         Ok(remote_file_indices)
     }
+
+    /// Commit transaction with retry.
+    ///
+    /// TODO(hjiang): Add unit test; currently it's hard due to the difficulty to mock opendal.
+    async fn commit_transaction_with_retry(&self, txn: Transaction) -> IcebergResult<IcebergTable> {
+        let retry_strategy = ExponentialBackoff::from_millis(TABLE_COMMIT_RETRY_MIN_MS_DEFAULT)
+            .factor(table_property::TABLE_COMMIT_RETRY_FACTOR)
+            .max_delay(std::time::Duration::from_millis(
+                TABLE_COMMIT_RETRY_MAX_MS_DEFAULT,
+            ))
+            .map(jitter);
+
+        let catalog = &*self.catalog;
+        let iceberg_table = Retry::spawn(retry_strategy, || {
+            let txn = txn.clone();
+            async move {
+                let table = txn
+                    .commit(catalog)
+                    .await
+                    .map_err(tokio_retry_utils::iceberg_to_tokio_retry_error)?;
+                Ok::<IcebergTable, RetryError<IcebergError>>(table)
+            }
+        })
+        .await?;
+
+        Ok(iceberg_table)
+    }
 }
 
 /// TODO(hjiang): Parallelize all IO operations.
@@ -790,8 +822,9 @@ impl TableManager for IcebergTableManager {
             snapshot_payload.flush_lsn.to_string(),
         );
         txn = action.apply(txn)?;
+        let updated_iceberg_table = self.commit_transaction_with_retry(txn).await?;
+        self.iceberg_table = Some(updated_iceberg_table);
 
-        self.iceberg_table = Some(txn.commit(&*self.catalog).await?);
         self.catalog.clear_puffin_metadata();
 
         // NOTICE: persisted data files and file indices are returned in the order of (1) newly imported ones; (2) index merge ones; (3) data compacted ones.

--- a/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
@@ -742,7 +742,7 @@ impl IcebergTableManager {
 
     /// Commit transaction with retry.
     ///
-    /// TODO(hjiang): Add unit test; currently it's hard due to the difficulty to mock opendal.
+    /// TODO(hjiang): Add unit test; currently it's hard due to the difficulty to mock opendal or catalog.
     async fn commit_transaction_with_retry(&self, txn: Transaction) -> IcebergResult<IcebergTable> {
         let retry_strategy = ExponentialBackoff::from_millis(TABLE_COMMIT_RETRY_MIN_MS_DEFAULT)
             .factor(table_property::TABLE_COMMIT_RETRY_FACTOR)

--- a/src/moonlink/src/storage/iceberg/table_property.rs
+++ b/src/moonlink/src/storage/iceberg/table_property.rs
@@ -12,7 +12,7 @@ pub(crate) const METADATA_COMPRESSION_DEFAULT: &str = "none";
 
 /// Retry properties.
 pub(crate) const TABLE_COMMIT_RETRY_NUM: &str = "commit.retry.num-retries";
-pub(crate) const TABLE_COMMIT_RETRY_NUM_DEFAULT: u64 = 3;
+pub(crate) const TABLE_COMMIT_RETRY_NUM_DEFAULT: u64 = 5;
 
 pub(crate) const TABLE_COMMIT_RETRY_MIN_MS: &str = "commit.retry.min-wait-ms";
 pub(crate) const TABLE_COMMIT_RETRY_MIN_MS_DEFAULT: u64 = 200;

--- a/src/moonlink/src/storage/iceberg/table_property.rs
+++ b/src/moonlink/src/storage/iceberg/table_property.rs
@@ -12,16 +12,18 @@ pub(crate) const METADATA_COMPRESSION_DEFAULT: &str = "none";
 
 /// Retry properties.
 pub(crate) const TABLE_COMMIT_RETRY_NUM: &str = "commit.retry.num-retries";
-pub(crate) const TABLE_COMMIT_RETRY_NUM_DEFAULT: u64 = 0;
+pub(crate) const TABLE_COMMIT_RETRY_NUM_DEFAULT: u64 = 3;
 
 pub(crate) const TABLE_COMMIT_RETRY_MIN_MS: &str = "commit.retry.min-wait-ms";
-pub(crate) const TABLE_COMMIT_RETRY_MIN_MS_DEFAULT: u64 = 0;
+pub(crate) const TABLE_COMMIT_RETRY_MIN_MS_DEFAULT: u64 = 200;
 
 pub(crate) const TABLE_COMMIT_RETRY_MAX_MS: &str = "commit.retry.max-wait-ms";
-pub(crate) const TABLE_COMMIT_RETRY_MAX_MS_DEFAULT: u64 = 0;
+pub(crate) const TABLE_COMMIT_RETRY_MAX_MS_DEFAULT: u64 = 30000; // 30 second
 
 pub(crate) const TABLE_COMMIT_RETRY_TIMEOUT_MS: &str = "commit.retry.total-timeout-ms";
-pub(crate) const TABLE_COMMIT_RETRY_TIMEOUT_MS_DEFAULT: u64 = 0;
+pub(crate) const TABLE_COMMIT_RETRY_TIMEOUT_MS_DEFAULT: u64 = 120000; // 2 min
+
+pub(crate) const TABLE_COMMIT_RETRY_FACTOR: u64 = 2;
 
 // Create iceberg table properties from table config.
 pub(crate) fn create_iceberg_table_properties() -> HashMap<String, String> {

--- a/src/moonlink/src/storage/iceberg/tokio_retry_utils.rs
+++ b/src/moonlink/src/storage/iceberg/tokio_retry_utils.rs
@@ -5,10 +5,12 @@ use tokio_retry2::RetryError as TokioRetryError;
 /// Convert iceberg error to tokio retry error. Only `Unexpected` iceberg error translates to transient error.
 pub(crate) fn iceberg_to_tokio_retry_error(err: IcebergError) -> TokioRetryError<IcebergError> {
     match err.kind() {
-        iceberg::ErrorKind::Unexpected => TokioRetryError::Transient {
-            err,
-            retry_after: None,
-        },
+        iceberg::ErrorKind::Unexpected | iceberg::ErrorKind::CatalogCommitConflicts => {
+            TokioRetryError::Transient {
+                err,
+                retry_after: None,
+            }
+        }
         _ => TokioRetryError::Permanent(err),
     }
 }

--- a/src/moonlink/src/storage/iceberg/tokio_retry_utils.rs
+++ b/src/moonlink/src/storage/iceberg/tokio_retry_utils.rs
@@ -3,7 +3,6 @@ use iceberg::Error as IcebergError;
 use tokio_retry2::RetryError as TokioRetryError;
 
 /// Convert iceberg error to tokio retry error. Only `Unexpected` iceberg error translates to transient error.
-#[allow(dead_code)]
 pub(crate) fn iceberg_to_tokio_retry_error(err: IcebergError) -> TokioRetryError<IcebergError> {
     match err.kind() {
         iceberg::ErrorKind::Unexpected => TokioRetryError::Transient {


### PR DESCRIPTION
## Summary

Transaction commit is part of the iceberg spec: https://iceberg.apache.org/docs/latest/configuration/#table-behavior-properties
In this PR, I implement the retry with exponential backoff with jitter, and update the corresponding table properties.

Unfortunately it's hard to test via mock, because both the underlying catalog and opendal is hard to mock.
Later I will likely create a layer above opendal for fault injection.

TODO: if iceberg-rust supports retry internally, I will likely remove the retry here; but not sure how community is going to implement, and how it affects our own file catalog.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/627

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
