### PR TITLE
[storage] Integrate async bit writer into index block construction

### DIFF
--- a/src/moonlink/src/storage/async_bitwriter.rs
+++ b/src/moonlink/src/storage/async_bitwriter.rs
@@ -7,24 +7,40 @@ use tokio_bitstream_io::{BitQueue, Endianness, Numeric};
 const BUFFER_SIZE: usize = 4096;
 
 /// [`BitWriter`] implement asynchronous write for bits;
-/// - To avoid excessive runtime rescheduling caused by `await`, it takes cooperative interface, which means it requires users to explicit flush.
-/// - To avoid excessive syscalls, bits are buffered in-memory until it reaches flush threshold.
+/// - Uses a cooperative interface: users are responsible for flushing when needed (check [`write`] return value).
+/// - Buffers bits into memory to avoid frequent syscalls and runtime suspension from `await`.
 ///
-/// TODO(hjiang): Add example and maybe doc test.
-#[allow(dead_code)]
+/// Example usage:
+/// let writer = AsyncBitWriter(internal_writer);
+///
+/// // If known in advance that overall bits to write is less than buffer size, callers could safely buffer them all before flush,
+/// // allowing to avoid flushing mid-way and eliminate unnecessary `await` calls.
+/// let _ = writer.write(some bits);
+/// let _ = writer.write(some bits);
+/// let to_flush = writer.write(some bits);
+/// if to_flush {
+///   writer.flush().await;
+/// }
+///
+/// // Finalize any partial byte before flush.
+/// let _ = writer.write(some bits);
+///
+/// // It's required to make sure alignment before final flush.
+/// writer.byte_align();
+/// writer.flush().await;
 pub struct BitWriter<W: AsyncWrite + Unpin + Send + Sync, E: Endianness> {
     /// Async writer.
     writer: W,
     /// Two alternating buffers.
     buffers: [[u8; BUFFER_SIZE]; 2],
-    /// Points to currently active buffer
-    active_index: usize,
+    /// Points to currently active buffer.
+    active_buffer_index: usize,
     /// Builds 8-bit values from bits.
     /// All bits goes to [`bitqueue`] first then buffer when queue full.
     bitqueue: BitQueue<E, u8>,
-    /// Current write position for the active buffer.
+    /// Current write offset for the active buffer.
     active_buffer_pos: usize,
-    /// Current write opsition for the inactive buffer.
+    /// Current write offset for the inactive buffer.
     inactive_buffer_pos: usize,
 }
 
@@ -32,57 +48,56 @@ impl<W: AsyncWrite + Unpin + Send + Sync, E: Endianness> BitWriter<W, E> {
     /// Number of bits to hold in the bitqueue.
     const BITQUEUE_SIZE: u32 = 8;
 
-    #[allow(dead_code)]
     pub fn new(writer: W) -> Self {
         Self {
             writer,
             buffers: [[0u8; BUFFER_SIZE]; 2],
-            active_index: 0,
+            active_buffer_index: 0,
             bitqueue: BitQueue::new(),
             active_buffer_pos: 0,
             inactive_buffer_pos: 0,
         }
     }
 
-    #[allow(dead_code)]
     pub fn endian(writer: W, _endian: E) -> Self {
-        Self::new(writer)
+        BitWriter::<W, E>::new(writer)
     }
 
-    /// Flush current contents and switch buffer.
-    #[allow(dead_code)]
+    /// Flush buffered current content.
     pub async fn flush(&mut self) -> io::Result<()> {
         if self.active_buffer_pos > 0 {
-            let flushed_data = &self.buffers[self.active_index][..self.active_buffer_pos];
+            let flushed_data = &self.buffers[self.active_buffer_index][..self.active_buffer_pos];
             self.writer.write_all(flushed_data).await?;
         }
 
-        // Switch buffer for inactive / active buffers.
+        // Switch for inactive / active buffers.
         self.active_buffer_pos = self.inactive_buffer_pos;
         self.inactive_buffer_pos = 0;
-        self.active_index = 1 - self.active_index;
+        self.active_buffer_index = 1 - self.active_buffer_index;
 
         self.writer.flush().await
     }
 
-    /// Append the given [`byte`] to the active buffer.
-    /// Return whether the active buffer has been full, and requires a flush.
+    /// Appends a byte to the active buffer or spills to the inactive buffer if full.
+    /// Returns `true` if the active buffer was full and the byte was written to the inactive buffer.
+    /// Panic if both buffers exceed their capacity, which should never happen in intended cooperative usage.
     fn buffer_byte(&mut self, byte: u8) -> bool {
-        // There're free space at the current active buffer.
+        // There're free space at the active buffer.
         if self.active_buffer_pos < BUFFER_SIZE {
             let pos = self.active_buffer_pos;
-            self.buffers[self.active_index][pos] = byte;
+            self.buffers[self.active_buffer_index][pos] = byte;
             self.active_buffer_pos += 1;
             return false;
         }
 
-        // Write bytes to the inactive buffer first, which will be switch to the active one later.
-        self.buffers[1 - self.active_index][self.inactive_buffer_pos] = byte;
+        // Write bytes to the inactive buffer, which will be switch to the active one later.
+        self.buffers[1 - self.active_buffer_index][self.inactive_buffer_pos] = byte;
         self.inactive_buffer_pos += 1;
         true
     }
 
-    /// Append one single bit.
+    /// Append one single bit, and return whether caller needs to flush.
+    /// It's of the same effect as [`write`] with one single bit.
     #[must_use]
     pub fn write_bit(&mut self, bit: bool) -> bool {
         assert!(!self.bitqueue.is_full());
@@ -96,8 +111,22 @@ impl<W: AsyncWrite + Unpin + Send + Sync, E: Endianness> BitWriter<W, E> {
         false
     }
 
-    /// Return whether caller needs to flush.
-    #[allow(dead_code)]
+    /// Write [`value`] into buffer, and return whether caller needs to flush.
+    /// Notice, this function never performs flushing itself — the caller must check the return value and call [`flush`] if needed.
+    ///
+    /// Internally, async bit writer leverages two buffers, with each of size 4KiB.
+    /// So even if one fills up, the second backup buffer could still take new bits.
+    /// It's used for performance optimization to reduce async functions and write calls.
+    /// But if both buffer goes out of memory, it will panic.
+    ///
+    /// An example usage is
+    /// func some_write_func() -> bool {
+    ///   // It's safe to ignore the first two writes return value.
+    ///   let _ = bitwriter.write(some bits);
+    ///   let _ = bitwriter.write(some bits);
+    ///   bitwriter.write(some bits)
+    /// }
+    /// If the overall bits to write is less than buffer size 4KiB, we don't need to declare [`some_write_func`] as `async` and flush immediately.
     #[must_use]
     pub fn write<U>(&mut self, bits: u32, value: U) -> bool
     where
@@ -112,13 +141,13 @@ impl<W: AsyncWrite + Unpin + Send + Sync, E: Endianness> BitWriter<W, E> {
         let mut acc = BitQueue::<E, U>::from_value(value, bits);
         let mut to_flush = false;
         while !acc.is_empty() {
-            let bits_to_fill = 8 - self.bitqueue.len();
+            let bits_to_fill = Self::BITQUEUE_SIZE - self.bitqueue.len();
             let n = bits_to_fill.min(acc.len());
             let bits_chunk = acc.pop(n).to_u8();
             self.bitqueue.push(n, bits_chunk);
 
             if self.bitqueue.is_full() {
-                let byte = self.bitqueue.pop(8);
+                let byte = self.bitqueue.pop(Self::BITQUEUE_SIZE);
                 if self.buffer_byte(byte) {
                     to_flush = true;
                 }
@@ -128,16 +157,19 @@ impl<W: AsyncWrite + Unpin + Send + Sync, E: Endianness> BitWriter<W, E> {
         to_flush
     }
 
-    /// Fill in bits into bitqueue, until the buffer is aligned.
-    #[allow(dead_code)]
-    pub fn byte_align(&mut self) {
+    /// Pads the current bit queue with zeros until aligned to the next byte boundary.
+    /// This should be called before the final flush to ensure the output is byte-aligned.
+    /// Returns `true` if a flush is required due to buffer spill.
+    pub fn byte_align(&mut self) -> bool {
         let cur_bit_len = self.bitqueue.len();
         if cur_bit_len == 0 {
-            return;
+            return false;
         }
+        let mut to_flush = false;
         for _ in cur_bit_len..8 {
-            assert!(!self.write_bit(false));
+            to_flush = self.write_bit(false);
         }
+        to_flush
     }
 }
 
@@ -145,12 +177,13 @@ impl<W: AsyncWrite + Unpin + Send + Sync, E: Endianness> BitWriter<W, E> {
 mod tests {
     use super::*;
     use tokio::io::BufWriter;
+    use tokio_bitstream_io::BigEndian;
 
     #[tokio::test]
     async fn test_bitwriter_flush_empty() {
         let inner = Vec::new();
         let writer = BufWriter::new(inner);
-        let mut bit_writer = BitWriter::<_, tokio_bitstream_io::BigEndian>::new(writer);
+        let mut bit_writer = BitWriter::<_, BigEndian>::new(writer);
         bit_writer.flush().await.unwrap();
 
         let result = bit_writer.writer.into_inner();
@@ -161,7 +194,7 @@ mod tests {
     async fn test_bitwriter_buffered_write_and_flush() {
         let inner = Vec::new();
         let writer = BufWriter::new(inner);
-        let mut bit_writer = BitWriter::<_, tokio_bitstream_io::BigEndian>::new(writer);
+        let mut bit_writer = BitWriter::<_, BigEndian>::new(writer);
 
         assert!(!bit_writer.write_bit(true));
         assert!(!bit_writer.write_bit(false));
@@ -185,13 +218,12 @@ mod tests {
     async fn test_bitwriter_1bit_flush_across_buffers() {
         let inner = Vec::new();
         let writer = BufWriter::new(inner);
-        let mut bit_writer = BitWriter::<_, tokio_bitstream_io::BigEndian>::new(writer);
+        let mut bit_writer = BitWriter::<_, BigEndian>::new(writer);
 
         let mut switched = false;
         let mut bit_index: u8 = 0;
 
         for _ in 0..(5000 * 8) {
-            // Write 'true' as 1-bit
             let to_flush = bit_writer.write_bit(true);
             if to_flush {
                 switched = true;
@@ -211,7 +243,7 @@ mod tests {
         for (i, byte) in result.iter().enumerate() {
             assert_eq!(*byte, 0b1111_1111, "mismatch at index {}", i);
         }
-        assert!(switched, "should have triggered buffer flush at least once");
+        assert!(switched);
     }
 
     /// Testing scenario: write aligned 8 bits everytime, and overall writes requires buffer switching.
@@ -219,7 +251,7 @@ mod tests {
     async fn test_bitwriter_aligned_8bit_flush_across_buffers() {
         let inner = Vec::new();
         let writer = BufWriter::new(inner);
-        let mut bit_writer = BitWriter::<_, tokio_bitstream_io::BigEndian>::new(writer);
+        let mut bit_writer = BitWriter::<_, BigEndian>::new(writer);
 
         let mut switched = false;
         for i in 0..5000 {
@@ -238,21 +270,17 @@ mod tests {
         for (i, byte) in result.iter().enumerate() {
             assert_eq!(*byte, (i % 256) as u8, "mismatch at index {}", i);
         }
-        assert!(switched, "should have triggered buffer flush at least once");
+        assert!(switched);
     }
 
     /// Testing scenario: write unaligned 7 bits everytime, and overall writes requires buffer switching.
     #[tokio::test]
     async fn test_bitwriter_unaligned_7bit_flush_across_buffers() {
-        use tokio::io::BufWriter;
-
         let inner = Vec::new();
         let writer = BufWriter::new(inner);
-        let mut bit_writer = BitWriter::<_, tokio_bitstream_io::BigEndian>::new(writer);
+        let mut bit_writer = BitWriter::<_, BigEndian>::new(writer);
 
         let mut switched = false;
-
-        // Each write is 7 bits — fill more than 4096 bytes
         for i in 0..5000 {
             let to_flush = bit_writer.write::<u8>(7, (i % 128) as u8);
             if to_flush {
@@ -287,15 +315,12 @@ mod tests {
         for (i, actual) in decoded.iter().enumerate() {
             assert_eq!(*actual, (i % 128) as u8, "mismatch at index {}", i);
         }
-        assert!(switched, "buffer switch did not occur");
+        assert!(switched);
     }
 
     /// Testing scenario: value to append is larger than bitqueue capacity.
     #[tokio::test]
-    async fn test_bitwriter_write_u16_cross_byte_boundary() {
-        use tokio::io::BufWriter;
-        use tokio_bitstream_io::BigEndian;
-
+    async fn test_bitwriter_write_u16_cross_bitqueue_boundary() {
         let inner = Vec::new();
         let writer = BufWriter::new(inner);
         let mut bit_writer = BitWriter::<_, BigEndian>::new(writer);

--- a/src/moonlink/src/storage/index/persisted_bucket_hash_map.rs
+++ b/src/moonlink/src/storage/index/persisted_bucket_hash_map.rs
@@ -1,4 +1,5 @@
 use crate::create_data_file;
+use crate::storage::async_bitwriter::BitWriter as AsyncBitWriter;
 use crate::storage::storage_utils::{MooncakeDataFileRef, RecordLocation};
 use crate::NonEvictableHandle;
 use futures::executor::block_on;
@@ -15,7 +16,6 @@ use tokio::fs::File as AsyncFile;
 use tokio::io::BufWriter as AsyncBufWriter;
 use tokio_bitstream_io::{
     BigEndian as AsyncBigEndian, BitRead as AsyncBitRead, BitReader as AsyncBitReader,
-    BitWrite as AsyncBitWrite, BitWriter as AsyncBitWriter,
 };
 
 // Constants
@@ -350,33 +350,36 @@ impl IndexBlockBuilder {
         }
     }
 
-    pub async fn write_entry(
+    /// Return whether buffer inside of bitwriter is full and could be flushed.
+    pub fn write_entry(
         &mut self,
         hash: u64,
         seg_idx: usize,
         row_idx: usize,
         metadata: &GlobalIndex,
-    ) {
+    ) -> bool {
         while (hash >> metadata.hash_lower_bits) != self.current_bucket as u64 {
             self.current_bucket += 1;
             self.buckets[self.current_bucket as usize] = self.current_entry;
         }
-        self.entry_writer
-            .write(
-                metadata.hash_lower_bits,
-                hash & ((1 << metadata.hash_lower_bits) - 1),
-            )
-            .await
-            .unwrap();
-        self.entry_writer
-            .write(metadata.seg_id_bits, seg_idx as u32)
-            .await
-            .unwrap();
-        self.entry_writer
-            .write(metadata.row_id_bits, row_idx as u32)
-            .await
-            .unwrap();
+        let _ = self.entry_writer.write(
+            metadata.hash_lower_bits,
+            hash & ((1 << metadata.hash_lower_bits) - 1),
+        );
+        let _ = self
+            .entry_writer
+            .write(metadata.seg_id_bits, seg_idx as u32);
+        let to_flush = self
+            .entry_writer
+            .write(metadata.row_id_bits, row_idx as u32);
         self.current_entry += 1;
+
+        to_flush
+    }
+
+    /// Flush the buffer inside of bitwriter.
+    pub async fn flush(&mut self) {
+        self.entry_writer.flush().await.unwrap()
     }
 
     pub async fn build(mut self, metadata: &GlobalIndex, file_id: u64) -> IndexBlock {
@@ -387,12 +390,12 @@ impl IndexBlockBuilder {
             * (metadata.hash_lower_bits + metadata.seg_id_bits + metadata.row_id_bits) as u64;
         let buckets = std::mem::take(&mut self.buckets);
         for cur_bucket in buckets {
-            self.entry_writer
-                .write(metadata.bucket_bits, cur_bucket)
-                .await
-                .unwrap();
+            let to_flush = self.entry_writer.write(metadata.bucket_bits, cur_bucket);
+            if to_flush {
+                self.entry_writer.flush().await.unwrap();
+            }
         }
-        self.entry_writer.byte_align().await.unwrap();
+        self.entry_writer.byte_align();
         self.entry_writer.flush().await.unwrap();
         drop(self.entry_writer);
         IndexBlock::new(
@@ -502,9 +505,11 @@ impl GlobalIndexBuilder {
         let mut index_block_builder =
             IndexBlockBuilder::new(0, num_buckets + 1, self.directory.clone()).await;
         for entry in iter {
-            index_block_builder
-                .write_entry(entry.0, entry.1, entry.2, &global_index)
-                .await;
+            let to_flush =
+                index_block_builder.write_entry(entry.0, entry.1, entry.2, &global_index);
+            if to_flush {
+                index_block_builder.flush().await;
+            }
         }
         index_blocks.push(index_block_builder.build(&global_index, file_id).await);
         global_index.index_blocks = index_blocks;
@@ -544,9 +549,11 @@ impl GlobalIndexBuilder {
         let mut index_block_builder =
             IndexBlockBuilder::new(0, num_buckets + 1, self.directory.clone()).await;
         while let Some(entry) = iter.next().await {
-            index_block_builder
-                .write_entry(entry.0, entry.1, entry.2, &global_index)
-                .await;
+            let to_flush =
+                index_block_builder.write_entry(entry.0, entry.1, entry.2, &global_index);
+            if to_flush {
+                index_block_builder.flush().await;
+            }
         }
 
         let mut index_blocks = Vec::new();
@@ -627,9 +634,11 @@ impl GlobalIndexBuilder {
                     _ => panic!("Expected DiskFile variant"),
                 };
                 let new_seg_idx = get_seg_idx(new_record_location);
-                index_block_builder
-                    .write_entry(hash, new_seg_idx, new_row_idx, &global_index)
-                    .await;
+                let to_flush =
+                    index_block_builder.write_entry(hash, new_seg_idx, new_row_idx, &global_index);
+                if to_flush {
+                    index_block_builder.flush().await;
+                }
             }
             // The record doesn't exist in compacted data files, which means the corresponding row doesn't exist in the data file after compaction, simply ignore.
         }

--- a/src/moonlink/src/storage/index/persisted_bucket_hash_map.rs
+++ b/src/moonlink/src/storage/index/persisted_bucket_hash_map.rs
@@ -350,7 +350,7 @@ impl IndexBlockBuilder {
         }
     }
 
-    /// Return whether buffer inside of bitwriter is full and could be flushed.
+    /// Append current entry to the index block, and return whether buffer inside of bitwriter is full and should be flushed.
     pub fn write_entry(
         &mut self,
         hash: u64,
@@ -377,7 +377,7 @@ impl IndexBlockBuilder {
         to_flush
     }
 
-    /// Flush the buffer inside of bitwriter.
+    /// Flush buffered entries written to disk.
     pub async fn flush(&mut self) {
         self.entry_writer.flush().await.unwrap()
     }


### PR DESCRIPTION
## Summary

This PR integrate self-implemented async index writer to hash index construction.
Check https://github.com/Mooncake-Labs/moonlink/pull/721 for details.

Tested with pg_mooncake
```sh
--- beginning regression test run ---
PASS setup 25ms
PASS partitioned_table 709ms
PASS sanity 696ms
passed=3, failed=0
```

Performance improvement metrics (checked for 5 times for each metrics):
- Building index block with 250000 index entries, before change: 329ms, after change: 233ms
- Building index block with 1000000 index entries, before change: 1.35s, after change: 955ms 

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/697

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [x] Documentation updated if necessary
- [x] I have reviewed my own changes
