### PR TITLE
Fix metadata store trait

### DIFF
--- a/src/moonlink_metadata_store/src/base_metadata_store.rs
+++ b/src/moonlink_metadata_store/src/base_metadata_store.rs
@@ -18,7 +18,7 @@ pub struct TableMetadataEntry {
 }
 
 #[async_trait]
-pub trait MetadataStoreTrait: Send {
+pub trait MetadataStoreTrait: Send + Sync {
     /// Get database id.
     #[allow(async_fn_in_trait)]
     async fn get_database_id(&self) -> Result<u32>;


### PR DESCRIPTION
## Summary

... otherwise pg_mooncake compilation fails.
Lesson learnt: whenever make an interface (aka, trait), explicitly marks its thread-safety trait.

I checked with pg_mooncake regression test:
```sh
--- beginning regression test run ---
PASS setup 27ms
PASS partitioned_table 718ms
PASS sanity 689ms
passed=3, failed=0
```

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/675

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
