### PR TITLE
[storage] Add benchmark for index build

### DIFF
--- a/src/moonlink/benches/microbench_index_stress.rs
+++ b/src/moonlink/benches/microbench_index_stress.rs
@@ -4,8 +4,35 @@ use moonlink::{GlobalIndex, GlobalIndexBuilder};
 use rand::Rng;
 use tokio::runtime::Runtime;
 
-fn bench_index_stress(c: &mut Criterion) {
-    let mut group = c.benchmark_group("index_stress");
+fn bench_build_index(c: &mut Criterion) {
+    let mut group = c.benchmark_group("index_build");
+    group.measurement_time(std::time::Duration::from_secs(10));
+    group.sample_size(10);
+
+    let files = vec![create_data_file(0, "test.parquet".to_string())];
+    let vec = (0..10_000_000)
+        .map(|i| (i as u64, 0, i))
+        .collect::<Vec<_>>();
+
+    let dir = tempfile::tempdir().unwrap();
+    let dir_path = dir.path().to_path_buf();
+
+    let rt = Runtime::new().unwrap();
+
+    group.bench_function("build_index_10m_entries", |b| {
+        b.iter(|| {
+            let mut builder = GlobalIndexBuilder::new();
+            builder
+                .set_files(files.clone())
+                .set_directory(dir_path.clone());
+            let index = rt.block_on(builder.build_from_flush(vec.clone(), 1));
+            black_box(index);
+        });
+    });
+}
+
+fn bench_index_query(c: &mut Criterion) {
+    let mut group = c.benchmark_group("index_query");
     group.measurement_time(std::time::Duration::from_secs(10));
     group.sample_size(10);
     let files = vec![create_data_file(
@@ -32,9 +59,5 @@ fn bench_index_stress(c: &mut Criterion) {
     });
 }
 
-criterion_group! {
-    name = benches;
-    config = Criterion::default();
-    targets = bench_index_stress
-}
+criterion_group!(benches, bench_build_index, bench_index_query);
 criterion_main!(benches);


### PR DESCRIPTION
## Summary

This PR adds benchmark to index construction, which is necessary for optimization.

Current result:
```sh
vscode@36b8aa3bdd4e$ cargo bench --features bench --bench microbench_index_stress
index_build/build_index_10m_entries
                        time:   [1.1969 s 1.2103 s 1.2236 s]

index_query/search_10m_entries
                        time:   [786.67 ns 817.28 ns 838.35 ns]
```

## Related Issues

Related to https://github.com/Mooncake-Labs/moonlink/issues/697

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
