### PR TITLE
[storage] Place periodical snapshot into eventloop

### DIFF
--- a/src/moonlink/src/storage/iceberg/test_utils.rs
+++ b/src/moonlink/src/storage/iceberg/test_utils.rs
@@ -252,7 +252,7 @@ pub(crate) async fn get_mooncake_snapshot_result(
 ) {
     let notification = notify_rx.recv().await.unwrap();
     match notification {
-        TableEvent::MooncakeTableSnapshot {
+        TableEvent::MooncakeTableSnapshotResult {
             lsn,
             iceberg_snapshot_payload,
             file_indice_merge_payload,

--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -1094,7 +1094,7 @@ impl MooncakeTable {
             .update_snapshot(next_snapshot_task, opt)
             .await;
         table_notify
-            .send(TableEvent::MooncakeTableSnapshot {
+            .send(TableEvent::MooncakeTableSnapshotResult {
                 lsn: snapshot_result.commit_lsn,
                 iceberg_snapshot_payload: snapshot_result.iceberg_snapshot_payload,
                 data_compaction_payload: snapshot_result.data_compaction_payload,

--- a/src/moonlink/src/storage/mooncake_table/state_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/state_test_utils.rs
@@ -642,7 +642,7 @@ async fn sync_mooncake_snapshot(
     Vec<String>,
 ) {
     let notification = receiver.recv().await.unwrap();
-    if let TableEvent::MooncakeTableSnapshot {
+    if let TableEvent::MooncakeTableSnapshotResult {
         iceberg_snapshot_payload,
         file_indice_merge_payload,
         data_compaction_payload,

--- a/src/moonlink/src/storage/mooncake_table/test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/test_utils.rs
@@ -166,7 +166,7 @@ pub async fn snapshot(
     assert!(table.create_snapshot(SnapshotOption::default()));
     let table_notify = notify_rx.recv().await.unwrap();
     match table_notify {
-        TableEvent::MooncakeTableSnapshot {
+        TableEvent::MooncakeTableSnapshotResult {
             lsn,
             iceberg_snapshot_payload,
             data_compaction_payload,

--- a/src/moonlink/src/table_notify.rs
+++ b/src/moonlink/src/table_notify.rs
@@ -57,8 +57,10 @@ pub enum TableEvent {
     /// Table internal events
     /// ==============================
     ///
+    /// Periodical mooncake snapshot.
+    PeriodicalMooncakeTableSnapshot,
     /// Mooncake snapshot completes.
-    MooncakeTableSnapshot {
+    MooncakeTableSnapshotResult {
         /// Mooncake snapshot LSN.
         lsn: u64,
         /// Payload used to create an iceberg snapshot.


### PR DESCRIPTION
## Summary

This PR places the last separate arm (periodical mooncake snapshot) into table event, so everything's handled in one arm.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/694

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
