### PR TITLE
[storage] Integrate create and drop table with metadata store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2437,6 +2437,7 @@ dependencies = [
  "console-subscriber",
  "moonlink",
  "moonlink_connectors",
+ "moonlink_metadata_store",
  "more-asserts",
  "nix 0.27.1",
  "parquet",

--- a/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
@@ -224,7 +224,7 @@ impl IcebergTableManager {
             .reserve(expected_file_indices_count);
         let mut file_indices = Vec::with_capacity(new_file_indices_count);
         for mut cur_iceberg_file_indice in file_index_blob.file_indices.into_iter() {
-            let table_id = TableId(self.mooncake_table_metadata.id);
+            let table_id = TableId(self.mooncake_table_metadata.table_id);
             let cur_mooncake_file_indice = cur_iceberg_file_indice
                 .as_mooncake_file_index(
                     &self.remote_data_file_to_file_id,
@@ -300,7 +300,7 @@ impl IcebergTableManager {
         let cur_file_id = *next_file_id;
         *next_file_id += 1;
         let unique_file_id = TableUniqueFileId {
-            table_id: TableId(self.mooncake_table_metadata.id),
+            table_id: TableId(self.mooncake_table_metadata.table_id),
             file_id: FileId(cur_file_id),
         };
         let (cache_handle, evicted_files_to_delete) = self
@@ -391,7 +391,7 @@ impl IcebergTableManager {
         let cur_file_idx =
             puffin_index - storage_utils::NUM_FILES_PER_FLUSH * unique_table_auto_incre_id_offset;
         TableUniqueFileId {
-            table_id: TableId(self.mooncake_table_metadata.id),
+            table_id: TableId(self.mooncake_table_metadata.table_id),
             file_id: FileId(get_unique_file_id_for_flush(
                 cur_table_auto_incr_id,
                 cur_file_idx,

--- a/src/moonlink/src/storage/iceberg/test_utils.rs
+++ b/src/moonlink/src/storage/iceberg/test_utils.rs
@@ -148,7 +148,7 @@ pub(crate) fn create_test_table_metadata_with_config(
 ) -> Arc<MooncakeTableMetadata> {
     Arc::new(MooncakeTableMetadata {
         name: "test_table".to_string(),
-        id: 0,
+        table_id: 0,
         schema: create_test_arrow_schema(),
         config: mooncake_table_config,
         path: std::path::PathBuf::from(local_table_directory),

--- a/src/moonlink/src/storage/iceberg/test_utils.rs
+++ b/src/moonlink/src/storage/iceberg/test_utils.rs
@@ -218,7 +218,7 @@ pub(crate) async fn create_table_and_iceberg_manager_with_data_compaction_config
     let mut table = MooncakeTable::new(
         schema.as_ref().clone(),
         "test_table".to_string(),
-        /*version=*/ 1,
+        /*table_id=*/ 1,
         path,
         identity_property,
         iceberg_table_config.clone(),

--- a/src/moonlink/src/storage/iceberg/tests.rs
+++ b/src/moonlink/src/storage/iceberg/tests.rs
@@ -795,7 +795,7 @@ async fn test_create_snapshot_when_no_committed_deletion_log_to_flush() {
     let mut table = MooncakeTable::new(
         schema.as_ref().clone(),
         "test_table".to_string(),
-        /*version=*/ 1,
+        /*table_id=*/ 1,
         path,
         identity_property,
         iceberg_table_config.clone(),
@@ -837,7 +837,7 @@ async fn test_skip_iceberg_snapshot() {
     let mut table = MooncakeTable::new(
         schema.as_ref().clone(),
         "test_table".to_string(),
-        /*version=*/ 1,
+        /*table_id=*/ 1,
         path,
         identity_property,
         iceberg_table_config.clone(),
@@ -895,7 +895,7 @@ async fn test_small_batch_size_and_large_parquet_size() {
     let mut table = MooncakeTable::new(
         schema.as_ref().clone(),
         "test_table".to_string(),
-        /*version=*/ 1,
+        /*table_id=*/ 1,
         path,
         identity_property,
         iceberg_table_config.clone(),
@@ -1173,7 +1173,7 @@ async fn mooncake_table_snapshot_persist_impl(warehouse_uri: String) {
     let mut table = MooncakeTable::new(
         schema.as_ref().clone(),
         "test_table".to_string(),
-        /*version=*/ 1,
+        /*table_id=*/ 1,
         path,
         identity_property.clone(),
         iceberg_table_config.clone(),
@@ -1526,7 +1526,7 @@ async fn test_drop_table_at_creation() {
     let mut table = MooncakeTable::new(
         create_test_arrow_schema().as_ref().clone(),
         "test_table".to_string(),
-        /*version=*/ 1,
+        /*table_id=*/ 1,
         PathBuf::from(&path),
         mooncake_table_metadata.identity.clone(),
         iceberg_table_config.clone(),
@@ -1582,7 +1582,7 @@ async fn test_multiple_table_ids_for_deletion_vector() {
     let mut table = MooncakeTable::new(
         schema.as_ref().clone(),
         "test_table".to_string(),
-        /*version=*/ 1,
+        /*table_id=*/ 1,
         path,
         identity_property,
         iceberg_table_config.clone(),

--- a/src/moonlink/src/storage/iceberg/tests.rs
+++ b/src/moonlink/src/storage/iceberg/tests.rs
@@ -647,7 +647,7 @@ async fn test_index_merge_and_create_snapshot() {
 
     let mooncake_table_metadata = Arc::new(MooncakeTableMetadata {
         name: "test_table".to_string(),
-        id: 0,
+        table_id: 0,
         schema: create_test_arrow_schema(),
         config: mooncake_table_config.clone(),
         path: std::path::PathBuf::from(tmp_dir.path().to_str().unwrap().to_string()),

--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -164,7 +164,7 @@ pub struct TableMetadata {
     /// table name
     pub(crate) name: String,
     /// table id
-    pub(crate) id: u64,
+    pub(crate) table_id: u32,
     /// table schema
     pub(crate) schema: Arc<Schema>,
     /// table config
@@ -230,7 +230,7 @@ impl Snapshot {
         let mut directory = PathBuf::from(&self.metadata.config.temp_files_directory);
         directory.push(format!(
             "inmemory_{}_{}_{}.parquet",
-            self.metadata.name, self.metadata.id, self.snapshot_version
+            self.metadata.name, self.metadata.table_id, self.snapshot_version
         ));
         directory
     }
@@ -442,7 +442,7 @@ impl MooncakeTable {
     pub async fn new(
         schema: Schema,
         name: String,
-        version: u64,
+        table_id: u32,
         base_path: PathBuf,
         identity: IdentityProp,
         iceberg_table_config: IcebergTableConfig,
@@ -451,7 +451,7 @@ impl MooncakeTable {
     ) -> Result<Self> {
         let metadata = Arc::new(TableMetadata {
             name,
-            id: version,
+            table_id,
             schema: Arc::new(schema.clone()),
             config: table_config.clone(),
             path: base_path,

--- a/src/moonlink/src/storage/mooncake_table/file_index_state_tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/file_index_state_tests.rs
@@ -200,7 +200,7 @@ pub(super) async fn create_mooncake_table_and_notify_for_index_merge(
     let mut table = MooncakeTable::new(
         schema.as_ref().clone(),
         "test_table".to_string(),
-        /*version=*/ TEST_TABLE_ID.0,
+        TEST_TABLE_ID.0,
         path,
         identity_property,
         iceberg_table_config.clone(),

--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -134,7 +134,7 @@ impl SnapshotTableState {
     /// Util function to get table unique file id.
     fn get_table_unique_file_id(&self, file_id: FileId) -> TableUniqueFileId {
         TableUniqueFileId {
-            table_id: TableId(self.mooncake_table_metadata.id),
+            table_id: TableId(self.mooncake_table_metadata.table_id),
             file_id,
         }
     }
@@ -444,7 +444,7 @@ impl SnapshotTableState {
             // Tentatively decide data file to compact.
             let single_file_to_compact = SingleFileToCompact {
                 file_id: TableUniqueFileId {
-                    table_id: TableId(self.mooncake_table_metadata.id),
+                    table_id: TableId(self.mooncake_table_metadata.table_id),
                     file_id: cur_data_file.file_id(),
                 },
                 filepath: cur_data_file.file_path().to_string(),
@@ -929,7 +929,7 @@ impl SnapshotTableState {
     /// Import batch write and stream file indices into cache.
     /// Return evicted files to delete.
     async fn import_file_indices_into_cache(&mut self, task: &mut SnapshotTask) -> Vec<String> {
-        let table_id = TableId(self.mooncake_table_metadata.id);
+        let table_id = TableId(self.mooncake_table_metadata.table_id);
 
         // Aggregate evicted files to delete.
         let mut evicted_files_to_delete = vec![];

--- a/src/moonlink/src/storage/mooncake_table/tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/tests.rs
@@ -232,7 +232,7 @@ async fn test_snapshot_initialization() -> Result<()> {
     let identity = IdentityProp::Keys(vec![0]);
     let metadata = Arc::new(TableMetadata {
         name: "test_table".to_string(),
-        id: 1,
+        table_id: 1,
         schema: Arc::new(schema),
         config: MooncakeTableConfig::default(), // No temp files generated.
         path: PathBuf::new(),
@@ -410,7 +410,7 @@ async fn test_snapshot_load_failure() {
     let temp_dir = TempDir::new().unwrap();
     let table_metadata = Arc::new(TableMetadata {
         name: "test_table".to_string(),
-        id: 1,
+        table_id: 1,
         schema: Arc::new(test_schema()),
         config: MooncakeTableConfig::default(), // No temp files generated.
         path: PathBuf::from(temp_dir.path()),
@@ -443,7 +443,7 @@ async fn test_snapshot_store_failure() {
     let temp_dir = TempDir::new().unwrap();
     let table_metadata = Arc::new(TableMetadata {
         name: "test_table".to_string(),
-        id: 1,
+        table_id: 1,
         schema: Arc::new(test_schema()),
         config: MooncakeTableConfig::default(), // No temp files generated.
         path: PathBuf::from(temp_dir.path()),

--- a/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
+++ b/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
@@ -303,7 +303,7 @@ impl SnapshotTableState {
 
                         // Import data files into cache.
                         let file_id = TableUniqueFileId {
-                            table_id: TableId(self.mooncake_table_metadata.id),
+                            table_id: TableId(self.mooncake_table_metadata.table_id),
                             file_id: file.file_id(),
                         };
                         let (cache_handle, cur_evicted_files) = self

--- a/src/moonlink/src/storage/storage_utils.rs
+++ b/src/moonlink/src/storage/storage_utils.rs
@@ -63,7 +63,7 @@ pub struct FileId(pub(crate) u64);
 
 /// Unique table id.
 #[derive(Debug, Clone, PartialEq, Eq, Copy, Hash)]
-pub struct TableId(pub(crate) u64);
+pub struct TableId(pub(crate) u32);
 
 /// A globally unique id for a file.
 #[derive(Debug, Clone, PartialEq, Eq, Copy)]

--- a/src/moonlink/src/table_handler/test_utils.rs
+++ b/src/moonlink/src/table_handler/test_utils.rs
@@ -156,7 +156,7 @@ impl TestEnvironment {
         let table_name = "table_name";
         let mooncake_table_metadata = Arc::new(MooncakeTableMetadata {
             name: table_name.to_string(),
-            id: 0,
+            table_id: 0,
             schema: Arc::new(default_schema()),
             config: mooncake_table_config.clone(),
             path: self.temp_dir.path().to_path_buf(),

--- a/src/moonlink/src/table_handler/tests.rs
+++ b/src/moonlink/src/table_handler/tests.rs
@@ -1100,7 +1100,7 @@ async fn test_iceberg_snapshot_failure_mock_test() {
         MooncakeTableConfig::new(temp_dir.path().to_str().unwrap().to_string());
     let mooncake_table_metadata = Arc::new(MooncakeTableMetadata {
         name: "table_name".to_string(),
-        id: 0,
+        table_id: 0,
         schema: Arc::new(default_schema()),
         config: mooncake_table_config.clone(),
         path: temp_dir.path().to_path_buf(),
@@ -1162,7 +1162,7 @@ async fn test_iceberg_drop_table_failure_mock_test() {
         MooncakeTableConfig::new(temp_dir.path().to_str().unwrap().to_string());
     let mooncake_table_metadata = Arc::new(MooncakeTableMetadata {
         name: "table_name".to_string(),
-        id: 0,
+        table_id: 0,
         schema: Arc::new(default_schema()),
         config: mooncake_table_config.clone(),
         path: temp_dir.path().to_path_buf(),

--- a/src/moonlink_backend/Cargo.toml
+++ b/src/moonlink_backend/Cargo.toml
@@ -12,6 +12,7 @@ arrow-array.workspace = true
 console-subscriber = { workspace = true }
 moonlink = { path = "../moonlink", features = ["test-utils"] }
 moonlink_connectors = { path = "../moonlink_connectors" }
+moonlink_metadata_store = { path = "../moonlink_metadata_store"}
 more-asserts = { workspace = true }
 nix = { workspace = true }
 parquet = { workspace = true, features = ["arrow"] }

--- a/src/moonlink_backend/Cargo.toml
+++ b/src/moonlink_backend/Cargo.toml
@@ -12,7 +12,7 @@ arrow-array.workspace = true
 console-subscriber = { workspace = true }
 moonlink = { path = "../moonlink", features = ["test-utils"] }
 moonlink_connectors = { path = "../moonlink_connectors" }
-moonlink_metadata_store = { path = "../moonlink_metadata_store"}
+moonlink_metadata_store = { path = "../moonlink_metadata_store" }
 more-asserts = { workspace = true }
 nix = { workspace = true }
 parquet = { workspace = true, features = ["arrow"] }

--- a/src/moonlink_backend/src/columnstore_table_id.rs
+++ b/src/moonlink_backend/src/columnstore_table_id.rs
@@ -2,12 +2,12 @@ use std::fmt::{Display, Formatter, Result as FmtResult};
 use std::hash::Hash;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct ColumnstoreTableId<D, T> {
+pub struct DbColumnstoreTableId<D, T> {
     pub database_id: D,
     pub table_id: T,
 }
 
-impl<D, T> Display for ColumnstoreTableId<D, T>
+impl<D, T> Display for DbColumnstoreTableId<D, T>
 where
     D: Display,
     T: Display,

--- a/src/moonlink_backend/src/error.rs
+++ b/src/moonlink_backend/src/error.rs
@@ -1,12 +1,16 @@
 use moonlink::Error as MoonlinkError;
 use moonlink_connectors::Error as MoonlinkConnectorError;
 use moonlink_connectors::PostgresSourceError;
+use moonlink_metadata_store::error::Error as MoonlinkMetadataStoreError;
+use std::num::ParseIntError;
 use std::result;
 use thiserror::Error;
 
 /// Custom error type for moonlink_backend
 #[derive(Debug, Error)]
 pub enum Error {
+    #[error("Parse integer error: {source}")]
+    ParseIntError { source: ParseIntError },
     #[error("Postgres source error: {0}")]
     PostgresSource(#[from] PostgresSourceError),
     #[error("IO error: {0}")]
@@ -15,9 +19,17 @@ pub enum Error {
     MoonlinkConnectorError { source: MoonlinkConnectorError },
     #[error("Moonlink error: {source}")]
     MoonlinkError { source: MoonlinkError },
+    #[error("Moonlink metadata error: {source}")]
+    MoonlinkMetadataStoreError { source: MoonlinkMetadataStoreError },
 }
 
 pub type Result<T> = result::Result<T, Error>;
+
+impl From<ParseIntError> for Error {
+    fn from(source: ParseIntError) -> Self {
+        Error::ParseIntError { source }
+    }
+}
 
 impl From<MoonlinkConnectorError> for Error {
     fn from(source: MoonlinkConnectorError) -> Self {
@@ -28,5 +40,11 @@ impl From<MoonlinkConnectorError> for Error {
 impl From<MoonlinkError> for Error {
     fn from(source: MoonlinkError) -> Self {
         Error::MoonlinkError { source }
+    }
+}
+
+impl From<MoonlinkMetadataStoreError> for Error {
+    fn from(source: MoonlinkMetadataStoreError) -> Self {
+        Error::MoonlinkMetadataStoreError { source }
     }
 }

--- a/src/moonlink_backend/src/lib.rs
+++ b/src/moonlink_backend/src/lib.rs
@@ -146,8 +146,6 @@ where
     ) -> Result<()> {
         let columnstore_table_id = Self::get_columnstore_table_id(&table_id)?;
 
-        println!("create row of columnstore oid {}", columnstore_table_id);
-
         // Add column store table to replication, and create corresponding mooncake table.
         let moonlink_table_config = {
             let mut manager = self.replication_manager.write().await;
@@ -176,8 +174,6 @@ where
             cur_metadata_store_client
                 .store_table_config(columnstore_table_id, &src_table_name, moonlink_table_config)
                 .await?;
-
-            println!("add metadata for {}", columnstore_table_id);
         }
 
         Ok(())
@@ -193,12 +189,6 @@ where
             };
             manager.drop_table(db_columnstore_table_id).await.unwrap()
         };
-
-        println!(
-            "table to drop exists ? {}, to drop {}",
-            table_exists, columnstore_table_id
-        );
-
         if !table_exists {
             return;
         }

--- a/src/moonlink_backend/src/lib.rs
+++ b/src/moonlink_backend/src/lib.rs
@@ -121,8 +121,8 @@ where
 
     /// # Arguments
     ///
-    /// * src_uri: connection string for source database.
-    /// * dst_uri: connection string for
+    /// * src_uri: connection string for source database (row storage database).
+    /// * dst_uri: connection string for metadata storage.
     pub async fn create_table(
         &self,
         database_id: D,
@@ -136,9 +136,10 @@ where
             database_id,
             table_id,
         };
-        manager
+        let moonlink_table_config = manager
             .add_table(&src_uri, columnstore_table_id, &src_table_name)
             .await?;
+
         Ok(())
     }
 

--- a/src/moonlink_backend/src/lib.rs
+++ b/src/moonlink_backend/src/lib.rs
@@ -5,12 +5,11 @@ mod logging;
 use columnstore_table_id::DbColumnstoreTableId;
 pub use error::{Error, Result};
 pub use moonlink::ReadState;
-use moonlink::{ObjectStorageCache, ObjectStorageCacheConfig, TableEvent};
+use moonlink::{ObjectStorageCache, ObjectStorageCacheConfig};
 use moonlink_connectors::ReplicationManager;
 use moonlink_metadata_store::base_metadata_store::MetadataStoreTrait;
 use moonlink_metadata_store::PgMetadataStore;
 use more_asserts as ma;
-use nix::libc::ETH_DATA_LEN;
 use std::collections::HashMap;
 use std::hash::Hash;
 use std::io::ErrorKind;
@@ -156,10 +155,10 @@ where
                 database_id: database_id.clone(),
                 table_id: table_id.clone(),
             };
-            let moonlink_table_config = manager
+
+            manager
                 .add_table(&src_uri, db_columnstore_table_id, &src_table_name)
-                .await?;
-            moonlink_table_config
+                .await?
         };
 
         // Create metadata store entry.

--- a/src/moonlink_backend/src/mooncake_table_id.rs
+++ b/src/moonlink_backend/src/mooncake_table_id.rs
@@ -16,3 +16,13 @@ where
         write!(f, "{}.{}", self.database_id, self.table_id)
     }
 }
+
+impl<D, T> MooncakeTableId<D, T>
+where
+    T: Display,
+{
+    /// Get integer version of table id.
+    pub fn get_table_id_value(&self) -> u32 {
+        self.table_id.to_string().parse::<u32>().unwrap()
+    }
+}

--- a/src/moonlink_backend/src/mooncake_table_id.rs
+++ b/src/moonlink_backend/src/mooncake_table_id.rs
@@ -2,12 +2,12 @@ use std::fmt::{Display, Formatter, Result as FmtResult};
 use std::hash::Hash;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct DbColumnstoreTableId<D, T> {
+pub struct MooncakeTableId<D, T> {
     pub database_id: D,
     pub table_id: T,
 }
 
-impl<D, T> Display for DbColumnstoreTableId<D, T>
+impl<D, T> Display for MooncakeTableId<D, T>
 where
     D: Display,
     T: Display,

--- a/src/moonlink_backend/tests/test_backend.rs
+++ b/src/moonlink_backend/tests/test_backend.rs
@@ -132,7 +132,7 @@ mod tests {
             .await
             .unwrap();
         client
-            .simple_query(&format!("DROP TABLE IF EXISTS mooncake.tables"))
+            .simple_query("DROP TABLE IF EXISTS mooncake.tables")
             .await
             .unwrap();
         backend

--- a/src/moonlink_backend/tests/test_backend.rs
+++ b/src/moonlink_backend/tests/test_backend.rs
@@ -16,6 +16,8 @@ mod tests {
 
     const SRC_URI: &str = "postgresql://postgres:postgres@postgres:5432/postgres";
     const DST_URI: &str = "postgresql://postgres:postgres@postgres:5432/postgres";
+    const CREATE_TABLE_SCHEMA_SQL: &str =
+        include_str!("../../moonlink_metadata_store/src/postgres/sql/create_tables.sql");
 
     type DatabaseId = u64;
     type TableId = u64;
@@ -129,6 +131,10 @@ mod tests {
             ))
             .await
             .unwrap();
+        client
+            .simple_query(&format!("DROP TABLE IF EXISTS mooncake.tables"))
+            .await
+            .unwrap();
         backend
             .create_table(
                 DATABASE_ID,
@@ -157,11 +163,16 @@ mod tests {
             )
             .await
             .unwrap();
+        client
+            .simple_query("DROP TABLE IF EXISTS mooncake.tables;")
+            .await
+            .unwrap();
+        client.simple_query(CREATE_TABLE_SCHEMA_SQL).await.unwrap();
 
         backend
             .create_table(
                 DATABASE_ID,
-                /*table_id*=*/ TABLE_ID,
+                TABLE_ID,
                 DST_URI.to_string(),
                 /*table_name=*/ "public.test".to_string(),
                 uri.to_string(),

--- a/src/moonlink_connectors/src/pg_replicate/clients/postgres.rs
+++ b/src/moonlink_connectors/src/pg_replicate/clients/postgres.rs
@@ -1,9 +1,7 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::pg_replicate::conversions::text::TextFormatConverter;
-use crate::pg_replicate::table::{
-    ColumnSchema, LookupKey, RowstoreTableId, TableName, TableSchema,
-};
+use crate::pg_replicate::table::{ColumnSchema, LookupKey, SrcTableId, TableName, TableSchema};
 use pg_escape::{quote_identifier, quote_literal};
 use postgres_replication::LogicalReplicationStream;
 use thiserror::Error;
@@ -132,7 +130,7 @@ impl ReplicationClient {
     /// Returns a vector of columns of a table, optionally filtered by a publication's column list
     pub async fn get_column_schemas(
         &self,
-        table_id: RowstoreTableId,
+        table_id: SrcTableId,
         table_name: &TableName,
         publication: Option<&str>,
     ) -> Result<Vec<ColumnSchema>, ReplicationClientError> {
@@ -273,7 +271,7 @@ impl ReplicationClient {
 
     async fn fetch_lookup_key(
         &self,
-        table_id: RowstoreTableId,
+        table_id: SrcTableId,
         published_column_names: HashSet<String>,
     ) -> Result<Option<LookupKey>, ReplicationClientError> {
         let index_rows = self.fetch_index_rows(table_id).await?;
@@ -320,7 +318,7 @@ impl ReplicationClient {
     /// Follows same definition as PG replica identity [https://www.postgresql.org/docs/current/sql-altertable.html#SQL-ALTERTABLE-REPLICA-IDENTITY]
     async fn fetch_index_rows(
         &self,
-        rowstore_table_id: RowstoreTableId,
+        src_table_id: SrcTableId,
     ) -> Result<Vec<SimpleQueryRow>, ReplicationClientError> {
         let query = format!(
             "
@@ -341,7 +339,7 @@ impl ReplicationClient {
             AND (con.condeferrable IS NULL OR con.condeferrable = false)
             ORDER BY i.indisprimary DESC, c2.relname
             ",
-            rowstore_table_id
+            src_table_id
         );
 
         let result = self.postgres_client.simple_query(&query).await?;
@@ -357,7 +355,7 @@ impl ReplicationClient {
 
     async fn fetch_index_columns(
         &self,
-        rowstore_table_id: RowstoreTableId,
+        src_table_id: SrcTableId,
         indkey: &str,
     ) -> Result<Vec<(String, bool)>, ReplicationClientError> {
         let query = format!(
@@ -368,7 +366,7 @@ impl ReplicationClient {
             AND a.attnum = ANY(string_to_array('{}', ' ')::smallint[])
             ORDER BY array_position(string_to_array('{}', ' ')::smallint[], a.attnum)
             ",
-            rowstore_table_id, indkey, indkey
+            src_table_id, indkey, indkey
         );
 
         let result = self.postgres_client.simple_query(&query).await?;
@@ -388,15 +386,12 @@ impl ReplicationClient {
 
     pub async fn get_lookup_key(
         &self,
-        rowstore_table_id: RowstoreTableId,
+        src_table_id: SrcTableId,
         column_schemas: &Vec<ColumnSchema>,
     ) -> Result<LookupKey, ReplicationClientError> {
         let column_names: HashSet<String> =
             column_schemas.iter().map(|cs| cs.name.clone()).collect();
-        if let Some(unique_index_key) = self
-            .fetch_lookup_key(rowstore_table_id, column_names)
-            .await?
-        {
+        if let Some(unique_index_key) = self.fetch_lookup_key(src_table_id, column_names).await? {
             return Ok(unique_index_key);
         }
 
@@ -408,14 +403,14 @@ impl ReplicationClient {
         &self,
         table_names: &[TableName],
         publication: Option<&str>,
-    ) -> Result<HashMap<RowstoreTableId, TableSchema>, ReplicationClientError> {
+    ) -> Result<HashMap<SrcTableId, TableSchema>, ReplicationClientError> {
         let mut table_schemas = HashMap::new();
 
         for table_name in table_names {
             let table_schema = self
                 .get_table_schema(table_name.clone(), publication)
                 .await?;
-            table_schemas.insert(table_schema.rowstore_table_id, table_schema);
+            table_schemas.insert(table_schema.src_table_id, table_schema);
         }
 
         Ok(table_schemas)
@@ -426,34 +421,32 @@ impl ReplicationClient {
         table_name: TableName,
         publication: Option<&str>,
     ) -> Result<TableSchema, ReplicationClientError> {
-        let rowstore_table_id = self
-            .get_table_id(&table_name)
+        let src_table_id = self
+            .get_src_table_id(&table_name)
             .await?
             .ok_or(ReplicationClientError::MissingTable(table_name.clone()))?;
 
         let column_schemas = self
-            .get_column_schemas(rowstore_table_id, &table_name, publication)
+            .get_column_schemas(src_table_id, &table_name, publication)
             .await?;
-        let lookup_key = self
-            .get_lookup_key(rowstore_table_id, &column_schemas)
-            .await?;
+        let lookup_key = self.get_lookup_key(src_table_id, &column_schemas).await?;
 
         let table_schema = TableSchema {
             table_name,
-            rowstore_table_id,
+            src_table_id,
             column_schemas,
             lookup_key,
         };
         Ok(table_schema)
     }
 
-    /// Returns the table id (called relation id in Postgres) of a table
+    /// Returns the src table id (called relation id in Postgres) of a table
     /// Also checks whether the replica identity is default or full and
     /// returns an error if not.
-    pub async fn get_table_id(
+    pub async fn get_src_table_id(
         &self,
         table: &TableName,
-    ) -> Result<Option<RowstoreTableId>, ReplicationClientError> {
+    ) -> Result<Option<SrcTableId>, ReplicationClientError> {
         let quoted_schema = quote_literal(&table.schema);
         let quoted_name = quote_literal(&table.name);
 

--- a/src/moonlink_connectors/src/pg_replicate/clients/postgres.rs
+++ b/src/moonlink_connectors/src/pg_replicate/clients/postgres.rs
@@ -1,7 +1,9 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::pg_replicate::conversions::text::TextFormatConverter;
-use crate::pg_replicate::table::{ColumnSchema, LookupKey, TableId, TableName, TableSchema};
+use crate::pg_replicate::table::{
+    ColumnSchema, LookupKey, RowStoreTableId, TableName, TableSchema,
+};
 use pg_escape::{quote_identifier, quote_literal};
 use postgres_replication::LogicalReplicationStream;
 use thiserror::Error;
@@ -130,7 +132,7 @@ impl ReplicationClient {
     /// Returns a vector of columns of a table, optionally filtered by a publication's column list
     pub async fn get_column_schemas(
         &self,
-        table_id: TableId,
+        table_id: RowStoreTableId,
         table_name: &TableName,
         publication: Option<&str>,
     ) -> Result<Vec<ColumnSchema>, ReplicationClientError> {
@@ -271,7 +273,7 @@ impl ReplicationClient {
 
     async fn fetch_lookup_key(
         &self,
-        table_id: TableId,
+        table_id: RowStoreTableId,
         published_column_names: HashSet<String>,
     ) -> Result<Option<LookupKey>, ReplicationClientError> {
         let index_rows = self.fetch_index_rows(table_id).await?;
@@ -318,7 +320,7 @@ impl ReplicationClient {
     /// Follows same definition as PG replica identity [https://www.postgresql.org/docs/current/sql-altertable.html#SQL-ALTERTABLE-REPLICA-IDENTITY]
     async fn fetch_index_rows(
         &self,
-        table_id: TableId,
+        rowstore_table_id: RowStoreTableId,
     ) -> Result<Vec<SimpleQueryRow>, ReplicationClientError> {
         let query = format!(
             "
@@ -339,7 +341,7 @@ impl ReplicationClient {
             AND (con.condeferrable IS NULL OR con.condeferrable = false)
             ORDER BY i.indisprimary DESC, c2.relname
             ",
-            table_id
+            rowstore_table_id
         );
 
         let result = self.postgres_client.simple_query(&query).await?;
@@ -355,7 +357,7 @@ impl ReplicationClient {
 
     async fn fetch_index_columns(
         &self,
-        table_id: TableId,
+        rowstore_table_id: RowStoreTableId,
         indkey: &str,
     ) -> Result<Vec<(String, bool)>, ReplicationClientError> {
         let query = format!(
@@ -366,7 +368,7 @@ impl ReplicationClient {
             AND a.attnum = ANY(string_to_array('{}', ' ')::smallint[])
             ORDER BY array_position(string_to_array('{}', ' ')::smallint[], a.attnum)
             ",
-            table_id, indkey, indkey
+            rowstore_table_id, indkey, indkey
         );
 
         let result = self.postgres_client.simple_query(&query).await?;
@@ -386,12 +388,15 @@ impl ReplicationClient {
 
     pub async fn get_lookup_key(
         &self,
-        table_id: TableId,
+        rowstore_table_id: RowStoreTableId,
         column_schemas: &Vec<ColumnSchema>,
     ) -> Result<LookupKey, ReplicationClientError> {
         let column_names: HashSet<String> =
             column_schemas.iter().map(|cs| cs.name.clone()).collect();
-        if let Some(unique_index_key) = self.fetch_lookup_key(table_id, column_names).await? {
+        if let Some(unique_index_key) = self
+            .fetch_lookup_key(rowstore_table_id, column_names)
+            .await?
+        {
             return Ok(unique_index_key);
         }
 
@@ -403,14 +408,14 @@ impl ReplicationClient {
         &self,
         table_names: &[TableName],
         publication: Option<&str>,
-    ) -> Result<HashMap<TableId, TableSchema>, ReplicationClientError> {
+    ) -> Result<HashMap<RowStoreTableId, TableSchema>, ReplicationClientError> {
         let mut table_schemas = HashMap::new();
 
         for table_name in table_names {
             let table_schema = self
                 .get_table_schema(table_name.clone(), publication)
                 .await?;
-            table_schemas.insert(table_schema.table_id, table_schema);
+            table_schemas.insert(table_schema.rowstore_table_id, table_schema);
         }
 
         Ok(table_schemas)
@@ -421,19 +426,21 @@ impl ReplicationClient {
         table_name: TableName,
         publication: Option<&str>,
     ) -> Result<TableSchema, ReplicationClientError> {
-        let table_id = self
+        let rowstore_table_id = self
             .get_table_id(&table_name)
             .await?
             .ok_or(ReplicationClientError::MissingTable(table_name.clone()))?;
 
         let column_schemas = self
-            .get_column_schemas(table_id, &table_name, publication)
+            .get_column_schemas(rowstore_table_id, &table_name, publication)
             .await?;
-        let lookup_key = self.get_lookup_key(table_id, &column_schemas).await?;
+        let lookup_key = self
+            .get_lookup_key(rowstore_table_id, &column_schemas)
+            .await?;
 
         let table_schema = TableSchema {
             table_name,
-            table_id,
+            rowstore_table_id,
             column_schemas,
             lookup_key,
         };
@@ -446,7 +453,7 @@ impl ReplicationClient {
     pub async fn get_table_id(
         &self,
         table: &TableName,
-    ) -> Result<Option<TableId>, ReplicationClientError> {
+    ) -> Result<Option<RowStoreTableId>, ReplicationClientError> {
         let quoted_schema = quote_literal(&table.schema);
         let quoted_name = quote_literal(&table.name);
 

--- a/src/moonlink_connectors/src/pg_replicate/clients/postgres.rs
+++ b/src/moonlink_connectors/src/pg_replicate/clients/postgres.rs
@@ -2,7 +2,7 @@ use std::collections::{HashMap, HashSet};
 
 use crate::pg_replicate::conversions::text::TextFormatConverter;
 use crate::pg_replicate::table::{
-    ColumnSchema, LookupKey, RowStoreTableId, TableName, TableSchema,
+    ColumnSchema, LookupKey, RowstoreTableId, TableName, TableSchema,
 };
 use pg_escape::{quote_identifier, quote_literal};
 use postgres_replication::LogicalReplicationStream;
@@ -132,7 +132,7 @@ impl ReplicationClient {
     /// Returns a vector of columns of a table, optionally filtered by a publication's column list
     pub async fn get_column_schemas(
         &self,
-        table_id: RowStoreTableId,
+        table_id: RowstoreTableId,
         table_name: &TableName,
         publication: Option<&str>,
     ) -> Result<Vec<ColumnSchema>, ReplicationClientError> {
@@ -273,7 +273,7 @@ impl ReplicationClient {
 
     async fn fetch_lookup_key(
         &self,
-        table_id: RowStoreTableId,
+        table_id: RowstoreTableId,
         published_column_names: HashSet<String>,
     ) -> Result<Option<LookupKey>, ReplicationClientError> {
         let index_rows = self.fetch_index_rows(table_id).await?;
@@ -320,7 +320,7 @@ impl ReplicationClient {
     /// Follows same definition as PG replica identity [https://www.postgresql.org/docs/current/sql-altertable.html#SQL-ALTERTABLE-REPLICA-IDENTITY]
     async fn fetch_index_rows(
         &self,
-        rowstore_table_id: RowStoreTableId,
+        rowstore_table_id: RowstoreTableId,
     ) -> Result<Vec<SimpleQueryRow>, ReplicationClientError> {
         let query = format!(
             "
@@ -357,7 +357,7 @@ impl ReplicationClient {
 
     async fn fetch_index_columns(
         &self,
-        rowstore_table_id: RowStoreTableId,
+        rowstore_table_id: RowstoreTableId,
         indkey: &str,
     ) -> Result<Vec<(String, bool)>, ReplicationClientError> {
         let query = format!(
@@ -388,7 +388,7 @@ impl ReplicationClient {
 
     pub async fn get_lookup_key(
         &self,
-        rowstore_table_id: RowStoreTableId,
+        rowstore_table_id: RowstoreTableId,
         column_schemas: &Vec<ColumnSchema>,
     ) -> Result<LookupKey, ReplicationClientError> {
         let column_names: HashSet<String> =
@@ -408,7 +408,7 @@ impl ReplicationClient {
         &self,
         table_names: &[TableName],
         publication: Option<&str>,
-    ) -> Result<HashMap<RowStoreTableId, TableSchema>, ReplicationClientError> {
+    ) -> Result<HashMap<RowstoreTableId, TableSchema>, ReplicationClientError> {
         let mut table_schemas = HashMap::new();
 
         for table_name in table_names {
@@ -453,7 +453,7 @@ impl ReplicationClient {
     pub async fn get_table_id(
         &self,
         table: &TableName,
-    ) -> Result<Option<RowStoreTableId>, ReplicationClientError> {
+    ) -> Result<Option<RowstoreTableId>, ReplicationClientError> {
         let quoted_schema = quote_literal(&table.schema);
         let quoted_name = quote_literal(&table.name);
 

--- a/src/moonlink_connectors/src/pg_replicate/conversions/cdc_event.rs
+++ b/src/moonlink_connectors/src/pg_replicate/conversions/cdc_event.rs
@@ -8,7 +8,7 @@ use postgres_replication::protocol::{
 };
 use thiserror::Error;
 
-use crate::pg_replicate::table::{ColumnSchema, RowStoreTableId, TableSchema};
+use crate::pg_replicate::table::{ColumnSchema, RowstoreTableId, TableSchema};
 
 use super::{
     table_row::TableRow,
@@ -34,7 +34,7 @@ pub enum CdcEventConversionError {
     MissingTupleInDeleteBody,
 
     #[error("schema missing for table id {0}")]
-    MissingSchema(RowStoreTableId),
+    MissingSchema(RowstoreTableId),
 
     #[error("from bytes error: {0}")]
     FromBytes(#[from] FromTextError),
@@ -68,7 +68,7 @@ impl CdcEventConverter {
     }
 
     fn try_from_insert_body(
-        rowstore_table_id: RowStoreTableId,
+        rowstore_table_id: RowstoreTableId,
         column_schemas: &[ColumnSchema],
         insert_body: InsertBody,
     ) -> Result<CdcEvent, CdcEventConversionError> {
@@ -84,7 +84,7 @@ impl CdcEventConverter {
 
     // TODO: handle when identity columns are changed
     fn try_from_update_body(
-        rowstore_table_id: RowStoreTableId,
+        rowstore_table_id: RowstoreTableId,
         column_schemas: &[ColumnSchema],
         update_body: UpdateBody,
     ) -> Result<CdcEvent, CdcEventConversionError> {
@@ -104,7 +104,7 @@ impl CdcEventConverter {
     }
 
     fn try_from_delete_body(
-        rowstore_table_id: RowStoreTableId,
+        rowstore_table_id: RowstoreTableId,
         column_schemas: &[ColumnSchema],
         delete_body: DeleteBody,
     ) -> Result<CdcEvent, CdcEventConversionError> {
@@ -124,7 +124,7 @@ impl CdcEventConverter {
 
     pub fn try_from(
         value: ReplicationMessage<LogicalReplicationMessage>,
-        table_schemas: &HashMap<RowStoreTableId, TableSchema>,
+        table_schemas: &HashMap<RowstoreTableId, TableSchema>,
     ) -> Result<CdcEvent, CdcEventConversionError> {
         match value {
             ReplicationMessage::XLogData(xlog_data) => match xlog_data.into_data() {
@@ -202,9 +202,9 @@ impl CdcEventConverter {
 pub enum CdcEvent {
     Begin(BeginBody),
     Commit(CommitBody),
-    Insert((RowStoreTableId, TableRow, Option<u32>)),
-    Update((RowStoreTableId, Option<TableRow>, TableRow, Option<u32>)),
-    Delete((RowStoreTableId, TableRow, Option<u32>)),
+    Insert((RowstoreTableId, TableRow, Option<u32>)),
+    Update((RowstoreTableId, Option<TableRow>, TableRow, Option<u32>)),
+    Delete((RowstoreTableId, TableRow, Option<u32>)),
     Relation(RelationBody),
     Type(TypeBody),
     PrimaryKeepAlive(PrimaryKeepAliveBody),

--- a/src/moonlink_connectors/src/pg_replicate/conversions/cdc_event.rs
+++ b/src/moonlink_connectors/src/pg_replicate/conversions/cdc_event.rs
@@ -8,7 +8,7 @@ use postgres_replication::protocol::{
 };
 use thiserror::Error;
 
-use crate::pg_replicate::table::{ColumnSchema, TableId, TableSchema};
+use crate::pg_replicate::table::{ColumnSchema, RowStoreTableId, TableSchema};
 
 use super::{
     table_row::TableRow,
@@ -34,7 +34,7 @@ pub enum CdcEventConversionError {
     MissingTupleInDeleteBody,
 
     #[error("schema missing for table id {0}")]
-    MissingSchema(TableId),
+    MissingSchema(RowStoreTableId),
 
     #[error("from bytes error: {0}")]
     FromBytes(#[from] FromTextError),
@@ -68,19 +68,23 @@ impl CdcEventConverter {
     }
 
     fn try_from_insert_body(
-        table_id: TableId,
+        rowstore_table_id: RowStoreTableId,
         column_schemas: &[ColumnSchema],
         insert_body: InsertBody,
     ) -> Result<CdcEvent, CdcEventConversionError> {
         let row =
             Self::try_from_tuple_data_slice(column_schemas, insert_body.tuple().tuple_data())?;
 
-        Ok(CdcEvent::Insert((table_id, row, insert_body.xid())))
+        Ok(CdcEvent::Insert((
+            rowstore_table_id,
+            row,
+            insert_body.xid(),
+        )))
     }
 
-    //TODO: handle when identity columns are changed
+    // TODO: handle when identity columns are changed
     fn try_from_update_body(
-        table_id: TableId,
+        rowstore_table_id: RowStoreTableId,
         column_schemas: &[ColumnSchema],
         update_body: UpdateBody,
     ) -> Result<CdcEvent, CdcEventConversionError> {
@@ -92,7 +96,7 @@ impl CdcEventConverter {
             Self::try_from_tuple_data_slice(column_schemas, update_body.new_tuple().tuple_data())?;
 
         Ok(CdcEvent::Update((
-            table_id,
+            rowstore_table_id,
             old_row,
             new_row,
             update_body.xid(),
@@ -100,7 +104,7 @@ impl CdcEventConverter {
     }
 
     fn try_from_delete_body(
-        table_id: TableId,
+        rowstore_table_id: RowStoreTableId,
         column_schemas: &[ColumnSchema],
         delete_body: DeleteBody,
     ) -> Result<CdcEvent, CdcEventConversionError> {
@@ -111,12 +115,16 @@ impl CdcEventConverter {
 
         let row = Self::try_from_tuple_data_slice(column_schemas, tuple.tuple_data())?;
 
-        Ok(CdcEvent::Delete((table_id, row, delete_body.xid())))
+        Ok(CdcEvent::Delete((
+            rowstore_table_id,
+            row,
+            delete_body.xid(),
+        )))
     }
 
     pub fn try_from(
         value: ReplicationMessage<LogicalReplicationMessage>,
-        table_schemas: &HashMap<TableId, TableSchema>,
+        table_schemas: &HashMap<RowStoreTableId, TableSchema>,
     ) -> Result<CdcEvent, CdcEventConversionError> {
         match value {
             ReplicationMessage::XLogData(xlog_data) => match xlog_data.into_data() {
@@ -194,9 +202,9 @@ impl CdcEventConverter {
 pub enum CdcEvent {
     Begin(BeginBody),
     Commit(CommitBody),
-    Insert((TableId, TableRow, Option<u32>)),
-    Update((TableId, Option<TableRow>, TableRow, Option<u32>)),
-    Delete((TableId, TableRow, Option<u32>)),
+    Insert((RowStoreTableId, TableRow, Option<u32>)),
+    Update((RowStoreTableId, Option<TableRow>, TableRow, Option<u32>)),
+    Delete((RowStoreTableId, TableRow, Option<u32>)),
     Relation(RelationBody),
     Type(TypeBody),
     PrimaryKeepAlive(PrimaryKeepAliveBody),

--- a/src/moonlink_connectors/src/pg_replicate/moonlink_sink.rs
+++ b/src/moonlink_connectors/src/pg_replicate/moonlink_sink.rs
@@ -2,7 +2,7 @@ use crate::pg_replicate::util::PostgresTableRow;
 use crate::pg_replicate::{
     conversions::{cdc_event::CdcEvent, table_row::TableRow},
     replication_state::ReplicationState,
-    table::RowstoreTableId,
+    table::SrcTableId,
 };
 use moonlink::TableEvent;
 use std::collections::{HashMap, HashSet};
@@ -16,12 +16,12 @@ use tracing::{debug, warn};
 #[derive(Default)]
 struct TransactionState {
     final_lsn: u64,
-    touched_tables: HashSet<RowstoreTableId>,
+    touched_tables: HashSet<SrcTableId>,
 }
 
 pub struct Sink {
-    event_senders: HashMap<RowstoreTableId, Sender<TableEvent>>,
-    commit_lsn_txs: HashMap<RowstoreTableId, watch::Sender<u64>>,
+    event_senders: HashMap<SrcTableId, Sender<TableEvent>>,
+    commit_lsn_txs: HashMap<SrcTableId, watch::Sender<u64>>,
     streaming_transactions_state: HashMap<u32, TransactionState>,
     transaction_state: TransactionState,
     replication_state: Arc<ReplicationState>,
@@ -45,16 +45,16 @@ impl Sink {
 impl Sink {
     pub fn add_table(
         &mut self,
-        rowstore_table_id: RowstoreTableId,
+        src_table_id: SrcTableId,
         event_sender: Sender<TableEvent>,
         commit_lsn_tx: watch::Sender<u64>,
     ) {
-        self.event_senders.insert(rowstore_table_id, event_sender);
-        self.commit_lsn_txs.insert(rowstore_table_id, commit_lsn_tx);
+        self.event_senders.insert(src_table_id, event_sender);
+        self.commit_lsn_txs.insert(src_table_id, commit_lsn_tx);
     }
-    pub fn drop_table(&mut self, rowstore_table_id: RowstoreTableId) {
-        self.event_senders.remove(&rowstore_table_id).unwrap();
-        self.commit_lsn_txs.remove(&rowstore_table_id).unwrap();
+    pub fn drop_table(&mut self, src_table_id: SrcTableId) {
+        self.event_senders.remove(&src_table_id).unwrap();
+        self.commit_lsn_txs.remove(&src_table_id).unwrap();
     }
 
     pub async fn process_cdc_event(&mut self, event: CdcEvent) -> Result<(), Infallible> {

--- a/src/moonlink_connectors/src/pg_replicate/moonlink_sink.rs
+++ b/src/moonlink_connectors/src/pg_replicate/moonlink_sink.rs
@@ -2,7 +2,7 @@ use crate::pg_replicate::util::PostgresTableRow;
 use crate::pg_replicate::{
     conversions::{cdc_event::CdcEvent, table_row::TableRow},
     replication_state::ReplicationState,
-    table::TableId,
+    table::RowStoreTableId,
 };
 use moonlink::TableEvent;
 use std::collections::{HashMap, HashSet};
@@ -16,12 +16,12 @@ use tracing::{debug, warn};
 #[derive(Default)]
 struct TransactionState {
     final_lsn: u64,
-    touched_tables: HashSet<TableId>,
+    touched_tables: HashSet<RowStoreTableId>,
 }
 
 pub struct Sink {
-    event_senders: HashMap<TableId, Sender<TableEvent>>,
-    commit_lsn_txs: HashMap<TableId, watch::Sender<u64>>,
+    event_senders: HashMap<RowStoreTableId, Sender<TableEvent>>,
+    commit_lsn_txs: HashMap<RowStoreTableId, watch::Sender<u64>>,
     streaming_transactions_state: HashMap<u32, TransactionState>,
     transaction_state: TransactionState,
     replication_state: Arc<ReplicationState>,
@@ -45,16 +45,16 @@ impl Sink {
 impl Sink {
     pub fn add_table(
         &mut self,
-        table_id: TableId,
+        rowstore_table_id: RowStoreTableId,
         event_sender: Sender<TableEvent>,
         commit_lsn_tx: watch::Sender<u64>,
     ) {
-        self.event_senders.insert(table_id, event_sender);
-        self.commit_lsn_txs.insert(table_id, commit_lsn_tx);
+        self.event_senders.insert(rowstore_table_id, event_sender);
+        self.commit_lsn_txs.insert(rowstore_table_id, commit_lsn_tx);
     }
-    pub fn drop_table(&mut self, table_id: TableId) {
-        self.event_senders.remove(&table_id).unwrap();
-        self.commit_lsn_txs.remove(&table_id).unwrap();
+    pub fn drop_table(&mut self, rowstore_table_id: RowStoreTableId) {
+        self.event_senders.remove(&rowstore_table_id).unwrap();
+        self.commit_lsn_txs.remove(&rowstore_table_id).unwrap();
     }
 
     pub async fn process_cdc_event(&mut self, event: CdcEvent) -> Result<(), Infallible> {

--- a/src/moonlink_connectors/src/pg_replicate/moonlink_sink.rs
+++ b/src/moonlink_connectors/src/pg_replicate/moonlink_sink.rs
@@ -2,7 +2,7 @@ use crate::pg_replicate::util::PostgresTableRow;
 use crate::pg_replicate::{
     conversions::{cdc_event::CdcEvent, table_row::TableRow},
     replication_state::ReplicationState,
-    table::RowStoreTableId,
+    table::RowstoreTableId,
 };
 use moonlink::TableEvent;
 use std::collections::{HashMap, HashSet};
@@ -16,12 +16,12 @@ use tracing::{debug, warn};
 #[derive(Default)]
 struct TransactionState {
     final_lsn: u64,
-    touched_tables: HashSet<RowStoreTableId>,
+    touched_tables: HashSet<RowstoreTableId>,
 }
 
 pub struct Sink {
-    event_senders: HashMap<RowStoreTableId, Sender<TableEvent>>,
-    commit_lsn_txs: HashMap<RowStoreTableId, watch::Sender<u64>>,
+    event_senders: HashMap<RowstoreTableId, Sender<TableEvent>>,
+    commit_lsn_txs: HashMap<RowstoreTableId, watch::Sender<u64>>,
     streaming_transactions_state: HashMap<u32, TransactionState>,
     transaction_state: TransactionState,
     replication_state: Arc<ReplicationState>,
@@ -45,14 +45,14 @@ impl Sink {
 impl Sink {
     pub fn add_table(
         &mut self,
-        rowstore_table_id: RowStoreTableId,
+        rowstore_table_id: RowstoreTableId,
         event_sender: Sender<TableEvent>,
         commit_lsn_tx: watch::Sender<u64>,
     ) {
         self.event_senders.insert(rowstore_table_id, event_sender);
         self.commit_lsn_txs.insert(rowstore_table_id, commit_lsn_tx);
     }
-    pub fn drop_table(&mut self, rowstore_table_id: RowStoreTableId) {
+    pub fn drop_table(&mut self, rowstore_table_id: RowstoreTableId) {
         self.event_senders.remove(&rowstore_table_id).unwrap();
         self.commit_lsn_txs.remove(&rowstore_table_id).unwrap();
     }

--- a/src/moonlink_connectors/src/pg_replicate/postgres_source.rs
+++ b/src/moonlink_connectors/src/pg_replicate/postgres_source.rs
@@ -18,7 +18,7 @@ use crate::pg_replicate::{
         cdc_event::{CdcEvent, CdcEventConversionError, CdcEventConverter},
         table_row::{TableRow, TableRowConversionError, TableRowConverter},
     },
-    table::{ColumnSchema, RowStoreTableId, TableName, TableSchema},
+    table::{ColumnSchema, RowstoreTableId, TableName, TableSchema},
 };
 
 pub enum TableNamesFrom {
@@ -49,7 +49,7 @@ pub enum PostgresSourceError {
 
 pub struct PostgresSource {
     replication_client: ReplicationClient,
-    table_schemas: HashMap<RowStoreTableId, TableSchema>,
+    table_schemas: HashMap<RowstoreTableId, TableSchema>,
     slot_name: Option<String>,
     publication: Option<String>,
     confirmed_flush_lsn: PgLsn,
@@ -62,7 +62,7 @@ pub struct CdcStreamConfig {
     pub publication: String,
     pub slot_name: String,
     pub confirmed_flush_lsn: PgLsn,
-    pub table_schemas: HashMap<RowStoreTableId, TableSchema>,
+    pub table_schemas: HashMap<RowstoreTableId, TableSchema>,
 }
 
 impl PostgresSource {
@@ -134,7 +134,7 @@ impl PostgresSource {
         })
     }
 
-    pub async fn get_table_schemas(&self) -> HashMap<RowStoreTableId, TableSchema> {
+    pub async fn get_table_schemas(&self) -> HashMap<RowstoreTableId, TableSchema> {
         self.table_schemas.clone()
     }
 
@@ -306,7 +306,7 @@ pin_project! {
     pub struct CdcStream {
         #[pin]
         stream: LogicalReplicationStream,
-        table_schemas: HashMap<RowStoreTableId, TableSchema>,
+        table_schemas: HashMap<RowstoreTableId, TableSchema>,
         postgres_epoch: SystemTime,
     }
 }
@@ -340,7 +340,7 @@ impl CdcStream {
         this.table_schemas.insert(schema.rowstore_table_id, schema);
     }
 
-    pub fn remove_table_schema(self: Pin<&mut Self>, rowstore_table_id: RowStoreTableId) {
+    pub fn remove_table_schema(self: Pin<&mut Self>, rowstore_table_id: RowstoreTableId) {
         let this = self.project();
         this.table_schemas.remove(&rowstore_table_id);
     }

--- a/src/moonlink_connectors/src/pg_replicate/postgres_source.rs
+++ b/src/moonlink_connectors/src/pg_replicate/postgres_source.rs
@@ -18,7 +18,7 @@ use crate::pg_replicate::{
         cdc_event::{CdcEvent, CdcEventConversionError, CdcEventConverter},
         table_row::{TableRow, TableRowConversionError, TableRowConverter},
     },
-    table::{ColumnSchema, TableId, TableName, TableSchema},
+    table::{ColumnSchema, RowStoreTableId, TableName, TableSchema},
 };
 
 pub enum TableNamesFrom {
@@ -49,7 +49,7 @@ pub enum PostgresSourceError {
 
 pub struct PostgresSource {
     replication_client: ReplicationClient,
-    table_schemas: HashMap<TableId, TableSchema>,
+    table_schemas: HashMap<RowStoreTableId, TableSchema>,
     slot_name: Option<String>,
     publication: Option<String>,
     confirmed_flush_lsn: PgLsn,
@@ -62,7 +62,7 @@ pub struct CdcStreamConfig {
     pub publication: String,
     pub slot_name: String,
     pub confirmed_flush_lsn: PgLsn,
-    pub table_schemas: HashMap<TableId, TableSchema>,
+    pub table_schemas: HashMap<RowStoreTableId, TableSchema>,
 }
 
 impl PostgresSource {
@@ -134,7 +134,7 @@ impl PostgresSource {
         })
     }
 
-    pub async fn get_table_schemas(&self) -> HashMap<TableId, TableSchema> {
+    pub async fn get_table_schemas(&self) -> HashMap<RowStoreTableId, TableSchema> {
         self.table_schemas.clone()
     }
 
@@ -156,7 +156,7 @@ impl PostgresSource {
             .await?;
         // Add the table schema to the source so that we can use it to convert cdc events.
         self.table_schemas
-            .insert(table_schema.table_id, table_schema.clone());
+            .insert(table_schema.rowstore_table_id, table_schema.clone());
         debug!(table_name, "fetched table schema");
         Ok(table_schema)
     }
@@ -306,7 +306,7 @@ pin_project! {
     pub struct CdcStream {
         #[pin]
         stream: LogicalReplicationStream,
-        table_schemas: HashMap<TableId, TableSchema>,
+        table_schemas: HashMap<RowStoreTableId, TableSchema>,
         postgres_epoch: SystemTime,
     }
 }
@@ -337,12 +337,12 @@ impl CdcStream {
 
     pub fn add_table_schema(self: Pin<&mut Self>, schema: TableSchema) {
         let this = self.project();
-        this.table_schemas.insert(schema.table_id, schema);
+        this.table_schemas.insert(schema.rowstore_table_id, schema);
     }
 
-    pub fn remove_table_schema(self: Pin<&mut Self>, table_id: TableId) {
+    pub fn remove_table_schema(self: Pin<&mut Self>, rowstore_table_id: RowStoreTableId) {
         let this = self.project();
-        this.table_schemas.remove(&table_id);
+        this.table_schemas.remove(&rowstore_table_id);
     }
 }
 

--- a/src/moonlink_connectors/src/pg_replicate/replication_state.rs
+++ b/src/moonlink_connectors/src/pg_replicate/replication_state.rs
@@ -6,7 +6,7 @@ use std::sync::{
 use tokio::sync::watch;
 use tokio_postgres::types::PgLsn;
 
-use super::table::RowStoreTableId;
+use super::table::RowstoreTableId;
 
 /// Tracks replication progress and notifies listeners when the replicated
 /// LSN advances.

--- a/src/moonlink_connectors/src/pg_replicate/replication_state.rs
+++ b/src/moonlink_connectors/src/pg_replicate/replication_state.rs
@@ -6,7 +6,7 @@ use std::sync::{
 use tokio::sync::watch;
 use tokio_postgres::types::PgLsn;
 
-use super::table::RowstoreTableId;
+use super::table::SrcTableId;
 
 /// Tracks replication progress and notifies listeners when the replicated
 /// LSN advances.

--- a/src/moonlink_connectors/src/pg_replicate/replication_state.rs
+++ b/src/moonlink_connectors/src/pg_replicate/replication_state.rs
@@ -6,7 +6,7 @@ use std::sync::{
 use tokio::sync::watch;
 use tokio_postgres::types::PgLsn;
 
-use super::table::TableId;
+use super::table::RowStoreTableId;
 
 /// Tracks replication progress and notifies listeners when the replicated
 /// LSN advances.

--- a/src/moonlink_connectors/src/pg_replicate/table.rs
+++ b/src/moonlink_connectors/src/pg_replicate/table.rs
@@ -49,12 +49,12 @@ pub enum LookupKey {
     FullRow,
 }
 
-pub type RowStoreTableId = u32;
+pub type RowstoreTableId = u32;
 
 #[derive(Debug, Clone)]
 pub struct TableSchema {
     pub table_name: TableName,
-    pub rowstore_table_id: RowStoreTableId,
+    pub rowstore_table_id: RowstoreTableId,
     pub column_schemas: Vec<ColumnSchema>,
     pub lookup_key: LookupKey,
 }

--- a/src/moonlink_connectors/src/pg_replicate/table.rs
+++ b/src/moonlink_connectors/src/pg_replicate/table.rs
@@ -49,12 +49,12 @@ pub enum LookupKey {
     FullRow,
 }
 
-pub type TableId = u32;
+pub type RowStoreTableId = u32;
 
 #[derive(Debug, Clone)]
 pub struct TableSchema {
     pub table_name: TableName,
-    pub table_id: TableId,
+    pub rowstore_table_id: RowStoreTableId,
     pub column_schemas: Vec<ColumnSchema>,
     pub lookup_key: LookupKey,
 }

--- a/src/moonlink_connectors/src/pg_replicate/table.rs
+++ b/src/moonlink_connectors/src/pg_replicate/table.rs
@@ -49,12 +49,12 @@ pub enum LookupKey {
     FullRow,
 }
 
-pub type RowstoreTableId = u32;
+pub type SrcTableId = u32;
 
 #[derive(Debug, Clone)]
 pub struct TableSchema {
     pub table_name: TableName,
-    pub rowstore_table_id: RowstoreTableId,
+    pub src_table_id: SrcTableId,
     pub column_schemas: Vec<ColumnSchema>,
     pub lookup_key: LookupKey,
 }

--- a/src/moonlink_connectors/src/pg_replicate/table_init.rs
+++ b/src/moonlink_connectors/src/pg_replicate/table_init.rs
@@ -43,26 +43,27 @@ fn create_table_event_syncer() -> (EventSyncSender, EventSyncReceiver) {
 
 /// Build all components needed to replicate `table_schema`.
 pub async fn build_table_components(
-    table_id: String,
+    mooncake_table_id: String,
+    table_id: u32,
     table_schema: &TableSchema,
     base_path: &Path,
     table_temp_files_directory: String,
     replication_state: &ReplicationState,
     object_storage_cache: ObjectStorageCache,
 ) -> Result<(TableResources, MoonlinkTableConfig)> {
-    let table_path = PathBuf::from(base_path).join(&table_id);
+    let table_path = PathBuf::from(base_path).join(&mooncake_table_id);
     tokio::fs::create_dir_all(&table_path).await.unwrap();
     let (arrow_schema, identity) = postgres_schema_to_moonlink_schema(table_schema);
     let iceberg_table_config = IcebergTableConfig {
         warehouse_uri: base_path.to_str().unwrap().to_string(),
         namespace: vec![table_schema.table_name.schema.clone()],
-        table_name: table_id,
+        table_name: mooncake_table_id,
     };
     let mooncake_table_config = MooncakeTableConfig::new(table_temp_files_directory);
     let table = MooncakeTable::new(
         arrow_schema,
         table_schema.table_name.to_string(),
-        table_schema.rowstore_table_id as u64,
+        table_id,
         table_path,
         identity,
         iceberg_table_config.clone(),

--- a/src/moonlink_connectors/src/pg_replicate/table_init.rs
+++ b/src/moonlink_connectors/src/pg_replicate/table_init.rs
@@ -4,7 +4,8 @@ use crate::pg_replicate::util::postgres_schema_to_moonlink_schema;
 use crate::{Error, Result};
 use moonlink::{
     EventSyncReceiver, EventSyncSender, IcebergTableConfig, MooncakeTable, MooncakeTableConfig,
-    ObjectStorageCache, ReadStateManager, TableEvent, TableEventManager, TableHandler,
+    MoonlinkTableConfig, ObjectStorageCache, ReadStateManager, TableEvent, TableEventManager,
+    TableHandler,
 };
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -48,7 +49,7 @@ pub async fn build_table_components(
     table_temp_files_directory: String,
     replication_state: &ReplicationState,
     object_storage_cache: ObjectStorageCache,
-) -> Result<TableResources> {
+) -> Result<(TableResources, MoonlinkTableConfig)> {
     let table_path = PathBuf::from(base_path).join(&table_id);
     tokio::fs::create_dir_all(&table_path).await.unwrap();
     let (arrow_schema, identity) = postgres_schema_to_moonlink_schema(table_schema);
@@ -61,11 +62,11 @@ pub async fn build_table_components(
     let table = MooncakeTable::new(
         arrow_schema,
         table_schema.table_name.to_string(),
-        table_schema.table_id as u64,
+        table_schema.rowstore_table_id as u64,
         table_path,
         identity,
-        iceberg_table_config,
-        mooncake_table_config,
+        iceberg_table_config.clone(),
+        mooncake_table_config.clone(),
         object_storage_cache,
     )
     .await?;
@@ -80,11 +81,17 @@ pub async fn build_table_components(
         TableEventManager::new(handler.get_event_sender(), event_sync_receiver);
     let event_sender = handler.get_event_sender();
 
-    Ok(TableResources {
+    let table_resource = TableResources {
         event_sender,
         read_state_manager,
         table_event_manager,
         commit_lsn_tx,
         flush_lsn_rx,
-    })
+    };
+    let moonlink_table_config = MoonlinkTableConfig {
+        mooncake_table_config,
+        iceberg_table_config,
+    };
+
+    Ok((table_resource, moonlink_table_config))
 }

--- a/src/moonlink_connectors/src/pg_replicate/util.rs
+++ b/src/moonlink_connectors/src/pg_replicate/util.rs
@@ -408,7 +408,7 @@ mod tests {
                 schema: "public".to_string(),
                 name: "test_table".to_string(),
             },
-            rowstore_table_id: 1,
+            src_table_id: 1,
             column_schemas: vec![
                 ColumnSchema {
                     name: "bool_field".to_string(),

--- a/src/moonlink_connectors/src/pg_replicate/util.rs
+++ b/src/moonlink_connectors/src/pg_replicate/util.rs
@@ -408,7 +408,7 @@ mod tests {
                 schema: "public".to_string(),
                 name: "test_table".to_string(),
             },
-            table_id: 1,
+            rowstore_table_id: 1,
             column_schemas: vec![
                 ColumnSchema {
                     name: "bool_field".to_string(),

--- a/src/moonlink_connectors/src/replication_connection.rs
+++ b/src/moonlink_connectors/src/replication_connection.rs
@@ -16,7 +16,7 @@ use tokio_postgres::types::PgLsn;
 use tokio_postgres::{tls::NoTlsStream, Connection, Socket};
 
 use crate::pg_replicate::replication_state::ReplicationState;
-use crate::pg_replicate::table::{RowStoreTableId, TableSchema};
+use crate::pg_replicate::table::{RowstoreTableId, TableSchema};
 use futures::StreamExt;
 use moonlink::TableEvent;
 use std::collections::HashMap;
@@ -29,14 +29,14 @@ use tracing::{debug, error, info, info_span, warn};
 
 pub enum Command {
     AddTable {
-        rowstore_table_id: RowStoreTableId,
+        rowstore_table_id: RowstoreTableId,
         schema: TableSchema,
         event_sender: mpsc::Sender<TableEvent>,
         commit_lsn_tx: watch::Sender<u64>,
         flush_lsn_rx: watch::Receiver<u64>,
     },
     DropTable {
-        rowstore_table_id: RowStoreTableId,
+        rowstore_table_id: RowstoreTableId,
     },
     Shutdown,
 }
@@ -47,8 +47,8 @@ pub struct ReplicationConnection {
     table_temp_files_directory: String,
     postgres_client: Client,
     handle: Option<JoinHandle<Result<()>>>,
-    table_readers: HashMap<RowStoreTableId, ReadStateManager>,
-    table_event_managers: HashMap<RowStoreTableId, TableEventManager>,
+    table_readers: HashMap<RowstoreTableId, ReadStateManager>,
+    table_event_managers: HashMap<RowstoreTableId, TableEventManager>,
     cmd_tx: mpsc::Sender<Command>,
     cmd_rx: Option<mpsc::Receiver<Command>>,
     replication_state: Arc<ReplicationState>,
@@ -244,7 +244,7 @@ impl ReplicationConnection {
         Ok(())
     }
 
-    pub fn get_table_reader(&self, rowstore_table_id: RowStoreTableId) -> &ReadStateManager {
+    pub fn get_table_reader(&self, rowstore_table_id: RowstoreTableId) -> &ReadStateManager {
         self.table_readers.get(&rowstore_table_id).unwrap()
     }
 
@@ -254,7 +254,7 @@ impl ReplicationConnection {
 
     pub fn get_table_event_manager(
         &mut self,
-        rowstore_table_id: RowStoreTableId,
+        rowstore_table_id: RowstoreTableId,
     ) -> &mut TableEventManager {
         self.table_event_managers
             .get_mut(&rowstore_table_id)
@@ -320,7 +320,7 @@ impl ReplicationConnection {
 
     async fn remove_table_from_replication(
         &mut self,
-        rowstore_table_id: RowStoreTableId,
+        rowstore_table_id: RowstoreTableId,
     ) -> Result<()> {
         debug!(rowstore_table_id, "removing table from replication");
         self.table_readers.remove_entry(&rowstore_table_id).unwrap();
@@ -369,7 +369,7 @@ impl ReplicationConnection {
         &mut self,
         table_name: &str,
         external_table_id: &T,
-    ) -> Result<(RowStoreTableId, MoonlinkTableConfig)> {
+    ) -> Result<(RowstoreTableId, MoonlinkTableConfig)> {
         info!(table_name, "adding table");
         // TODO: We should not naively alter the replica identity of a table. We should only do this if we are sure that the table does not already have a FULL replica identity. [https://github.com/Mooncake-Labs/moonlink/issues/104]
         self.alter_table_replica_identity(table_name).await?;
@@ -471,7 +471,7 @@ async fn run_event_loop(
     debug!("replication event loop started");
 
     let mut status_interval = tokio::time::interval(Duration::from_secs(10));
-    let mut flush_lsn_rxs: HashMap<RowStoreTableId, watch::Receiver<u64>> = HashMap::new();
+    let mut flush_lsn_rxs: HashMap<RowstoreTableId, watch::Receiver<u64>> = HashMap::new();
 
     loop {
         tokio::select! {

--- a/src/moonlink_connectors/src/replication_connection.rs
+++ b/src/moonlink_connectors/src/replication_connection.rs
@@ -16,7 +16,7 @@ use tokio_postgres::types::PgLsn;
 use tokio_postgres::{tls::NoTlsStream, Connection, Socket};
 
 use crate::pg_replicate::replication_state::ReplicationState;
-use crate::pg_replicate::table::{RowstoreTableId, TableSchema};
+use crate::pg_replicate::table::{SrcTableId, TableSchema};
 use futures::StreamExt;
 use moonlink::TableEvent;
 use std::collections::HashMap;
@@ -29,14 +29,14 @@ use tracing::{debug, error, info, info_span, warn};
 
 pub enum Command {
     AddTable {
-        rowstore_table_id: RowstoreTableId,
+        src_table_id: SrcTableId,
         schema: TableSchema,
         event_sender: mpsc::Sender<TableEvent>,
         commit_lsn_tx: watch::Sender<u64>,
         flush_lsn_rx: watch::Receiver<u64>,
     },
     DropTable {
-        rowstore_table_id: RowstoreTableId,
+        src_table_id: SrcTableId,
     },
     Shutdown,
 }
@@ -47,8 +47,8 @@ pub struct ReplicationConnection {
     table_temp_files_directory: String,
     postgres_client: Client,
     handle: Option<JoinHandle<Result<()>>>,
-    table_readers: HashMap<RowstoreTableId, ReadStateManager>,
-    table_event_managers: HashMap<RowstoreTableId, TableEventManager>,
+    table_readers: HashMap<SrcTableId, ReadStateManager>,
+    table_event_managers: HashMap<SrcTableId, TableEventManager>,
     cmd_tx: mpsc::Sender<Command>,
     cmd_rx: Option<mpsc::Receiver<Command>>,
     replication_state: Arc<ReplicationState>,
@@ -244,21 +244,16 @@ impl ReplicationConnection {
         Ok(())
     }
 
-    pub fn get_table_reader(&self, rowstore_table_id: RowstoreTableId) -> &ReadStateManager {
-        self.table_readers.get(&rowstore_table_id).unwrap()
+    pub fn get_table_reader(&self, src_table_id: SrcTableId) -> &ReadStateManager {
+        self.table_readers.get(&src_table_id).unwrap()
     }
 
     pub fn table_readers_count(&self) -> usize {
         self.table_readers.len()
     }
 
-    pub fn get_table_event_manager(
-        &mut self,
-        rowstore_table_id: RowstoreTableId,
-    ) -> &mut TableEventManager {
-        self.table_event_managers
-            .get_mut(&rowstore_table_id)
-            .unwrap()
+    pub fn get_table_event_manager(&mut self, src_table_id: SrcTableId) -> &mut TableEventManager {
+        self.table_event_managers.get_mut(&src_table_id).unwrap()
     }
 
     async fn spawn_replication_task(
@@ -281,12 +276,14 @@ impl ReplicationConnection {
     async fn add_table_to_replication<T: std::fmt::Display>(
         &mut self,
         schema: &TableSchema,
-        external_table_id: &T,
+        mooncake_table_id: &T,
+        table_id: u32,
     ) -> Result<MoonlinkTableConfig> {
-        let rowstore_table_id = schema.rowstore_table_id;
-        debug!(rowstore_table_id, "adding table to replication");
+        let src_table_id = schema.src_table_id;
+        debug!(src_table_id, "adding table to replication");
         let (table_resources, moonlink_table_config) = build_table_components(
-            external_table_id.to_string(),
+            mooncake_table_id.to_string(),
+            table_id,
             schema,
             Path::new(&self.table_base_path),
             self.table_temp_files_directory.clone(),
@@ -296,13 +293,13 @@ impl ReplicationConnection {
         .await?;
 
         self.table_readers
-            .insert(rowstore_table_id, table_resources.read_state_manager);
+            .insert(src_table_id, table_resources.read_state_manager);
         self.table_event_managers
-            .insert(rowstore_table_id, table_resources.table_event_manager);
+            .insert(src_table_id, table_resources.table_event_manager);
         if let Err(e) = self
             .cmd_tx
             .send(Command::AddTable {
-                rowstore_table_id,
+                src_table_id,
                 schema: schema.clone(),
                 event_sender: table_resources.event_sender,
                 commit_lsn_tx: table_resources.commit_lsn_tx,
@@ -313,28 +310,21 @@ impl ReplicationConnection {
             error!(error = ?e, "failed to enqueue AddTable command");
         }
 
-        debug!(rowstore_table_id, "table added to replication");
+        debug!(src_table_id, "table added to replication");
 
         Ok(moonlink_table_config)
     }
 
-    async fn remove_table_from_replication(
-        &mut self,
-        rowstore_table_id: RowstoreTableId,
-    ) -> Result<()> {
-        debug!(rowstore_table_id, "removing table from replication");
-        self.table_readers.remove_entry(&rowstore_table_id).unwrap();
+    async fn remove_table_from_replication(&mut self, src_table_id: SrcTableId) -> Result<()> {
+        debug!(src_table_id, "removing table from replication");
+        self.table_readers.remove_entry(&src_table_id).unwrap();
         // Notify the table handler to clean up cache, mooncake and iceberg table state.
-        self.drop_iceberg_table(rowstore_table_id).await?;
-        if let Err(e) = self
-            .cmd_tx
-            .send(Command::DropTable { rowstore_table_id })
-            .await
-        {
+        self.drop_iceberg_table(src_table_id).await?;
+        if let Err(e) = self.cmd_tx.send(Command::DropTable { src_table_id }).await {
             error!(error = ?e, "failed to enqueue DropTable command");
         }
 
-        debug!(rowstore_table_id, "table removed from replication");
+        debug!(src_table_id, "table removed from replication");
 
         Ok(())
     }
@@ -369,38 +359,35 @@ impl ReplicationConnection {
         &mut self,
         table_name: &str,
         external_table_id: &T,
-    ) -> Result<(RowstoreTableId, MoonlinkTableConfig)> {
+        table_id: u32,
+    ) -> Result<(SrcTableId, MoonlinkTableConfig)> {
         info!(table_name, "adding table");
         // TODO: We should not naively alter the replica identity of a table. We should only do this if we are sure that the table does not already have a FULL replica identity. [https://github.com/Mooncake-Labs/moonlink/issues/104]
         self.alter_table_replica_identity(table_name).await?;
         let table_schema = self.source.fetch_table_schema(table_name, None).await?;
 
         let moonlink_table_config = self
-            .add_table_to_replication(&table_schema, external_table_id)
+            .add_table_to_replication(&table_schema, external_table_id, table_id)
             .await?;
 
         self.add_table_to_publication(table_name).await?;
 
-        info!(
-            rowstore_table_id = table_schema.rowstore_table_id,
-            "table added"
-        );
+        info!(src_table_id = table_schema.src_table_id, "table added");
 
-        Ok((table_schema.rowstore_table_id, moonlink_table_config))
+        Ok((table_schema.src_table_id, moonlink_table_config))
     }
 
     /// Remove the given table from connection.
-    pub async fn drop_table(&mut self, rowstore_table_id: u32) -> Result<()> {
-        info!(rowstore_table_id, "dropping table");
-        let table_name = self.source.get_table_name_from_id(rowstore_table_id);
+    pub async fn drop_table(&mut self, src_table_id: u32) -> Result<()> {
+        info!(src_table_id, "dropping table");
+        let table_name = self.source.get_table_name_from_id(src_table_id);
 
         // Remove table from publication as the first step, to prevent further events.
         self.remove_table_from_publication(&table_name).await?;
-        self.source.remove_table_schema(rowstore_table_id);
-        self.remove_table_from_replication(rowstore_table_id)
-            .await?;
+        self.source.remove_table_schema(src_table_id);
+        self.remove_table_from_replication(src_table_id).await?;
 
-        info!(rowstore_table_id, "table dropped");
+        info!(src_table_id, "table dropped");
         Ok(())
     }
 
@@ -471,7 +458,7 @@ async fn run_event_loop(
     debug!("replication event loop started");
 
     let mut status_interval = tokio::time::interval(Duration::from_secs(10));
-    let mut flush_lsn_rxs: HashMap<RowstoreTableId, watch::Receiver<u64>> = HashMap::new();
+    let mut flush_lsn_rxs: HashMap<SrcTableId, watch::Receiver<u64>> = HashMap::new();
 
     loop {
         tokio::select! {
@@ -494,15 +481,15 @@ async fn run_event_loop(
                             }
                         },
                         Some(cmd) = cmd_rx.recv() => match cmd {
-                            Command::AddTable { rowstore_table_id, schema, event_sender, commit_lsn_tx, flush_lsn_rx } => {
-                                sink.add_table(rowstore_table_id, event_sender, commit_lsn_tx);
-                                flush_lsn_rxs.insert(rowstore_table_id, flush_lsn_rx);
+                            Command::AddTable { src_table_id, schema, event_sender, commit_lsn_tx, flush_lsn_rx } => {
+                                sink.add_table(src_table_id, event_sender, commit_lsn_tx);
+                                flush_lsn_rxs.insert(src_table_id, flush_lsn_rx);
                                 stream.as_mut().add_table_schema(schema);
                             }
-                            Command::DropTable { rowstore_table_id } => {
-                                sink.drop_table(rowstore_table_id);
-                                flush_lsn_rxs.remove(&rowstore_table_id);
-                                stream.as_mut().remove_table_schema(rowstore_table_id);
+                            Command::DropTable { src_table_id } => {
+                                sink.drop_table(src_table_id);
+                                flush_lsn_rxs.remove(&src_table_id);
+                                stream.as_mut().remove_table_schema(src_table_id);
                             }
                             Command::Shutdown => {
                                 info!("received shutdown command");

--- a/src/moonlink_connectors/src/replication_manager.rs
+++ b/src/moonlink_connectors/src/replication_manager.rs
@@ -96,12 +96,13 @@ impl<T: Clone + Eq + Hash + std::fmt::Display> ReplicationManager<T> {
 
     /// Drop table specified by the given table id.
     /// If the table is not tracked, logs a message and returns successfully.
-    pub async fn drop_table(&mut self, external_table_id: T) -> Result<()> {
+    /// Return whether the table is tracked by moonlink.
+    pub async fn drop_table(&mut self, external_table_id: T) -> Result<bool> {
         let (table_uri, table_id) = match self.table_info.get(&external_table_id) {
             Some(info) => info.clone(),
             None => {
                 warn!("attempted to drop table that is not tracked by moonlink - table may already be dropped");
-                return Ok(());
+                return Ok(false);
             }
         };
         info!(table_id, %table_uri, "dropping table through manager");
@@ -112,7 +113,7 @@ impl<T: Clone + Eq + Hash + std::fmt::Display> ReplicationManager<T> {
         }
 
         info!(table_id, "table dropped through manager");
-        Ok(())
+        Ok(true)
     }
 
     pub fn get_table_reader(&self, table_id: &T) -> &ReadStateManager {

--- a/src/moonlink_connectors/src/replication_manager.rs
+++ b/src/moonlink_connectors/src/replication_manager.rs
@@ -1,7 +1,7 @@
-use crate::pg_replicate::table::TableId;
+use crate::pg_replicate::table::RowStoreTableId;
 use crate::Result;
 use crate::{PostgresSourceError, ReplicationConnection};
-use moonlink::{ObjectStorageCache, ReadStateManager, TableEventManager};
+use moonlink::{MoonlinkTableConfig, ObjectStorageCache, ReadStateManager, TableEventManager};
 use std::collections::HashMap;
 use std::hash::Hash;
 use tokio::task::JoinHandle;
@@ -16,8 +16,8 @@ use tracing::{debug, info, warn};
 pub struct ReplicationManager<T: Clone + Eq + Hash + std::fmt::Display> {
     /// Maps from uri to replication connection.
     connections: HashMap<String, ReplicationConnection>,
-    /// Maps from table id (string format) to (uri, table id).
-    table_info: HashMap<T, (String, TableId)>,
+    /// Maps from table id (string format) to (uri, row store table id).
+    table_info: HashMap<T, (String, RowStoreTableId)>,
     /// Base directory for mooncake tables.
     table_base_path: String,
     /// Base directory for temporary files used in union read.
@@ -50,13 +50,13 @@ impl<T: Clone + Eq + Hash + std::fmt::Display> ReplicationManager<T> {
     /// source will be created.
     pub async fn add_table(
         &mut self,
-        uri: &str,
-        external_table_id: T,
+        src_uri: &str,
+        columnstore_table_id: T,
         table_name: &str,
-    ) -> Result<()> {
-        info!(%uri, table_name, "adding table through manager");
-        if !self.connections.contains_key(uri) {
-            debug!(%uri, "creating replication connection");
+    ) -> Result<MoonlinkTableConfig> {
+        info!(%src_uri, table_name, "adding table through manager");
+        if !self.connections.contains_key(src_uri) {
+            debug!(%src_uri, "creating replication connection");
             // Lazily create the directory that will hold all tables.
             // This will not overwrite any existing directory.
             tokio::fs::create_dir_all(&self.table_base_path)
@@ -66,30 +66,32 @@ impl<T: Clone + Eq + Hash + std::fmt::Display> ReplicationManager<T> {
                 .await
                 .map_err(PostgresSourceError::Io)?;
             let replication_connection = ReplicationConnection::new(
-                uri.to_owned(),
+                src_uri.to_string(),
                 base_path.to_str().unwrap().to_string(),
                 self.table_temp_files_directory.clone(),
                 self.object_storage_cache.clone(),
             )
             .await?;
             self.connections
-                .insert(uri.to_string(), replication_connection);
+                .insert(src_uri.to_string(), replication_connection);
         }
-        let replication_connection = self.connections.get_mut(uri).unwrap();
+        let replication_connection = self.connections.get_mut(src_uri).unwrap();
 
         if !replication_connection.replication_started() {
             replication_connection.start_replication().await?;
         }
 
-        let rowstore_table_id = replication_connection
-            .add_table(table_name, &external_table_id)
+        let (rowstore_table_id, moonlink_table_config) = replication_connection
+            .add_table(table_name, &columnstore_table_id)
             .await?;
-        self.table_info
-            .insert(external_table_id, (uri.to_string(), rowstore_table_id));
+        self.table_info.insert(
+            columnstore_table_id,
+            (src_uri.to_string(), rowstore_table_id),
+        );
 
         info!(rowstore_table_id, "table added through manager");
 
-        Ok(())
+        Ok(moonlink_table_config)
     }
 
     /// Drop table specified by the given table id.

--- a/src/moonlink_connectors/src/replication_manager.rs
+++ b/src/moonlink_connectors/src/replication_manager.rs
@@ -1,4 +1,4 @@
-use crate::pg_replicate::table::RowStoreTableId;
+use crate::pg_replicate::table::RowstoreTableId;
 use crate::Result;
 use crate::{PostgresSourceError, ReplicationConnection};
 use moonlink::{MoonlinkTableConfig, ObjectStorageCache, ReadStateManager, TableEventManager};
@@ -17,7 +17,7 @@ pub struct ReplicationManager<T: Clone + Eq + Hash + std::fmt::Display> {
     /// Maps from uri to replication connection.
     connections: HashMap<String, ReplicationConnection>,
     /// Maps from table id (string format) to (uri, row store table id).
-    table_info: HashMap<T, (String, RowStoreTableId)>,
+    table_info: HashMap<T, (String, RowstoreTableId)>,
     /// Base directory for mooncake tables.
     table_base_path: String,
     /// Base directory for temporary files used in union read.

--- a/src/moonlink_metadata_store/src/base_metadata_store.rs
+++ b/src/moonlink_metadata_store/src/base_metadata_store.rs
@@ -20,4 +20,9 @@ pub trait MetadataStoreTrait: Send {
         table_name: &str,
         moonlink_table_config: MoonlinkTableConfig,
     ) -> Result<()>;
+
+    /// Delete table config for the given table.
+    /// Precondition: the requested table id has been record in the metadata storage.
+    #[allow(async_fn_in_trait)]
+    async fn delete_table_config(&self, table_id: u32) -> Result<()>;
 }

--- a/src/moonlink_metadata_store/src/error.rs
+++ b/src/moonlink_metadata_store/src/error.rs
@@ -7,6 +7,9 @@ pub enum Error {
     #[error("tokio postgres error: {0}")]
     TokioPostgresError(#[from] TokioPostgresError),
 
+    #[error("metadata operation row number doesn't match {0} vs {1}")]
+    PostgresRowCountError(u32, u32),
+
     #[error("serde json error: {0}")]
     SerdeJsonError(#[from] SerdeJsonError),
 

--- a/src/moonlink_metadata_store/src/postgres/pg_metadata_store.rs
+++ b/src/moonlink_metadata_store/src/postgres/pg_metadata_store.rs
@@ -68,10 +68,13 @@ impl MetadataStoreTrait for PgMetadataStore {
 
     async fn delete_table_config(&self, table_id: u32) -> Result<()> {
         let guard = self.postgres_client.lock().await;
-        guard
+        let rows_affected = guard
             .execute("DELETE FROM mooncake.tables WHERE oid = $1", &[&table_id])
             .await?;
 
+        if rows_affected != 1 {
+            return Err(Error::PostgresRowCountError(1, rows_affected as u32));
+        }
         Ok(())
     }
 }

--- a/src/moonlink_metadata_store/src/postgres/pg_metadata_store.rs
+++ b/src/moonlink_metadata_store/src/postgres/pg_metadata_store.rs
@@ -65,6 +65,15 @@ impl MetadataStoreTrait for PgMetadataStore {
 
         Ok(())
     }
+
+    async fn delete_table_config(&self, table_id: u32) -> Result<()> {
+        let guard = self.postgres_client.lock().await;
+        guard
+            .execute("DELETE FROM mooncake.tables WHERE oid = $1", &[&table_id])
+            .await?;
+
+        Ok(())
+    }
 }
 
 impl PgMetadataStore {

--- a/src/moonlink_metadata_store/tests/test_pg_metadata_store.rs
+++ b/src/moonlink_metadata_store/tests/test_pg_metadata_store.rs
@@ -72,4 +72,30 @@ mod tests {
             .await;
         assert!(res.is_err());
     }
+
+    /// Test senario: delete table metadata store.
+    #[tokio::test]
+    #[serial]
+    async fn test_delete_table_metadata_store() {
+        let _test_environment = TestEnvironment::new(URI).await;
+        let metadata_store = PgMetadataStore::new(URI).await.unwrap();
+        let moonlink_table_config = get_moonlink_table_config();
+
+        // Store moonlink table config to metadata storage.
+        metadata_store
+            .store_table_config(TABLE_ID, TABLE_NAME, moonlink_table_config.clone())
+            .await
+            .unwrap();
+        let actual_config = metadata_store.load_table_config(TABLE_ID).await.unwrap();
+        assert_eq!(moonlink_table_config, actual_config);
+
+        // Delete moonlink table config to metadata storage and check.
+        metadata_store.delete_table_config(TABLE_ID).await.unwrap();
+        let res = metadata_store.load_table_config(TABLE_ID).await;
+        assert!(res.is_err());
+
+        // Delete for the second time also fails.
+        let res = metadata_store.delete_table_config(TABLE_ID).await;
+        assert!(res.is_err());
+    }
 }


### PR DESCRIPTION
## Summary

This PR does three things:
- Integrate metadata store with create and drop table, corresponding integration tests added to check metadata storage
- Check affected rows operated by SQL
- Rename changes see https://github.com/Mooncake-Labs/moonlink/pull/648#issuecomment-3021297352

Tested with pg_mooncake regression test:
```sh
--- beginning regression test run ---
PASS setup 23ms
PASS partitioned_table 734ms
PASS sanity 707ms
```

I tested with pg_mooncake SQL statements:
```sql
pg_mooncake (pid: 121405) =# SELECT * FROM mooncake.tables;
(0 rows)

pg_mooncake (pid: 121405) =# DROP TABLE IF EXISTS r;
CREATE EXTENSION IF NOT EXISTS pg_mooncake;
CREATE TABLE r (a int primary key, b text);
CALL mooncake.create_table('c', 'r');
INSERT INTO r SELECT a, 'val_' || a FROM generate_series(1, 250000) AS a;
SELECT count(*) FROM c;
DELETE FROM r;
SELECT count(*) FROM c;
NOTICE:  table "r" does not exist, skipping
DROP TABLE
NOTICE:  extension "pg_mooncake" already exists, skipping
CREATE EXTENSION
CREATE TABLE
CALL
INSERT 0 250000
-[ RECORD 1 ]-
count | 250000

DELETE 250000
-[ RECORD 1 ]-
count | 250000

pg_mooncake (pid: 121405) =# SELECT * FROM mooncake.tables;
-[ RECORD 1 ]------------------------------------------------------------------------------------------------------------------------------------
oid         | 41255
table_name  | public.r
uri         | 
config      | {"iceberg_table_config":{"namespace":"public","table_name":"16384.41255","warehouse_uri":"/home/vscode/.pgrx/data-17/pg_mooncake"}}
cardinality | 

pg_mooncake (pid: 121405) =# DROP TABLE IF EXISTS r, c;
DROP TABLE
pg_mooncake (pid: 121405) =# SELECT * FROM mooncake.tables;
(0 rows)

pg_mooncake (pid: 121405) =# DROP TABLE IF EXISTS r, c;
CREATE EXTENSION IF NOT EXISTS pg_mooncake;
CREATE TABLE r (a int primary key, b text);
CALL mooncake.create_table('c', 'r');
INSERT INTO r SELECT a, 'val_' || a FROM generate_series(1, 250000) AS a;
SELECT count(*) FROM c;
DELETE FROM r;
SELECT count(*) FROM c;
NOTICE:  table "r" does not exist, skipping
NOTICE:  table "c" does not exist, skipping
DROP TABLE
NOTICE:  extension "pg_mooncake" already exists, skipping
CREATE EXTENSION
CREATE TABLE
CALL
INSERT 0 250000
-[ RECORD 1 ]-
count | 250000

DELETE 250000
-[ RECORD 1 ]-
count | 250000

pg_mooncake (pid: 121405) =# SELECT * FROM mooncake.tables;
-[ RECORD 1 ]------------------------------------------------------------------------------------------------------------------------------------
oid         | 41267
table_name  | public.r
uri         | 
config      | {"iceberg_table_config":{"namespace":"public","table_name":"16384.41267","warehouse_uri":"/home/vscode/.pgrx/data-17/pg_mooncake"}}
cardinality | 
```

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/622

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
