### PR TITLE
Fix warning

### DIFF
--- a/src/moonlink_connectors/src/pg_replicate/clients/postgres.rs
+++ b/src/moonlink_connectors/src/pg_replicate/clients/postgres.rs
@@ -81,8 +81,12 @@ impl ReplicationClient {
 
     /// Starts a read-only trasaction with repeatable read isolation level
     pub async fn begin_readonly_transaction(&mut self) -> Result<(), ReplicationClientError> {
+        // First, ensure any existing transaction is properly rolled back
+        self.rollback_txn().await?;
+
+        // Now start the new read-only transaction
         self.postgres_client
-            .simple_query("abort; begin read only isolation level repeatable read;")
+            .simple_query("begin read only isolation level repeatable read;")
             .await?;
         self.in_txn = true;
         Ok(())

--- a/src/moonlink_connectors/src/replication_manager.rs
+++ b/src/moonlink_connectors/src/replication_manager.rs
@@ -5,7 +5,7 @@ use moonlink::{MoonlinkTableConfig, ObjectStorageCache, ReadStateManager, TableE
 use std::collections::HashMap;
 use std::hash::Hash;
 use tokio::task::JoinHandle;
-use tracing::{debug, warn};
+use tracing::debug;
 
 /// Manage replication sources keyed by their connection URI.
 ///

--- a/src/moonlink_connectors/src/replication_manager.rs
+++ b/src/moonlink_connectors/src/replication_manager.rs
@@ -102,7 +102,7 @@ impl<T: Clone + Eq + Hash + std::fmt::Display> ReplicationManager<T> {
         let (table_uri, src_table_id) = match self.table_info.get(&mooncake_table_id) {
             Some(info) => info.clone(),
             None => {
-                warn!("attempted to drop table that is not tracked by moonlink - table may already be dropped");
+                debug!("attempted to drop table that is not tracked by moonlink - table may already be dropped");
                 return Ok(false);
             }
         };


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

On some postgres operations the log would output `WARN: No transaction in progress`. In order to remove this we should first call `rollback txn` rather than `abort`.

Also changes a `warn!` to `debug!` given it occurs quite frequently and is benign. 

## Related Issues

Small follow up to https://github.com/Mooncake-Labs/moonlink/issues/660

## Changes

- rollback txn first
- change warn to debug
- 

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
