### PR TITLE
[storage] Iceberg upload migrate to filesystem accessor

### DIFF
--- a/src/moonlink/src/storage/filesystem.rs
+++ b/src/moonlink/src/storage/filesystem.rs
@@ -5,3 +5,4 @@ pub(crate) mod gcs;
 #[cfg(feature = "storage-s3")]
 pub(crate) mod s3;
 pub(crate) mod test_utils;
+pub mod utils;

--- a/src/moonlink/src/storage/filesystem/accessor/base_filesystem_accessor.rs
+++ b/src/moonlink/src/storage/filesystem/accessor/base_filesystem_accessor.rs
@@ -6,6 +6,7 @@ use async_trait::async_trait;
 #[cfg(test)]
 use mockall::*;
 
+/// All interfaces accept both relative path (relative to root directory on local filesystem, or bucket for object storage) and absolute path.
 #[async_trait]
 #[cfg_attr(test, automock)]
 pub trait BaseFileSystemAccess: std::fmt::Debug + Send + Sync {

--- a/src/moonlink/src/storage/filesystem/accessor/base_filesystem_accessor.rs
+++ b/src/moonlink/src/storage/filesystem/accessor/base_filesystem_accessor.rs
@@ -33,7 +33,7 @@ pub trait BaseFileSystemAccess: std::fmt::Debug + Send + Sync {
     async fn read_object(&self, object: &str) -> Result<String>;
 
     /// Write the whole content to the given object.
-    async fn write_object(&self, object_filepath: &str, content: &str) -> Result<()>;
+    async fn write_object(&self, object_filepath: &str, content: Vec<u8>) -> Result<()>;
 
     /// Delete the given object.
     async fn delete_object(&self, object_filepath: &str) -> Result<()>;

--- a/src/moonlink/src/storage/filesystem/accessor/filesystem_accessor.rs
+++ b/src/moonlink/src/storage/filesystem/accessor/filesystem_accessor.rs
@@ -181,11 +181,11 @@ impl BaseFileSystemAccess for FileSystemAccessor {
         Ok(String::from_utf8(content.to_vec())?)
     }
 
-    // TODO(hjiang): Could avoid copy.
-    async fn write_object(&self, object_filepath: &str, content: &str) -> Result<()> {
-        let data = content.as_bytes().to_vec();
+    async fn write_object(&self, object_filepath: &str, content: Vec<u8>) -> Result<()> {
         let operator = self.get_operator().await?;
-        operator.write(object_filepath, data).await?;
+        let expected_len = content.len();
+        let metadata = operator.write(object_filepath, content).await?;
+        assert_eq!(metadata.content_length(), expected_len as u64);
         Ok(())
     }
 
@@ -196,8 +196,8 @@ impl BaseFileSystemAccess for FileSystemAccessor {
     }
 
     async fn copy_from_local_to_remote(&self, src: &str, dst: &str) -> Result<()> {
-        let content = tokio::fs::read_to_string(src).await?;
-        self.write_object(dst, &content).await?;
+        let content = tokio::fs::read(src).await?;
+        self.write_object(dst, content).await?;
         Ok(())
     }
 }

--- a/src/moonlink/src/storage/filesystem/accessor/filesystem_accessor.rs
+++ b/src/moonlink/src/storage/filesystem/accessor/filesystem_accessor.rs
@@ -10,10 +10,13 @@ use tokio::sync::OnceCell;
 use crate::storage::filesystem::accessor::base_filesystem_accessor::BaseFileSystemAccess;
 use crate::storage::filesystem::accessor::configs::*;
 use crate::storage::filesystem::filesystem_config::FileSystemConfig;
+use crate::storage::filesystem::utils::path_utils::get_root_path;
 use crate::Result;
 
 #[derive(Debug)]
 pub struct FileSystemAccessor {
+    /// Root path.
+    root_path: String,
     /// Operator to manager all IO operations.
     operator: OnceCell<Operator>,
     /// Filesystem configuration.
@@ -23,9 +26,16 @@ pub struct FileSystemAccessor {
 impl FileSystemAccessor {
     pub fn new(config: FileSystemConfig) -> Self {
         Self {
+            root_path: get_root_path(&config),
             operator: OnceCell::new(),
             config,
         }
+    }
+
+    /// Sanitize given path.
+    /// Opendal works on relative path, so attempt to sanitize absolute path to relative one if applicable.
+    fn sanitize_path<'a>(&self, path: &'a str) -> &'a str {
+        path.strip_prefix(&self.root_path).unwrap_or(path)
     }
 
     /// Get IO operator from the catalog.
@@ -97,7 +107,8 @@ impl BaseFileSystemAccess for FileSystemAccessor {
     /// ===============================
     ///
     async fn list_direct_subdirectories(&self, folder: &str) -> Result<Vec<String>> {
-        let prefix = format!("{}/", folder);
+        let sanitized_folder = self.sanitize_path(folder);
+        let prefix = format!("{}/", sanitized_folder);
         let mut dirs = Vec::new();
         let lister = self.get_operator().await?.list(&prefix).await?;
 
@@ -128,21 +139,19 @@ impl BaseFileSystemAccess for FileSystemAccessor {
         } else {
             format!("{}/", directory)
         };
+        let sanitized_path = self.sanitize_path(&path);
 
         let operator = self.get_operator().await?;
-        let mut lister = operator.lister(&path).await?;
+        let mut lister = operator.lister(sanitized_path).await?;
         let mut entries = Vec::new();
 
         while let Some(entry) = lister.try_next().await? {
             // List operation returns target path.
-            if entry.path() != path {
+            if entry.path() != sanitized_path {
                 entries.push(entry.path().to_string());
             }
         }
         for entry_path in entries {
-            if entry_path == path {
-                continue;
-            }
             if entry_path.ends_with('/') {
                 Box::pin(self.remove_directory(&entry_path)).await?;
             } else {
@@ -150,8 +159,8 @@ impl BaseFileSystemAccess for FileSystemAccessor {
             }
         }
 
-        if !path.is_empty() && path != "/" {
-            operator.remove_all(&path).await?;
+        if !sanitized_path.is_empty() && sanitized_path != "/" {
+            operator.remove_all(sanitized_path).await?;
         }
 
         Ok(())
@@ -159,8 +168,9 @@ impl BaseFileSystemAccess for FileSystemAccessor {
 
     #[cfg(not(feature = "storage-gcs"))]
     async fn remove_directory(&self, directory: &str) -> Result<()> {
+        let sanitized_directory = self.sanitize_path(&directory);
         let op = self.get_operator().await?.clone();
-        op.remove_all(directory).await?;
+        op.remove_all(sanitized_directory).await?;
         Ok(())
     }
 
@@ -169,7 +179,8 @@ impl BaseFileSystemAccess for FileSystemAccessor {
     /// ===============================
     ///
     async fn object_exists(&self, object: &str) -> Result<bool> {
-        match self.get_operator().await?.stat(object).await {
+        let sanitized_object = self.sanitize_path(object);
+        match self.get_operator().await?.stat(sanitized_object).await {
             Ok(_) => Ok(true),
             Err(e) if e.kind() == opendal::ErrorKind::NotFound => Ok(false),
             Err(e) => Err(e.into()),
@@ -177,27 +188,31 @@ impl BaseFileSystemAccess for FileSystemAccessor {
     }
 
     async fn read_object(&self, object: &str) -> Result<String> {
-        let content = self.get_operator().await?.read(object).await?;
+        let sanitized_object = self.sanitize_path(object);
+        let content = self.get_operator().await?.read(sanitized_object).await?;
         Ok(String::from_utf8(content.to_vec())?)
     }
 
-    async fn write_object(&self, object_filepath: &str, content: Vec<u8>) -> Result<()> {
+    async fn write_object(&self, object: &str, content: Vec<u8>) -> Result<()> {
+        let sanitized_object = self.sanitize_path(object);
         let operator = self.get_operator().await?;
         let expected_len = content.len();
-        let metadata = operator.write(object_filepath, content).await?;
+        let metadata = operator.write(sanitized_object, content).await?;
         assert_eq!(metadata.content_length(), expected_len as u64);
         Ok(())
     }
 
-    async fn delete_object(&self, object_filepath: &str) -> Result<()> {
+    async fn delete_object(&self, object: &str) -> Result<()> {
+        let sanitized_object = self.sanitize_path(object);
         let operator = self.get_operator().await?;
-        operator.delete(object_filepath).await?;
+        operator.delete(sanitized_object).await?;
         Ok(())
     }
 
     async fn copy_from_local_to_remote(&self, src: &str, dst: &str) -> Result<()> {
+        let sanitized_dst = self.sanitize_path(dst);
         let content = tokio::fs::read(src).await?;
-        self.write_object(dst, content).await?;
+        self.write_object(sanitized_dst, content).await?;
         Ok(())
     }
 }

--- a/src/moonlink/src/storage/filesystem/gcs/tests.rs
+++ b/src/moonlink/src/storage/filesystem/gcs/tests.rs
@@ -17,7 +17,7 @@ async fn test_copy_from_local_to_remote() {
 
     // Copy from src to dst.
     let filesystem_accessor = FileSystemAccessor::new(gcs_filesystem_config);
-    let dst_filepath = "dst".to_string();
+    let dst_filepath = format!("{}/dst", root_directory);
     filesystem_accessor
         .copy_from_local_to_remote(&src_filepath, &dst_filepath)
         .await

--- a/src/moonlink/src/storage/filesystem/s3/tests.rs
+++ b/src/moonlink/src/storage/filesystem/s3/tests.rs
@@ -17,7 +17,7 @@ async fn test_copy_from_local_to_remote() {
 
     // Copy from src to dst.
     let filesystem_accessor = FileSystemAccessor::new(s3_filesystem_config);
-    let dst_filepath = "dst".to_string();
+    let dst_filepath = format!("{}/dst", root_directory);
     filesystem_accessor
         .copy_from_local_to_remote(&src_filepath, &dst_filepath)
         .await

--- a/src/moonlink/src/storage/filesystem/utils.rs
+++ b/src/moonlink/src/storage/filesystem/utils.rs
@@ -1,0 +1,1 @@
+pub mod path_utils;

--- a/src/moonlink/src/storage/filesystem/utils/path_utils.rs
+++ b/src/moonlink/src/storage/filesystem/utils/path_utils.rs
@@ -1,0 +1,13 @@
+use crate::FileSystemConfig;
+
+/// Get root path for the given filesystem config.
+pub fn get_root_path(filesystem_config: &FileSystemConfig) -> String {
+    match &filesystem_config {
+        #[cfg(feature = "storage-fs")]
+        FileSystemConfig::FileSystem { root_directory } => root_directory.to_string(),
+        #[cfg(feature = "storage-gcs")]
+        FileSystemConfig::Gcs { bucket, .. } => format!("gs://{}", bucket),
+        #[cfg(feature = "storage-s3")]
+        FileSystemConfig::S3 { bucket, .. } => format!("s3://{}", bucket),
+    }
+}

--- a/src/moonlink/src/storage/iceberg/file_catalog.rs
+++ b/src/moonlink/src/storage/iceberg/file_catalog.rs
@@ -351,7 +351,7 @@ impl Catalog for FileCatalog {
         self.filesystem_accessor
             .write_object(
                 &FileCatalog::get_namespace_indicator_name(namespace_ident),
-                /*content=*/ "",
+                /*content=*/ vec![],
             )
             .await
             .map_err(|e| {
@@ -474,7 +474,10 @@ impl Catalog for FileCatalog {
         let version_hint_filepath =
             format!("{}/{}/metadata/version-hint.text", directory, creation.name);
         self.filesystem_accessor
-            .write_object(&version_hint_filepath, /*content=*/ "0")
+            .write_object(
+                &version_hint_filepath,
+                /*content=*/ "0".as_bytes().to_vec(),
+            )
             .await
             .map_err(|e| {
                 IcebergError::new(
@@ -491,9 +494,9 @@ impl Catalog for FileCatalog {
         );
 
         let table_metadata = TableMetadataBuilder::from_table_creation(creation)?.build()?;
-        let metadata_json = serde_json::to_string(&table_metadata.metadata)?;
+        let metadata_json = serde_json::to_vec(&table_metadata.metadata)?;
         self.filesystem_accessor
-            .write_object(&metadata_filepath, /*content=*/ &metadata_json)
+            .write_object(&metadata_filepath, /*content=*/ metadata_json)
             .await
             .map_err(|e| {
                 IcebergError::new(
@@ -592,9 +595,9 @@ impl Catalog for FileCatalog {
             commit.identifier().name()
         );
         let new_metadata_filepath = format!("{}/v{}.metadata.json", metadata_directory, version,);
-        let metadata_json = serde_json::to_string(&metadata)?;
+        let metadata_json = serde_json::to_vec(&metadata)?;
         self.filesystem_accessor
-            .write_object(&new_metadata_filepath, &metadata_json)
+            .write_object(&new_metadata_filepath, metadata_json)
             .await
             .map_err(|e| {
                 IcebergError::new(
@@ -618,7 +621,7 @@ impl Catalog for FileCatalog {
         // Write version hint file.
         let version_hint_path = format!("{}/version-hint.text", metadata_directory);
         self.filesystem_accessor
-            .write_object(&version_hint_path, &format!("{version}"))
+            .write_object(&version_hint_path, format!("{version}").as_bytes().to_vec())
             .await
             .map_err(|e| {
                 IcebergError::new(

--- a/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
@@ -94,7 +94,7 @@ pub struct IcebergTableManager {
     pub(crate) object_storage_cache: ObjectStorageCache,
 
     /// Filesystem accessor.
-    pub(crate) _filesystem_accessor: Arc<dyn BaseFileSystemAccess>,
+    pub(crate) filesystem_accessor: Arc<dyn BaseFileSystemAccess>,
 
     /// Maps from already persisted data file filepath to its deletion vector, and iceberg `DataFile`.
     pub(crate) persisted_data_files: HashMap<FileId, DataFileEntry>,
@@ -121,7 +121,7 @@ impl IcebergTableManager {
             catalog,
             iceberg_table: None,
             object_storage_cache,
-            _filesystem_accessor: filesystem_accessor,
+            filesystem_accessor,
             persisted_data_files: HashMap::new(),
             persisted_file_indices: HashMap::new(),
             remote_data_file_to_file_id: HashMap::new(),
@@ -143,7 +143,7 @@ impl IcebergTableManager {
             catalog,
             iceberg_table: None,
             object_storage_cache,
-            _filesystem_accessor: filesystem_accessor,
+            filesystem_accessor,
             persisted_data_files: HashMap::new(),
             persisted_file_indices: HashMap::new(),
             remote_data_file_to_file_id: HashMap::new(),

--- a/src/moonlink/src/storage/iceberg/iceberg_table_syncer.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_syncer.rs
@@ -155,7 +155,7 @@ impl IcebergTableManager {
                 self.iceberg_table.as_ref().unwrap(),
                 local_data_file.file_path(),
                 self.iceberg_table.as_ref().unwrap().metadata(),
-                &self.config.catalog_config,
+                self.filesystem_accessor.as_ref(),
             )
             .await?;
 
@@ -339,7 +339,7 @@ impl IcebergTableManager {
                 let remote_index_block = utils::upload_index_file(
                     self.iceberg_table.as_ref().unwrap(),
                     cur_index_block.index_file.file_path(),
-                    &self.config.catalog_config,
+                    self.filesystem_accessor.as_ref(),
                 )
                 .await?;
                 local_index_file_to_remote.insert(


### PR DESCRIPTION
## Summary

This PR does two things:
- Migrate local file upload from tokio (which only supports local filesystem) to filesystem accessor (which also supports object storage)
- Handle both absolute path and relative path in the accessor

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/757
Closes https://github.com/Mooncake-Labs/moonlink/issues/750

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
