### PR TITLE
[storage] Reflect iceberg persistence result into snapshot

### DIFF
--- a/src/moonlink/src/storage/iceberg/compaction_tests.rs
+++ b/src/moonlink/src/storage/iceberg/compaction_tests.rs
@@ -413,6 +413,14 @@ async fn test_compaction_1_1_2() {
         "Deleted rows are {:?}",
         deleted_rows
     );
+    // Check data files and file indices in mooncake table snapshot is the same as iceberg persisted ones.
+    let actual_file_indices = get_file_indices_for_table(&table).await;
+    check_snapshot_reflects_persistence_for_compaction(
+        &snapshot,
+        compacted_data_file,
+        actual_file_indices,
+    )
+    .await;
 
     // Check deletion log for the current mooncake snapshot.
     let (committed_deletion_log, uncommitted_deletion_log) =
@@ -490,6 +498,14 @@ async fn test_compaction_1_2_1() {
         "Deleted rows are {:?}",
         deleted_rows
     );
+    // Check data files and file indices in mooncake table snapshot is the same as iceberg persisted ones.
+    let actual_file_indices = get_file_indices_for_table(&table).await;
+    check_snapshot_reflects_persistence_for_compaction(
+        &snapshot,
+        compacted_data_file,
+        actual_file_indices,
+    )
+    .await;
 
     // Check deletion log for the current mooncake snapshot.
     let (committed_deletion_log, uncommitted_deletion_log) =
@@ -567,6 +583,14 @@ async fn test_compaction_1_2_2() {
         "Deleted rows are {:?}",
         deleted_rows
     );
+    // Check data files and file indices in mooncake table snapshot is the same as iceberg persisted ones.
+    let actual_file_indices = get_file_indices_for_table(&table).await;
+    check_snapshot_reflects_persistence_for_compaction(
+        &snapshot,
+        compacted_data_file,
+        actual_file_indices,
+    )
+    .await;
 
     // Check deletion log for the current mooncake snapshot.
     let (committed_deletion_log, uncommitted_deletion_log) =
@@ -656,6 +680,14 @@ async fn test_compaction_2_2_1() {
         "Deleted rows are {:?}",
         deleted_rows
     );
+    // Check data files and file indices in mooncake table snapshot is the same as iceberg persisted ones.
+    let actual_file_indices = get_file_indices_for_table(&table).await;
+    check_snapshot_reflects_persistence_for_compaction(
+        &snapshot,
+        compacted_data_file,
+        actual_file_indices,
+    )
+    .await;
 
     // Check deletion log for the current mooncake snapshot.
     let (committed_deletion_log, uncommitted_deletion_log) =
@@ -735,6 +767,14 @@ async fn test_compaction_2_2_2() {
         "Deleted rows are {:?}",
         deleted_rows
     );
+    // Check data files and file indices in mooncake table snapshot is the same as iceberg persisted ones.
+    let actual_file_indices = get_file_indices_for_table(&table).await;
+    check_snapshot_reflects_persistence_for_compaction(
+        &snapshot,
+        compacted_data_file,
+        actual_file_indices,
+    )
+    .await;
 
     // Check deletion log for the current mooncake snapshot.
     let (committed_deletion_log, uncommitted_deletion_log) =
@@ -817,9 +857,13 @@ async fn test_compaction_2_3_1() {
     // Check disk files for the current mooncake snapshot.
     let disk_files = get_disk_files_for_table(&table).await;
     assert_eq!(disk_files.len(), 1);
-    let (_, disk_file_entry) = disk_files.iter().next().unwrap();
+    let (data_file, disk_file_entry) = disk_files.iter().next().unwrap();
     assert!(disk_file_entry.puffin_deletion_blob.is_none());
     assert!(disk_file_entry.batch_deletion_vector.is_empty());
+    // Check data files and file indices in mooncake table snapshot is the same as iceberg persisted ones.
+    let actual_file_indices = get_file_indices_for_table(&table).await;
+    check_snapshot_reflects_persistence_for_compaction(&snapshot, data_file, actual_file_indices)
+        .await;
 
     // Check deletion log for current snapshot.
     let (committed_deletion_log, uncommitted_deletion_log) =
@@ -893,6 +937,14 @@ async fn test_compaction_2_3_2() {
         .map(|idx| *idx as usize)
         .collect();
     assert_eq!(committed_compacted_row_indice.len(), 1);
+    // Check data files and file indices in mooncake table snapshot is the same as iceberg persisted ones.
+    let actual_file_indices = get_file_indices_for_table(&table).await;
+    check_snapshot_reflects_persistence_for_compaction(
+        &snapshot,
+        compacted_data_file,
+        actual_file_indices,
+    )
+    .await;
     // Check referenced deleted arrow batches.
     let committed_deleted_arrow_batches = get_arrow_batches_with_row_idx(
         compacted_data_file.file_path(),
@@ -981,6 +1033,15 @@ async fn test_compaction_3_2_1() {
     assert!(disk_file_entry.puffin_deletion_blob.is_none());
     let deleted_rows = disk_file_entry.batch_deletion_vector.collect_deleted_rows();
     assert_eq!(deleted_rows, vec![0, 1, 2, 3]);
+
+    // Check data files and file indices in mooncake table snapshot is the same as iceberg persisted ones.
+    let actual_file_indices = get_file_indices_for_table(&table).await;
+    check_snapshot_reflects_persistence_for_compaction(
+        &snapshot,
+        compacted_data_file,
+        actual_file_indices,
+    )
+    .await;
 
     // Check deletion log for the current mooncake snapshot.
     let (committed_deletion_log, uncommitted_deletion_log) =

--- a/src/moonlink/src/storage/iceberg/index.rs
+++ b/src/moonlink/src/storage/iceberg/index.rs
@@ -27,7 +27,7 @@ pub(crate) struct IndexBlock {
     bucket_start_idx: u32,
     bucket_end_idx: u32,
     bucket_start_offset: u64,
-    filepath: String,
+    pub(crate) filepath: String,
 }
 
 /// Corresponds to [storage::index::FileIndex], used to persist at iceberg table.

--- a/src/moonlink/src/storage/mooncake_table/data_file_state_tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/data_file_state_tests.rs
@@ -1611,7 +1611,7 @@ async fn test_2_read_over_1_with_local_optimization(#[case] use_batch_write: boo
     drop(read_state);
 
     // Check data file has been recorded in mooncake table.
-    let disk_files = get_disk_files_for_snapshot(&table).await;
+    let disk_files = get_disk_files_for_table(&table).await;
     assert_eq!(disk_files.len(), 1);
     let (file, disk_file_entry) = disk_files.iter().next().unwrap();
     assert!(disk_file_entry.cache_handle.is_none());
@@ -1688,7 +1688,7 @@ async fn test_3_compact_3_5_without_local_filesystem_optimization() {
     assert!(files_to_delete.is_empty());
 
     // Get old compacted files before compaction.
-    let disk_files = get_disk_files_for_snapshot(&table).await;
+    let disk_files = get_disk_files_for_table(&table).await;
     assert_eq!(disk_files.len(), 2);
     let old_compacted_data_files = disk_files.keys().cloned().collect::<Vec<_>>();
     let old_compacted_index_block_files = get_index_block_filepaths(&table).await;
@@ -1807,7 +1807,7 @@ async fn test_3_compact_3_5_with_local_filesystem_optimization() {
     let local_index_blocks = get_index_block_filepaths(&table).await;
 
     // Get old compacted files before compaction.
-    let disk_files = get_disk_files_for_snapshot(&table).await;
+    let disk_files = get_disk_files_for_table(&table).await;
     assert_eq!(disk_files.len(), 2);
     let old_compacted_data_files = disk_files.keys().cloned().collect::<Vec<_>>();
     let old_compacted_index_block_file_ids = get_index_block_file_ids(&table).await;
@@ -1921,7 +1921,7 @@ async fn test_3_compact_1_5_without_local_filesystem_optimization() {
     assert!(files_to_delete.is_empty());
 
     // Get old compacted files before compaction.
-    let disk_files = get_disk_files_for_snapshot(&table).await;
+    let disk_files = get_disk_files_for_table(&table).await;
     assert_eq!(disk_files.len(), 2);
     let mut old_compacted_data_files = disk_files
         .keys()
@@ -2013,7 +2013,7 @@ async fn test_3_compact_1_5_with_local_filesystem_optimization() {
     assert!(files_to_delete.is_empty());
 
     // Get old compacted files before compaction.
-    let disk_files = get_disk_files_for_snapshot(&table).await;
+    let disk_files = get_disk_files_for_table(&table).await;
     assert_eq!(disk_files.len(), 2);
     let old_compacted_data_files = disk_files
         .keys()
@@ -2104,7 +2104,7 @@ async fn test_1_compact_1_5_without_local_optimization() {
     assert!(files_to_delete.is_empty());
 
     // Get old compacted files before compaction.
-    let _ = get_disk_files_for_snapshot_and_assert(&table, /*expected_file_num=*/ 2).await;
+    let _ = get_disk_files_for_table_and_assert(&table, /*expected_file_num=*/ 2).await;
 
     // Persist and reflect result to mooncake snapshot.
     create_mooncake_and_persist_for_test(&mut table, &mut table_notify).await;

--- a/src/moonlink/src/storage/mooncake_table/deletion_vector_puffin_state_tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/deletion_vector_puffin_state_tests.rs
@@ -466,7 +466,7 @@ async fn test_2_compact_without_local_optimization() {
     assert!(files_to_delete.is_empty());
 
     // Get old snapshot disk files.
-    let disk_files = get_disk_files_for_snapshot(&table).await;
+    let disk_files = get_disk_files_for_table(&table).await;
     assert_eq!(disk_files.len(), 2);
     let mut old_compacted_puffin_file_ids = vec![];
     let mut old_compacted_puffin_files = vec![];
@@ -525,7 +525,7 @@ async fn test_2_compact_without_local_optimization() {
     assert!(evicted_files.contains(&old_compacted_index_block_files[1]));
 
     // Check data file has been pinned in mooncake table.
-    let disk_files = get_disk_files_for_snapshot(&table).await;
+    let disk_files = get_disk_files_for_table(&table).await;
     assert!(disk_files.is_empty());
 
     // Check cache state.
@@ -554,7 +554,7 @@ async fn test_2_compact_with_local_optimization() {
     assert_eq!(files_to_delete, local_data_files_and_index_blocks);
 
     // Get old snapshot disk files.
-    let disk_files = get_disk_files_for_snapshot(&table).await;
+    let disk_files = get_disk_files_for_table(&table).await;
     assert_eq!(disk_files.len(), 2);
     let mut old_compacted_puffin_file_ids = vec![];
     let mut old_compacted_puffin_files = vec![];
@@ -608,7 +608,7 @@ async fn test_2_compact_with_local_optimization() {
     assert!(evicted_files.is_empty());
 
     // Check data file has been pinned in mooncake table.
-    let disk_files = get_disk_files_for_snapshot(&table).await;
+    let disk_files = get_disk_files_for_table(&table).await;
     assert!(disk_files.is_empty());
 
     // Check cache state.

--- a/src/moonlink/src/storage/mooncake_table/file_index_state_tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/file_index_state_tests.rs
@@ -275,7 +275,7 @@ async fn test_3_index_merge() {
     let index_merge_payload = index_merge_payload.unwrap();
 
     // Get data files and old merged index block files.
-    let disk_files = get_disk_files_for_snapshot(&table).await;
+    let disk_files = get_disk_files_for_table(&table).await;
     assert_eq!(disk_files.len(), 2);
     let mut old_compacted_index_block_files = get_index_block_filepaths(&table).await;
     assert_eq!(old_compacted_index_block_files.len(), 2);

--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -415,13 +415,13 @@ impl SnapshotTableState {
             .await;
         evicted_files_to_delete.extend(cur_evicted_files);
 
-        // Step-2: Handle imported file indices.
+        // Step-2: Handle persisted file indices.
         let cur_evicted_files = self
             .update_file_indices_to_persisted(persisted_file_indices, updated_file_ids)
             .await;
         evicted_files_to_delete.extend(cur_evicted_files);
 
-        // Step-3: Handle imported deletion vector.
+        // Step-3: Handle persisted deletion vector.
         let cur_evicted_files = self
             .update_deletion_vector_to_persisted(
                 task.iceberg_persisted_records

--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -368,6 +368,8 @@ impl SnapshotTableState {
     /// also import local write through cache to globally managed object storage cache, so they could be pinned and evicted when necessary.
     ///
     /// Return evicted data files to delete when unreference existing disk file entries.
+    ///
+    /// TODO(hjiang): Update current snapshot for index merge results.
     async fn update_current_snapshot_with_iceberg_snapshot(
         &mut self,
         task: &SnapshotTask,

--- a/src/moonlink/src/storage/mooncake_table/table_accessor_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_accessor_test_utils.rs
@@ -277,9 +277,7 @@ pub(crate) fn get_index_block_files(
 }
 
 /// Test util function to get index block filepath from file indices, and assert there's only one index block file within it.
-pub(crate) fn get_only_index_block_file_from_file_indices(
-    file_indices: &Vec<GlobalIndex>,
-) -> String {
+pub(crate) fn get_only_index_block_file_from_file_indices(file_indices: &[GlobalIndex]) -> String {
     assert_eq!(file_indices.len(), 1);
     let index_blocks = file_indices[0].index_blocks.clone();
     assert_eq!(index_blocks.len(), 1);

--- a/src/moonlink/src/storage/mooncake_table/table_accessor_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_accessor_test_utils.rs
@@ -4,21 +4,28 @@ use std::collections::HashMap;
 use tempfile::TempDir;
 
 use crate::storage::index::persisted_bucket_hash_map::GlobalIndex;
+use crate::storage::index::FileIndex;
 use crate::storage::mooncake_table::test_utils_commons::*;
 use crate::storage::mooncake_table::{DiskFileEntry, Snapshot};
 use crate::storage::storage_utils::{FileId, MooncakeDataFileRef, ProcessedDeletionRecord};
 use crate::storage::{MooncakeTable, PuffinBlobRef};
 
 /// Test util function to get disk files for the given mooncake table.
-pub(crate) async fn get_disk_files_for_snapshot(
+pub(crate) async fn get_disk_files_for_table(
     table: &MooncakeTable,
 ) -> HashMap<MooncakeDataFileRef, DiskFileEntry> {
     let guard = table.snapshot.read().await;
     guard.current_snapshot.disk_files.clone()
 }
 
+/// Test util function to get file indices for the given mooncake table.
+pub(crate) async fn get_file_indices_for_table(table: &MooncakeTable) -> Vec<FileIndex> {
+    let guard = table.snapshot.read().await;
+    guard.current_snapshot.indices.file_indices.clone()
+}
+
 /// Test util function to get sorted data file filepaths for the given mooncake table, and assert on expected disk file number.
-pub(crate) async fn get_disk_files_for_snapshot_and_assert(
+pub(crate) async fn get_disk_files_for_table_and_assert(
     table: &MooncakeTable,
     expected_file_num: usize,
 ) -> Vec<String> {
@@ -32,6 +39,26 @@ pub(crate) async fn get_disk_files_for_snapshot_and_assert(
         .sorted()
         .collect::<Vec<_>>();
     data_files
+}
+
+/// Test util function to get disk files for the given snapshot.
+pub(crate) async fn get_disk_files_for_snapshot_and_assert(
+    snapshot: &Snapshot,
+    expected_file_num: usize,
+) -> Vec<String> {
+    assert_eq!(snapshot.disk_files.len(), expected_file_num);
+    let data_files = snapshot
+        .disk_files
+        .keys()
+        .map(|f| f.file_path().to_string())
+        .sorted()
+        .collect::<Vec<_>>();
+    data_files
+}
+
+/// Test util function to get file indices for the given snapshot
+pub(crate) fn get_file_indices_for_snapshot(snapshot: &Snapshot) -> Vec<FileIndex> {
+    snapshot.indices.file_indices.clone()
 }
 
 /// Test util to get all index block file ids for the table, and assert there's only one file.
@@ -225,7 +252,7 @@ pub(crate) async fn get_new_compacted_local_file_size_and_id(
     table: &MooncakeTable,
     temp_dir: &TempDir,
 ) -> (usize, FileId) {
-    let disk_files = get_disk_files_for_snapshot(table).await;
+    let disk_files = get_disk_files_for_table(table).await;
     assert_eq!(disk_files.len(), 1);
     let (new_compacted_file, disk_file_entry) = disk_files.iter().next().unwrap();
     assert!(disk_file_entry.cache_handle.is_some());
@@ -247,4 +274,14 @@ pub(crate) fn get_index_block_files(
         }
     }
     (index_block_files, overall_file_size)
+}
+
+/// Test util function to get index block filepath from file indices, and assert there's only one index block file within it.
+pub(crate) fn get_only_index_block_file_from_file_indices(
+    file_indices: &Vec<GlobalIndex>,
+) -> String {
+    assert_eq!(file_indices.len(), 1);
+    let index_blocks = file_indices[0].index_blocks.clone();
+    assert_eq!(index_blocks.len(), 1);
+    index_blocks[0].index_file.file_path().to_string()
 }


### PR DESCRIPTION
## Summary

This PR is a bug fix, that current implementation doesn't reflect iceberg persistence to mooncake snapshot.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/739

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
