### PR TITLE
[storage] [1/N] Integrate table recovery with backend initialization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2481,6 +2481,7 @@ version = "0.0.1"
 dependencies = [
  "async-trait",
  "moonlink",
+ "more-asserts",
  "postgres-types",
  "serde",
  "serde_json",

--- a/src/moonlink_backend/src/lib.rs
+++ b/src/moonlink_backend/src/lib.rs
@@ -134,6 +134,13 @@ where
                 mooncake_table_id,
                 metadata_entry.table_id,
                 &metadata_entry.src_table_name,
+                /*override_table_base_path=*/
+                Some(
+                    &metadata_entry
+                        .moonlink_table_config
+                        .iceberg_table_config
+                        .warehouse_uri,
+                ),
             )
             .await?;
         Ok(())
@@ -216,7 +223,13 @@ where
         let moonlink_table_config = {
             let mut manager = self.replication_manager.write().await;
             manager
-                .add_table(&src_uri, mooncake_table_id, table_id, &src_table_name)
+                .add_table(
+                    &src_uri,
+                    mooncake_table_id,
+                    table_id,
+                    &src_table_name,
+                    /*override_table_base_path=*/ None,
+                )
                 .await?
         };
 

--- a/src/moonlink_backend/src/lib.rs
+++ b/src/moonlink_backend/src/lib.rs
@@ -7,7 +7,7 @@ use mooncake_table_id::MooncakeTableId;
 pub use moonlink::ReadState;
 use moonlink::{ObjectStorageCache, ObjectStorageCacheConfig};
 use moonlink_connectors::ReplicationManager;
-use moonlink_metadata_store::base_metadata_store::MetadataStoreTrait;
+use moonlink_metadata_store::base_metadata_store::{MetadataStoreTrait, TableMetadataEntry};
 use moonlink_metadata_store::PgMetadataStore;
 use more_asserts as ma;
 use std::collections::hash_map::Entry as HashMapEntry;
@@ -17,14 +17,16 @@ use std::io::ErrorKind;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
-// Default local filesystem directory under the above base directory (which defaults to `PGDATA/pg_mooncake`) where all temporary files (used for union read) will be stored under.
-// The whole directory is cleaned up at moonlink backend start, to prevent file leak.
+/// Default local filesystem directory under the above base directory (which defaults to `PGDATA/pg_mooncake`) where all temporary files (used for union read) will be stored under.
+/// The whole directory is cleaned up at moonlink backend start, to prevent file leak.
 pub const DEFAULT_MOONLINK_TEMP_FILE_PATH: &str = "./temp/";
-// Default object storage read-through cache directory under the above mooncake directory (which defaults to `PGDATA/pg_mooncake`).
-// The whole directory is cleaned up at moonlink backend start, to prevent file leak.
+/// Default object storage read-through cache directory under the above mooncake directory (which defaults to `PGDATA/pg_mooncake`).
+/// The whole directory is cleaned up at moonlink backend start, to prevent file leak.
 pub const DEFAULT_MOONLINK_OBJECT_STORAGE_CACHE_PATH: &str = "./read_through_cache/";
-// Min left disk space for on-disk cache of the filesystem which cache directory is mounted on.
+/// Min left disk space for on-disk cache of the filesystem which cache directory is mounted on.
 const MIN_DISK_SPACE_FOR_CACHE: u64 = 1 << 30; // 1GiB
+/// Database schema for moonlink.
+const MOONLINK_SCHEMA: &str = "mooncake";
 
 /// Get temporary directory under base path.
 fn get_temp_file_directory_under_base(base_path: &str) -> std::path::PathBuf {
@@ -52,8 +54,8 @@ pub fn recreate_directory(dir: &str) -> Result<()> {
 }
 
 pub struct MoonlinkBackend<
-    D: Eq + Hash + Clone + std::fmt::Display,
-    T: Eq + Hash + Clone + std::fmt::Display,
+    D: std::convert::From<u32> + Eq + Hash + Clone + std::fmt::Display,
+    T: std::convert::From<u32> + Eq + Hash + Clone + std::fmt::Display,
 > {
     // Could be either relative or absolute path.
     replication_manager: RwLock<ReplicationManager<MooncakeTableId<D, T>>>,
@@ -91,8 +93,8 @@ fn create_default_object_storage_cache(
 
 impl<D, T> MoonlinkBackend<D, T>
 where
-    D: Eq + Hash + Clone + std::fmt::Display,
-    T: Eq + Hash + Clone + std::fmt::Display,
+    D: std::convert::From<u32> + Eq + Hash + Clone + std::fmt::Display,
+    T: std::convert::From<u32> + Eq + Hash + Clone + std::fmt::Display,
 {
     pub fn new(base_path: String) -> Self {
         logging::init_logging();
@@ -113,14 +115,69 @@ where
         }
     }
 
+    /// Recovery the given table.
+    async fn recover_table(
+        &mut self,
+        src_uri: &str,
+        database_id: u32,
+        metadata_entry: TableMetadataEntry,
+    ) -> Result<()> {
+        let mooncake_table_id = MooncakeTableId {
+            database_id: D::from(database_id),
+            table_id: T::from(metadata_entry.table_id),
+        };
+
+        let mut manager = self.replication_manager.write().await;
+        manager
+            .add_table(
+                src_uri,
+                mooncake_table_id,
+                metadata_entry.table_id,
+                &metadata_entry.src_table_name,
+            )
+            .await?;
+        Ok(())
+    }
+
+    /// Recovery all databases indicated by the connection strings.
+    ///
+    /// TODO(hjiang): Parallelize all IO operations.
+    async fn recover_all_tables(&mut self, uris: HashMap<String, String>) -> Result<()> {
+        for (src_uri, metadata_store_uri) in uris.into_iter() {
+            // If "mooncake" schema doesn't exist for the given database, it means no table under the current database is managed by moonlink.
+            let pg_metadata_store = PgMetadataStore::new(&metadata_store_uri).await?;
+            let schema_exists = pg_metadata_store.schema_exists(MOONLINK_SCHEMA).await?;
+            if !schema_exists {
+                continue;
+            }
+
+            // Get database id.
+            let database_id = pg_metadata_store.get_database_id().await?;
+            // Get all mooncake tables to recovery.
+            let table_metadata_entries = pg_metadata_store.get_all_table_metadata_entries().await?;
+
+            // Load config and try recovery.
+            for cur_metadata_entry in table_metadata_entries.into_iter() {
+                self.recover_table(&src_uri, database_id, cur_metadata_entry)
+                    .await?;
+            }
+        }
+
+        Ok(())
+    }
+
     /// TODO(hjiang): Add this new initialization construct for dev purpose, should merge with [`new`] at the end of the day.
     ///
     /// # Arguments
     ///
     /// * uris: maps from source uris to metadata store uris.
-    pub fn new_with_recovery(base_path: String, uris: HashMap<String, String>) -> Self {
-        let backend = Self::new(base_path);
-        backend
+    pub async fn new_with_recovery(
+        base_path: String,
+        uris: HashMap<String, String>,
+    ) -> Result<Self> {
+        let mut backend = Self::new(base_path);
+        backend.recover_all_tables(uris).await?;
+        Ok(backend)
     }
 
     /// Create an iceberg snapshot with the given LSN, return when the a snapshot is successfully created.

--- a/src/moonlink_backend/src/lib.rs
+++ b/src/moonlink_backend/src/lib.rs
@@ -113,6 +113,16 @@ where
         }
     }
 
+    /// TODO(hjiang): Add this new initialization construct for dev purpose, should merge with [`new`] at the end of the day.
+    ///
+    /// # Arguments
+    ///
+    /// * uris: maps from source uris to metadata store uris.
+    pub fn new_with_recovery(base_path: String, uris: HashMap<String, String>) -> Self {
+        let backend = Self::new(base_path);
+        backend
+    }
+
     /// Create an iceberg snapshot with the given LSN, return when the a snapshot is successfully created.
     pub async fn create_snapshot(&self, database_id: D, table_id: T, lsn: u64) -> Result<()> {
         let mut rx = {

--- a/src/moonlink_connectors/src/replication_connection.rs
+++ b/src/moonlink_connectors/src/replication_connection.rs
@@ -273,11 +273,15 @@ impl ReplicationConnection {
         })
     }
 
+    /// # Arguments
+    ///
+    /// * override_table_base_path: directory for the table to add into replication, fallback to [`self.table_base_path`] if unassigned.
     async fn add_table_to_replication<T: std::fmt::Display>(
         &mut self,
         schema: &TableSchema,
         mooncake_table_id: &T,
         table_id: u32,
+        override_table_base_path: Option<&str>,
     ) -> Result<MoonlinkTableConfig> {
         let src_table_id = schema.src_table_id;
         debug!(src_table_id, "adding table to replication");
@@ -285,7 +289,7 @@ impl ReplicationConnection {
             mooncake_table_id.to_string(),
             table_id,
             schema,
-            Path::new(&self.table_base_path),
+            Path::new(override_table_base_path.unwrap_or(&self.table_base_path)),
             self.table_temp_files_directory.clone(),
             &self.replication_state,
             self.object_storage_cache.clone(),
@@ -360,6 +364,7 @@ impl ReplicationConnection {
         table_name: &str,
         external_table_id: &T,
         table_id: u32,
+        override_table_base_path: Option<&str>,
     ) -> Result<(SrcTableId, MoonlinkTableConfig)> {
         info!(table_name, "adding table");
         // TODO: We should not naively alter the replica identity of a table. We should only do this if we are sure that the table does not already have a FULL replica identity. [https://github.com/Mooncake-Labs/moonlink/issues/104]
@@ -367,7 +372,12 @@ impl ReplicationConnection {
         let table_schema = self.source.fetch_table_schema(table_name, None).await?;
 
         let moonlink_table_config = self
-            .add_table_to_replication(&table_schema, external_table_id, table_id)
+            .add_table_to_replication(
+                &table_schema,
+                external_table_id,
+                table_id,
+                override_table_base_path,
+            )
             .await?;
 
         self.add_table_to_publication(table_name).await?;

--- a/src/moonlink_connectors/src/replication_connection.rs
+++ b/src/moonlink_connectors/src/replication_connection.rs
@@ -275,7 +275,7 @@ impl ReplicationConnection {
 
     /// # Arguments
     ///
-    /// * override_table_base_path: directory for the table to add into replication, fallback to [`self.table_base_path`] if unassigned.
+    /// * override_table_base_path: mooncake table directory, fallback to [`self.table_base_path`] if unassigned.
     async fn add_table_to_replication<T: std::fmt::Display>(
         &mut self,
         schema: &TableSchema,

--- a/src/moonlink_metadata_store/Cargo.toml
+++ b/src/moonlink_metadata_store/Cargo.toml
@@ -7,6 +7,7 @@ license = { workspace = true }
 [dependencies]
 async-trait = { workspace = true }
 moonlink = { path = "../moonlink" }
+more-asserts = { workspace = true }
 postgres-types = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/src/moonlink_metadata_store/src/base_metadata_store.rs
+++ b/src/moonlink_metadata_store/src/base_metadata_store.rs
@@ -5,6 +5,7 @@ use crate::error::Result;
 use moonlink::MoonlinkTableConfig;
 
 /// Metadata entry for each table.
+#[derive(Clone, Debug)]
 pub struct TableMetadataEntry {
     /// Table id.
     pub table_id: u32,
@@ -29,11 +30,6 @@ pub trait MetadataStoreTrait: Send {
     /// Notice, schema existence should be checked beforehand, otherwise empty entries will be returned.
     #[allow(async_fn_in_trait)]
     async fn get_all_table_metadata_entries(&self) -> Result<Vec<TableMetadataEntry>>;
-
-    /// Load configuration for the given table.
-    /// Precondition: the requested table id has been record in the metadata storage.
-    #[allow(async_fn_in_trait)]
-    async fn load_table_config(&self, table_id: u32) -> Result<MoonlinkTableConfig>;
 
     /// Store table config for the given table.
     /// Precondition: the requested table id hasn't been recorded in the metadata storage.

--- a/src/moonlink_metadata_store/src/base_metadata_store.rs
+++ b/src/moonlink_metadata_store/src/base_metadata_store.rs
@@ -11,7 +11,7 @@ pub struct TableMetadataEntry {
     pub table_id: u32,
     /// Src table name.
     pub src_table_name: String,
-    /// Moonlink table config.
+    /// Moonlink table config, including mooncake and iceberg table config.
     pub moonlink_table_config: MoonlinkTableConfig,
 }
 
@@ -27,7 +27,7 @@ pub trait MetadataStoreTrait: Send {
     async fn schema_exists(&self, schema_name: &str) -> Result<bool>;
 
     /// Get all mooncake table metadata entries in the metadata storage table.
-    /// Notice, schema existence should be checked beforehand, otherwise empty entries will be returned.
+    /// Notice, schema existence should be checked beforehand, otherwise empty entries will be returned if schema doesn't exist.
     #[allow(async_fn_in_trait)]
     async fn get_all_table_metadata_entries(&self) -> Result<Vec<TableMetadataEntry>>;
 

--- a/src/moonlink_metadata_store/src/base_metadata_store.rs
+++ b/src/moonlink_metadata_store/src/base_metadata_store.rs
@@ -6,6 +6,10 @@ use moonlink::MoonlinkTableConfig;
 
 #[async_trait]
 pub trait MetadataStoreTrait: Send {
+    /// Get database id.
+    #[allow(async_fn_in_trait)]
+    async fn get_database_id(&self) -> Result<u32>;
+
     /// Load configuration for the given table.
     /// Precondition: the requested table id has been record in the metadata storage.
     #[allow(async_fn_in_trait)]

--- a/src/moonlink_metadata_store/src/base_metadata_store.rs
+++ b/src/moonlink_metadata_store/src/base_metadata_store.rs
@@ -4,11 +4,31 @@ use async_trait::async_trait;
 use crate::error::Result;
 use moonlink::MoonlinkTableConfig;
 
+/// Metadata entry for each table.
+pub struct TableMetadataEntry {
+    /// Table id.
+    pub table_id: u32,
+    /// Src table name.
+    pub src_table_name: String,
+    /// Moonlink table config.
+    pub moonlink_table_config: MoonlinkTableConfig,
+}
+
 #[async_trait]
 pub trait MetadataStoreTrait: Send {
     /// Get database id.
     #[allow(async_fn_in_trait)]
     async fn get_database_id(&self) -> Result<u32>;
+
+    /// Return whether the given schema exists.
+    /// Context: database concept hierarchy is database -> schema -> table.
+    #[allow(async_fn_in_trait)]
+    async fn schema_exists(&self, schema_name: &str) -> Result<bool>;
+
+    /// Get all mooncake table metadata entries in the metadata storage table.
+    /// Notice, schema existence should be checked beforehand, otherwise empty entries will be returned.
+    #[allow(async_fn_in_trait)]
+    async fn get_all_table_metadata_entries(&self) -> Result<Vec<TableMetadataEntry>>;
 
     /// Load configuration for the given table.
     /// Precondition: the requested table id has been record in the metadata storage.

--- a/src/moonlink_metadata_store/src/postgres/pg_metadata_store.rs
+++ b/src/moonlink_metadata_store/src/postgres/pg_metadata_store.rs
@@ -1,3 +1,4 @@
+use crate::base_metadata_store::TableMetadataEntry;
 use crate::error::Result;
 use crate::postgres::config_utils;
 use crate::{base_metadata_store::MetadataStoreTrait, error::Error};
@@ -24,15 +25,63 @@ pub struct PgMetadataStore {
 #[async_trait]
 impl MetadataStoreTrait for PgMetadataStore {
     async fn get_database_id(&self) -> Result<u32> {
-        let guard = self.postgres_client.lock().await;
-        let row = guard
-            .query_one(
-                "SELECT oid FROM pg_database WHERE datname = current_database()",
-                &[],
-            )
-            .await?;
+        let row = {
+            let guard = self.postgres_client.lock().await;
+            guard
+                .query_one(
+                    "SELECT oid FROM pg_database WHERE datname = current_database()",
+                    &[],
+                )
+                .await?
+        };
         let oid = row.get("oid");
         Ok(oid)
+    }
+
+    async fn get_all_table_metadata_entries(&self) -> Result<Vec<TableMetadataEntry>> {
+        let rows = {
+            let guard = self.postgres_client.lock().await;
+            guard
+                .query("SELECT oid, table_name, config FROM mooncake.tables", &[])
+                .await?
+        };
+
+        let mut metadata_entries = Vec::with_capacity(rows.len());
+        for cur_row in rows.into_iter() {
+            assert_eq!(cur_row.len(), 3);
+            let table_id = cur_row.get("oid");
+            let src_table_name = cur_row.get("table_name");
+            let serialized_config = cur_row.get("config");
+            let moonlink_table_config =
+                config_utils::deserialze_moonlink_table_config(serialized_config)?;
+            metadata_entries.push(TableMetadataEntry {
+                table_id,
+                src_table_name,
+                moonlink_table_config,
+            });
+        }
+        Ok(metadata_entries)
+    }
+
+    async fn schema_exists(&self, schema_name: &str) -> Result<bool> {
+        let rows = {
+            let guard = self.postgres_client.lock().await;
+            guard
+                .query(
+                    "SELECT 1 FROM pg_namespace WHERE nspname = $1;",
+                    &[&schema_name],
+                )
+                .await?
+        };
+
+        if rows.is_empty() {
+            return Ok(false);
+        }
+        if rows.len() == 1 {
+            return Ok(true);
+        }
+
+        Err(Error::PostgresRowCountError(1, rows.len() as u32))
     }
 
     async fn load_table_config(&self, table_id: u32) -> Result<MoonlinkTableConfig> {
@@ -41,8 +90,7 @@ impl MetadataStoreTrait for PgMetadataStore {
 
             guard
                 .query("SELECT * FROM mooncake.tables WHERE oid = $1", &[&table_id])
-                .await
-                .expect("Failed to query tables")
+                .await?
         };
 
         if rows.is_empty() {

--- a/src/moonlink_metadata_store/src/postgres/pg_metadata_store.rs
+++ b/src/moonlink_metadata_store/src/postgres/pg_metadata_store.rs
@@ -23,6 +23,18 @@ pub struct PgMetadataStore {
 
 #[async_trait]
 impl MetadataStoreTrait for PgMetadataStore {
+    async fn get_database_id(&self) -> Result<u32> {
+        let guard = self.postgres_client.lock().await;
+        let row = guard
+            .query_one(
+                "SELECT oid FROM pg_database WHERE datname = current_database()",
+                &[],
+            )
+            .await?;
+        let oid = row.get("oid");
+        Ok(oid)
+    }
+
     async fn load_table_config(&self, table_id: u32) -> Result<MoonlinkTableConfig> {
         let rows = {
             let guard = self.postgres_client.lock().await;

--- a/src/moonlink_metadata_store/src/postgres/pg_metadata_store.rs
+++ b/src/moonlink_metadata_store/src/postgres/pg_metadata_store.rs
@@ -64,24 +64,17 @@ impl MetadataStoreTrait for PgMetadataStore {
     }
 
     async fn schema_exists(&self, schema_name: &str) -> Result<bool> {
-        let rows = {
+        let row = {
             let guard = self.postgres_client.lock().await;
             guard
-                .query(
+                .query_opt(
                     "SELECT 1 FROM pg_namespace WHERE nspname = $1;",
                     &[&schema_name],
                 )
                 .await?
         };
 
-        if rows.is_empty() {
-            return Ok(false);
-        }
-        if rows.len() == 1 {
-            return Ok(true);
-        }
-
-        Err(Error::PostgresRowCountError(1, rows.len() as u32))
+        Ok(row.is_some())
     }
 
     async fn store_table_config(

--- a/src/moonlink_metadata_store/src/postgres/pg_metadata_store.rs
+++ b/src/moonlink_metadata_store/src/postgres/pg_metadata_store.rs
@@ -84,29 +84,6 @@ impl MetadataStoreTrait for PgMetadataStore {
         Err(Error::PostgresRowCountError(1, rows.len() as u32))
     }
 
-    async fn load_table_config(&self, table_id: u32) -> Result<MoonlinkTableConfig> {
-        let rows = {
-            let guard = self.postgres_client.lock().await;
-
-            guard
-                .query("SELECT * FROM mooncake.tables WHERE oid = $1", &[&table_id])
-                .await?
-        };
-
-        if rows.is_empty() {
-            return Err(Error::TableIdNotFound(table_id));
-        }
-        if rows.len() != 1 {
-            return Err(Error::PostgresRowCountError(1, rows.len() as u32));
-        }
-
-        let row = &rows[0];
-        let config_json = row.get("config");
-        let moonlink_config = config_utils::deserialze_moonlink_table_config(config_json)?;
-
-        Ok(moonlink_config)
-    }
-
     async fn store_table_config(
         &self,
         table_id: u32,

--- a/src/moonlink_metadata_store/tests/test_pg_metadata_store.rs
+++ b/src/moonlink_metadata_store/tests/test_pg_metadata_store.rs
@@ -1,10 +1,11 @@
 mod common;
 
+use common::test_environment::*;
+use common::test_utils::*;
 use moonlink_metadata_store::base_metadata_store::MetadataStoreTrait;
 use moonlink_metadata_store::PgMetadataStore;
 
-use common::test_environment::*;
-use common::test_utils::*;
+use more_asserts as ma;
 
 /// Test connection string.
 const URI: &str = "postgresql://postgres:postgres@postgres:5432/postgres";
@@ -18,6 +19,15 @@ mod tests {
     use super::*;
 
     use serial_test::serial;
+
+    #[tokio::test]
+    #[serial]
+    async fn test_get_database_id() {
+        let _test_environment = TestEnvironment::new(URI).await;
+        let metadata_store = PgMetadataStore::new(URI).await.unwrap();
+        let database_id = metadata_store.get_database_id().await.unwrap();
+        ma::assert_gt!(database_id, 0);
+    }
 
     #[tokio::test]
     #[serial]


### PR DESCRIPTION
## Summary

This PR is the first PR to integrate recovery with moonlink backend.
Disclaimer:
- This is only the first part of the recovery logic, and it hasn't been integrated with pg_mooncake
- cdc publish and subscribe part hasn't been integrated, I will followup with another PR
- This PR is supposed to be a no-op change

Did some testing on pg_mooncake side to make sure it doesn't affect production.
regression test:
```sh
--- beginning regression test run ---
PASS setup 25ms
PASS partitioned_table 717ms
PASS sanity 726ms
passed=3, failed=0
```

pg_mooncake SQL statements
```sql
pg_mooncake (pid: 102224) =# DROP TABLE IF EXISTS r;
DROP EXTENSION pg_mooncake CASCADE;
CREATE EXTENSION pg_mooncake;
CREATE TABLE r (a int primary key, b text);
CALL mooncake.create_table('c', 'r');
INSERT INTO r VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd'), (5, 'e'), (6, 'f');
CALL mooncake.create_snapshot('c');
UPDATE r SET b = a + 1 WHERE a = 3 or a = 5;
CALL mooncake.create_snapshot('c');
SELECT * FROM c;
DROP TABLE
NOTICE:  drop cascades to 3 other objects
DETAIL:  drop cascades to table mooncake.tables
drop cascades to table c
drop cascades to table c1
DROP EXTENSION
CREATE EXTENSION
CREATE TABLE
CALL
INSERT 0 6
CALL
UPDATE 2
CALL
 a | b 
---+---
 1 | a
 2 | b
 4 | d
 6 | f
 3 | 4
 5 | 6
(6 rows)
```

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
