### PR TITLE
Use debug instead of info

### DIFF
--- a/src/moonlink/src/table_handler.rs
+++ b/src/moonlink/src/table_handler.rs
@@ -9,7 +9,7 @@ use tokio::sync::{oneshot, watch};
 use tokio::task::JoinHandle;
 use tokio::time::{self, Duration};
 use tracing::Instrument;
-use tracing::{debug, error, info, info_span, warn};
+use tracing::{debug, error, info_span, warn};
 
 /// Handler for table operations
 pub struct TableHandler {
@@ -291,7 +291,7 @@ impl TableHandler {
                             if let Err(e) = table.shutdown().await {
                                 error!(error = %e, "failed to shutdown table");
                             }
-                            info!("shutting down table handler");
+                            debug!("shutting down table handler");
                             break;
                         }
                         // ==============================
@@ -472,7 +472,7 @@ impl TableHandler {
                     if let Err(e) = table.shutdown().await {
                         error!(error = %e, "failed to shutdown table");
                     }
-                    info!("all event senders dropped, shutting down table handler");
+                    debug!("all event senders dropped, shutting down table handler");
                     break;
                 }
             }

--- a/src/moonlink_connectors/src/pg_replicate/clients/postgres.rs
+++ b/src/moonlink_connectors/src/pg_replicate/clients/postgres.rs
@@ -12,7 +12,7 @@ use tokio_postgres::{
 };
 use tokio_postgres::{tls::NoTlsStream, Connection, Socket};
 use tracing::Instrument;
-use tracing::{info, info_span, warn};
+use tracing::{debug, info_span, warn};
 
 pub struct SlotInfo {
     pub confirmed_flush_lsn: PgLsn,
@@ -62,13 +62,13 @@ impl ReplicationClient {
     pub async fn connect_no_tls(
         uri: &str,
     ) -> Result<(ReplicationClient, Connection<Socket, NoTlsStream>), ReplicationClientError> {
-        info!("connecting to postgres");
+        debug!("connecting to postgres");
 
         let mut config = uri.parse::<Config>()?;
         config.replication_mode(ReplicationMode::Logical);
         let (postgres_client, connection) = config.connect(NoTls).await?;
 
-        info!("successfully connected to postgres");
+        debug!("successfully connected to postgres");
 
         Ok((
             ReplicationClient {

--- a/src/moonlink_connectors/src/pg_replicate/postgres_source.rs
+++ b/src/moonlink_connectors/src/pg_replicate/postgres_source.rs
@@ -10,7 +10,7 @@ use pin_project_lite::pin_project;
 use postgres_replication::LogicalReplicationStream;
 use thiserror::Error;
 use tokio_postgres::{tls::NoTlsStream, types::PgLsn, Connection, CopyOutStream, Socket};
-use tracing::{debug, error, info, info_span, warn, Instrument};
+use tracing::{debug, error, info_span, warn, Instrument};
 
 use crate::pg_replicate::{
     clients::postgres::{ReplicationClient, ReplicationClientError},
@@ -183,7 +183,7 @@ impl PostgresSource {
         table_name: &TableName,
         column_schemas: &[ColumnSchema],
     ) -> Result<TableCopyStream, PostgresSourceError> {
-        info!("starting table copy stream for table {table_name}");
+        debug!("starting table copy stream for table {table_name}");
 
         let stream = self
             .replication_client
@@ -229,7 +229,7 @@ impl PostgresSource {
         mut replication_client: ReplicationClient,
         config: CdcStreamConfig,
     ) -> Result<CdcStream, PostgresSourceError> {
-        info!("creating cdc stream");
+        debug!("creating cdc stream");
 
         let stream = replication_client
             .get_logical_replication_stream(

--- a/src/moonlink_connectors/src/replication_manager.rs
+++ b/src/moonlink_connectors/src/replication_manager.rs
@@ -5,7 +5,7 @@ use moonlink::{MoonlinkTableConfig, ObjectStorageCache, ReadStateManager, TableE
 use std::collections::HashMap;
 use std::hash::Hash;
 use tokio::task::JoinHandle;
-use tracing::{debug, info, warn};
+use tracing::{debug, warn};
 
 /// Manage replication sources keyed by their connection URI.
 ///
@@ -56,7 +56,7 @@ impl<T: Clone + Eq + Hash + std::fmt::Display> ReplicationManager<T> {
         table_name: &str,
         override_table_base_path: Option<&str>,
     ) -> Result<MoonlinkTableConfig> {
-        info!(%src_uri, table_name, "adding table through manager");
+        debug!(%src_uri, table_name, "adding table through manager");
         if !self.connections.contains_key(src_uri) {
             debug!(%src_uri, "creating replication connection");
             // Lazily create the directory that will hold all tables.
@@ -90,7 +90,7 @@ impl<T: Clone + Eq + Hash + std::fmt::Display> ReplicationManager<T> {
         self.table_info
             .insert(mooncake_table_id, (src_uri.to_string(), src_table_id));
 
-        info!(src_table_id, "table added through manager");
+        debug!(src_table_id, "table added through manager");
 
         Ok(moonlink_table_config)
     }
@@ -106,14 +106,14 @@ impl<T: Clone + Eq + Hash + std::fmt::Display> ReplicationManager<T> {
                 return Ok(false);
             }
         };
-        info!(src_table_id, %table_uri, "dropping table through manager");
+        debug!(src_table_id, %table_uri, "dropping table through manager");
         let repl_conn = self.connections.get_mut(&table_uri).unwrap();
         repl_conn.drop_table(src_table_id).await?;
         if repl_conn.table_readers_count() == 0 {
             self.shutdown_connection(&table_uri);
         }
 
-        info!(src_table_id, "table dropped through manager");
+        debug!(src_table_id, "table dropped through manager");
         Ok(true)
     }
 


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

Use `debug` instead of `info` so we only get verbose logging when `RUST_LOG=debug` is set.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/660

## Changes

- 
- 
- 

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
