### PR TITLE
[storage] Add invariant check

### DIFF
--- a/src/moonlink/src/storage/iceberg/test_utils.rs
+++ b/src/moonlink/src/storage/iceberg/test_utils.rs
@@ -242,6 +242,7 @@ pub(crate) async fn create_table_and_iceberg_manager_with_data_compaction_config
 
 /// Test util function to block wait a mooncake snapshot and get its result.
 pub(crate) async fn get_mooncake_snapshot_result(
+    table: &mut MooncakeTable,
     notify_rx: &mut Receiver<TableEvent>,
 ) -> (
     u64,
@@ -251,6 +252,7 @@ pub(crate) async fn get_mooncake_snapshot_result(
     Vec<String>,
 ) {
     let notification = notify_rx.recv().await.unwrap();
+    table.mark_mooncake_snapshot_completed();
     match notification {
         TableEvent::MooncakeTableSnapshotResult {
             lsn,
@@ -283,7 +285,7 @@ pub(crate) async fn create_mooncake_snapshot(
     Vec<String>,
 ) {
     assert!(table.create_snapshot(SnapshotOption::default()));
-    get_mooncake_snapshot_result(notify_rx).await
+    get_mooncake_snapshot_result(table, notify_rx).await
 }
 
 /// Test util function to perform an iceberg snapshot, block wait its completion and gets its result.

--- a/src/moonlink/src/storage/iceberg/tests.rs
+++ b/src/moonlink/src/storage/iceberg/tests.rs
@@ -884,7 +884,8 @@ async fn test_skip_iceberg_snapshot() {
         skip_file_indices_merge: false,
         skip_data_file_compaction: false,
     }));
-    let (_, iceberg_snapshot_payload, _, _, _) = get_mooncake_snapshot_result(&mut notify_rx).await;
+    let (_, iceberg_snapshot_payload, _, _, _) =
+        get_mooncake_snapshot_result(&mut table, &mut notify_rx).await;
     assert!(iceberg_snapshot_payload.is_none());
 }
 

--- a/src/moonlink/src/storage/mooncake_table/test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/test_utils.rs
@@ -165,6 +165,7 @@ pub async fn snapshot(
 ) {
     assert!(table.create_snapshot(SnapshotOption::default()));
     let table_notify = notify_rx.recv().await.unwrap();
+    table.mark_mooncake_snapshot_completed();
     match table_notify {
         TableEvent::MooncakeTableSnapshotResult {
             lsn,

--- a/src/moonlink/src/table_handler.rs
+++ b/src/moonlink/src/table_handler.rs
@@ -478,6 +478,9 @@ impl TableHandler {
                             // Spawn a detached best-effort task to delete evicted object storage cache.
                             start_task_to_delete_evicted(evicted_data_files_to_delete);
 
+                            // Mark mooncake snapshot as completed.
+                            table.mark_mooncake_snapshot_completed();
+
                             // Drop table if requested, and table at a clean state.
                             if drop_table_requested && !iceberg_snapshot_ongoing {
                                 drop_table(&mut table, event_sync_sender).await;


### PR DESCRIPTION
## Summary

There're 4 invariants I could think of for snapshot / mooncake table:
- There's at most one mooncake snapshot ongoing
- There's at most one iceberg snapshot ongoing
- Flush only happens after commit, when table is at a clean state
- Flush LSN never regresses

But it's broken leading to weird behavior, I think it's better to check invariants at the first place especially in testing, instead of let it happen in a non-deterministic style in production.
This PR adds corresponding invariant check in the code.

Tested with pg_mooncake regression test
```sh
--- beginning regression test run ---
PASS setup 25ms
PASS partitioned_table 756ms
PASS sanity 728ms
passed=3, failed=0
```
Tested with pg_mooncake sql
```sql
pg_mooncake (pid: 3855) =# CREATE EXTENSION pg_mooncake;
CREATE TABLE r (a int primary key, b text);
CALL mooncake.create_table('c', 'r');
INSERT INTO r SELECT a, 'val_' || a FROM generate_series(1, 100000) AS a;
SELECT count(*) FROM c;
DELETE FROM r WHERE a % 2 = 0;
SELECT count(*) FROM c;
CREATE EXTENSION
CREATE TABLE
CALL
INSERT 0 100000
 count  
--------
 100000
(1 row)

DELETE 50000
 count 
-------
 50000
(1 row)
```

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
