### PR TITLE
[storage] [3/N] Adapt iceberg integration to leverage remote storage

### DIFF
--- a/src/moonlink/benches/microbench_write_mooncake_table.rs
+++ b/src/moonlink/benches/microbench_write_mooncake_table.rs
@@ -55,7 +55,7 @@ fn bench_write_mooncake_table(c: &mut Criterion) {
         warehouse_uri: warehouse_location.clone(),
         namespace: vec!["default".to_string()],
         table_name: table_name.to_string(),
-        catalog_config: moonlink::FileSystemConfig::FileSystem {
+        filesystem_config: moonlink::FileSystemConfig::FileSystem {
             root_directory: warehouse_location.clone(),
         },
     };

--- a/src/moonlink/src/storage/filesystem/gcs/tests.rs
+++ b/src/moonlink/src/storage/filesystem/gcs/tests.rs
@@ -30,8 +30,6 @@ async fn test_copy_from_local_to_remote() {
         .unwrap();
     assert_eq!(actual_content, TEST_CONTEST);
 
-    // Delete all objects within the bucket, otherwise fake GCS server doesn't allow deletion.
-    filesystem_accessor.remove_directory("/").await.unwrap();
     // Clean up test bucket.
     delete_test_gcs_bucket(bucket.clone()).await.unwrap();
 }
@@ -60,4 +58,7 @@ async fn test_copy_from_remote_to_local() {
     // Validate destination file content.
     let actual_content = tokio::fs::read_to_string(dst_filepath).await.unwrap();
     assert_eq!(actual_content, TEST_CONTEST);
+
+    // Clean up test bucket.
+    delete_test_gcs_bucket(bucket.clone()).await.unwrap();
 }

--- a/src/moonlink/src/storage/filesystem/s3/s3_test_utils.rs
+++ b/src/moonlink/src/storage/filesystem/s3/s3_test_utils.rs
@@ -101,7 +101,7 @@ pub(crate) async fn create_test_s3_bucket(bucket: String) -> IcebergResult<()> {
     Ok(())
 }
 
-/// Util function to delete all objects in a GCS bucket.
+/// Util function to delete all objects in a S3 bucket.
 async fn delete_s3_bucket_objects(bucket: &str) -> IcebergResult<()> {
     let filesystem_config = create_s3_filesystem_config(&format!("s3://{}", bucket));
     let filesystem_accessor = FileSystemAccessor::new(filesystem_config);

--- a/src/moonlink/src/storage/filesystem/s3/s3_test_utils.rs
+++ b/src/moonlink/src/storage/filesystem/s3/s3_test_utils.rs
@@ -1,3 +1,5 @@
+use crate::storage::filesystem::accessor::base_filesystem_accessor::BaseFileSystemAccess;
+use crate::storage::filesystem::accessor::filesystem_accessor::FileSystemAccessor;
 use crate::storage::filesystem::filesystem_config::FileSystemConfig;
 use crate::storage::filesystem::test_utils::object_storage_test_utils::*;
 use crate::storage::iceberg::tokio_retry_utils;
@@ -47,15 +49,6 @@ pub(crate) fn create_s3_filesystem_config(warehouse_uri: &str) -> FileSystemConf
 pub(crate) fn get_test_s3_bucket_and_warehouse(
 ) -> (String /*bucket_name*/, String /*warehouse_url*/) {
     get_bucket_and_warehouse(S3_TEST_BUCKET_PREFIX, S3_TEST_WAREHOUSE_URI_PREFIX)
-}
-
-#[allow(dead_code)]
-pub(crate) fn get_test_minio_bucket(warehouse_uri: &str) -> String {
-    let random_string = warehouse_uri
-        .strip_prefix(S3_TEST_WAREHOUSE_URI_PREFIX)
-        .unwrap()
-        .to_string();
-    format!("{}{}", S3_TEST_BUCKET_PREFIX, random_string)
 }
 
 /// Create test bucket in minio server.
@@ -108,8 +101,28 @@ pub(crate) async fn create_test_s3_bucket(bucket: String) -> IcebergResult<()> {
     Ok(())
 }
 
+/// Util function to delete all objects in a GCS bucket.
+async fn delete_s3_bucket_objects(bucket: &str) -> IcebergResult<()> {
+    let filesystem_config = create_s3_filesystem_config(&format!("s3://{}", bucket));
+    let filesystem_accessor = FileSystemAccessor::new(filesystem_config);
+    filesystem_accessor
+        .remove_directory("/")
+        .await
+        .map_err(|e| {
+            IcebergError::new(
+                iceberg::ErrorKind::Unexpected,
+                format!("Failed to remove directory in bucket {}: {}", bucket, e),
+            )
+        })?;
+    Ok(())
+}
+
 /// Delete test bucket in minio server.
 pub async fn delete_test_s3_bucket_impl(bucket: Arc<String>) -> IcebergResult<()> {
+    // Delete all objects in the bucket first.
+    delete_s3_bucket_objects(&bucket).await?;
+
+    // Now delete the bucket.
     let date = Utc::now().format("%a, %d %b %Y %T GMT").to_string();
     let string_to_sign = format!("DELETE\n\n\n{}\n/{}", date, bucket);
 

--- a/src/moonlink/src/storage/filesystem/s3/tests.rs
+++ b/src/moonlink/src/storage/filesystem/s3/tests.rs
@@ -30,8 +30,6 @@ async fn test_copy_from_local_to_remote() {
         .unwrap();
     assert_eq!(actual_content, TEST_CONTEST);
 
-    // Delete all objects within the bucket.
-    filesystem_accessor.remove_directory("/").await.unwrap();
     // Clean up test bucket.
     delete_test_s3_bucket(bucket.clone()).await.unwrap();
 }
@@ -60,4 +58,7 @@ async fn test_copy_from_remote_to_local() {
     // Validate destination file content.
     let actual_content = tokio::fs::read_to_string(dst_filepath).await.unwrap();
     assert_eq!(actual_content, TEST_CONTEST);
+
+    // Clean up test bucket.
+    delete_test_s3_bucket(bucket.clone()).await.unwrap();
 }

--- a/src/moonlink/src/storage/iceberg/compaction_tests.rs
+++ b/src/moonlink/src/storage/iceberg/compaction_tests.rs
@@ -36,6 +36,7 @@ use crate::storage::storage_utils::{
     FileId, MooncakeDataFileRef, ProcessedDeletionRecord, RawDeletionRecord, RecordLocation,
 };
 use crate::storage::MooncakeTable;
+use crate::FileSystemAccessor;
 use arrow_array::{Int32Array, RecordBatch, StringArray};
 use iceberg::io::FileIOBuilder;
 use std::sync::Arc;
@@ -307,6 +308,7 @@ async fn check_snapshot_reflects_persistence_for_compaction(
 #[tokio::test]
 async fn test_compaction_1_1_1() {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager_to_load, mut receiver) =
         create_table_and_iceberg_manager_with_data_compaction_config(
             &temp_dir,
@@ -338,6 +340,7 @@ async fn test_compaction_1_1_1() {
     validate_recovered_snapshot(
         &snapshot,
         &iceberg_table_manager_to_load.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
     )
     .await;
 
@@ -362,6 +365,7 @@ async fn test_compaction_1_1_1() {
 #[tokio::test]
 async fn test_compaction_1_1_2() {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager_to_load, mut receiver) =
         create_table_and_iceberg_manager_with_data_compaction_config(
             &temp_dir,
@@ -399,6 +403,7 @@ async fn test_compaction_1_1_2() {
     validate_recovered_snapshot(
         &snapshot,
         &iceberg_table_manager_to_load.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
     )
     .await;
 
@@ -451,6 +456,7 @@ async fn test_compaction_1_1_2() {
 #[tokio::test]
 async fn test_compaction_1_2_1() {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager_to_load, mut receiver) =
         create_table_and_iceberg_manager_with_data_compaction_config(
             &temp_dir,
@@ -484,6 +490,7 @@ async fn test_compaction_1_2_1() {
     validate_recovered_snapshot(
         &snapshot,
         &iceberg_table_manager_to_load.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
     )
     .await;
 
@@ -528,6 +535,7 @@ async fn test_compaction_1_2_1() {
 #[tokio::test]
 async fn test_compaction_1_2_2() {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager_to_load, mut receiver) =
         create_table_and_iceberg_manager_with_data_compaction_config(
             &temp_dir,
@@ -569,6 +577,7 @@ async fn test_compaction_1_2_2() {
     validate_recovered_snapshot(
         &snapshot,
         &iceberg_table_manager_to_load.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
     )
     .await;
 
@@ -627,6 +636,7 @@ async fn test_compaction_1_2_2() {
 #[tokio::test]
 async fn test_compaction_2_2_1() {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager_to_load, mut receiver) =
         create_table_and_iceberg_manager_with_data_compaction_config(
             &temp_dir,
@@ -666,6 +676,7 @@ async fn test_compaction_2_2_1() {
     validate_recovered_snapshot(
         &snapshot,
         &iceberg_table_manager_to_load.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
     )
     .await;
 
@@ -707,6 +718,7 @@ async fn test_compaction_2_2_1() {
 #[tokio::test]
 async fn test_compaction_2_2_2() {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager_to_load, mut receiver) =
         create_table_and_iceberg_manager_with_data_compaction_config(
             &temp_dir,
@@ -752,6 +764,7 @@ async fn test_compaction_2_2_2() {
     validate_recovered_snapshot(
         &snapshot,
         &iceberg_table_manager_to_load.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
     )
     .await;
 
@@ -811,6 +824,7 @@ async fn test_compaction_2_2_2() {
 #[tokio::test]
 async fn test_compaction_2_3_1() {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager_to_load, mut receiver) =
         create_table_and_iceberg_manager_with_data_compaction_config(
             &temp_dir,
@@ -851,6 +865,7 @@ async fn test_compaction_2_3_1() {
     validate_recovered_snapshot(
         &snapshot,
         &iceberg_table_manager_to_load.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
     )
     .await;
 
@@ -875,6 +890,7 @@ async fn test_compaction_2_3_1() {
 #[tokio::test]
 async fn test_compaction_2_3_2() {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager_to_load, mut receiver) =
         create_table_and_iceberg_manager_with_data_compaction_config(
             &temp_dir,
@@ -921,6 +937,7 @@ async fn test_compaction_2_3_2() {
     validate_recovered_snapshot(
         &snapshot,
         &iceberg_table_manager_to_load.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
     )
     .await;
 
@@ -981,6 +998,7 @@ async fn test_compaction_2_3_2() {
 #[tokio::test]
 async fn test_compaction_3_2_1() {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager_to_load, mut receiver) =
         create_table_and_iceberg_manager_with_data_compaction_config(
             &temp_dir,
@@ -1023,6 +1041,7 @@ async fn test_compaction_3_2_1() {
     validate_recovered_snapshot(
         &snapshot,
         &iceberg_table_manager_to_load.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
     )
     .await;
 
@@ -1070,6 +1089,7 @@ async fn test_compaction_3_2_1() {
 #[tokio::test]
 async fn test_compaction_3_3_1() {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager_to_load, mut receiver) =
         create_table_and_iceberg_manager_with_data_compaction_config(
             &temp_dir,
@@ -1112,6 +1132,7 @@ async fn test_compaction_3_3_1() {
     validate_recovered_snapshot(
         &snapshot,
         &iceberg_table_manager_to_load.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
     )
     .await;
 

--- a/src/moonlink/src/storage/iceberg/gcs_test_utils.rs
+++ b/src/moonlink/src/storage/iceberg/gcs_test_utils.rs
@@ -3,6 +3,6 @@ use crate::storage::iceberg::file_catalog::FileCatalog;
 
 #[allow(dead_code)]
 pub(crate) fn create_gcs_catalog(warehouse_uri: &str) -> FileCatalog {
-    let catalog_config = create_gcs_filesystem_config(warehouse_uri);
-    FileCatalog::new(catalog_config).unwrap()
+    let filesystem_config = create_gcs_filesystem_config(warehouse_uri);
+    FileCatalog::new(filesystem_config).unwrap()
 }

--- a/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
@@ -40,8 +40,8 @@ pub struct IcebergTableConfig {
     pub namespace: Vec<String>,
     /// Iceberg table name.
     pub table_name: String,
-    // Catalog config.
-    pub catalog_config: FileSystemConfig,
+    // Filesystem config.
+    pub filesystem_config: FileSystemConfig,
 }
 
 impl IcebergTableConfig {
@@ -56,7 +56,7 @@ impl Default for IcebergTableConfig {
             warehouse_uri: Self::DEFAULT_WAREHOUSE_URI.to_string(),
             namespace: vec![Self::DEFAULT_NAMESPACE.to_string()],
             table_name: Self::DEFAULT_TABLE.to_string(),
-            catalog_config: FileSystemConfig::FileSystem {
+            filesystem_config: FileSystemConfig::FileSystem {
                 root_directory: Self::DEFAULT_WAREHOUSE_URI.to_string(),
             },
         }

--- a/src/moonlink/src/storage/iceberg/s3_test_utils.rs
+++ b/src/moonlink/src/storage/iceberg/s3_test_utils.rs
@@ -5,6 +5,6 @@ use crate::storage::iceberg::file_catalog::FileCatalog;
 /// Create a S3 catalog, which communicates with local minio server.
 #[allow(dead_code)]
 pub(crate) fn create_test_s3_catalog(warehouse_uri: &str) -> FileCatalog {
-    let catalog_config = create_s3_filesystem_config(warehouse_uri);
-    FileCatalog::new(catalog_config).unwrap()
+    let filesystem_config = create_s3_filesystem_config(warehouse_uri);
+    FileCatalog::new(filesystem_config).unwrap()
 }

--- a/src/moonlink/src/storage/iceberg/state_tests.rs
+++ b/src/moonlink/src/storage/iceberg/state_tests.rs
@@ -70,7 +70,7 @@ async fn prepare_committed_and_flushed_data_files(
     (row_2, row_1)
 }
 
-// Test util function to check whether the data file in iceberg snapshot is the same as initially-prepared one from `prepare_committed_and_flushed_data_files`.
+// Test util function to check whether the data file in iceberg snapshot is the same as initially-prepared one from [`prepare_committed_and_flushed_data_files`].
 //
 // # Arguments
 //
@@ -87,6 +87,9 @@ async fn check_prev_data_files(
         .as_ref()
         .unwrap()
         .file_io();
+
+    println!("Loading arrow batch from file: {}", data_file.file_path());
+
     let loaded_arrow_batch = load_arrow_batch(file_io, data_file.file_path().as_str())
         .await
         .unwrap();

--- a/src/moonlink/src/storage/iceberg/state_tests.rs
+++ b/src/moonlink/src/storage/iceberg/state_tests.rs
@@ -40,6 +40,7 @@ use crate::storage::mooncake_table::validation_test_utils::*;
 use crate::storage::mooncake_table::Snapshot;
 use crate::storage::mooncake_table::SnapshotOption;
 use crate::storage::MooncakeTable;
+use crate::FileSystemAccessor;
 
 // Test util function to prepare for committed and persisted data file,
 // here we write two rows and assume they'll be included in one arrow record batch and one data file.
@@ -234,6 +235,7 @@ async fn check_prev_and_new_data_files(
 #[tokio::test]
 async fn test_state_1_1() -> IcebergResult<()> {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager, _) =
         create_table_and_iceberg_manager(&temp_dir).await;
 
@@ -255,7 +257,12 @@ async fn test_state_1_1() -> IcebergResult<()> {
     assert!(snapshot.indices.file_indices.is_empty());
     assert!(snapshot.data_file_flush_lsn.is_none());
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
-    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
+    )
+    .await;
 
     Ok(())
 }
@@ -264,6 +271,7 @@ async fn test_state_1_1() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_state_1_2() -> IcebergResult<()> {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager, _) =
         create_table_and_iceberg_manager(&temp_dir).await;
 
@@ -287,7 +295,12 @@ async fn test_state_1_2() -> IcebergResult<()> {
     assert!(snapshot.indices.file_indices.is_empty());
     assert!(snapshot.data_file_flush_lsn.is_none());
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
-    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
+    )
+    .await;
 
     Ok(())
 }
@@ -296,6 +309,7 @@ async fn test_state_1_2() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_state_1_3() -> IcebergResult<()> {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager, mut notify_rx) =
         create_table_and_iceberg_manager(&temp_dir).await;
 
@@ -322,7 +336,12 @@ async fn test_state_1_3() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 100);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
-    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
+    )
+    .await;
 
     Ok(())
 }
@@ -331,6 +350,7 @@ async fn test_state_1_3() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_state_1_4() -> IcebergResult<()> {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager, mut notify_rx) =
         create_table_and_iceberg_manager(&temp_dir).await;
 
@@ -359,7 +379,12 @@ async fn test_state_1_4() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 100);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
-    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
+    )
+    .await;
 
     Ok(())
 }
@@ -368,6 +393,7 @@ async fn test_state_1_4() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_state_1_5() -> IcebergResult<()> {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager, mut notify_rx) =
         create_table_and_iceberg_manager(&temp_dir).await;
 
@@ -395,7 +421,12 @@ async fn test_state_1_5() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 300);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
-    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
+    )
+    .await;
 
     Ok(())
 }
@@ -404,6 +435,7 @@ async fn test_state_1_5() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_state_1_6() -> IcebergResult<()> {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager, mut notify_rx) =
         create_table_and_iceberg_manager(&temp_dir).await;
 
@@ -433,7 +465,12 @@ async fn test_state_1_6() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 300);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
-    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
+    )
+    .await;
 
     Ok(())
 }
@@ -442,6 +479,7 @@ async fn test_state_1_6() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_state_2_1() -> IcebergResult<()> {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager, mut notify_rx) =
         create_table_and_iceberg_manager(&temp_dir).await;
 
@@ -464,7 +502,12 @@ async fn test_state_2_1() -> IcebergResult<()> {
     assert!(snapshot.indices.file_indices.is_empty());
     assert!(snapshot.data_file_flush_lsn.is_none());
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
-    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
+    )
+    .await;
 
     Ok(())
 }
@@ -473,6 +516,7 @@ async fn test_state_2_1() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_state_2_2() -> IcebergResult<()> {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager, mut notify_rx) =
         create_table_and_iceberg_manager(&temp_dir).await;
 
@@ -497,7 +541,12 @@ async fn test_state_2_2() -> IcebergResult<()> {
     assert!(snapshot.indices.file_indices.is_empty());
     assert!(snapshot.data_file_flush_lsn.is_none());
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
-    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
+    )
+    .await;
 
     Ok(())
 }
@@ -506,6 +555,7 @@ async fn test_state_2_2() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_state_2_3() -> IcebergResult<()> {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager, mut notify_rx) =
         create_table_and_iceberg_manager(&temp_dir).await;
 
@@ -533,7 +583,12 @@ async fn test_state_2_3() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 100);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
-    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
+    )
+    .await;
 
     Ok(())
 }
@@ -542,6 +597,7 @@ async fn test_state_2_3() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_state_2_4() -> IcebergResult<()> {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager, mut notify_rx) =
         create_table_and_iceberg_manager(&temp_dir).await;
 
@@ -571,7 +627,12 @@ async fn test_state_2_4() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 100);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
-    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
+    )
+    .await;
 
     Ok(())
 }
@@ -580,6 +641,7 @@ async fn test_state_2_4() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_state_2_5() -> IcebergResult<()> {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager, mut notify_rx) =
         create_table_and_iceberg_manager(&temp_dir).await;
 
@@ -608,7 +670,12 @@ async fn test_state_2_5() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 300);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
-    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
+    )
+    .await;
 
     Ok(())
 }
@@ -617,6 +684,7 @@ async fn test_state_2_5() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_state_2_6() -> IcebergResult<()> {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager, mut notify_rx) =
         create_table_and_iceberg_manager(&temp_dir).await;
 
@@ -647,7 +715,12 @@ async fn test_state_2_6() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 300);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
-    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
+    )
+    .await;
 
     Ok(())
 }
@@ -656,6 +729,7 @@ async fn test_state_2_6() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_state_3_1() -> IcebergResult<()> {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager, mut notify_rx) =
         create_table_and_iceberg_manager(&temp_dir).await;
 
@@ -679,7 +753,12 @@ async fn test_state_3_1() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 200);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
-    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
+    )
+    .await;
 
     Ok(())
 }
@@ -688,6 +767,7 @@ async fn test_state_3_1() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_state_3_2() -> IcebergResult<()> {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager, mut notify_rx) =
         create_table_and_iceberg_manager(&temp_dir).await;
 
@@ -713,7 +793,12 @@ async fn test_state_3_2() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 200);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
-    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
+    )
+    .await;
 
     Ok(())
 }
@@ -722,6 +807,7 @@ async fn test_state_3_2() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_state_3_3_deletion_before_flush() -> IcebergResult<()> {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager, mut notify_rx) =
         create_table_and_iceberg_manager(&temp_dir).await;
 
@@ -755,7 +841,12 @@ async fn test_state_3_3_deletion_before_flush() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 2);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 500);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
-    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
+    )
+    .await;
 
     Ok(())
 }
@@ -764,6 +855,7 @@ async fn test_state_3_3_deletion_before_flush() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_state_3_3_deletion_after_flush() -> IcebergResult<()> {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager, mut notify_rx) =
         create_table_and_iceberg_manager(&temp_dir).await;
 
@@ -797,7 +889,12 @@ async fn test_state_3_3_deletion_after_flush() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 2);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 300);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
-    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
+    )
+    .await;
 
     Ok(())
 }
@@ -806,6 +903,7 @@ async fn test_state_3_3_deletion_after_flush() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_state_3_4_committed_deletion_before_flush() -> IcebergResult<()> {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager, mut notify_rx) =
         create_table_and_iceberg_manager(&temp_dir).await;
 
@@ -841,7 +939,12 @@ async fn test_state_3_4_committed_deletion_before_flush() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 2);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 500);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
-    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
+    )
+    .await;
 
     Ok(())
 }
@@ -850,6 +953,7 @@ async fn test_state_3_4_committed_deletion_before_flush() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_state_3_4_committed_deletion_after_flush() -> IcebergResult<()> {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager, mut notify_rx) =
         create_table_and_iceberg_manager(&temp_dir).await;
 
@@ -885,7 +989,12 @@ async fn test_state_3_4_committed_deletion_after_flush() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 2);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 300);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
-    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
+    )
+    .await;
 
     Ok(())
 }
@@ -894,6 +1003,7 @@ async fn test_state_3_4_committed_deletion_after_flush() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_state_3_5() -> IcebergResult<()> {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager, mut notify_rx) =
         create_table_and_iceberg_manager(&temp_dir).await;
 
@@ -928,7 +1038,12 @@ async fn test_state_3_5() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 2);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 400);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
-    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
+    )
+    .await;
 
     Ok(())
 }
@@ -937,6 +1052,7 @@ async fn test_state_3_5() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_state_3_6() -> IcebergResult<()> {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager, mut notify_rx) =
         create_table_and_iceberg_manager(&temp_dir).await;
 
@@ -973,7 +1089,12 @@ async fn test_state_3_6() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 2);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 400);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
-    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
+    )
+    .await;
 
     Ok(())
 }
@@ -982,6 +1103,7 @@ async fn test_state_3_6() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_state_4_1() -> IcebergResult<()> {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager, mut notify_rx) =
         create_table_and_iceberg_manager(&temp_dir).await;
 
@@ -1011,7 +1133,12 @@ async fn test_state_4_1() -> IcebergResult<()> {
     assert!(snapshot.indices.file_indices.is_empty());
     assert!(snapshot.data_file_flush_lsn.is_none());
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
-    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
+    )
+    .await;
 
     Ok(())
 }
@@ -1020,6 +1147,7 @@ async fn test_state_4_1() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_state_4_2() -> IcebergResult<()> {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager, mut notify_rx) =
         create_table_and_iceberg_manager(&temp_dir).await;
 
@@ -1051,7 +1179,12 @@ async fn test_state_4_2() -> IcebergResult<()> {
     assert!(snapshot.indices.file_indices.is_empty());
     assert!(snapshot.data_file_flush_lsn.is_none());
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
-    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
+    )
+    .await;
 
     Ok(())
 }
@@ -1060,6 +1193,7 @@ async fn test_state_4_2() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_state_4_3() -> IcebergResult<()> {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager, mut notify_rx) =
         create_table_and_iceberg_manager(&temp_dir).await;
 
@@ -1094,7 +1228,12 @@ async fn test_state_4_3() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 100);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
-    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
+    )
+    .await;
 
     Ok(())
 }
@@ -1103,6 +1242,7 @@ async fn test_state_4_3() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_state_4_4() -> IcebergResult<()> {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager, mut notify_rx) =
         create_table_and_iceberg_manager(&temp_dir).await;
 
@@ -1139,7 +1279,12 @@ async fn test_state_4_4() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 100);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
-    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
+    )
+    .await;
 
     Ok(())
 }
@@ -1148,6 +1293,7 @@ async fn test_state_4_4() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_state_4_5() -> IcebergResult<()> {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager, mut notify_rx) =
         create_table_and_iceberg_manager(&temp_dir).await;
 
@@ -1183,7 +1329,12 @@ async fn test_state_4_5() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 300);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
-    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
+    )
+    .await;
 
     Ok(())
 }
@@ -1192,6 +1343,7 @@ async fn test_state_4_5() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_state_4_6() -> IcebergResult<()> {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager, mut notify_rx) =
         create_table_and_iceberg_manager(&temp_dir).await;
 
@@ -1229,7 +1381,12 @@ async fn test_state_4_6() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 300);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
-    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
+    )
+    .await;
 
     Ok(())
 }
@@ -1238,6 +1395,7 @@ async fn test_state_4_6() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_state_5_1() -> IcebergResult<()> {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager, mut notify_rx) =
         create_table_and_iceberg_manager(&temp_dir).await;
 
@@ -1269,7 +1427,12 @@ async fn test_state_5_1() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 200);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
-    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
+    )
+    .await;
 
     Ok(())
 }
@@ -1278,6 +1441,7 @@ async fn test_state_5_1() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_state_5_2() -> IcebergResult<()> {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager, mut notify_rx) =
         create_table_and_iceberg_manager(&temp_dir).await;
 
@@ -1311,7 +1475,12 @@ async fn test_state_5_2() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 200);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
-    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
+    )
+    .await;
 
     Ok(())
 }
@@ -1320,6 +1489,7 @@ async fn test_state_5_2() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_state_5_3_deletion_before_flush() -> IcebergResult<()> {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager, mut notify_rx) =
         create_table_and_iceberg_manager(&temp_dir).await;
 
@@ -1361,7 +1531,12 @@ async fn test_state_5_3_deletion_before_flush() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 2);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 500);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
-    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
+    )
+    .await;
 
     Ok(())
 }
@@ -1370,6 +1545,7 @@ async fn test_state_5_3_deletion_before_flush() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_state_5_3_deletion_after_flush() -> IcebergResult<()> {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager, mut notify_rx) =
         create_table_and_iceberg_manager(&temp_dir).await;
 
@@ -1411,7 +1587,12 @@ async fn test_state_5_3_deletion_after_flush() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 2);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 300);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
-    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
+    )
+    .await;
 
     Ok(())
 }
@@ -1420,6 +1601,7 @@ async fn test_state_5_3_deletion_after_flush() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_state_5_4_committed_deletion_before_flush() -> IcebergResult<()> {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager, mut notify_rx) =
         create_table_and_iceberg_manager(&temp_dir).await;
 
@@ -1463,7 +1645,12 @@ async fn test_state_5_4_committed_deletion_before_flush() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 2);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 500);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
-    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
+    )
+    .await;
 
     Ok(())
 }
@@ -1472,6 +1659,7 @@ async fn test_state_5_4_committed_deletion_before_flush() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_state_5_4_committed_deletion_after_flush() -> IcebergResult<()> {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager, mut notify_rx) =
         create_table_and_iceberg_manager(&temp_dir).await;
 
@@ -1515,7 +1703,12 @@ async fn test_state_5_4_committed_deletion_after_flush() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 2);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 300);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
-    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
+    )
+    .await;
 
     Ok(())
 }
@@ -1524,6 +1717,7 @@ async fn test_state_5_4_committed_deletion_after_flush() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_state_5_5() -> IcebergResult<()> {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager, mut notify_rx) =
         create_table_and_iceberg_manager(&temp_dir).await;
 
@@ -1566,7 +1760,12 @@ async fn test_state_5_5() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 2);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 400);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
-    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
+    )
+    .await;
 
     Ok(())
 }
@@ -1575,6 +1774,7 @@ async fn test_state_5_5() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_state_5_6() -> IcebergResult<()> {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager, mut notify_rx) =
         create_table_and_iceberg_manager(&temp_dir).await;
 
@@ -1619,7 +1819,12 @@ async fn test_state_5_6() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 2);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 400);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
-    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
+    )
+    .await;
 
     Ok(())
 }
@@ -1628,6 +1833,7 @@ async fn test_state_5_6() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_state_6_1() -> IcebergResult<()> {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager, mut notify_rx) =
         create_table_and_iceberg_manager(&temp_dir).await;
 
@@ -1666,7 +1872,12 @@ async fn test_state_6_1() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 200);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
-    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
+    )
+    .await;
 
     Ok(())
 }
@@ -1675,6 +1886,7 @@ async fn test_state_6_1() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_state_6_2() -> IcebergResult<()> {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager, mut notify_rx) =
         create_table_and_iceberg_manager(&temp_dir).await;
 
@@ -1715,7 +1927,12 @@ async fn test_state_6_2() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 200);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
-    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
+    )
+    .await;
 
     Ok(())
 }
@@ -1724,6 +1941,7 @@ async fn test_state_6_2() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_state_6_3_deletion_before_flush() -> IcebergResult<()> {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager, mut notify_rx) =
         create_table_and_iceberg_manager(&temp_dir).await;
 
@@ -1772,7 +1990,12 @@ async fn test_state_6_3_deletion_before_flush() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 2);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 500);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
-    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
+    )
+    .await;
 
     Ok(())
 }
@@ -1781,6 +2004,7 @@ async fn test_state_6_3_deletion_before_flush() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_state_6_3_deletion_after_flush() -> IcebergResult<()> {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager, mut notify_rx) =
         create_table_and_iceberg_manager(&temp_dir).await;
 
@@ -1829,7 +2053,12 @@ async fn test_state_6_3_deletion_after_flush() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 2);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 300);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
-    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
+    )
+    .await;
 
     Ok(())
 }
@@ -1838,6 +2067,7 @@ async fn test_state_6_3_deletion_after_flush() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_state_6_4_committed_deletion_before_flush() -> IcebergResult<()> {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager, mut notify_rx) =
         create_table_and_iceberg_manager(&temp_dir).await;
     // Prepare environment setup.
@@ -1887,7 +2117,12 @@ async fn test_state_6_4_committed_deletion_before_flush() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 2);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 500);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
-    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
+    )
+    .await;
 
     Ok(())
 }
@@ -1896,6 +2131,7 @@ async fn test_state_6_4_committed_deletion_before_flush() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_state_6_4_committed_deletion_after_flush() -> IcebergResult<()> {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager, mut notify_rx) =
         create_table_and_iceberg_manager(&temp_dir).await;
 
@@ -1946,7 +2182,12 @@ async fn test_state_6_4_committed_deletion_after_flush() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 2);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 300);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
-    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
+    )
+    .await;
 
     Ok(())
 }
@@ -1955,6 +2196,7 @@ async fn test_state_6_4_committed_deletion_after_flush() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_state_6_5() -> IcebergResult<()> {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager, mut notify_rx) =
         create_table_and_iceberg_manager(&temp_dir).await;
 
@@ -2004,7 +2246,12 @@ async fn test_state_6_5() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 2);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 400);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
-    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
+    )
+    .await;
 
     Ok(())
 }
@@ -2013,6 +2260,7 @@ async fn test_state_6_5() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_state_6_6() -> IcebergResult<()> {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager, mut notify_rx) =
         create_table_and_iceberg_manager(&temp_dir).await;
 
@@ -2064,7 +2312,12 @@ async fn test_state_6_6() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 2);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 400);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
-    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
+    )
+    .await;
 
     Ok(())
 }
@@ -2073,6 +2326,7 @@ async fn test_state_6_6() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_state_7_1() -> IcebergResult<()> {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager, mut notify_rx) =
         create_table_and_iceberg_manager(&temp_dir).await;
 
@@ -2086,7 +2340,12 @@ async fn test_state_7_1() -> IcebergResult<()> {
     assert!(snapshot.indices.file_indices.is_empty());
     assert!(snapshot.data_file_flush_lsn.is_none());
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
-    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
+    )
+    .await;
 
     Ok(())
 }
@@ -2095,6 +2354,7 @@ async fn test_state_7_1() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_state_7_2() -> IcebergResult<()> {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager, mut notify_rx) =
         create_table_and_iceberg_manager(&temp_dir).await;
 
@@ -2113,7 +2373,12 @@ async fn test_state_7_2() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 100);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
-    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
+    )
+    .await;
 
     Ok(())
 }
@@ -2122,6 +2387,7 @@ async fn test_state_7_2() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_state_7_3() -> IcebergResult<()> {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager, mut notify_rx) =
         create_table_and_iceberg_manager(&temp_dir).await;
 
@@ -2141,7 +2407,12 @@ async fn test_state_7_3() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 100);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
-    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
+    )
+    .await;
 
     Ok(())
 }
@@ -2150,6 +2421,7 @@ async fn test_state_7_3() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_state_7_4() -> IcebergResult<()> {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager, mut notify_rx) =
         create_table_and_iceberg_manager(&temp_dir).await;
 
@@ -2172,7 +2444,12 @@ async fn test_state_7_4() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 100);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
-    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
+    )
+    .await;
 
     Ok(())
 }
@@ -2181,6 +2458,7 @@ async fn test_state_7_4() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_state_7_5() -> IcebergResult<()> {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager, mut notify_rx) =
         create_table_and_iceberg_manager(&temp_dir).await;
 
@@ -2201,7 +2479,12 @@ async fn test_state_7_5() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 300);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
-    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
+    )
+    .await;
 
     Ok(())
 }
@@ -2210,6 +2493,7 @@ async fn test_state_7_5() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_state_7_6() -> IcebergResult<()> {
     let temp_dir = tempfile::tempdir().unwrap();
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
     let (mut table, mut iceberg_table_manager, mut notify_rx) =
         create_table_and_iceberg_manager(&temp_dir).await;
     // Prepare environment setup.
@@ -2232,7 +2516,12 @@ async fn test_state_7_6() -> IcebergResult<()> {
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 300);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
-    validate_recovered_snapshot(&snapshot, &iceberg_table_manager.config.warehouse_uri).await;
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_manager.config.warehouse_uri,
+        filesystem_accessor.as_ref(),
+    )
+    .await;
 
     Ok(())
 }

--- a/src/moonlink/src/storage/iceberg/tests.rs
+++ b/src/moonlink/src/storage/iceberg/tests.rs
@@ -561,10 +561,7 @@ async fn test_sync_snapshots() {
     let tmp_dir = tempdir().unwrap();
     let mooncake_table_metadata =
         create_test_table_metadata(tmp_dir.path().to_str().unwrap().to_string());
-    let iceberg_table_config = IcebergTableConfig {
-        warehouse_uri: tmp_dir.path().to_str().unwrap().to_string(),
-        ..Default::default()
-    };
+    let iceberg_table_config = get_iceberg_table_config(&tmp_dir);
     test_store_and_load_snapshot_impl(
         mooncake_table_metadata.clone(),
         iceberg_table_config.clone(),
@@ -1625,7 +1622,6 @@ async fn test_drop_table_at_creation() {
 async fn test_multiple_table_ids_for_deletion_vector() {
     let temp_dir = tempfile::tempdir().unwrap();
     let path = temp_dir.path().to_path_buf();
-    let warehouse_uri = path.clone().to_str().unwrap().to_string();
     let mooncake_table_config = MooncakeTableConfig {
         // Flush as long as there's new rows appended at commit.
         mem_slice_size: 1,
@@ -1639,7 +1635,7 @@ async fn test_multiple_table_ids_for_deletion_vector() {
     );
     let identity_property = mooncake_table_metadata.identity.clone();
 
-    let iceberg_table_config = create_iceberg_table_config(warehouse_uri);
+    let iceberg_table_config = get_iceberg_table_config(&temp_dir);
     let schema = create_test_arrow_schema();
     let mut table = MooncakeTable::new(
         schema.as_ref().clone(),

--- a/src/moonlink/src/storage/mooncake_table/deletion_vector_puffin_state_tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/deletion_vector_puffin_state_tests.rs
@@ -204,7 +204,7 @@ async fn test_1_recover_2_without_local_optimization(#[case] use_batch_write: bo
     let mut iceberg_table_manager_to_recover = IcebergTableManager::new(
         table.metadata.clone(),
         cache_for_recovery.clone(),
-        create_local_filesystem_accessor(&iceberg_table_config),
+        create_test_filesystem_accessor(&iceberg_table_config),
         iceberg_table_config,
     )
     .unwrap();
@@ -263,7 +263,7 @@ async fn test_1_recover_2_with_local_optimization(#[case] use_batch_write: bool)
     let mut iceberg_table_manager_to_recover = IcebergTableManager::new(
         table.metadata.clone(),
         cache_for_recovery.clone(),
-        create_local_filesystem_accessor(&iceberg_table_config),
+        create_test_filesystem_accessor(&iceberg_table_config),
         iceberg_table_config,
     )
     .unwrap();

--- a/src/moonlink/src/storage/mooncake_table/file_index_state_tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/file_index_state_tests.rs
@@ -104,7 +104,7 @@ async fn test_1_recover_3() {
     let mut iceberg_table_manager_to_recover = IcebergTableManager::new(
         table.metadata.clone(),
         object_storage_cache_for_recovery.clone(),
-        create_local_filesystem_accessor(&iceberg_table_config),
+        create_test_filesystem_accessor(&iceberg_table_config),
         iceberg_table_config,
     )
     .unwrap();
@@ -210,7 +210,7 @@ pub(super) async fn create_mooncake_table_and_notify_for_index_merge(
         iceberg_table_config.clone(),
         mooncake_table_config,
         object_storage_cache,
-        create_local_filesystem_accessor(&iceberg_table_config),
+        create_test_filesystem_accessor(&iceberg_table_config),
     )
     .await
     .unwrap();

--- a/src/moonlink/src/storage/mooncake_table/table_creation_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_creation_test_utils.rs
@@ -2,7 +2,6 @@
 use crate::row::IdentityProp as RowIdentity;
 use crate::storage::compaction::compaction_config::DataCompactionConfig;
 use crate::storage::filesystem::accessor::base_filesystem_accessor::BaseFileSystemAccess;
-use crate::storage::filesystem::filesystem_config::FileSystemConfig;
 use crate::storage::iceberg::iceberg_table_manager::IcebergTableConfig;
 use crate::storage::iceberg::iceberg_table_manager::IcebergTableManager;
 use crate::storage::mooncake_table::test_utils_commons::*;
@@ -50,12 +49,12 @@ pub(crate) fn create_test_arrow_schema() -> Arc<ArrowSchema> {
 }
 
 /// Test util function to create local filesystem accessor from iceberg table config.
-pub(crate) fn create_local_filesystem_accessor(
+pub(crate) fn create_test_filesystem_accessor(
     iceberg_table_config: &IcebergTableConfig,
 ) -> Arc<dyn BaseFileSystemAccess> {
-    Arc::new(FileSystemAccessor::new(FileSystemConfig::FileSystem {
-        root_directory: iceberg_table_config.warehouse_uri.clone(),
-    }))
+    Arc::new(FileSystemAccessor::new(
+        iceberg_table_config.filesystem_config.clone(),
+    ))
 }
 
 /// Test util function to create mooncake table metadata.
@@ -113,7 +112,7 @@ pub(crate) async fn create_table_and_iceberg_manager_with_config(
         iceberg_table_config.clone(),
         mooncake_table_metadata.as_ref().config.clone(),
         object_storage_cache.clone(),
-        create_local_filesystem_accessor(&iceberg_table_config),
+        create_test_filesystem_accessor(&iceberg_table_config),
     )
     .await
     .unwrap();
@@ -121,7 +120,7 @@ pub(crate) async fn create_table_and_iceberg_manager_with_config(
     let iceberg_table_manager = IcebergTableManager::new(
         mooncake_table_metadata.clone(),
         object_storage_cache.clone(),
-        create_local_filesystem_accessor(&iceberg_table_config),
+        create_test_filesystem_accessor(&iceberg_table_config),
         iceberg_table_config.clone(),
     )
     .unwrap();
@@ -169,7 +168,7 @@ pub(crate) async fn create_table_and_iceberg_manager_with_data_compaction_config
         iceberg_table_config.clone(),
         mooncake_table_config,
         object_storage_cache.clone(),
-        create_local_filesystem_accessor(&iceberg_table_config),
+        create_test_filesystem_accessor(&iceberg_table_config),
     )
     .await
     .unwrap();
@@ -177,7 +176,7 @@ pub(crate) async fn create_table_and_iceberg_manager_with_data_compaction_config
     let iceberg_table_manager = IcebergTableManager::new(
         mooncake_table_metadata.clone(),
         object_storage_cache.clone(),
-        create_local_filesystem_accessor(&iceberg_table_config),
+        create_test_filesystem_accessor(&iceberg_table_config),
         iceberg_table_config.clone(),
     )
     .unwrap();
@@ -230,7 +229,7 @@ pub(crate) async fn create_mooncake_table_and_notify_for_compaction(
         iceberg_table_config.clone(),
         mooncake_table_config,
         object_storage_cache,
-        create_local_filesystem_accessor(&iceberg_table_config),
+        create_test_filesystem_accessor(&iceberg_table_config),
     )
     .await
     .unwrap();
@@ -272,7 +271,7 @@ pub(crate) async fn create_mooncake_table_and_notify_for_read(
         iceberg_table_config.clone(),
         mooncake_table_config,
         object_storage_cache,
-        create_local_filesystem_accessor(&iceberg_table_config),
+        create_test_filesystem_accessor(&iceberg_table_config),
     )
     .await
     .unwrap();

--- a/src/moonlink/src/storage/mooncake_table/test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/test_utils.rs
@@ -7,6 +7,7 @@ use crate::storage::mooncake_table::snapshot::PuffinDeletionBlobAtRead;
 use crate::storage::mooncake_table::snapshot_read_output::DataFileForRead;
 use crate::storage::mooncake_table::table_creation_test_utils::*;
 use crate::storage::mooncake_table::table_operation_test_utils::*;
+use crate::FileSystemConfig;
 use arrow::array::Int32Array;
 use futures::future::join_all;
 use iceberg::io::FileIOBuilder;
@@ -44,11 +45,12 @@ pub fn test_row(id: i32, name: &str, age: i32) -> MoonlinkRow {
 
 /// Test util function to get iceberg table config for testing purpose.
 pub fn test_iceberg_table_config(context: &TestContext, table_name: &str) -> IcebergTableConfig {
+    let root_directory = context.path().to_str().unwrap().to_string();
     IcebergTableConfig {
-        warehouse_uri: context.path().to_str().unwrap().to_string(),
+        warehouse_uri: root_directory.clone(),
         namespace: vec!["default".to_string()],
         table_name: table_name.to_string(),
-        ..Default::default()
+        filesystem_config: FileSystemConfig::FileSystem { root_directory },
     }
 }
 

--- a/src/moonlink/src/storage/mooncake_table/test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/test_utils.rs
@@ -75,7 +75,7 @@ pub async fn test_table(
         iceberg_table_config.clone(),
         table_config,
         ObjectStorageCache::default_for_test(&context.temp_dir),
-        create_local_filesystem_accessor(&iceberg_table_config),
+        create_test_filesystem_accessor(&iceberg_table_config),
     )
     .await
     .unwrap()

--- a/src/moonlink/src/storage/mooncake_table/tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/tests.rs
@@ -499,7 +499,7 @@ async fn test_table_recovery() {
         iceberg_table_config.clone(),
         test_mooncake_table_config(&context),
         ObjectStorageCache::default_for_test(&context.temp_dir),
-        create_local_filesystem_accessor(&iceberg_table_config),
+        create_test_filesystem_accessor(&iceberg_table_config),
     )
     .await
     .unwrap();

--- a/src/moonlink/src/table_handler/test_utils.rs
+++ b/src/moonlink/src/table_handler/test_utils.rs
@@ -6,7 +6,10 @@ use crate::storage::IcebergTableConfig;
 use crate::storage::{verify_files_and_deletions, MooncakeTable};
 use crate::table_handler::{EventSyncSender, TableEvent, TableHandler}; // Ensure this path is correct
 use crate::union_read::{decode_read_state_for_testing, ReadStateManager};
-use crate::{EventSyncReceiver, IcebergTableManager, MooncakeTableConfig, TableEventManager};
+use crate::{
+    EventSyncReceiver, FileSystemConfig, IcebergTableManager, MooncakeTableConfig,
+    TableEventManager,
+};
 use crate::{ObjectStorageCache, Result};
 
 use arrow_array::RecordBatch;
@@ -29,10 +32,12 @@ pub fn create_row(id: i32, name: &str, age: i32) -> MoonlinkRow {
 /// Get iceberg table manager config.
 pub fn get_iceberg_manager_config(table_name: String, warehouse_uri: String) -> IcebergTableConfig {
     IcebergTableConfig {
-        warehouse_uri,
+        warehouse_uri: warehouse_uri.clone(),
         namespace: vec!["default".to_string()],
         table_name,
-        ..Default::default()
+        filesystem_config: FileSystemConfig::FileSystem {
+            root_directory: warehouse_uri,
+        },
     }
 }
 

--- a/src/moonlink/src/table_handler/test_utils.rs
+++ b/src/moonlink/src/table_handler/test_utils.rs
@@ -127,7 +127,7 @@ impl TestEnvironment {
             iceberg_table_config.clone(),
             mooncake_table_config,
             ObjectStorageCache::default_for_test(&temp_dir),
-            create_local_filesystem_accessor(&iceberg_table_config),
+            create_test_filesystem_accessor(&iceberg_table_config),
         )
         .await
         .unwrap();
@@ -156,7 +156,7 @@ impl TestEnvironment {
         IcebergTableManager::new(
             mooncake_table_metadata,
             self.object_storage_cache.clone(),
-            create_local_filesystem_accessor(&iceberg_table_config),
+            create_test_filesystem_accessor(&iceberg_table_config),
             iceberg_table_config.clone(),
         )
         .unwrap()


### PR DESCRIPTION
## Summary

IMO, not all test cases need to adapt from local storage to remote storage, for example, state machine based tests is ok with local filesystem iceberg warehouse.
In this PR, I adapt some integration style unit tests to leverage remote object storage, and update a few test cases and utils.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/440

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
