### PR TITLE
[storage] Discard already persisted content after recovery

### DIFF
--- a/src/moonlink/src/storage.rs
+++ b/src/moonlink/src/storage.rs
@@ -26,6 +26,8 @@ pub(crate) use iceberg::puffin_utils::*;
 #[cfg(test)]
 pub(crate) use iceberg::table_manager::MockTableManager;
 #[cfg(test)]
+pub(crate) use iceberg::table_manager::PersistenceResult;
+#[cfg(test)]
 pub(crate) use mooncake_table::test_utils::*;
 
 #[cfg(feature = "bench")]

--- a/src/moonlink/src/storage/iceberg/table_manager.rs
+++ b/src/moonlink/src/storage/iceberg/table_manager.rs
@@ -21,7 +21,7 @@ pub struct PersistenceFileParams {
 }
 
 /// Iceberg persistence results.
-#[derive(Clone, Debug)]
+#[derive(Clone, Default, Debug)]
 pub struct PersistenceResult {
     /// Imported data files, which only contain remote file paths.
     /// NOTICE: It's guaranteed that remote data files contain imported data files and compacted new files; and are placed in this order.

--- a/src/moonlink/src/storage/index.rs
+++ b/src/moonlink/src/storage/index.rs
@@ -11,6 +11,8 @@ use persisted_bucket_hash_map::GlobalIndex;
 use std::collections::HashSet;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
+
+#[derive(Clone)]
 pub struct MooncakeIndex {
     pub(crate) in_memory_index: HashSet<IndexPtr>,
     pub(crate) file_indices: Vec<FileIndex>,

--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -195,6 +195,7 @@ pub(crate) struct DiskFileEntry {
 /// Snapshot contains state of the table at a given time.
 /// A snapshot maps directly to an iceberg snapshot.
 ///
+#[derive(Clone)]
 pub struct Snapshot {
     /// table metadata
     pub(crate) metadata: Arc<TableMetadata>,

--- a/src/moonlink/src/table_handler.rs
+++ b/src/moonlink/src/table_handler.rs
@@ -205,7 +205,7 @@ impl TableHandler {
                         // ==============================
                         //
                         TableEvent::Begin { lsn } => {
-                            current_non_streaming_txn_kept = lsn <= initial_persistence_lsn;
+                            current_non_streaming_txn_kept = lsn > initial_persistence_lsn;
                         }
                         TableEvent::Append { is_copied, row, xact_id } => {
                             if !current_non_streaming_txn_kept {
@@ -287,6 +287,9 @@ impl TableHandler {
                                         warn!(error = %e, "flush failed in commit");
                                     }
                                 }
+                            } else {
+                                // Reset discard state.
+                                current_non_streaming_txn_kept = true;
                             }
 
                             if force_snapshot {

--- a/src/moonlink/src/table_handler.rs
+++ b/src/moonlink/src/table_handler.rs
@@ -3,6 +3,7 @@ use crate::storage::mooncake_table::INITIAL_COPY_XACT_ID;
 use crate::storage::{io_utils, MooncakeTable};
 use crate::table_notify::TableEvent;
 use crate::{Error, Result};
+use more_asserts as ma;
 use std::collections::BTreeMap;
 use tokio::sync::mpsc::{self, Receiver, Sender};
 use tokio::sync::{oneshot, watch};
@@ -71,6 +72,16 @@ impl TableHandler {
         mut table: MooncakeTable,
     ) {
         let mut periodic_snapshot_interval = time::interval(Duration::from_millis(500));
+
+        // Initial persisted LSN.
+        //
+        // On moonlink recovery, it's possible that moonlink hasn't sent back latest flush LSN back to source table, so source database (i.e. postgres) will replay unacknowledged parts, which might contain already persisted content.
+        // To avoid duplicate records, we compare iceberg initial flush LSN with new coming messages' LSN.
+        // - For streaming events, we keep a buffer as usual, and decide whether to keep or discard the buffer at stream commit;
+        // - For non-streaming events, they start with a [`Begin`] message containing the final LSN of the current transaction, which we could leverage to decide keep or not.
+        let initial_persistence_lsn = table.get_iceberg_snapshot_lsn().unwrap_or(0);
+        // Whether the current non-streaming transaction changes will be kept.
+        let mut current_non_streaming_txn_kept = true;
 
         // Requested minimum LSN for a force snapshot request.
         let mut force_snapshot_lsns: BTreeMap<u64, Vec<Sender<Result<()>>>> = BTreeMap::new();
@@ -193,7 +204,13 @@ impl TableHandler {
                         // Replication events
                         // ==============================
                         //
+                        TableEvent::Begin { lsn } => {
+                            current_non_streaming_txn_kept = lsn <= initial_persistence_lsn;
+                        }
                         TableEvent::Append { is_copied, row, xact_id } => {
+                            if !current_non_streaming_txn_kept {
+                                continue;
+                            }
                             if is_copied || (!table.is_in_initial_copy() && xact_id.is_none()) {
                                 if let Err(e) = table.append(row) {
                                     warn!(error = %e, "failed to append row");
@@ -220,6 +237,9 @@ impl TableHandler {
                             }
                         }
                         TableEvent::Delete { row, lsn, xact_id } => {
+                            if !current_non_streaming_txn_kept {
+                                continue;
+                            }
                             if !table.is_in_initial_copy() && xact_id.is_none() {
                                 table.delete(row, lsn).await;
                                 continue;
@@ -237,20 +257,30 @@ impl TableHandler {
                                 && lsn >= *force_snapshot_lsns.iter().next().as_ref().unwrap().0
                                 && !mooncake_snapshot_ongoing;
 
+                            // Handle initial copy situation.
                             if table.is_in_initial_copy() {
                                 let xid = xact_id.unwrap_or(INITIAL_COPY_XACT_ID);
                                 let commit = table
                                     .prepare_transaction_stream_commit(xid, lsn)
                                     .await.unwrap();
                                 table.buffer_initial_copy_commit(commit);
-                            } else if let Some(xid) = xact_id {
+                            }
+                            // Handle streaming write situation.
+                            else if let Some(xid) = xact_id {
+                                // Discard streaming write buffer, if content already persisted.
+                                if lsn <= initial_persistence_lsn {
+                                    table.abort_in_stream_batch(xid);
+                                    continue;
+                                }
                                 let commit = table
                                     .prepare_transaction_stream_commit(xid, lsn)
                                     .await.unwrap();
                                 if let Err(e) = table.commit_transaction_stream(commit).await {
                                     warn!(error = %e, "stream commit flush failed");
                                 }
-                            } else {
+                            }
+                            // Handle non-streaming write situation.
+                            else if current_non_streaming_txn_kept {
                                 table.commit(lsn);
                                 if table.should_flush() || force_snapshot {
                                     if let Err(e) = table.flush(lsn).await {
@@ -274,6 +304,10 @@ impl TableHandler {
                             table.abort_in_stream_batch(xact_id);
                         }
                         TableEvent::Flush { lsn } => {
+                            if !current_non_streaming_txn_kept {
+                                ma::assert_le!(lsn, initial_persistence_lsn);
+                                continue;
+                            }
                             if table.is_in_initial_copy() {
                                 if let Err(e) = table.flush_transaction_stream(INITIAL_COPY_XACT_ID).await {
                                     warn!(error = %e, "explicit flush failed");

--- a/src/moonlink/src/table_handler/test_utils.rs
+++ b/src/moonlink/src/table_handler/test_utils.rs
@@ -194,6 +194,11 @@ impl TestEnvironment {
 
     // --- Operation Helpers ---
 
+    // Begin a non-streaming transaction.
+    pub async fn begin(&self, lsn: u64) {
+        self.send_event(TableEvent::Begin { lsn }).await
+    }
+
     pub async fn append_row(&self, id: i32, name: &str, age: i32, xact_id: Option<u32>) {
         let row = create_row(id, name, age);
         self.send_event(TableEvent::Append {

--- a/src/moonlink/src/table_notify.rs
+++ b/src/moonlink/src/table_notify.rs
@@ -22,6 +22,11 @@ pub enum TableEvent {
     /// Replication events
     /// ==============================
     ///
+    /// Marks the beginning of a non-streaming transaction.
+    Begin {
+        /// The final LSN of the current transaction.
+        lsn: u64,
+    },
     /// Append a row to the table
     Append {
         row: MoonlinkRow,


### PR DESCRIPTION
## Summary

Moonlink sends back persisted flush LSN to pg, so WAL could be recycled.
However, chances are that before pg handles confirmed LSN, moonlink / pg_mooncake already crashes.

After load snapshot from iceberg table, we are able to recover up to flush LSN, but due to the situation described above, pg's still possible to resent persisted content which we need to handle.

In this PR, I discard already persisted content by checking LSN for 
- LSN for non-streaming writes in begin message
- LSN for stream write in stream commit message

Testing doc: https://docs.google.com/document/d/1Go02j9Nv2HrhABM-GBpBA4lPACJG3twC58J8pnKHAmA/edit?usp=sharing

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/686

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [x] Documentation updated if necessary
- [x] I have reviewed my own changes
