### PR TITLE
[storage] Fix flush in non-streaming flush

### DIFF
--- a/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
+++ b/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
@@ -39,6 +39,10 @@ pub struct TransactionStreamCommit {
 }
 
 impl TransactionStreamCommit {
+    /// Get commit LSN.
+    pub(crate) fn get_commit_lsn(&self) -> u64 {
+        self.commit_lsn
+    }
     /// Get flushed data files for the current streaming commit.
     pub(crate) fn get_flushed_data_files(&self) -> Vec<MooncakeDataFileRef> {
         self.flushed_files.keys().cloned().collect::<Vec<_>>()

--- a/src/moonlink/src/table_handler.rs
+++ b/src/moonlink/src/table_handler.rs
@@ -240,14 +240,11 @@ impl TableHandler {
                                 if let Err(e) = table.append(row) {
                                     warn!(error = %e, "failed to append row");
                                 }
-                                if table.should_flush() {
-                                    if let Err(e) = table.flush(0).await {
-                                        warn!(error = %e, "flush failed in append");
-                                    }
-                                }
+                                // TODO: optimize initial copy performance; current implement would buffer everything in memory.
                                 continue;
                             }
 
+                            // If mooncake is at initial copy state, buffer all changes to stream batches, which get applied when initial copy finished.
                             let xid = xact_id.unwrap_or(INITIAL_COPY_XACT_ID);
 
                             if let Err(e) = table.append_in_stream_batch(row, xid) {

--- a/src/moonlink/src/table_handler.rs
+++ b/src/moonlink/src/table_handler.rs
@@ -1,5 +1,5 @@
 use crate::storage::mooncake_table::SnapshotOption;
-use crate::storage::mooncake_table::INITIAL_COPY_XACT_ID;
+use crate::storage::mooncake_table::{INITIAL_COPY_CDC_XACT_ID, INITIAL_COPY_XACT_ID};
 use crate::storage::{io_utils, MooncakeTable};
 use crate::table_notify::TableEvent;
 use crate::{Error, Result};
@@ -236,16 +236,22 @@ impl TableHandler {
                             if to_discard(lsn) {
                                 continue;
                             }
-                            if is_copied || (!table.is_in_initial_copy() && xact_id.is_none()) {
+
+                            // General non-streaming append.
+                            if !table.is_in_initial_copy() && xact_id.is_none() {
                                 if let Err(e) = table.append(row) {
                                     warn!(error = %e, "failed to append row");
                                 }
-                                // TODO: optimize initial copy performance; current implement would buffer everything in memory.
                                 continue;
                             }
 
-                            // If mooncake is at initial copy state, buffer all changes to stream batches, which get applied when initial copy finished.
-                            let xid = xact_id.unwrap_or(INITIAL_COPY_XACT_ID);
+                            let xid = if is_copied {
+                                // For initial copy operations, leverage streaming write operation as well.
+                                INITIAL_COPY_XACT_ID
+                            } else {
+                                // If mooncake is at initial copy state, buffer all cdc changes to stream batches, which get applied when initial copy finished.
+                                xact_id.unwrap_or(INITIAL_COPY_CDC_XACT_ID)
+                            };
 
                             if let Err(e) = table.append_in_stream_batch(row, xid) {
                                 warn!(error = %e, "failed to append row in batch");
@@ -267,7 +273,7 @@ impl TableHandler {
                                 continue;
                             }
 
-                            let xid = xact_id.unwrap_or(INITIAL_COPY_XACT_ID);
+                            let xid = xact_id.unwrap_or(INITIAL_COPY_CDC_XACT_ID);
                             table.delete_in_stream_batch(row, xid).await;
                         }
                         TableEvent::Commit { lsn, xact_id } => {
@@ -281,7 +287,7 @@ impl TableHandler {
 
                             // Handle initial copy situation.
                             if table.is_in_initial_copy() {
-                                let xid = xact_id.unwrap_or(INITIAL_COPY_XACT_ID);
+                                let xid = xact_id.unwrap_or(INITIAL_COPY_CDC_XACT_ID);
                                 let commit = table
                                     .prepare_transaction_stream_commit(xid, lsn)
                                     .await.unwrap();
@@ -330,7 +336,7 @@ impl TableHandler {
                                 continue;
                             }
                             if table.is_in_initial_copy() {
-                                if let Err(e) = table.flush_transaction_stream(INITIAL_COPY_XACT_ID).await {
+                                if let Err(e) = table.flush_transaction_stream(INITIAL_COPY_CDC_XACT_ID).await {
                                     error!(error = %e, "explicit flush failed");
                                 }
                             } else if let Err(e) = table.flush(lsn).await {


### PR DESCRIPTION
## Summary

This PR removes flush in non-streaming write situations.

 There're two invariants for snapshot / table handler:
- Flush when the table is at a clean state
- Flush LSN only progresses and never regresses

Flush operation in the middle of a non-streaming transaction breaks both.

Flush inside of initial copy also breaks, but should be handled differently, because
- Normal non-streaming writes only happens for small volume of updates
- But initial copy could have indefinitely large number of updates, which cannot buffer all of them in memory.

As for initial copy appends, I considered a few possible fixes:
1. Flush LSN affects iceberg snapshot, but not mooncake snapshot; so an easy fix is to explicitly skip iceberg snapshot during initial copy operation. The code change is the least (3 LOC), but hard to reason.
2. Modify invariants for snapshot creation. Similar to https://github.com/Mooncake-Labs/moonlink/pull/699, update the invariants and special handle (aka, skip) initial copy.
3. (selected fix) Use streaming write, instead of non-streaming one to take initial copy writes, which works well under current assumptions.

I prefer (3) over (2) because (3) scopes all initial copy logic in table handler, instead of populating it elsewhere like mooncake snapshot / iceberg snapshots.

CC @nbiscaro 

All unit tests / integration tests have passed, and the failed sql statements linked in the issue work without issues.

Tested with pg_mooncake regression test
```sh
--- beginning regression test run ---
PASS setup 24ms
PASS partitioned_table 742ms
PASS sanity 733ms
passed=3, failed=0
```

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/716

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
