### PR TITLE
[storage] Fix metadata access for mooncake tables

### DIFF
--- a/src/moonlink_backend/src/lib.rs
+++ b/src/moonlink_backend/src/lib.rs
@@ -9,7 +9,6 @@ use moonlink::{ObjectStorageCache, ObjectStorageCacheConfig};
 use moonlink_connectors::ReplicationManager;
 use moonlink_metadata_store::base_metadata_store::{MetadataStoreTrait, TableMetadataEntry};
 use moonlink_metadata_store::metadata_store_utils;
-use moonlink_metadata_store::PgMetadataStore;
 use more_asserts as ma;
 use std::collections::hash_map::Entry as HashMapEntry;
 use std::collections::HashMap;

--- a/src/moonlink_backend/src/lib.rs
+++ b/src/moonlink_backend/src/lib.rs
@@ -158,7 +158,7 @@ where
 
         for cur_metadata_store_uri in metadata_store_uris.into_iter() {
             let metadata_store_accessor =
-                metadata_store_utils::create_metadata_storage(cur_metadata_store_uri)?;
+                metadata_store_utils::create_metadata_store_accessor(cur_metadata_store_uri)?;
 
             // Step-1: check schema existence, skip if not.
             if !metadata_store_accessor.schema_exists().await? {
@@ -256,7 +256,7 @@ where
                 HashMapEntry::Occupied(entry) => entry.into_mut(),
                 HashMapEntry::Vacant(entry) => {
                     let new_metadata_store =
-                        metadata_store_utils::create_metadata_storage(metadata_store_uri)?;
+                        metadata_store_utils::create_metadata_store_accessor(metadata_store_uri)?;
                     entry.insert(new_metadata_store)
                 }
             };

--- a/src/moonlink_backend/src/lib.rs
+++ b/src/moonlink_backend/src/lib.rs
@@ -145,6 +145,11 @@ where
     /// Recovery all databases indicated by the connection strings.
     /// Return recovered metadata storage clients.
     ///
+    /// Recovery process for each database:
+    /// - if schema not exist, skip
+    /// - if metadata table not exist, skip
+    /// - load metadata table, and perform recovery on all mooncake tables
+    ///
     /// TODO(hjiang): Parallelize all IO operations.
     async fn recover_all_tables(
         &mut self,
@@ -153,26 +158,36 @@ where
         let mut recovered_metadata_stores: HashMap<D, Box<dyn MetadataStoreTrait>> = HashMap::new();
 
         for cur_metadata_store_uri in metadata_store_uris.into_iter() {
-            // If "mooncake" schema doesn't exist for the given database, it means no table under the current database is managed by moonlink. Skip recovery process.
-            if let Some(metadata_store_accessor) =
-                metadata_store_utils::create_metadata_storage(&cur_metadata_store_uri).await?
-            {
-                // Get database id.
-                let database_id = metadata_store_accessor.get_database_id().await?;
+            let metadata_store_accessor =
+                metadata_store_utils::create_metadata_storage(cur_metadata_store_uri)?;
 
-                // Get all mooncake tables to recovery.
-                let table_metadata_entries = metadata_store_accessor
-                    .get_all_table_metadata_entries()
-                    .await?;
-
-                // Load config and try recovery.
-                for cur_metadata_entry in table_metadata_entries.into_iter() {
-                    self.recover_table(database_id, cur_metadata_entry).await?;
-                }
-
-                // Place into metadata store clients map.
-                recovered_metadata_stores.insert(D::from(database_id), metadata_store_accessor);
+            // Step-1: check schema existence, skip if not.
+            if !metadata_store_accessor.schema_exists().await? {
+                continue;
             }
+
+            // Skep-2: check metadata store table existence, skip if not.
+            if !metadata_store_accessor.metadata_table_exists().await? {
+                continue;
+            }
+
+            // Step-3: load persisted metadata from storage, perform recovery for each managed tables.
+            //
+            // Get database id.
+            let database_id = metadata_store_accessor.get_database_id().await?;
+
+            // Get all mooncake tables to recovery.
+            let table_metadata_entries = metadata_store_accessor
+                .get_all_table_metadata_entries()
+                .await?;
+
+            // Perform recovery on all managed tables.
+            for cur_metadata_entry in table_metadata_entries.into_iter() {
+                self.recover_table(database_id, cur_metadata_entry).await?;
+            }
+
+            // Place into metadata store clients map.
+            recovered_metadata_stores.insert(D::from(database_id), metadata_store_accessor);
         }
 
         Ok(recovered_metadata_stores)
@@ -241,14 +256,13 @@ where
             let cur_metadata_store_accessor = match guard.entry(database_id.clone()) {
                 HashMapEntry::Occupied(entry) => entry.into_mut(),
                 HashMapEntry::Vacant(entry) => {
-                    // Precondition: [`mooncake`] schema already exists in the current database.
                     let new_metadata_store =
-                        Box::new(PgMetadataStore::new(&metadata_store_uri).await?.unwrap());
+                        metadata_store_utils::create_metadata_storage(metadata_store_uri)?;
                     entry.insert(new_metadata_store)
                 }
             };
             cur_metadata_store_accessor
-                .store_table_config(table_id, &src_table_name, &src_uri, moonlink_table_config)
+                .store_table_metadata(table_id, &src_table_name, &src_uri, moonlink_table_config)
                 .await?;
         }
 
@@ -275,7 +289,10 @@ where
             let mut guard = self.metadata_store_accessors.write().await;
             guard.remove(&database_id).unwrap()
         };
-        metadata_store.delete_table_config(table_id).await.unwrap()
+        metadata_store
+            .delete_table_metadata(table_id)
+            .await
+            .unwrap()
     }
 
     pub async fn scan_table(

--- a/src/moonlink_backend/tests/test_backend.rs
+++ b/src/moonlink_backend/tests/test_backend.rs
@@ -508,7 +508,7 @@ mod tests {
         let (guard, _) = TestGuard::new("metadata_store").await;
         // Till now, table [`metadata_store`] has been created at both row storage and column storage database.
         let backend = guard.backend.as_ref().unwrap();
-        let metadata_store = PgMetadataStore::new(DST_URI).await.unwrap().unwrap();
+        let metadata_store = PgMetadataStore::new(METADATA_STORE_URI.to_string()).unwrap();
 
         // Check metadata storage after table creation.
         let metadata_entries = metadata_store

--- a/src/moonlink_metadata_store/src/base_metadata_store.rs
+++ b/src/moonlink_metadata_store/src/base_metadata_store.rs
@@ -4,6 +4,13 @@ use async_trait::async_trait;
 use crate::error::Result;
 use moonlink::MoonlinkTableConfig;
 
+/// Constants for moonlink metadata storage.
+///
+/// Database schema for moonlink.
+pub const MOONLINK_SCHEMA: &str = "mooncake";
+/// Metadata table name for moonlink.
+pub const MOONLINK_METADATA_TABLE: &str = "tables";
+
 /// Metadata entry for each table.
 #[derive(Clone, Debug)]
 pub struct TableMetadataEntry {
@@ -19,19 +26,34 @@ pub struct TableMetadataEntry {
 
 #[async_trait]
 pub trait MetadataStoreTrait: Send + Sync {
+    /// Return whether schema exists.
+    #[allow(async_fn_in_trait)]
+    async fn schema_exists(&self) -> Result<bool>;
+
+    /// Return whether metadata table exists.
+    #[allow(async_fn_in_trait)]
+    async fn metadata_table_exists(&self) -> Result<bool>;
+
     /// Get database id.
     #[allow(async_fn_in_trait)]
     async fn get_database_id(&self) -> Result<u32>;
 
     /// Get all mooncake table metadata entries in the metadata storage table.
-    /// Notice, schema existence should be checked beforehand, otherwise empty entries will be returned if schema doesn't exist.
+    ///
+    /// Precondition:
+    /// - moonlink schema already exists;
+    /// - metadata table already exists.
     #[allow(async_fn_in_trait)]
     async fn get_all_table_metadata_entries(&self) -> Result<Vec<TableMetadataEntry>>;
 
-    /// Store table config for the given table.
-    /// Precondition: the requested table id hasn't been recorded in the metadata storage.
+    /// Store table config for the given mooncake table.
+    /// Metadata table will be created if it doesn't exists.
+    ///
+    /// Precondition:
+    /// - moonlink schema already exists;
+    /// - the requested table id hasn't been recorded in the metadata storage.
     #[allow(async_fn_in_trait)]
-    async fn store_table_config(
+    async fn store_table_metadata(
         &self,
         table_id: u32,
         table_name: &str,
@@ -42,5 +64,5 @@ pub trait MetadataStoreTrait: Send + Sync {
     /// Delete table config for the given table.
     /// Precondition: the requested table id has been record in the metadata storage.
     #[allow(async_fn_in_trait)]
-    async fn delete_table_config(&self, table_id: u32) -> Result<()>;
+    async fn delete_table_metadata(&self, table_id: u32) -> Result<()>;
 }

--- a/src/moonlink_metadata_store/src/base_metadata_store.rs
+++ b/src/moonlink_metadata_store/src/base_metadata_store.rs
@@ -26,6 +26,10 @@ pub struct TableMetadataEntry {
 
 #[async_trait]
 pub trait MetadataStoreTrait: Send + Sync {
+    /// Get database id.
+    #[allow(async_fn_in_trait)]
+    async fn get_database_id(&self) -> Result<u32>;
+
     /// Return whether schema exists.
     #[allow(async_fn_in_trait)]
     async fn schema_exists(&self) -> Result<bool>;
@@ -33,10 +37,6 @@ pub trait MetadataStoreTrait: Send + Sync {
     /// Return whether metadata table exists.
     #[allow(async_fn_in_trait)]
     async fn metadata_table_exists(&self) -> Result<bool>;
-
-    /// Get database id.
-    #[allow(async_fn_in_trait)]
-    async fn get_database_id(&self) -> Result<u32>;
 
     /// Get all mooncake table metadata entries in the metadata storage table.
     ///
@@ -46,7 +46,7 @@ pub trait MetadataStoreTrait: Send + Sync {
     #[allow(async_fn_in_trait)]
     async fn get_all_table_metadata_entries(&self) -> Result<Vec<TableMetadataEntry>>;
 
-    /// Store table config for the given mooncake table.
+    /// Store table metadata for the given mooncake table.
     /// Metadata table will be created if it doesn't exists.
     ///
     /// Precondition:

--- a/src/moonlink_metadata_store/src/error.rs
+++ b/src/moonlink_metadata_store/src/error.rs
@@ -10,6 +10,9 @@ pub enum Error {
     #[error("metadata operation row number doesn't match {0} vs {1}")]
     PostgresRowCountError(u32, u32),
 
+    #[error("metadata access failed precondition: {0}")]
+    MetadataStoreFailedPrecondition(String),
+
     #[error("serde json error: {0}")]
     SerdeJsonError(#[from] SerdeJsonError),
 

--- a/src/moonlink_metadata_store/src/metadata_store_utils.rs
+++ b/src/moonlink_metadata_store/src/metadata_store_utils.rs
@@ -4,7 +4,7 @@ use crate::postgres::pg_metadata_store::PgMetadataStore;
 
 /// A factory function to create metadata storage.
 /// Return [`None`] if current database is not managed by moonlink.
-pub fn create_metadata_storage(uri: String) -> Result<Box<dyn MetadataStoreTrait>> {
+pub fn create_metadata_store_accessor(uri: String) -> Result<Box<dyn MetadataStoreTrait>> {
     let pg_metadata_storage = PgMetadataStore::new(uri)?;
     Ok(Box::new(pg_metadata_storage))
 }

--- a/src/moonlink_metadata_store/src/metadata_store_utils.rs
+++ b/src/moonlink_metadata_store/src/metadata_store_utils.rs
@@ -4,10 +4,7 @@ use crate::postgres::pg_metadata_store::PgMetadataStore;
 
 /// A factory function to create metadata storage.
 /// Return [`None`] if current database is not managed by moonlink.
-pub async fn create_metadata_storage(uri: &str) -> Result<Option<Box<dyn MetadataStoreTrait>>> {
-    let pg_metadata_storage = PgMetadataStore::new(uri).await?;
-    if let Some(pg_metadata_storage) = pg_metadata_storage {
-        return Ok(Some(Box::new(pg_metadata_storage)));
-    }
-    Ok(None)
+pub fn create_metadata_storage(uri: String) -> Result<Box<dyn MetadataStoreTrait>> {
+    let pg_metadata_storage = PgMetadataStore::new(uri)?;
+    Ok(Box::new(pg_metadata_storage))
 }

--- a/src/moonlink_metadata_store/src/postgres.rs
+++ b/src/moonlink_metadata_store/src/postgres.rs
@@ -1,3 +1,4 @@
 mod config_utils;
+mod pg_client_wrapper;
 pub mod pg_metadata_store;
 pub mod utils;

--- a/src/moonlink_metadata_store/src/postgres/pg_client_wrapper.rs
+++ b/src/moonlink_metadata_store/src/postgres/pg_client_wrapper.rs
@@ -1,0 +1,30 @@
+use tokio_postgres::{connect, Client, NoTls};
+
+use crate::error::Result;
+
+/// A wrapper around tokio postgres client and connection.
+
+pub(super) struct PgClientWrapper {
+    /// Postgres client.
+    pub(super) postgres_client: Client,
+    /// Postgres connection join handle, which would be cancelled at destruction.
+    _pg_connection: tokio::task::JoinHandle<()>,
+}
+
+impl PgClientWrapper {
+    pub(super) async fn new(uri: &str) -> Result<Self> {
+        let (postgres_client, connection) = connect(uri, NoTls).await?;
+
+        // Spawn connection driver in background to keep eventloop alive.
+        let _pg_connection = tokio::spawn(async move {
+            if let Err(e) = connection.await {
+                eprintln!("Postgres connection error: {}", e);
+            }
+        });
+
+        Ok(PgClientWrapper {
+            postgres_client,
+            _pg_connection,
+        })
+    }
+}

--- a/src/moonlink_metadata_store/src/postgres/pg_client_wrapper.rs
+++ b/src/moonlink_metadata_store/src/postgres/pg_client_wrapper.rs
@@ -3,7 +3,6 @@ use tokio_postgres::{connect, Client, NoTls};
 use crate::error::Result;
 
 /// A wrapper around tokio postgres client and connection.
-
 pub(super) struct PgClientWrapper {
     /// Postgres client.
     pub(super) postgres_client: Client,

--- a/src/moonlink_metadata_store/src/postgres/pg_metadata_store.rs
+++ b/src/moonlink_metadata_store/src/postgres/pg_metadata_store.rs
@@ -1,55 +1,66 @@
+use crate::base_metadata_store::MetadataStoreTrait;
 use crate::base_metadata_store::TableMetadataEntry;
-use crate::error::Result;
+use crate::base_metadata_store::{MOONLINK_METADATA_TABLE, MOONLINK_SCHEMA};
+use crate::error::{Error, Result};
 use crate::postgres::config_utils;
+use crate::postgres::pg_client_wrapper::PgClientWrapper;
 use crate::postgres::utils;
-use crate::{base_metadata_store::MetadataStoreTrait, error::Error};
 use moonlink::MoonlinkTableConfig;
 
 use async_trait::async_trait;
 use postgres_types::Json as PgJson;
-use tokio::sync::Mutex;
-use tokio_postgres::{connect, Client, NoTls};
-
-use std::sync::Arc;
 
 /// SQL statements for moonlink metadata table schema.
 const CREATE_TABLE_SCHEMA_SQL: &str = include_str!("sql/create_tables.sql");
-/// Database schema for moonlink.
-const MOONLINK_SCHEMA: &str = "mooncake";
 
 pub struct PgMetadataStore {
-    /// Postgres client.
-    postgres_client: Arc<Mutex<Client>>,
-    /// Pg connection join handle.
-    _pg_connection: tokio::task::JoinHandle<()>,
+    /// Database connection string.
+    uri: String,
 }
 
 #[async_trait]
 impl MetadataStoreTrait for PgMetadataStore {
+    async fn schema_exists(&self) -> Result<bool> {
+        let pg_client = PgClientWrapper::new(&self.uri).await?;
+        utils::schema_exists(&pg_client.postgres_client, MOONLINK_SCHEMA).await
+    }
+
+    async fn metadata_table_exists(&self) -> Result<bool> {
+        let pg_client = PgClientWrapper::new(&self.uri).await?;
+        if !utils::table_exists(
+            &pg_client.postgres_client,
+            MOONLINK_SCHEMA,
+            MOONLINK_METADATA_TABLE,
+        )
+        .await?
+        {
+            return Ok(false);
+        }
+        Ok(true)
+    }
+
     async fn get_database_id(&self) -> Result<u32> {
-        let row = {
-            let guard = self.postgres_client.lock().await;
-            guard
-                .query_one(
-                    "SELECT oid FROM pg_database WHERE datname = current_database()",
-                    &[],
-                )
-                .await?
-        };
+        let pg_client = PgClientWrapper::new(&self.uri).await?;
+        let row = pg_client
+            .postgres_client
+            .query_one(
+                "SELECT oid FROM pg_database WHERE datname = current_database()",
+                &[],
+            )
+            .await?;
         let oid = row.get("oid");
         Ok(oid)
     }
 
     async fn get_all_table_metadata_entries(&self) -> Result<Vec<TableMetadataEntry>> {
-        let rows = {
-            let guard = self.postgres_client.lock().await;
-            guard
-                .query(
-                    "SELECT oid, table_name, uri, config FROM mooncake.tables",
-                    &[],
-                )
-                .await?
-        };
+        let pg_client = PgClientWrapper::new(&self.uri).await?;
+        let rows = pg_client
+            .postgres_client
+            .query(
+                "SELECT oid, table_name, uri, config FROM mooncake.tables",
+                &[],
+            )
+            .await?;
 
         let mut metadata_entries = Vec::with_capacity(rows.len());
         for cur_row in rows.into_iter() {
@@ -70,19 +81,36 @@ impl MetadataStoreTrait for PgMetadataStore {
         Ok(metadata_entries)
     }
 
-    async fn store_table_config(
+    async fn store_table_metadata(
         &self,
         table_id: u32,
         table_name: &str,
         table_uri: &str,
         moonlink_table_config: MoonlinkTableConfig,
     ) -> Result<()> {
+        let pg_client = PgClientWrapper::new(&self.uri).await?;
         let serialized_config =
             config_utils::serialize_moonlink_table_config(moonlink_table_config)?;
 
-        let guard = self.postgres_client.lock().await;
+        if !utils::schema_exists(&pg_client.postgres_client, MOONLINK_SCHEMA).await? {
+            return Err(Error::MetadataStoreFailedPrecondition(format!(
+                "Schema {} doesn't exist when store table metadata",
+                MOONLINK_SCHEMA
+            )));
+        }
+        if !utils::table_exists(
+            &pg_client.postgres_client,
+            MOONLINK_SCHEMA,
+            MOONLINK_METADATA_TABLE,
+        )
+        .await?
+        {
+            utils::create_table(&pg_client.postgres_client, CREATE_TABLE_SCHEMA_SQL).await?;
+        }
+
         // TODO(hjiang): Fill in other fields as well.
-        let rows_affected = guard
+        let rows_affected = pg_client
+            .postgres_client
             .execute(
                 "INSERT INTO mooncake.tables (oid, table_name, uri, config)
                 VALUES ($1, $2, $3, $4)",
@@ -102,9 +130,10 @@ impl MetadataStoreTrait for PgMetadataStore {
         Ok(())
     }
 
-    async fn delete_table_config(&self, table_id: u32) -> Result<()> {
-        let guard = self.postgres_client.lock().await;
-        let rows_affected = guard
+    async fn delete_table_metadata(&self, table_id: u32) -> Result<()> {
+        let pg_client = PgClientWrapper::new(&self.uri).await?;
+        let rows_affected = pg_client
+            .postgres_client
             .execute("DELETE FROM mooncake.tables WHERE oid = $1", &[&table_id])
             .await?;
 
@@ -117,28 +146,7 @@ impl MetadataStoreTrait for PgMetadataStore {
 
 impl PgMetadataStore {
     /// Attempt to create a metadata storage; if [`mooncake`] schema doesn't exist, current database is not managed by moonlink, return None.
-    pub async fn new(uri: &str) -> Result<Option<Self>> {
-        let (postgres_client, connection) = connect(uri, NoTls).await?;
-
-        // Spawn connection driver in background to keep eventloop alive.
-        let _pg_connection = tokio::spawn(async move {
-            if let Err(e) = connection.await {
-                eprintln!("Postgres connection error: {}", e);
-            }
-        });
-        let schema_exists = utils::schema_exists(&postgres_client, MOONLINK_SCHEMA).await?;
-        if !schema_exists {
-            return Ok(None);
-        }
-
-        // Create metadata storage table.
-        postgres_client
-            .simple_query(CREATE_TABLE_SCHEMA_SQL)
-            .await?;
-
-        Ok(Some(Self {
-            postgres_client: Arc::new(Mutex::new(postgres_client)),
-            _pg_connection,
-        }))
+    pub fn new(uri: String) -> Result<Self> {
+        Ok(Self { uri })
     }
 }

--- a/src/moonlink_metadata_store/src/postgres/sql/create_tables.sql
+++ b/src/moonlink_metadata_store/src/postgres/sql/create_tables.sql
@@ -1,5 +1,5 @@
 -- SQL statement(s) to store moonlink managed column store tables.
-CREATE TABLE IF NOT EXISTS mooncake.tables (
+CREATE TABLE mooncake.tables (
     oid oid PRIMARY KEY,          -- column store table OID
     table_name text NOT NULL,     -- source table name
     uri text,                     -- source URI

--- a/src/moonlink_metadata_store/src/postgres/utils.rs
+++ b/src/moonlink_metadata_store/src/postgres/utils.rs
@@ -14,3 +14,25 @@ pub async fn schema_exists(postgres_client: &Client, schema_name: &str) -> Resul
 
     Ok(row.is_some())
 }
+
+/// Return whether the given <schema>.<table> exists in the current database.
+pub async fn table_exists(
+    postgres_client: &Client,
+    schema_name: &str,
+    table_name: &str,
+) -> Result<bool> {
+    let row = postgres_client
+        .query_opt(
+            "SELECT 1 FROM information_schema.tables WHERE table_schema = $1 AND table_name = $2;",
+            &[&schema_name, &table_name],
+        )
+        .await?;
+
+    Ok(row.is_some())
+}
+
+/// Create metadata storage table, which fails if the table already exists.
+pub async fn create_table(postgres_client: &Client, statements: &str) -> Result<()> {
+    postgres_client.simple_query(statements).await?;
+    Ok(())
+}

--- a/src/moonlink_metadata_store/tests/common/test_environment.rs
+++ b/src/moonlink_metadata_store/tests/common/test_environment.rs
@@ -1,7 +1,8 @@
 /// Test environment to setup and cleanup a test case.
-use tokio_postgres::{connect, NoTls};
+use tokio_postgres::{connect, Client, NoTls};
 
 pub(crate) struct TestEnvironment {
+    postgres_client: Client,
     _connection_handle: tokio::task::JoinHandle<()>,
 }
 
@@ -22,6 +23,17 @@ impl TestEnvironment {
             .simple_query("CREATE SCHEMA IF NOT EXISTS mooncake;")
             .await
             .unwrap();
-        Self { _connection_handle }
+        Self {
+            postgres_client,
+            _connection_handle,
+        }
+    }
+
+    /// Delete moonlink schema.
+    pub(crate) async fn delete_mooncake_schema(&self) {
+        self.postgres_client
+            .simple_query("DROP SCHEMA IF EXISTS mooncake")
+            .await
+            .unwrap();
     }
 }

--- a/src/moonlink_metadata_store/tests/test_pg_metadata_store.rs
+++ b/src/moonlink_metadata_store/tests/test_pg_metadata_store.rs
@@ -66,7 +66,22 @@ mod tests {
         check_persisted_metadata(&metadata_store).await;
     }
 
-    /// Test scenario: load from non-existent row.
+    /// Test scenario: load from non-existent schema.
+    #[tokio::test]
+    #[serial]
+    async fn test_table_metadata_load_from_non_existent_schema() {
+        let test_environment = TestEnvironment::new(URI).await;
+        let metadata_store = PgMetadataStore::new(URI.to_string()).unwrap();
+
+        // Delete moonlink schema.
+        test_environment.delete_mooncake_schema().await;
+
+        // Load moonlink table config from metadata config.
+        let res = metadata_store.get_all_table_metadata_entries().await;
+        assert!(res.is_err());
+    }
+
+    /// Test scenario: load from non-existent table.
     #[tokio::test]
     #[serial]
     async fn test_table_metadata_load_from_non_existent_table() {
@@ -75,6 +90,24 @@ mod tests {
 
         // Load moonlink table config from metadata config.
         let res = metadata_store.get_all_table_metadata_entries().await;
+        assert!(res.is_err());
+    }
+
+    /// Test scenario: store table metadata for non-existent schema fails.
+    #[tokio::test]
+    #[serial]
+    async fn test_table_metadata_store_for_non_existent_schema() {
+        let test_environment = TestEnvironment::new(URI).await;
+        let metadata_store = PgMetadataStore::new(URI.to_string()).unwrap();
+        let moonlink_table_config = get_moonlink_table_config();
+
+        // Delete moonlink schema.
+        test_environment.delete_mooncake_schema().await;
+
+        // Store moonlink table config to metadata storage.
+        let res = metadata_store
+            .store_table_metadata(TABLE_ID, TABLE_NAME, URI, moonlink_table_config.clone())
+            .await;
         assert!(res.is_err());
     }
 
@@ -107,7 +140,7 @@ mod tests {
         let metadata_store = PgMetadataStore::new(URI.to_string()).unwrap();
         let moonlink_table_config = get_moonlink_table_config();
 
-        // Store moonlink table config to metadata storage.
+        // Store moonlink table metadata to metadata storage.
         metadata_store
             .store_table_metadata(TABLE_ID, TABLE_NAME, URI, moonlink_table_config.clone())
             .await

--- a/src/moonlink_metadata_store/tests/test_pg_metadata_store.rs
+++ b/src/moonlink_metadata_store/tests/test_pg_metadata_store.rs
@@ -41,7 +41,7 @@ mod tests {
     #[serial]
     async fn test_get_database_id() {
         let _test_environment = TestEnvironment::new(URI).await;
-        let metadata_store = PgMetadataStore::new(URI).await.unwrap().unwrap();
+        let metadata_store = PgMetadataStore::new(URI.to_string()).unwrap();
         let database_id = metadata_store.get_database_id().await.unwrap();
         ma::assert_gt!(database_id, 0);
     }
@@ -51,14 +51,14 @@ mod tests {
     async fn test_table_metadata_store_and_load() {
         let _test_environment = TestEnvironment::new(URI).await;
         // Unused metadata storage, used to check it could be initialized for multiple times idempotently.
-        let _metadata_store = PgMetadataStore::new(URI).await.unwrap();
+        let _ = PgMetadataStore::new(URI.to_string()).unwrap();
         // Initialize for the second time.
-        let metadata_store = PgMetadataStore::new(URI).await.unwrap().unwrap();
+        let metadata_store = PgMetadataStore::new(URI.to_string()).unwrap();
         let moonlink_table_config = get_moonlink_table_config();
 
         // Store moonlink table config to metadata storage.
         metadata_store
-            .store_table_config(TABLE_ID, TABLE_NAME, URI, moonlink_table_config.clone())
+            .store_table_metadata(TABLE_ID, TABLE_NAME, URI, moonlink_table_config.clone())
             .await
             .unwrap();
 
@@ -71,14 +71,11 @@ mod tests {
     #[serial]
     async fn test_table_metadata_load_from_non_existent_table() {
         let _test_environment = TestEnvironment::new(URI).await;
-        let metadata_store = PgMetadataStore::new(URI).await.unwrap().unwrap();
+        let metadata_store = PgMetadataStore::new(URI.to_string()).unwrap();
 
         // Load moonlink table config from metadata config.
-        let metadata_entries = metadata_store
-            .get_all_table_metadata_entries()
-            .await
-            .unwrap();
-        assert!(metadata_entries.is_empty());
+        let res = metadata_store.get_all_table_metadata_entries().await;
+        assert!(res.is_err());
     }
 
     /// Test scenario: store for duplicate table ids.
@@ -86,18 +83,18 @@ mod tests {
     #[serial]
     async fn test_table_metadata_store_for_duplicate_tables() {
         let _test_environment = TestEnvironment::new(URI).await;
-        let metadata_store = PgMetadataStore::new(URI).await.unwrap().unwrap();
+        let metadata_store = PgMetadataStore::new(URI.to_string()).unwrap();
         let moonlink_table_config = get_moonlink_table_config();
 
         // Store moonlink table config to metadata storage.
         metadata_store
-            .store_table_config(TABLE_ID, TABLE_NAME, URI, moonlink_table_config.clone())
+            .store_table_metadata(TABLE_ID, TABLE_NAME, URI, moonlink_table_config.clone())
             .await
             .unwrap();
 
         // Store moonlink table config to metadata storage.
         let res = metadata_store
-            .store_table_config(TABLE_ID, TABLE_NAME, URI, moonlink_table_config.clone())
+            .store_table_metadata(TABLE_ID, TABLE_NAME, URI, moonlink_table_config.clone())
             .await;
         assert!(res.is_err());
     }
@@ -107,12 +104,12 @@ mod tests {
     #[serial]
     async fn test_delete_table_metadata_store() {
         let _test_environment = TestEnvironment::new(URI).await;
-        let metadata_store = PgMetadataStore::new(URI).await.unwrap().unwrap();
+        let metadata_store = PgMetadataStore::new(URI.to_string()).unwrap();
         let moonlink_table_config = get_moonlink_table_config();
 
         // Store moonlink table config to metadata storage.
         metadata_store
-            .store_table_config(TABLE_ID, TABLE_NAME, URI, moonlink_table_config.clone())
+            .store_table_metadata(TABLE_ID, TABLE_NAME, URI, moonlink_table_config.clone())
             .await
             .unwrap();
 
@@ -120,7 +117,10 @@ mod tests {
         check_persisted_metadata(&metadata_store).await;
 
         // Delete moonlink table config to metadata storage and check.
-        metadata_store.delete_table_config(TABLE_ID).await.unwrap();
+        metadata_store
+            .delete_table_metadata(TABLE_ID)
+            .await
+            .unwrap();
         let metadata_entries = metadata_store
             .get_all_table_metadata_entries()
             .await
@@ -128,7 +128,7 @@ mod tests {
         assert_eq!(metadata_entries.len(), 0);
 
         // Delete for the second time also fails.
-        let res = metadata_store.delete_table_config(TABLE_ID).await;
+        let res = metadata_store.delete_table_metadata(TABLE_ID).await;
         assert!(res.is_err());
     }
 }


### PR DESCRIPTION
## Summary

This PR updates metadata access to:
recovery:
- if schema not exist, skip
- if metadata table not exist, skip
- load metadata table, and perform recovery

create table:
- if schema not exist, abort
- if metadata table not exist, create
- store metadata row

drop table:
- if schema not exist, abort
- if metadata table not exist, abort
- delete metadata row

Tested with pg_mooncake regression tests:
```sh
--- beginning regression test run ---
PASS setup 24ms
PASS partitioned_table 712ms
PASS sanity 701ms
passed=3, failed=0
```

Tested with pg_mooncake sql statements:
```sql
pg_mooncake (pid: 245014) =# DROP TABLE r;
DROP EXTENSION pg_mooncake CASCADE;
CREATE EXTENSION pg_mooncake;
CREATE TABLE r (a int primary key, b text);
CALL mooncake.create_table('c', 'r');
INSERT INTO r VALUES (1, 'a'), (2, 'b'), (3, 'c');
SELECT * FROM c;
DROP TABLE
NOTICE:  drop cascades to 2 other objects
DETAIL:  drop cascades to table mooncake.tables
drop cascades to table c
DROP EXTENSION
CREATE EXTENSION
CREATE TABLE
CALL
INSERT 0 3
 a | b 
---+---
 1 | a
 2 | b
 3 | c
(3 rows)

pg_mooncake (pid: 245014) =# DROP TABLE r;
DROP EXTENSION pg_mooncake CASCADE;
CREATE EXTENSION pg_mooncake;
CREATE TABLE r (a int primary key, b text);
CALL mooncake.create_table('c', 'r');
INSERT INTO r VALUES (1, 'a'), (2, 'b'), (3, 'c');
SELECT * FROM c;
DROP TABLE
NOTICE:  drop cascades to 2 other objects
DETAIL:  drop cascades to table mooncake.tables
drop cascades to table c
DROP EXTENSION
CREATE EXTENSION
CREATE TABLE
CALL
INSERT 0 3
 a | b 
---+---
 1 | a
 2 | b
 3 | c
(3 rows)
```

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/679
Closes https://github.com/Mooncake-Labs/moonlink/issues/655

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [x] Documentation updated if necessary
- [x] I have reviewed my own changes
