### PR TITLE
[storage] Remove special handle to read snapshot

### DIFF
--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -480,6 +480,9 @@ impl MooncakeTable {
         let (table_snapshot_watch_sender, table_snapshot_watch_receiver) = watch::channel(0);
         let (next_file_id, current_snapshot) = table_manager.load_snapshot_from_table().await?;
         let last_iceberg_snapshot_lsn = current_snapshot.data_file_flush_lsn;
+        if let Some(persistence_lsn) = last_iceberg_snapshot_lsn {
+            table_snapshot_watch_sender.send(persistence_lsn).unwrap();
+        }
 
         Ok(Self {
             mem_slice: MemSlice::new(

--- a/src/moonlink/src/union_read/read_state_manager.rs
+++ b/src/moonlink/src/union_read/read_state_manager.rs
@@ -143,16 +143,8 @@ impl ReadStateManager {
         let mut last_read_state_guard = self.last_read_state.write().await;
         let is_snapshot_clean = current_snapshot_lsn == current_commit_lsn;
         let last_read_lsn = self.last_read_lsn.load(Ordering::Acquire);
-        // All LSN is 0, which means there're completely no activities on the mooncake table, perform a read from snapshot.
-        let table_no_activity = last_read_lsn == 0
-            && current_snapshot_lsn == 0
-            && current_commit_lsn == 0
-            && current_replication_lsn == 0;
 
-        // There're two cases we need to read current snapshot:
-        // 1. last read state is stale
-        // or 2. there's no activity in the current table
-        if last_read_lsn < current_snapshot_lsn || table_no_activity {
+        if last_read_lsn < current_snapshot_lsn {
             // If the snapshot is fully committed and replication has progressed further,
             // we can consider the state valid up to the replication LSN.
             let effective_lsn =


### PR DESCRIPTION
## Summary

I did a bad special handle to read snapshot: when there's no valid LSN (aka, everything 0), we perform a snapshot read instead of relying on cache.
A second thought, a better way is to notify current snapshot LSN after recovery, thus no special handle needed.

Existing test cases already cover the change.

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
