### PR TITLE
[storage] Fix sanity check for force snapshot

### DIFF
--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -1016,7 +1016,18 @@ impl SnapshotTableState {
                 }
 
                 // Invariant-2: flush must follow a commit, but commit doesn't need to be followed by a flush.
-                ma::assert_ge!(task.new_commit_lsn, new_flush_lsn);
+                //
+                // Force snapshot could flush as long as the table at a clean state (aka, no uncommitted states), possible to go without commit at current snapshot iteration.
+                if opt.force_create {
+                    assert!(
+                        task.new_commit_lsn == 0 || task.new_commit_lsn >= new_flush_lsn,
+                        "New commit LSN is {}, new flush LSN is {}",
+                        task.new_commit_lsn,
+                        new_flush_lsn
+                    );
+                } else {
+                    ma::assert_ge!(task.new_commit_lsn, new_flush_lsn);
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

See inline comments, it's possible to flush with latest commit LSN when table clean.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/744

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [x] Documentation updated if necessary
- [x] I have reviewed my own changes
