### PR TITLE
[postgres] Pin postgres-types version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,6 +45,7 @@ parquet = { version = "55", default-features = false, features = [
   "arrow_canonical_extension_types",
 ] }
 postgres-replication = { git = "https://github.com/Mooncake-labs/rust-postgres.git", rev = "e6bd7d5cacc4eb7a03930b5ca3db1ef9caf0a3d5" }
+postgres-types = { git = "https://github.com/Mooncake-Labs/rust-postgres.git", rev = "e6bd7d5cacc4eb7a03930b5ca3db1ef9caf0a3d5", features = ["with-serde_json-1"] }
 rand = "0.9"
 roaring = "0.10"
 serde = { version = "1.0", default-features = false, features = ["derive"] }

--- a/src/moonlink_metadata_store/Cargo.toml
+++ b/src/moonlink_metadata_store/Cargo.toml
@@ -7,7 +7,7 @@ license = { workspace = true }
 [dependencies]
 async-trait = { workspace = true }
 moonlink = { path = "../moonlink" }
-postgres-types = { version = "0.2", features = ["with-serde_json-1"] }
+postgres-types = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }


### PR DESCRIPTION
## Summary

I met a compilation error on latest moonlink and pg_mooncake
```sh
error[E0277]: the trait bound `postgres_types::Json<&serde_json::Value>: tokio_postgres::types::ToSql` is not satisfied
   --> moonlink/src/moonlink_metadata_store/src/postgres/pg_metadata_store.rs:65:43
    |
65  |                 &[&table_id, &table_name, &PgJson(&serialized_config)],
    |                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `tokio_postgres::types::ToSql` is not implemented for `postgres_types::Json<&serde_json::Value>`
    |
note: there are multiple different versions of crate `postgres_types` in the dependency graph
   --> /usr/local/cargo/git/checkouts/rust-postgres-72e3bb4aed4f8d49/e6bd7d5/postgres-types/src/lib.rs:864:1
    |
864 | pub trait ToSql: fmt::Debug {
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^ this is the required trait
```
I checked the dependency tree, 4 `postgres-types` dependencies live in the dependency tree and there're two version: 0.2.9 and 0.2.7 which don't share the same interface.

This PR pins its version, and I confirmed it compiles both on moonlink and pg_mooncake side.

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
