### PR TITLE
[postgres] Buffer replication messages when missing table schema

### DIFF
--- a/src/moonlink_connectors/src/pg_replicate/conversions/cdc_event.rs
+++ b/src/moonlink_connectors/src/pg_replicate/conversions/cdc_event.rs
@@ -114,10 +114,38 @@ impl CdcEventConverter {
         Ok(CdcEvent::Delete((src_table_id, row, delete_body.xid())))
     }
 
+    /// Attempt to get table id from the given replication message.
+    pub fn try_get_table_id(
+        value: &ReplicationMessage<LogicalReplicationMessage>,
+    ) -> Option<SrcTableId> {
+        match value {
+            ReplicationMessage::XLogData(xlog_data) => match xlog_data.data() {
+                LogicalReplicationMessage::Insert(insert_body) => Some(insert_body.rel_id()),
+                LogicalReplicationMessage::Update(update_body) => Some(update_body.rel_id()),
+                LogicalReplicationMessage::Delete(delete_body) => Some(delete_body.rel_id()),
+                _ => None,
+            },
+            _ => None,
+        }
+    }
+
+    /// Get column schemas for the requested table from table schemas.
+    fn get_column_schemas(
+        table_id: SrcTableId,
+        table_schemas: &HashMap<SrcTableId, TableSchema>,
+    ) -> &Vec<ColumnSchema> {
+        &table_schemas
+            .get(&table_id)
+            .ok_or(CdcEventConversionError::MissingSchema(table_id))?
+            .column_schemas
+    }
+
     pub fn try_from(
         value: ReplicationMessage<LogicalReplicationMessage>,
         table_schemas: &HashMap<SrcTableId, TableSchema>,
     ) -> Result<CdcEvent, CdcEventConversionError> {
+        println!("raw cdc event : {:?}", value);
+
         match value {
             ReplicationMessage::XLogData(xlog_data) => match xlog_data.into_data() {
                 LogicalReplicationMessage::Begin(begin_body) => Ok(CdcEvent::Begin(begin_body)),
@@ -131,10 +159,7 @@ impl CdcEventConverter {
                 LogicalReplicationMessage::Type(type_body) => Ok(CdcEvent::Type(type_body)),
                 LogicalReplicationMessage::Insert(insert_body) => {
                     let table_id = insert_body.rel_id();
-                    let column_schemas = &table_schemas
-                        .get(&table_id)
-                        .ok_or(CdcEventConversionError::MissingSchema(table_id))?
-                        .column_schemas;
+                    let column_schemas = Self::get_column_schemas(table_id, table_schemas);
                     Ok(Self::try_from_insert_body(
                         table_id,
                         column_schemas,
@@ -143,10 +168,7 @@ impl CdcEventConverter {
                 }
                 LogicalReplicationMessage::Update(update_body) => {
                     let table_id = update_body.rel_id();
-                    let column_schemas = &table_schemas
-                        .get(&table_id)
-                        .ok_or(CdcEventConversionError::MissingSchema(table_id))?
-                        .column_schemas;
+                    let column_schemas = Self::get_column_schemas(table_id, table_schemas);
                     Ok(Self::try_from_update_body(
                         table_id,
                         column_schemas,
@@ -155,10 +177,7 @@ impl CdcEventConverter {
                 }
                 LogicalReplicationMessage::Delete(delete_body) => {
                     let table_id = delete_body.rel_id();
-                    let column_schemas = &table_schemas
-                        .get(&table_id)
-                        .ok_or(CdcEventConversionError::MissingSchema(table_id))?
-                        .column_schemas;
+                    let column_schemas = Self::get_column_schemas(table_id, table_schemas);
                     Ok(Self::try_from_delete_body(
                         table_id,
                         column_schemas,

--- a/src/moonlink_connectors/src/pg_replicate/moonlink_sink.rs
+++ b/src/moonlink_connectors/src/pg_replicate/moonlink_sink.rs
@@ -120,8 +120,6 @@ impl Sink {
     }
 
     pub async fn process_cdc_event(&mut self, event: CdcEvent) -> Result<(), Infallible> {
-        println!("receive cdc {:?}", event);
-
         match event {
             CdcEvent::Begin(begin_body) => {
                 debug!(final_lsn = begin_body.final_lsn(), "begin transaction");

--- a/src/moonlink_connectors/src/pg_replicate/moonlink_sink.rs
+++ b/src/moonlink_connectors/src/pg_replicate/moonlink_sink.rs
@@ -120,6 +120,8 @@ impl Sink {
     }
 
     pub async fn process_cdc_event(&mut self, event: CdcEvent) -> Result<(), Infallible> {
+        println!("receive cdc {:?}", event);
+
         match event {
             CdcEvent::Begin(begin_body) => {
                 debug!(final_lsn = begin_body.final_lsn(), "begin transaction");

--- a/src/moonlink_connectors/src/pg_replicate/postgres_source.rs
+++ b/src/moonlink_connectors/src/pg_replicate/postgres_source.rs
@@ -8,6 +8,7 @@ use std::{
 use futures::{ready, Stream};
 use pin_project_lite::pin_project;
 use postgres_replication::LogicalReplicationStream;
+use std::collections::VecDeque;
 use thiserror::Error;
 use tokio_postgres::{tls::NoTlsStream, types::PgLsn, Connection, CopyOutStream, Socket};
 use tracing::{debug, error, info_span, warn, Instrument};
@@ -18,8 +19,9 @@ use crate::pg_replicate::{
         cdc_event::{CdcEvent, CdcEventConversionError, CdcEventConverter},
         table_row::{TableRow, TableRowConversionError, TableRowConverter},
     },
-    table::{ColumnSchema, SrcTableId, TableName, TableSchema},
+    table::{self, ColumnSchema, SrcTableId, TableName, TableSchema},
 };
+use postgres_replication::protocol::{LogicalReplicationMessage, ReplicationMessage};
 
 pub enum TableNamesFrom {
     Vec(Vec<TableName>),
@@ -247,6 +249,8 @@ impl PostgresSource {
             stream,
             table_schemas: config.table_schemas,
             postgres_epoch,
+            unprocessed_replication_messages: HashMap::new(),
+            ready_cdc_events: VecDeque::new(),
         })
     }
 }
@@ -308,6 +312,12 @@ pin_project! {
         stream: LogicalReplicationStream,
         table_schemas: HashMap<SrcTableId, TableSchema>,
         postgres_epoch: SystemTime,
+
+        // Buffered unprocessed messages due to missing table schema.
+        unprocessed_replication_messages: HashMap<SrcTableId, Vec<ReplicationMessage<LogicalReplicationMessage>>>,
+        // Buffered process messages due to missing table schema, which are ready to emit.
+        // Results are stored in the order of postgres cdc stream messages.
+        ready_cdc_events: VecDeque<Result<CdcEvent, CdcEventConversionError>>,
     }
 }
 
@@ -337,7 +347,18 @@ impl CdcStream {
 
     pub fn add_table_schema(self: Pin<&mut Self>, schema: TableSchema) {
         let this = self.project();
-        this.table_schemas.insert(schema.src_table_id, schema);
+        let cur_table_id = schema.src_table_id;
+        this.table_schemas.insert(cur_table_id, schema);
+
+        // Check unprocessed replication messages due to missing table schema.
+        if let Some(unprocessed_messages) =
+            this.unprocessed_replication_messages.remove(&cur_table_id)
+        {
+            for cur_msg in unprocessed_messages.into_iter() {
+                let res = CdcEventConverter::try_from(cur_msg, &this.table_schemas);
+                this.ready_cdc_events.push_back(res);
+            }
+        }
     }
 
     pub fn remove_table_schema(self: Pin<&mut Self>, src_table_id: SrcTableId) {
@@ -349,13 +370,41 @@ impl CdcStream {
 impl Stream for CdcStream {
     type Item = Result<CdcEvent, CdcStreamError>;
 
-    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let this = self.project();
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.as_mut().project();
+
+        if !this.ready_cdc_events.is_empty() {
+            let cur_cdc_event = this.ready_cdc_events.pop_front().unwrap();
+            match cur_cdc_event {
+                Ok(row) => {
+                    return Poll::Ready(Some(Ok(row)));
+                }
+                Err(e) => {
+                    return Poll::Ready(Some(Err(e.into())));
+                }
+            }
+        }
+
         match ready!(this.stream.poll_next(cx)) {
-            Some(Ok(msg)) => match CdcEventConverter::try_from(msg, &this.table_schemas) {
-                Ok(row) => Poll::Ready(Some(Ok(row))),
-                Err(e) => Poll::Ready(Some(Err(e.into()))),
-            },
+            Some(Ok(msg)) => {
+                // On recovery, it's non-deterministic on the order of setting table schema and resending cdc stream, which is prune to suffer missing schema error.
+                // Here we buffer unfound schema, which will gets populated when schema is set.
+                let table_id = CdcEventConverter::try_get_table_id(&msg);
+                if let Some(table_id) = table_id {
+                    if !this.table_schemas.contains_key(&table_id) {
+                        this.unprocessed_replication_messages
+                            .entry(table_id)
+                            .or_default()
+                            .push(msg);
+                        return Poll::Pending;
+                    }
+                }
+
+                match CdcEventConverter::try_from(msg, &this.table_schemas) {
+                    Ok(row) => Poll::Ready(Some(Ok(row))),
+                    Err(e) => Poll::Ready(Some(Err(e.into()))),
+                }
+            }
             Some(Err(e)) => Poll::Ready(Some(Err(e.into()))),
             None => Poll::Ready(None),
         }

--- a/src/moonlink_connectors/src/pg_replicate/postgres_source.rs
+++ b/src/moonlink_connectors/src/pg_replicate/postgres_source.rs
@@ -357,6 +357,8 @@ impl CdcStream {
         if let Some(unprocessed_messages) =
             this.unprocessed_replication_messages.remove(&cur_table_id)
         {
+            let new_len = this.ready_cdc_events.len() + unprocessed_messages.len();
+            this.ready_cdc_events.reserve(new_len);
             for cur_msg in unprocessed_messages.into_iter() {
                 let res = CdcEventConverter::try_from(cur_msg, &this.table_schemas);
                 this.ready_cdc_events.push_back(res);


### PR DESCRIPTION
## Summary

As described at https://github.com/Mooncake-Labs/moonlink/issues/695, we currently suffer race condition on recovery (or moonlink restart). In short words, cdc events could be emitted before table schema has been set, leading to missing schema error.

This PR handles certain case with buffering replication messages in a buffer, and emit when corresponding schema arrives.

I tested manually with pg_mooncake:
- Write a few rows to mooncake table, and don't trigger iceberg snapshot, so everything's unconfirmed
- Shutdown everything, make sure all rows are replayed and inserted into the mooncake table

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/695
Closes https://github.com/Mooncake-Labs/moonlink/issues/603

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [x] Documentation updated if necessary
- [x] I have reviewed my own changes
