### PR TITLE
[storage] Filesystem accessor support copy

### DIFF
--- a/src/moonlink/benches/bench_write.rs
+++ b/src/moonlink/benches/bench_write.rs
@@ -1,9 +1,13 @@
 use arrow::datatypes::{DataType, Field, Schema};
 use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
 use moonlink::row::{IdentityProp, MoonlinkRow, RowValue};
-use moonlink::{IcebergTableConfig, MooncakeTable, MooncakeTableConfig, ObjectStorageCache};
+use moonlink::{
+    FileSystemAccessor, FileSystemConfig, IcebergTableConfig, MooncakeTable, MooncakeTableConfig,
+    ObjectStorageCache,
+};
 use pprof::criterion::{Output, PProfProfiler};
 use std::collections::HashMap;
+use std::sync::Arc;
 use tempfile::tempdir;
 use tokio::runtime::Runtime;
 
@@ -51,7 +55,7 @@ fn bench_write(c: &mut Criterion) {
                 let temp_warehouse_dir = tempdir().unwrap();
                 let temp_warehouse_uri = temp_warehouse_dir.path().to_str().unwrap().to_string();
                 let iceberg_table_config = IcebergTableConfig {
-                    warehouse_uri: temp_warehouse_uri,
+                    warehouse_uri: temp_warehouse_uri.clone(),
                     ..Default::default()
                 };
                 let table_config =
@@ -65,6 +69,10 @@ fn bench_write(c: &mut Criterion) {
                     iceberg_table_config,
                     table_config,
                     ObjectStorageCache::default_for_bench(),
+                    Arc::new(FileSystemAccessor::new(
+                        FileSystemConfig::FileSystem,
+                        temp_warehouse_uri.clone(),
+                    )),
                 )
                 .await
                 .unwrap();
@@ -86,7 +94,7 @@ fn bench_write(c: &mut Criterion) {
                 let temp_warehouse_dir = tempdir().unwrap();
                 let temp_warehouse_uri = temp_warehouse_dir.path().to_str().unwrap().to_string();
                 let iceberg_table_config = IcebergTableConfig {
-                    warehouse_uri: temp_warehouse_uri,
+                    warehouse_uri: temp_warehouse_uri.clone(),
                     ..Default::default()
                 };
                 let table_config =
@@ -100,6 +108,10 @@ fn bench_write(c: &mut Criterion) {
                     iceberg_table_config,
                     table_config,
                     ObjectStorageCache::default_for_bench(),
+                    Arc::new(FileSystemAccessor::new(
+                        FileSystemConfig::FileSystem,
+                        temp_warehouse_uri.clone(),
+                    )),
                 )
                 .await
                 .unwrap();
@@ -124,7 +136,7 @@ fn bench_write(c: &mut Criterion) {
                 let temp_warehouse_dir = tempdir().unwrap();
                 let temp_warehouse_uri = temp_warehouse_dir.path().to_str().unwrap().to_string();
                 let iceberg_table_config = IcebergTableConfig {
-                    warehouse_uri: temp_warehouse_uri,
+                    warehouse_uri: temp_warehouse_uri.clone(),
                     ..Default::default()
                 };
                 let table_config =
@@ -139,6 +151,10 @@ fn bench_write(c: &mut Criterion) {
                         iceberg_table_config,
                         table_config,
                         ObjectStorageCache::default_for_bench(),
+                        Arc::new(FileSystemAccessor::new(
+                            FileSystemConfig::FileSystem,
+                            temp_warehouse_uri.clone(),
+                        )),
                     ))
                     .unwrap();
                 rt.block_on(async {

--- a/src/moonlink/src/lib.rs
+++ b/src/moonlink/src/lib.rs
@@ -13,7 +13,9 @@ pub use storage::{
     EventSyncReceiver, FileSystemConfig, IcebergTableConfig, IcebergTableManager, MooncakeTable,
     MooncakeTableConfig, TableEventManager, TableManager,
 };
-pub use storage::{MoonlinkTableConfig, ObjectStorageCache, ObjectStorageCacheConfig};
+pub use storage::{
+    FileSystemAccessor, MoonlinkTableConfig, ObjectStorageCache, ObjectStorageCacheConfig,
+};
 pub use table_handler::{EventSyncSender, TableHandler};
 pub use table_notify::TableEvent;
 pub use union_read::{ReadState, ReadStateManager};

--- a/src/moonlink/src/storage.rs
+++ b/src/moonlink/src/storage.rs
@@ -13,6 +13,7 @@ pub(crate) mod storage_utils;
 pub use cache::object_storage::cache_config::ObjectStorageCacheConfig;
 pub(crate) use cache::object_storage::cache_handle::NonEvictableHandle;
 pub use cache::object_storage::object_storage_cache::ObjectStorageCache;
+pub use filesystem::accessor::filesystem_accessor::FileSystemAccessor;
 pub use filesystem::filesystem_config::FileSystemConfig;
 pub use iceberg::iceberg_table_manager::{IcebergTableConfig, IcebergTableManager};
 pub use iceberg::table_event_manager::{EventSyncReceiver, TableEventManager};

--- a/src/moonlink/src/storage/filesystem/accessor.rs
+++ b/src/moonlink/src/storage/filesystem/accessor.rs
@@ -1,3 +1,6 @@
 pub(crate) mod base_filesystem_accessor;
 pub(crate) mod configs;
 pub(crate) mod filesystem_accessor;
+
+#[cfg(test)]
+pub(crate) mod test_utils;

--- a/src/moonlink/src/storage/filesystem/accessor/base_filesystem_accessor.rs
+++ b/src/moonlink/src/storage/filesystem/accessor/base_filesystem_accessor.rs
@@ -1,4 +1,4 @@
-/// This module defines the interface for object storage accessor.
+/// This module defines the interface for filesystem accessor.
 use crate::Result;
 
 use async_trait::async_trait;
@@ -8,7 +8,7 @@ use mockall::*;
 
 #[async_trait]
 #[cfg_attr(test, automock)]
-pub trait BaseObjectStorageAccess: std::fmt::Debug + Send + Sync {
+pub trait BaseFileSystemAccess: std::fmt::Debug + Send + Sync {
     /// ===============================
     /// Directory operations
     /// ===============================

--- a/src/moonlink/src/storage/filesystem/accessor/base_filesystem_accessor.rs
+++ b/src/moonlink/src/storage/filesystem/accessor/base_filesystem_accessor.rs
@@ -37,4 +37,7 @@ pub trait BaseFileSystemAccess: std::fmt::Debug + Send + Sync {
 
     /// Delete the given object.
     async fn delete_object(&self, object_filepath: &str) -> Result<()>;
+
+    /// Copy from local file [`src`] to remote file [`dst`].
+    async fn copy_from_local_to_remote(&self, src: &str, dst: &str) -> Result<()>;
 }

--- a/src/moonlink/src/storage/filesystem/accessor/filesystem_accessor.rs
+++ b/src/moonlink/src/storage/filesystem/accessor/filesystem_accessor.rs
@@ -4,16 +4,16 @@ use futures::TryStreamExt;
 use opendal::layers::RetryLayer;
 use opendal::services;
 use opendal::Operator;
-/// FileSystemOperator built upon opendal.
+/// FileSystemAccessor built upon opendal.
 use tokio::sync::OnceCell;
 
-use crate::storage::filesystem::accessor::base_filesystem_accessor::BaseObjectStorageAccess;
+use crate::storage::filesystem::accessor::base_filesystem_accessor::BaseFileSystemAccess;
 use crate::storage::filesystem::accessor::configs::*;
 use crate::storage::filesystem::filesystem_config::FileSystemConfig;
 use crate::Result;
 
 #[derive(Debug)]
-pub(crate) struct FileSystemOperator {
+pub struct FileSystemAccessor {
     /// Root directory for the operator.
     root_directory: String,
     /// Operator to manager all IO operations.
@@ -22,8 +22,8 @@ pub(crate) struct FileSystemOperator {
     config: FileSystemConfig,
 }
 
-impl FileSystemOperator {
-    pub(crate) fn new(config: FileSystemConfig, root_location: String) -> Self {
+impl FileSystemAccessor {
+    pub fn new(config: FileSystemConfig, root_location: String) -> Self {
         Self {
             root_directory: root_location,
             operator: OnceCell::new(),
@@ -32,7 +32,7 @@ impl FileSystemOperator {
     }
 
     /// Get IO operator from the catalog.
-    pub(crate) async fn get_operator(&self) -> Result<&Operator> {
+    async fn get_operator(&self) -> Result<&Operator> {
         let retry_layer = RetryLayer::new()
             .with_max_times(MAX_RETRY_COUNT)
             .with_jitter()
@@ -94,7 +94,7 @@ impl FileSystemOperator {
 }
 
 #[async_trait]
-impl BaseObjectStorageAccess for FileSystemOperator {
+impl BaseFileSystemAccess for FileSystemAccessor {
     /// ===============================
     /// Directory operations
     /// ===============================

--- a/src/moonlink/src/storage/filesystem/accessor/filesystem_accessor.rs
+++ b/src/moonlink/src/storage/filesystem/accessor/filesystem_accessor.rs
@@ -23,6 +23,7 @@ pub struct FileSystemAccessor {
 }
 
 impl FileSystemAccessor {
+    // TODO(hjiang): No need for [`root_location`], should bake in filesystem config.
     pub fn new(config: FileSystemConfig, root_location: String) -> Self {
         Self {
             root_directory: root_location,

--- a/src/moonlink/src/storage/filesystem/accessor/test_utils.rs
+++ b/src/moonlink/src/storage/filesystem/accessor/test_utils.rs
@@ -6,6 +6,6 @@ pub(crate) const TEST_CONTEST: &str = "helloworld";
 /// Test util function to create local file and write [`TEST_CONTEST`] to the destunation file (indicated by absolute path).
 pub(crate) async fn create_local_file(filepath: &str) {
     let mut file = tokio::fs::File::create(filepath).await.unwrap();
-    file.write(TEST_CONTEST.as_bytes()).await.unwrap();
+    let _ = file.write(TEST_CONTEST.as_bytes()).await.unwrap();
     file.flush().await.unwrap();
 }

--- a/src/moonlink/src/storage/filesystem/accessor/test_utils.rs
+++ b/src/moonlink/src/storage/filesystem/accessor/test_utils.rs
@@ -1,0 +1,11 @@
+use tokio::io::AsyncWriteExt;
+
+/// Test content.
+pub(crate) const TEST_CONTEST: &str = "helloworld";
+
+/// Test util function to create local file and write [`TEST_CONTEST`] to the destunation file (indicated by absolute path).
+pub(crate) async fn create_local_file(filepath: &str) {
+    let mut file = tokio::fs::File::create(filepath).await.unwrap();
+    file.write(TEST_CONTEST.as_bytes()).await.unwrap();
+    file.flush().await.unwrap();
+}

--- a/src/moonlink/src/storage/filesystem/gcs.rs
+++ b/src/moonlink/src/storage/filesystem/gcs.rs
@@ -1,3 +1,6 @@
 #[cfg(feature = "storage-gcs")]
 #[cfg(test)]
 pub(crate) mod gcs_test_utils;
+#[cfg(feature = "storage-gcs")]
+#[cfg(test)]
+pub(crate) mod tests;

--- a/src/moonlink/src/storage/filesystem/gcs/tests.rs
+++ b/src/moonlink/src/storage/filesystem/gcs/tests.rs
@@ -1,0 +1,38 @@
+use crate::storage::filesystem::accessor::base_filesystem_accessor::BaseFileSystemAccess;
+use crate::storage::filesystem::accessor::filesystem_accessor::FileSystemAccessor;
+use crate::storage::filesystem::accessor::test_utils::*;
+use crate::storage::filesystem::gcs::gcs_test_utils::*;
+
+#[tokio::test]
+async fn test_copy_from_local_to_remote() {
+    // Prepare src file.
+    let temp_dir = tempfile::tempdir().unwrap();
+    let root_directory = temp_dir.path().to_str().unwrap().to_string();
+    let src_filepath = format!("{}/src", &root_directory);
+    create_local_file(&src_filepath).await;
+
+    let (bucket, warehouse_uri) = get_test_gcs_bucket_and_warehouse();
+    create_test_gcs_bucket(bucket.clone()).await.unwrap();
+    let gcs_filesystem_config = create_gcs_filesystem_config(&warehouse_uri);
+
+    // Copy from src to dst.
+    let filesystem_accessor =
+        FileSystemAccessor::new(gcs_filesystem_config, root_directory.clone());
+    let dst_filepath = format!("dst");
+    filesystem_accessor
+        .copy_from_local_to_remote(&src_filepath, &dst_filepath)
+        .await
+        .unwrap();
+
+    // Validate destination file content.
+    let actual_content = filesystem_accessor
+        .read_object(&dst_filepath)
+        .await
+        .unwrap();
+    assert_eq!(actual_content, TEST_CONTEST);
+
+    // Delete all objects within the bucket, otherwise fake GCS server doesn't allow deletion.
+    filesystem_accessor.remove_directory("/").await.unwrap();
+    // Clean up test bucket.
+    delete_test_gcs_bucket(bucket.clone()).await.unwrap();
+}

--- a/src/moonlink/src/storage/filesystem/gcs/tests.rs
+++ b/src/moonlink/src/storage/filesystem/gcs/tests.rs
@@ -18,7 +18,7 @@ async fn test_copy_from_local_to_remote() {
     // Copy from src to dst.
     let filesystem_accessor =
         FileSystemAccessor::new(gcs_filesystem_config, root_directory.clone());
-    let dst_filepath = format!("dst");
+    let dst_filepath = "dst".to_string();
     filesystem_accessor
         .copy_from_local_to_remote(&src_filepath, &dst_filepath)
         .await

--- a/src/moonlink/src/storage/filesystem/s3.rs
+++ b/src/moonlink/src/storage/filesystem/s3.rs
@@ -1,3 +1,6 @@
 #[cfg(feature = "storage-s3")]
 #[cfg(test)]
 pub(crate) mod s3_test_utils;
+#[cfg(feature = "storage-s3")]
+#[cfg(test)]
+pub(crate) mod tests;

--- a/src/moonlink/src/storage/filesystem/s3/tests.rs
+++ b/src/moonlink/src/storage/filesystem/s3/tests.rs
@@ -1,0 +1,37 @@
+use crate::storage::filesystem::accessor::base_filesystem_accessor::BaseFileSystemAccess;
+use crate::storage::filesystem::accessor::filesystem_accessor::FileSystemAccessor;
+use crate::storage::filesystem::accessor::test_utils::*;
+use crate::storage::filesystem::s3::s3_test_utils::*;
+
+#[tokio::test]
+async fn test_copy_from_local_to_remote() {
+    // Prepare src file.
+    let temp_dir = tempfile::tempdir().unwrap();
+    let root_directory = temp_dir.path().to_str().unwrap().to_string();
+    let src_filepath = format!("{}/src", &root_directory);
+    create_local_file(&src_filepath).await;
+
+    let (bucket, warehouse_uri) = get_test_s3_bucket_and_warehouse();
+    create_test_s3_bucket(bucket.clone()).await.unwrap();
+    let s3_filesystem_config = create_s3_filesystem_config(&warehouse_uri);
+
+    // Copy from src to dst.
+    let filesystem_accessor = FileSystemAccessor::new(s3_filesystem_config, root_directory.clone());
+    let dst_filepath = format!("dst");
+    filesystem_accessor
+        .copy_from_local_to_remote(&src_filepath, &dst_filepath)
+        .await
+        .unwrap();
+
+    // Validate destination file content.
+    let actual_content = filesystem_accessor
+        .read_object(&dst_filepath)
+        .await
+        .unwrap();
+    assert_eq!(actual_content, TEST_CONTEST);
+
+    // Delete all objects within the bucket.
+    filesystem_accessor.remove_directory("/").await.unwrap();
+    // Clean up test bucket.
+    delete_test_s3_bucket(bucket.clone()).await.unwrap();
+}

--- a/src/moonlink/src/storage/filesystem/s3/tests.rs
+++ b/src/moonlink/src/storage/filesystem/s3/tests.rs
@@ -17,7 +17,7 @@ async fn test_copy_from_local_to_remote() {
 
     // Copy from src to dst.
     let filesystem_accessor = FileSystemAccessor::new(s3_filesystem_config, root_directory.clone());
-    let dst_filepath = format!("dst");
+    let dst_filepath = "dst".to_string();
     filesystem_accessor
         .copy_from_local_to_remote(&src_filepath, &dst_filepath)
         .await

--- a/src/moonlink/src/storage/iceberg/file_catalog.rs
+++ b/src/moonlink/src/storage/iceberg/file_catalog.rs
@@ -1,6 +1,6 @@
 use super::puffin_writer_proxy::append_puffin_metadata_and_rewrite;
-use crate::storage::filesystem::accessor::base_filesystem_accessor::BaseObjectStorageAccess;
-use crate::storage::filesystem::accessor::filesystem_accessor::FileSystemOperator;
+use crate::storage::filesystem::accessor::base_filesystem_accessor::BaseFileSystemAccess;
+use crate::storage::filesystem::accessor::filesystem_accessor::FileSystemAccessor;
 use crate::storage::filesystem::filesystem_config::FileSystemConfig;
 use crate::storage::iceberg::moonlink_catalog::PuffinWrite;
 use crate::storage::iceberg::puffin_writer_proxy::{
@@ -37,6 +37,7 @@ use std::collections::{HashMap, HashSet};
 /// 1. Before release we should support not only S3, but also R2, GCS, etc; necessary change should be minimal, only need to setup configuration like secret id and secret key.
 /// 2. Add integration test to actual object storage before pg_mooncake release.
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::vec;
 
 use async_trait::async_trait;
@@ -56,7 +57,7 @@ pub(super) const NAMESPACE_INDICATOR_OBJECT_NAME: &str = "indicator.text";
 #[derive(Debug)]
 pub struct FileCatalog {
     /// Filesystem operator.
-    filesystem_accessor: Box<dyn BaseObjectStorageAccess>,
+    filesystem_accessor: Arc<dyn BaseFileSystemAccess>,
     /// Similar to opendal operator, which also provides an abstraction above different storage backends.
     file_io: FileIO,
     /// Table location.
@@ -76,7 +77,7 @@ impl FileCatalog {
     pub fn new(warehouse_location: String, config: FileSystemConfig) -> IcebergResult<Self> {
         let file_io = utils::create_file_io(&config)?;
         Ok(Self {
-            filesystem_accessor: Box::new(FileSystemOperator::new(
+            filesystem_accessor: Arc::new(FileSystemAccessor::new(
                 config,
                 warehouse_location.clone(),
             )),
@@ -91,7 +92,7 @@ impl FileCatalog {
     /// Create a file catalog with the provided filesystem accessor.
     #[cfg(test)]
     pub fn new_with_filesystem_accessor(
-        filesystem_accessor: Box<dyn BaseObjectStorageAccess>,
+        filesystem_accessor: Arc<dyn BaseFileSystemAccess>,
     ) -> IcebergResult<Self> {
         use iceberg::io::FileIOBuilder;
         let file_io = FileIOBuilder::new_fs_io().build()?;

--- a/src/moonlink/src/storage/iceberg/file_catalog.rs
+++ b/src/moonlink/src/storage/iceberg/file_catalog.rs
@@ -543,7 +543,7 @@ impl Catalog for FileCatalog {
                 IcebergError::new(
                     iceberg::ErrorKind::Unexpected,
                     format!(
-                        "Failed to check version hint file existencee {:?}: {:?}",
+                        "Failed to check version hint file existence {:?}: {:?}",
                         version_hint_filepath, e
                     ),
                 )

--- a/src/moonlink/src/storage/iceberg/mock_filesystem_test.rs
+++ b/src/moonlink/src/storage/iceberg/mock_filesystem_test.rs
@@ -1,16 +1,18 @@
 use crate::storage::filesystem::accessor::base_filesystem_accessor::{
-    BaseObjectStorageAccess, MockBaseObjectStorageAccess,
+    BaseFileSystemAccess, MockBaseFileSystemAccess,
 };
 use crate::storage::iceberg::iceberg_table_manager::{IcebergTableConfig, IcebergTableManager};
 use crate::storage::mooncake_table::table_creation_test_utils::*;
 use crate::Error;
 use crate::{ObjectStorageCache, TableManager};
 
+use std::sync::Arc;
+
 /// Mock-based unit tests for iceberg table manager.
 ///
 /// Test util function to create an iceberg table manager with the given filesystem accessor.
 fn create_iceberg_table_manager_with_fs_accessor(
-    filesystem_accessor: Box<dyn BaseObjectStorageAccess>,
+    filesystem_accessor: Arc<dyn BaseFileSystemAccess>,
 ) -> IcebergTableManager {
     let temp_dir = tempfile::tempdir().unwrap();
     let mooncake_table_metadata =
@@ -19,15 +21,15 @@ fn create_iceberg_table_manager_with_fs_accessor(
     IcebergTableManager::new_with_filesystem_accessor(
         mooncake_table_metadata,
         object_storage_cache,
-        IcebergTableConfig::default(),
         filesystem_accessor,
+        IcebergTableConfig::default(),
     )
     .unwrap()
 }
 
 #[tokio::test]
 async fn test_failed_iceberg_table_manager_drop_table() {
-    let mut filesystem_accessor = MockBaseObjectStorageAccess::new();
+    let mut filesystem_accessor = MockBaseFileSystemAccess::new();
     filesystem_accessor
         .expect_remove_directory()
         .times(1)
@@ -39,14 +41,14 @@ async fn test_failed_iceberg_table_manager_drop_table() {
             })
         });
     let mut iceberg_table_manager =
-        create_iceberg_table_manager_with_fs_accessor(Box::new(filesystem_accessor));
+        create_iceberg_table_manager_with_fs_accessor(Arc::new(filesystem_accessor));
     let res = iceberg_table_manager.drop_table().await;
     assert!(res.is_err());
 }
 
 #[tokio::test]
 async fn test_failed_recover_from_iceberg_table() {
-    let mut filesystem_accessor = MockBaseObjectStorageAccess::new();
+    let mut filesystem_accessor = MockBaseFileSystemAccess::new();
     filesystem_accessor
         .expect_object_exists()
         .times(1)
@@ -58,7 +60,7 @@ async fn test_failed_recover_from_iceberg_table() {
             })
         });
     let mut iceberg_table_manager =
-        create_iceberg_table_manager_with_fs_accessor(Box::new(filesystem_accessor));
+        create_iceberg_table_manager_with_fs_accessor(Arc::new(filesystem_accessor));
     let res = iceberg_table_manager.load_snapshot_from_table().await;
     assert!(res.is_err());
 }

--- a/src/moonlink/src/storage/iceberg/tests.rs
+++ b/src/moonlink/src/storage/iceberg/tests.rs
@@ -202,6 +202,7 @@ async fn test_store_and_load_snapshot_impl(
     let mut iceberg_table_manager = IcebergTableManager::new(
         mooncake_table_metadata.clone(),
         object_storage_cache.clone(),
+        create_local_filesystem_accessor(&iceberg_table_config),
         iceberg_table_config.clone(),
     )
     .unwrap();
@@ -384,6 +385,7 @@ async fn test_store_and_load_snapshot_impl(
     let mut iceberg_table_manager_for_load = IcebergTableManager::new(
         mooncake_table_metadata.clone(),
         object_storage_cache.clone(),
+        create_local_filesystem_accessor(&iceberg_table_config),
         iceberg_table_config.clone(),
     )
     .unwrap();
@@ -455,6 +457,7 @@ async fn test_store_and_load_snapshot_impl(
     let mut iceberg_table_manager_for_load = IcebergTableManager::new(
         mooncake_table_metadata.clone(),
         object_storage_cache.clone(),
+        create_local_filesystem_accessor(&iceberg_table_config),
         iceberg_table_config.clone(),
     )
     .unwrap();
@@ -516,6 +519,7 @@ async fn test_store_and_load_snapshot_impl(
     let mut iceberg_table_manager_for_load = IcebergTableManager::new(
         mooncake_table_metadata.clone(),
         object_storage_cache.clone(),
+        create_local_filesystem_accessor(&iceberg_table_config),
         iceberg_table_config.clone(),
     )
     .unwrap();
@@ -562,6 +566,7 @@ async fn test_drop_table() {
     let mut iceberg_table_manager = IcebergTableManager::new(
         mooncake_table_metadata.clone(),
         object_storage_cache.clone(),
+        create_local_filesystem_accessor(&config),
         config.clone(),
     )
     .unwrap();
@@ -596,6 +601,7 @@ async fn test_empty_snapshot_load() {
     let mut iceberg_table_manager = IcebergTableManager::new(
         mooncake_table_metadata.clone(),
         object_storage_cache.clone(),
+        create_local_filesystem_accessor(&config),
         config.clone(),
     )
     .unwrap();
@@ -622,6 +628,7 @@ async fn test_snapshot_load_for_multiple_times() {
     let mut iceberg_table_manager = IcebergTableManager::new(
         mooncake_table_metadata.clone(),
         object_storage_cache.clone(),
+        create_local_filesystem_accessor(&config),
         config.clone(),
     )
     .unwrap();
@@ -709,6 +716,7 @@ async fn test_index_merge_and_create_snapshot() {
     let mut iceberg_table_manager_for_recovery = IcebergTableManager::new(
         mooncake_table_metadata.clone(),
         object_storage_cache.clone(),
+        create_local_filesystem_accessor(&iceberg_table_config),
         iceberg_table_config.clone(),
     )
     .unwrap();
@@ -742,6 +750,7 @@ async fn test_empty_content_snapshot_creation() {
     let mut iceberg_table_manager = IcebergTableManager::new(
         mooncake_table_metadata.clone(),
         object_storage_cache.clone(),
+        create_local_filesystem_accessor(&config),
         config.clone(),
     )
     .unwrap();
@@ -776,6 +785,7 @@ async fn test_empty_content_snapshot_creation() {
     let mut iceberg_table_manager = IcebergTableManager::new(
         mooncake_table_metadata.clone(),
         object_storage_cache.clone(),
+        create_local_filesystem_accessor(&config),
         config.clone(),
     )
     .unwrap();
@@ -812,6 +822,7 @@ async fn test_create_snapshot_when_no_committed_deletion_log_to_flush() {
         iceberg_table_config.clone(),
         MooncakeTableConfig::default(),
         ObjectStorageCache::default_for_test(&temp_dir),
+        create_local_filesystem_accessor(&iceberg_table_config),
     )
     .await
     .unwrap();
@@ -854,6 +865,7 @@ async fn test_skip_iceberg_snapshot() {
         iceberg_table_config.clone(),
         MooncakeTableConfig::default(),
         ObjectStorageCache::default_for_test(&temp_dir),
+        create_local_filesystem_accessor(&iceberg_table_config),
     )
     .await
     .unwrap();
@@ -913,6 +925,7 @@ async fn test_small_batch_size_and_large_parquet_size() {
         iceberg_table_config.clone(),
         mooncake_table_config,
         object_storage_cache.clone(),
+        create_local_filesystem_accessor(&iceberg_table_config),
     )
     .await
     .unwrap();
@@ -941,6 +954,7 @@ async fn test_small_batch_size_and_large_parquet_size() {
     let mut iceberg_table_manager = IcebergTableManager::new(
         mooncake_table_metadata.clone(),
         object_storage_cache.clone(),
+        create_local_filesystem_accessor(&iceberg_table_config),
         iceberg_table_config.clone(),
     )
     .unwrap();
@@ -1191,6 +1205,7 @@ async fn mooncake_table_snapshot_persist_impl(warehouse_uri: String) {
         iceberg_table_config.clone(),
         mooncake_table_config,
         ObjectStorageCache::default_for_test(&temp_dir),
+        create_local_filesystem_accessor(&iceberg_table_config),
     )
     .await
     .unwrap();
@@ -1229,6 +1244,7 @@ async fn mooncake_table_snapshot_persist_impl(warehouse_uri: String) {
     let mut iceberg_table_manager = IcebergTableManager::new(
         mooncake_table_metadata.clone(),
         ObjectStorageCache::default_for_test(&temp_dir), // Use separate and fresh new cache for each recovery.
+        create_local_filesystem_accessor(&iceberg_table_config),
         iceberg_table_config.clone(),
     )
     .unwrap();
@@ -1299,6 +1315,7 @@ async fn mooncake_table_snapshot_persist_impl(warehouse_uri: String) {
     let mut iceberg_table_manager = IcebergTableManager::new(
         mooncake_table_metadata.clone(),
         ObjectStorageCache::default_for_test(&temp_dir), // Use separate and fresh new cache for each recovery.
+        create_local_filesystem_accessor(&iceberg_table_config),
         iceberg_table_config.clone(),
     )
     .unwrap();
@@ -1364,6 +1381,7 @@ async fn mooncake_table_snapshot_persist_impl(warehouse_uri: String) {
     let mut iceberg_table_manager = IcebergTableManager::new(
         mooncake_table_metadata.clone(),
         ObjectStorageCache::default_for_test(&temp_dir), // Use separate and fresh new cache for each recovery.
+        create_local_filesystem_accessor(&iceberg_table_config),
         iceberg_table_config.clone(),
     )
     .unwrap();
@@ -1433,6 +1451,7 @@ async fn mooncake_table_snapshot_persist_impl(warehouse_uri: String) {
     let mut iceberg_table_manager = IcebergTableManager::new(
         mooncake_table_metadata.clone(),
         ObjectStorageCache::default_for_test(&temp_dir), // Use separate and fresh new cache for each recovery.
+        create_local_filesystem_accessor(&iceberg_table_config),
         iceberg_table_config.clone(),
     )
     .unwrap();
@@ -1530,6 +1549,7 @@ async fn test_drop_table_at_creation() {
         iceberg_table_config.clone(),
         mooncake_table_config,
         ObjectStorageCache::default_for_test(&temp_dir),
+        create_local_filesystem_accessor(&iceberg_table_config),
     )
     .await
     .unwrap();
@@ -1542,6 +1562,7 @@ async fn test_drop_table_at_creation() {
     let mut iceberg_table_manager = IcebergTableManager::new(
         mooncake_table_metadata.clone(),
         object_storage_cache.clone(),
+        create_local_filesystem_accessor(&iceberg_table_config),
         iceberg_table_config.clone(),
     )
     .unwrap();
@@ -1586,6 +1607,7 @@ async fn test_multiple_table_ids_for_deletion_vector() {
         iceberg_table_config.clone(),
         MooncakeTableConfig::default(),
         ObjectStorageCache::default_for_test(&temp_dir),
+        create_local_filesystem_accessor(&iceberg_table_config),
     )
     .await
     .unwrap();

--- a/src/moonlink/src/storage/iceberg/utils.rs
+++ b/src/moonlink/src/storage/iceberg/utils.rs
@@ -1,5 +1,5 @@
 #[cfg(test)]
-use crate::storage::filesystem::accessor::base_filesystem_accessor::BaseObjectStorageAccess;
+use crate::storage::filesystem::accessor::base_filesystem_accessor::BaseFileSystemAccess;
 use crate::storage::filesystem::filesystem_config::FileSystemConfig;
 #[cfg(feature = "storage-gcs")]
 #[cfg(test)]
@@ -127,7 +127,7 @@ pub fn create_catalog(warehouse_uri: &str) -> IcebergResult<Box<dyn MoonlinkCata
 /// Test util function to create catalog with provided filesystem accessor.
 #[cfg(test)]
 pub fn create_catalog_with_filesystem_accessor(
-    filesystem_accessor: Box<dyn BaseObjectStorageAccess>,
+    filesystem_accessor: Arc<dyn BaseFileSystemAccess>,
 ) -> IcebergResult<Box<dyn MoonlinkCatalog>> {
     Ok(Box::new(FileCatalog::new_with_filesystem_accessor(
         filesystem_accessor,

--- a/src/moonlink/src/storage/iceberg/utils.rs
+++ b/src/moonlink/src/storage/iceberg/utils.rs
@@ -127,7 +127,7 @@ pub fn create_catalog(warehouse_uri: &str) -> IcebergResult<Box<dyn MoonlinkCata
 /// Test util function to create catalog with provided filesystem accessor.
 #[cfg(test)]
 pub fn create_catalog_with_filesystem_accessor(
-    filesystem_accessor: Arc<dyn BaseFileSystemAccess>,
+    filesystem_accessor: std::sync::Arc<dyn BaseFileSystemAccess>,
 ) -> IcebergResult<Box<dyn MoonlinkCatalog>> {
     Ok(Box::new(FileCatalog::new_with_filesystem_accessor(
         filesystem_accessor,

--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -23,6 +23,7 @@ use crate::storage::compaction::compactor::{CompactionBuilder, CompactionFilePar
 pub(crate) use crate::storage::compaction::table_compaction::{
     DataCompactionPayload, DataCompactionResult,
 };
+use crate::storage::filesystem::accessor::base_filesystem_accessor::BaseFileSystemAccess;
 use crate::storage::iceberg::iceberg_table_manager::{IcebergTableConfig, IcebergTableManager};
 use crate::storage::iceberg::table_manager::{PersistenceFileParams, TableManager};
 use crate::storage::index::persisted_bucket_hash_map::GlobalIndexBuilder;
@@ -513,6 +514,7 @@ impl MooncakeTable {
         iceberg_table_config: IcebergTableConfig,
         table_config: MooncakeTableConfig,
         object_storage_cache: ObjectStorageCache,
+        filesystem_accessor: Arc<dyn BaseFileSystemAccess>,
     ) -> Result<Self> {
         let metadata = Arc::new(TableMetadata {
             name,
@@ -525,6 +527,7 @@ impl MooncakeTable {
         let iceberg_table_manager = Box::new(IcebergTableManager::new(
             metadata.clone(),
             object_storage_cache.clone(),
+            filesystem_accessor,
             iceberg_table_config,
         )?);
         Self::new_with_table_manager(metadata, iceberg_table_manager, object_storage_cache).await

--- a/src/moonlink/src/storage/mooncake_table/deletion_vector_puffin_state_tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/deletion_vector_puffin_state_tests.rs
@@ -202,10 +202,12 @@ async fn test_1_recover_2_without_local_optimization(#[case] use_batch_write: bo
 
     // Now the disk file and deletion vector has been persist into iceberg.
     let mut cache_for_recovery = ObjectStorageCache::default_for_test(&temp_dir);
+    let iceberg_table_config = get_iceberg_table_config(&temp_dir);
     let mut iceberg_table_manager_to_recover = IcebergTableManager::new(
         table.metadata.clone(),
         cache_for_recovery.clone(),
-        get_iceberg_table_config(&temp_dir),
+        create_local_filesystem_accessor(&iceberg_table_config),
+        iceberg_table_config,
     )
     .unwrap();
     let (next_file_id, mooncake_snapshot) = iceberg_table_manager_to_recover
@@ -259,10 +261,12 @@ async fn test_1_recover_2_with_local_optimization(#[case] use_batch_write: bool)
 
     // Now the disk file and deletion vector has been persist into iceberg.
     let mut cache_for_recovery = ObjectStorageCache::default_for_test(&temp_dir);
+    let iceberg_table_config = get_iceberg_table_config(&temp_dir);
     let mut iceberg_table_manager_to_recover = IcebergTableManager::new(
         table.metadata.clone(),
         cache_for_recovery.clone(),
-        get_iceberg_table_config(&temp_dir),
+        create_local_filesystem_accessor(&iceberg_table_config),
+        iceberg_table_config,
     )
     .unwrap();
     let (next_file_id, mooncake_snapshot) = iceberg_table_manager_to_recover

--- a/src/moonlink/src/storage/mooncake_table/file_index_state_tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/file_index_state_tests.rs
@@ -100,10 +100,12 @@ async fn test_1_recover_3() {
 
     // Now the disk file and deletion vector has been persist into iceberg.
     let object_storage_cache_for_recovery = ObjectStorageCache::default_for_test(&temp_dir);
+    let iceberg_table_config = get_iceberg_table_config(&temp_dir);
     let mut iceberg_table_manager_to_recover = IcebergTableManager::new(
         table.metadata.clone(),
         object_storage_cache_for_recovery.clone(),
-        get_iceberg_table_config(&temp_dir),
+        create_local_filesystem_accessor(&iceberg_table_config),
+        iceberg_table_config,
     )
     .unwrap();
     let (next_file_id, mooncake_snapshot) = iceberg_table_manager_to_recover
@@ -208,6 +210,7 @@ pub(super) async fn create_mooncake_table_and_notify_for_index_merge(
         iceberg_table_config.clone(),
         mooncake_table_config,
         object_storage_cache,
+        create_local_filesystem_accessor(&iceberg_table_config),
     )
     .await
     .unwrap();

--- a/src/moonlink/src/storage/mooncake_table/table_creation_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_creation_test_utils.rs
@@ -1,6 +1,7 @@
 /// This module contains table creation tests utils.
 use crate::row::IdentityProp as RowIdentity;
 use crate::storage::compaction::compaction_config::DataCompactionConfig;
+use crate::storage::filesystem::accessor::base_filesystem_accessor::BaseFileSystemAccess;
 use crate::storage::iceberg::iceberg_table_manager::IcebergTableConfig;
 use crate::storage::iceberg::iceberg_table_manager::IcebergTableManager;
 use crate::storage::mooncake_table::test_utils_commons::*;
@@ -8,6 +9,7 @@ use crate::storage::mooncake_table::IcebergPersistenceConfig;
 use crate::storage::mooncake_table::{MooncakeTableConfig, TableMetadata as MooncakeTableMetadata};
 use crate::storage::MooncakeTable;
 use crate::table_notify::TableEvent;
+use crate::FileSystemAccessor;
 use crate::ObjectStorageCache;
 
 use arrow::datatypes::Schema as ArrowSchema;
@@ -44,6 +46,16 @@ pub(crate) fn create_test_arrow_schema() -> Arc<ArrowSchema> {
             "2".to_string(),
         )])),
     ]))
+}
+
+/// Test util function to create local filesystem accessor from iceberg table config.
+pub(crate) fn create_local_filesystem_accessor(
+    iceberg_table_config: &IcebergTableConfig,
+) -> Arc<dyn BaseFileSystemAccess> {
+    Arc::new(FileSystemAccessor::new(
+        crate::FileSystemConfig::FileSystem,
+        iceberg_table_config.warehouse_uri.clone(),
+    ))
 }
 
 /// Test util function to create mooncake table metadata.
@@ -101,6 +113,7 @@ pub(crate) async fn create_table_and_iceberg_manager_with_config(
         iceberg_table_config.clone(),
         mooncake_table_metadata.as_ref().config.clone(),
         object_storage_cache.clone(),
+        create_local_filesystem_accessor(&iceberg_table_config),
     )
     .await
     .unwrap();
@@ -108,6 +121,7 @@ pub(crate) async fn create_table_and_iceberg_manager_with_config(
     let iceberg_table_manager = IcebergTableManager::new(
         mooncake_table_metadata.clone(),
         object_storage_cache.clone(),
+        create_local_filesystem_accessor(&iceberg_table_config),
         iceberg_table_config.clone(),
     )
     .unwrap();
@@ -155,6 +169,7 @@ pub(crate) async fn create_table_and_iceberg_manager_with_data_compaction_config
         iceberg_table_config.clone(),
         mooncake_table_config,
         object_storage_cache.clone(),
+        create_local_filesystem_accessor(&iceberg_table_config),
     )
     .await
     .unwrap();
@@ -162,6 +177,7 @@ pub(crate) async fn create_table_and_iceberg_manager_with_data_compaction_config
     let iceberg_table_manager = IcebergTableManager::new(
         mooncake_table_metadata.clone(),
         object_storage_cache.clone(),
+        create_local_filesystem_accessor(&iceberg_table_config),
         iceberg_table_config.clone(),
     )
     .unwrap();
@@ -214,6 +230,7 @@ pub(crate) async fn create_mooncake_table_and_notify_for_compaction(
         iceberg_table_config.clone(),
         mooncake_table_config,
         object_storage_cache,
+        create_local_filesystem_accessor(&iceberg_table_config),
     )
     .await
     .unwrap();
@@ -255,6 +272,7 @@ pub(crate) async fn create_mooncake_table_and_notify_for_read(
         iceberg_table_config.clone(),
         mooncake_table_config,
         object_storage_cache,
+        create_local_filesystem_accessor(&iceberg_table_config),
     )
     .await
     .unwrap();

--- a/src/moonlink/src/storage/mooncake_table/test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/test_utils.rs
@@ -72,9 +72,10 @@ pub async fn test_table(
         1,
         context.path(),
         identity,
-        iceberg_table_config,
+        iceberg_table_config.clone(),
         table_config,
         ObjectStorageCache::default_for_test(&context.temp_dir),
+        create_local_filesystem_accessor(&iceberg_table_config),
     )
     .await
     .unwrap()

--- a/src/moonlink/src/storage/mooncake_table/tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/tests.rs
@@ -488,15 +488,17 @@ async fn test_table_recovery() {
     create_mooncake_and_persist_for_test(&mut table, &mut event_completion_rx).await;
 
     // Recovery from iceberg snapshot and check mooncake table recovery.
+    let iceberg_table_config = test_iceberg_table_config(&context, table_name);
     let recovered_table = MooncakeTable::new(
         (*create_test_arrow_schema()).clone(),
         table_name.to_string(),
         /*table_id=*/ 1,
         context.path(),
         row_identity.clone(),
-        test_iceberg_table_config(&context, table_name),
+        iceberg_table_config.clone(),
         test_mooncake_table_config(&context),
         ObjectStorageCache::default_for_test(&context.temp_dir),
+        create_local_filesystem_accessor(&iceberg_table_config),
     )
     .await
     .unwrap();

--- a/src/moonlink/src/table_handler/test_utils.rs
+++ b/src/moonlink/src/table_handler/test_utils.rs
@@ -1,5 +1,6 @@
 use crate::row::{IdentityProp, MoonlinkRow, RowValue};
 use crate::storage::mooncake_table::table_creation_test_utils::create_test_arrow_schema;
+use crate::storage::mooncake_table::table_creation_test_utils::*;
 use crate::storage::mooncake_table::TableMetadata as MooncakeTableMetadata;
 use crate::storage::IcebergTableConfig;
 use crate::storage::{verify_files_and_deletions, MooncakeTable};
@@ -123,9 +124,10 @@ impl TestEnvironment {
             1,
             path,
             IdentityProp::Keys(vec![0]),
-            iceberg_table_config,
+            iceberg_table_config.clone(),
             mooncake_table_config,
             ObjectStorageCache::default_for_test(&temp_dir),
+            create_local_filesystem_accessor(&iceberg_table_config),
         )
         .await
         .unwrap();
@@ -154,7 +156,8 @@ impl TestEnvironment {
         IcebergTableManager::new(
             mooncake_table_metadata,
             self.object_storage_cache.clone(),
-            iceberg_table_config,
+            create_local_filesystem_accessor(&iceberg_table_config),
+            iceberg_table_config.clone(),
         )
         .unwrap()
     }


### PR DESCRIPTION
## Summary

The minimum object storage feature we need to support is copy local write-through cache to object storage.
I will integrate the API to iceberg table manager in the next PR.

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
