### PR TITLE
Revert "[postgres] Buffer replication messages when missing table schema"

### DIFF
--- a/src/moonlink_connectors/src/pg_replicate/conversions/cdc_event.rs
+++ b/src/moonlink_connectors/src/pg_replicate/conversions/cdc_event.rs
@@ -114,32 +114,6 @@ impl CdcEventConverter {
         Ok(CdcEvent::Delete((src_table_id, row, delete_body.xid())))
     }
 
-    /// Attempt to get table id from the given replication message.
-    pub fn try_get_table_id(
-        value: &ReplicationMessage<LogicalReplicationMessage>,
-    ) -> Option<SrcTableId> {
-        match value {
-            ReplicationMessage::XLogData(xlog_data) => match xlog_data.data() {
-                LogicalReplicationMessage::Insert(insert_body) => Some(insert_body.rel_id()),
-                LogicalReplicationMessage::Update(update_body) => Some(update_body.rel_id()),
-                LogicalReplicationMessage::Delete(delete_body) => Some(delete_body.rel_id()),
-                _ => None,
-            },
-            _ => None,
-        }
-    }
-
-    /// Get column schemas for the requested table from table schemas.
-    fn get_column_schemas(
-        table_id: SrcTableId,
-        table_schemas: &HashMap<SrcTableId, TableSchema>,
-    ) -> Result<&Vec<ColumnSchema>, CdcEventConversionError> {
-        Ok(&table_schemas
-            .get(&table_id)
-            .ok_or(CdcEventConversionError::MissingSchema(table_id))?
-            .column_schemas)
-    }
-
     pub fn try_from(
         value: ReplicationMessage<LogicalReplicationMessage>,
         table_schemas: &HashMap<SrcTableId, TableSchema>,
@@ -157,7 +131,10 @@ impl CdcEventConverter {
                 LogicalReplicationMessage::Type(type_body) => Ok(CdcEvent::Type(type_body)),
                 LogicalReplicationMessage::Insert(insert_body) => {
                     let table_id = insert_body.rel_id();
-                    let column_schemas = Self::get_column_schemas(table_id, table_schemas)?;
+                    let column_schemas = &table_schemas
+                        .get(&table_id)
+                        .ok_or(CdcEventConversionError::MissingSchema(table_id))?
+                        .column_schemas;
                     Ok(Self::try_from_insert_body(
                         table_id,
                         column_schemas,
@@ -166,7 +143,10 @@ impl CdcEventConverter {
                 }
                 LogicalReplicationMessage::Update(update_body) => {
                     let table_id = update_body.rel_id();
-                    let column_schemas = Self::get_column_schemas(table_id, table_schemas)?;
+                    let column_schemas = &table_schemas
+                        .get(&table_id)
+                        .ok_or(CdcEventConversionError::MissingSchema(table_id))?
+                        .column_schemas;
                     Ok(Self::try_from_update_body(
                         table_id,
                         column_schemas,
@@ -175,7 +155,10 @@ impl CdcEventConverter {
                 }
                 LogicalReplicationMessage::Delete(delete_body) => {
                     let table_id = delete_body.rel_id();
-                    let column_schemas = Self::get_column_schemas(table_id, table_schemas)?;
+                    let column_schemas = &table_schemas
+                        .get(&table_id)
+                        .ok_or(CdcEventConversionError::MissingSchema(table_id))?
+                        .column_schemas;
                     Ok(Self::try_from_delete_body(
                         table_id,
                         column_schemas,

--- a/src/moonlink_connectors/src/pg_replicate/postgres_source.rs
+++ b/src/moonlink_connectors/src/pg_replicate/postgres_source.rs
@@ -8,7 +8,6 @@ use std::{
 use futures::{ready, Stream};
 use pin_project_lite::pin_project;
 use postgres_replication::LogicalReplicationStream;
-use std::collections::VecDeque;
 use thiserror::Error;
 use tokio_postgres::{tls::NoTlsStream, types::PgLsn, Connection, CopyOutStream, Socket};
 use tracing::{debug, error, info_span, warn, Instrument};
@@ -19,9 +18,8 @@ use crate::pg_replicate::{
         cdc_event::{CdcEvent, CdcEventConversionError, CdcEventConverter},
         table_row::{TableRow, TableRowConversionError, TableRowConverter},
     },
-    table::{self, ColumnSchema, SrcTableId, TableName, TableSchema},
+    table::{ColumnSchema, SrcTableId, TableName, TableSchema},
 };
-use postgres_replication::protocol::{LogicalReplicationMessage, ReplicationMessage};
 
 pub enum TableNamesFrom {
     Vec(Vec<TableName>),
@@ -249,8 +247,6 @@ impl PostgresSource {
             stream,
             table_schemas: config.table_schemas,
             postgres_epoch,
-            unprocessed_replication_messages: HashMap::new(),
-            ready_cdc_events: VecDeque::new(),
         })
     }
 }
@@ -312,15 +308,6 @@ pin_project! {
         stream: LogicalReplicationStream,
         table_schemas: HashMap<SrcTableId, TableSchema>,
         postgres_epoch: SystemTime,
-
-        // Buffered unprocessed messages due to missing table schema.
-        unprocessed_replication_messages: HashMap<SrcTableId, Vec<ReplicationMessage<LogicalReplicationMessage>>>,
-        // Buffered process messages due to missing table schema, which are ready to emit.
-        //
-        // cdc events ordering guarantee:
-        // - Within each table, results are stored in the order of postgres cdc replication messages.
-        // - Across different tables, cdc events could be reordered.
-        ready_cdc_events: VecDeque<Result<CdcEvent, CdcEventConversionError>>,
     }
 }
 
@@ -350,20 +337,7 @@ impl CdcStream {
 
     pub fn add_table_schema(self: Pin<&mut Self>, schema: TableSchema) {
         let this = self.project();
-        let cur_table_id = schema.src_table_id;
-        this.table_schemas.insert(cur_table_id, schema);
-
-        // Check unprocessed replication messages due to missing table schema.
-        if let Some(unprocessed_messages) =
-            this.unprocessed_replication_messages.remove(&cur_table_id)
-        {
-            let new_len = this.ready_cdc_events.len() + unprocessed_messages.len();
-            this.ready_cdc_events.reserve(new_len);
-            for cur_msg in unprocessed_messages.into_iter() {
-                let res = CdcEventConverter::try_from(cur_msg, &this.table_schemas);
-                this.ready_cdc_events.push_back(res);
-            }
-        }
+        this.table_schemas.insert(schema.src_table_id, schema);
     }
 
     pub fn remove_table_schema(self: Pin<&mut Self>, src_table_id: SrcTableId) {
@@ -375,42 +349,13 @@ impl CdcStream {
 impl Stream for CdcStream {
     type Item = Result<CdcEvent, CdcStreamError>;
 
-    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
-        let this = self.as_mut().project();
-
-        // Emit already processed messages before processing new-coming ones to guarantee replication ordering.
-        if !this.ready_cdc_events.is_empty() {
-            let cur_cdc_event = this.ready_cdc_events.pop_front().unwrap();
-            match cur_cdc_event {
-                Ok(row) => {
-                    return Poll::Ready(Some(Ok(row)));
-                }
-                Err(e) => {
-                    return Poll::Ready(Some(Err(e.into())));
-                }
-            }
-        }
-
+    fn poll_next(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let this = self.project();
         match ready!(this.stream.poll_next(cx)) {
-            Some(Ok(msg)) => {
-                // On recovery, it's non-deterministic on the order of setting table schema and resending cdc stream, which is prune to suffer missing schema error.
-                // Here we buffer unfound schema, which will gets populated when schema is set.
-                let table_id = CdcEventConverter::try_get_table_id(&msg);
-                if let Some(table_id) = table_id {
-                    if !this.table_schemas.contains_key(&table_id) {
-                        this.unprocessed_replication_messages
-                            .entry(table_id)
-                            .or_default()
-                            .push(msg);
-                        return Poll::Pending;
-                    }
-                }
-
-                match CdcEventConverter::try_from(msg, &this.table_schemas) {
-                    Ok(row) => Poll::Ready(Some(Ok(row))),
-                    Err(e) => Poll::Ready(Some(Err(e.into()))),
-                }
-            }
+            Some(Ok(msg)) => match CdcEventConverter::try_from(msg, &this.table_schemas) {
+                Ok(row) => Poll::Ready(Some(Ok(row))),
+                Err(e) => Poll::Ready(Some(Err(e.into()))),
+            },
             Some(Err(e)) => Poll::Ready(Some(Err(e.into()))),
             None => Poll::Ready(None),
         }


### PR DESCRIPTION
Reverts Mooncake-Labs/moonlink#696

Instead of buffering if missing schema, we can deterministically ensure schema is added before replication started. 