### PR TITLE
[storage] Avoid double buffer at index write

### DIFF
--- a/src/moonlink/src/storage/index/persisted_bucket_hash_map.rs
+++ b/src/moonlink/src/storage/index/persisted_bucket_hash_map.rs
@@ -13,7 +13,6 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::{fmt, vec};
 use tokio::fs::File as AsyncFile;
-use tokio::io::BufWriter as AsyncBufWriter;
 use tokio_bitstream_io::{
     BigEndian as AsyncBigEndian, BitRead as AsyncBitRead, BitReader as AsyncBitReader,
 };
@@ -324,7 +323,7 @@ struct IndexBlockBuilder {
     bucket_end_idx: u32,
     buckets: Vec<u32>,
     file_path: PathBuf,
-    entry_writer: AsyncBitWriter<AsyncBufWriter<AsyncFile>, AsyncBigEndian>,
+    entry_writer: AsyncBitWriter<AsyncFile, AsyncBigEndian>,
     current_bucket: u32,
     current_entry: u32,
 }
@@ -336,8 +335,7 @@ impl IndexBlockBuilder {
         let file_path = directory.join(&file_name);
 
         let file = AsyncFile::create(&file_path).await.unwrap();
-        let buf_writer = AsyncBufWriter::new(file);
-        let entry_writer = AsyncBitWriter::endian(buf_writer, AsyncBigEndian);
+        let entry_writer = AsyncBitWriter::endian(file, AsyncBigEndian);
 
         Self {
             bucket_start_idx,


### PR DESCRIPTION
## Summary

We're now double buffer at index write, one for buffered writer, another within async index writer.
Quoted from doc: https://docs.rs/tokio/latest/tokio/io/struct.BufWriter.html
```
It does not help when writing very large amounts at once, or writing just one or a few times.
```
so basically it's adding potential copies and memory consumption.

After this change, I didn't spot performance change.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/727

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
