### PR TITLE
Deterministically add schemas before starting replication

### DIFF
--- a/src/moonlink/src/table_handler.rs
+++ b/src/moonlink/src/table_handler.rs
@@ -254,7 +254,7 @@ impl TableHandler {
                             }
 
                             // General non-streaming append.
-                            if !table.is_in_initial_copy() && xact_id.is_none() {
+                            if !table.is_in_initial_copy() && xact_id.is_none() && !is_copied {
                                 if let Err(e) = table.append(row) {
                                     warn!(error = %e, "failed to append row");
                                 }

--- a/src/moonlink_backend/src/lib.rs
+++ b/src/moonlink_backend/src/lib.rs
@@ -91,8 +91,8 @@ where
         let table_id = mooncake_table_id.get_table_id_value();
 
         // Add mooncake table to replication, and create corresponding mooncake table.
+        let mut manager = self.replication_manager.write().await;
         let moonlink_table_config = {
-            let mut manager = self.replication_manager.write().await;
             manager
                 .add_table(
                     &src_uri,
@@ -103,6 +103,7 @@ where
                 )
                 .await?
         };
+        manager.start_replication(&src_uri).await?;
 
         // Create metadata store entry.
         {

--- a/src/moonlink_connectors/src/replication_manager.rs
+++ b/src/moonlink_connectors/src/replication_manager.rs
@@ -75,10 +75,6 @@ impl<T: Clone + Eq + Hash + std::fmt::Display> ReplicationManager<T> {
         }
         let replication_connection = self.connections.get_mut(src_uri).unwrap();
 
-        if !replication_connection.replication_started() {
-            replication_connection.start_replication().await?;
-        }
-
         let (src_table_id, moonlink_table_config) = replication_connection
             .add_table(
                 table_name,
@@ -93,6 +89,16 @@ impl<T: Clone + Eq + Hash + std::fmt::Display> ReplicationManager<T> {
         debug!(src_table_id, "table added through manager");
 
         Ok(moonlink_table_config)
+    }
+
+    pub async fn start_replication(&mut self, src_uri: &str) -> Result<()> {
+        assert!(self.connections.contains_key(src_uri));
+
+        let connection = self.connections.get_mut(src_uri).unwrap();
+        if !connection.replication_started() {
+            connection.start_replication().await?;
+        }
+        Ok(())
     }
 
     /// Drop table specified by the given table id.


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

When recovering a table it's currently possible to receive CDC events before the table is configured on the moonlink side. Instead of buffering events until moonlink catches up, we can stall replication until all tables are configured. 

We do this by first calling `add_table` for each of the tables we want to add or recover. We keep track of each `src_uri` and once table addition is complete we start the replication for each connection. 

## Related Issues

Closes #<issue-number> or links to related issues.

## Changes

- 
- 
- 

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
