### PR TITLE
[storage] Assign table flush lsn after recovery

### DIFF
--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -479,6 +479,7 @@ impl MooncakeTable {
     ) -> Result<Self> {
         let (table_snapshot_watch_sender, table_snapshot_watch_receiver) = watch::channel(0);
         let (next_file_id, current_snapshot) = table_manager.load_snapshot_from_table().await?;
+        let last_iceberg_snapshot_lsn = current_snapshot.data_file_flush_lsn;
 
         Ok(Self {
             mem_slice: MemSlice::new(
@@ -501,7 +502,7 @@ impl MooncakeTable {
             table_snapshot_watch_receiver,
             next_file_id,
             iceberg_table_manager: Some(table_manager),
-            last_iceberg_snapshot_lsn: None,
+            last_iceberg_snapshot_lsn,
             table_notify: None,
         })
     }

--- a/src/moonlink/src/storage/mooncake_table/test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/test_utils.rs
@@ -15,8 +15,8 @@ use std::fs::{create_dir_all, File};
 use tempfile::{tempdir, TempDir};
 
 pub struct TestContext {
-    temp_dir: TempDir,
-    test_dir: PathBuf,
+    pub temp_dir: TempDir,
+    pub test_dir: PathBuf,
 }
 
 impl TestContext {
@@ -28,7 +28,7 @@ impl TestContext {
         Self { temp_dir, test_dir }
     }
 
-    fn path(&self) -> PathBuf {
+    pub fn path(&self) -> PathBuf {
         self.test_dir.clone()
     }
 }
@@ -58,19 +58,28 @@ pub fn test_row(id: i32, name: &str, age: i32) -> MoonlinkRow {
     ])
 }
 
+/// Test util function to get iceberg table config for testing purpose.
+pub fn test_iceberg_table_config(context: &TestContext, table_name: &str) -> IcebergTableConfig {
+    IcebergTableConfig {
+        warehouse_uri: context.path().to_str().unwrap().to_string(),
+        namespace: vec!["default".to_string()],
+        table_name: table_name.to_string(),
+    }
+}
+
+/// Test util function to get mooncake table config.
+pub fn test_mooncake_table_config(context: &TestContext) -> MooncakeTableConfig {
+    MooncakeTableConfig::new(context.temp_dir.path().to_str().unwrap().to_string())
+}
+
 pub async fn test_table(
     context: &TestContext,
     table_name: &str,
     identity: IdentityProp,
 ) -> MooncakeTable {
     // TODO(hjiang): Hard-code iceberg table namespace and table name.
-    let iceberg_table_config = IcebergTableConfig {
-        warehouse_uri: context.path().to_str().unwrap().to_string(),
-        namespace: vec!["default".to_string()],
-        table_name: table_name.to_string(),
-    };
-    let mut table_config =
-        MooncakeTableConfig::new(context.temp_dir.path().to_str().unwrap().to_string());
+    let iceberg_table_config = test_iceberg_table_config(context, table_name);
+    let mut table_config = test_mooncake_table_config(context);
     table_config.batch_size = 2;
     MooncakeTable::new(
         test_schema(),


### PR DESCRIPTION
## Summary

Flush LSN is recorded in the mooncake table for force snapshot usage.
This PR correctly populates its value at recovery.

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
