### PR TITLE
Add checks for special case flush lsn

### DIFF
--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -546,7 +546,7 @@ impl MooncakeTable {
         if contains_new_writes(iceberg_snapshot_res) {
             assert!(
                 self.last_iceberg_snapshot_lsn.is_none()
-                    || self.last_iceberg_snapshot_lsn.unwrap() < flush_lsn,
+                    || self.last_iceberg_snapshot_lsn.unwrap() < flush_lsn || flush_lsn == 0,
                 "Last iceberg snapshot LSN is {:?}, flush LSN is {:?}, imported data file number is {}, imported puffin file number is {}",
                 self.last_iceberg_snapshot_lsn,
                 flush_lsn,

--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -1057,7 +1057,10 @@ impl SnapshotTableState {
         // Assert and update flush LSN.
         if let Some(new_flush_lsn) = task.new_flush_lsn {
             // Assert flush LSN doesn't regress, if not force snapshot.
-            if self.current_snapshot.data_file_flush_lsn.is_some() && !opt.force_create {
+            if self.current_snapshot.data_file_flush_lsn.is_some()
+                && !opt.force_create
+                && new_flush_lsn != 0
+            {
                 ma::assert_lt!(
                     self.current_snapshot.data_file_flush_lsn.unwrap(),
                     new_flush_lsn


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

As of https://github.com/Mooncake-Labs/moonlink/pull/488 we need to support the case where the `flush_lsn` is 0, since at the time of initial copy the table will contain data at LSN 0. There are some assertions that don't currently support this and are causing failures. We should add this special case to their checks.


## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/692
Closes https://github.com/Mooncake-Labs/moonlink/issues/688

## Changes

- 
- 
- 

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
