### PR TITLE
[storage] Implement test guard for object storage

### DIFF
--- a/src/moonlink/src/storage/filesystem/gcs.rs
+++ b/src/moonlink/src/storage/filesystem/gcs.rs
@@ -3,4 +3,7 @@
 pub(crate) mod gcs_test_utils;
 #[cfg(feature = "storage-gcs")]
 #[cfg(test)]
+pub(crate) mod test_guard;
+#[cfg(feature = "storage-gcs")]
+#[cfg(test)]
 pub(crate) mod tests;

--- a/src/moonlink/src/storage/filesystem/gcs/gcs_test_utils.rs
+++ b/src/moonlink/src/storage/filesystem/gcs/gcs_test_utils.rs
@@ -140,7 +140,7 @@ pub(crate) async fn create_test_gcs_bucket(bucket: String) -> IcebergResult<()> 
 }
 
 #[allow(dead_code)]
-pub(crate) async fn delete_test_gcs_bucket(bucket: String) -> IcebergResult<()> {
+pub(crate) async fn delete_test_gcs_bucket(bucket: String) {
     let retry_strategy = ExponentialBackoff::from_millis(TEST_RETRY_INIT_MILLISEC)
         .map(jitter)
         .take(TEST_RETRY_COUNT);
@@ -156,6 +156,6 @@ pub(crate) async fn delete_test_gcs_bucket(bucket: String) -> IcebergResult<()> 
             }
         }
     })
-    .await?;
-    Ok(())
+    .await
+    .unwrap();
 }

--- a/src/moonlink/src/storage/filesystem/gcs/test_guard.rs
+++ b/src/moonlink/src/storage/filesystem/gcs/test_guard.rs
@@ -1,0 +1,27 @@
+/// A RAII-style test guard, which creates bucket at construction, and deletes at destruction.
+use crate::storage::filesystem::gcs::gcs_test_utils;
+
+pub(crate) struct TestGuard {
+    /// Bucket name.n
+    bucket: String,
+}
+
+impl TestGuard {
+    pub(crate) async fn new(bucket: String) -> Self {
+        gcs_test_utils::create_test_gcs_bucket(bucket.clone())
+            .await
+            .unwrap();
+        Self { bucket }
+    }
+}
+
+impl Drop for TestGuard {
+    fn drop(&mut self) {
+        let bucket = std::mem::take(&mut self.bucket);
+        tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(async move {
+                gcs_test_utils::delete_test_gcs_bucket(bucket).await;
+            });
+        });
+    }
+}

--- a/src/moonlink/src/storage/filesystem/s3.rs
+++ b/src/moonlink/src/storage/filesystem/s3.rs
@@ -3,4 +3,7 @@
 pub(crate) mod s3_test_utils;
 #[cfg(feature = "storage-s3")]
 #[cfg(test)]
+pub(crate) mod test_guard;
+#[cfg(feature = "storage-s3")]
+#[cfg(test)]
 pub(crate) mod tests;

--- a/src/moonlink/src/storage/filesystem/s3/s3_test_utils.rs
+++ b/src/moonlink/src/storage/filesystem/s3/s3_test_utils.rs
@@ -21,19 +21,13 @@ type HmacSha1 = Hmac<Sha1>;
 /// Minio related constants.
 ///
 /// Local minio warehouse needs special handling, so we simply prefix with special token.
-#[allow(dead_code)]
 pub(crate) static S3_TEST_BUCKET_PREFIX: &str = "test-minio-warehouse-";
-#[allow(dead_code)]
 pub(crate) static S3_TEST_WAREHOUSE_URI_PREFIX: &str = "s3://test-minio-warehouse-";
-#[allow(dead_code)]
 pub(crate) static S3_TEST_ACCESS_KEY_ID: &str = "minioadmin";
-#[allow(dead_code)]
 pub(crate) static S3_TEST_SECRET_ACCESS_KEY: &str = "minioadmin";
-#[allow(dead_code)]
 pub(crate) static S3_TEST_ENDPOINT: &str = "http://minio:9000";
 
 /// Create a S3 catalog config.
-#[allow(dead_code)]
 pub(crate) fn create_s3_filesystem_config(warehouse_uri: &str) -> FileSystemConfig {
     let bucket = get_bucket_from_warehouse_uri(warehouse_uri);
     FileSystemConfig::S3 {
@@ -45,14 +39,12 @@ pub(crate) fn create_s3_filesystem_config(warehouse_uri: &str) -> FileSystemConf
     }
 }
 
-#[allow(dead_code)]
 pub(crate) fn get_test_s3_bucket_and_warehouse(
 ) -> (String /*bucket_name*/, String /*warehouse_url*/) {
     get_bucket_and_warehouse(S3_TEST_BUCKET_PREFIX, S3_TEST_WAREHOUSE_URI_PREFIX)
 }
 
 /// Create test bucket in minio server.
-#[allow(dead_code)]
 async fn create_test_s3_bucket_impl(bucket: Arc<String>) -> IcebergResult<()> {
     let date = Utc::now().format("%a, %d %b %Y %T GMT").to_string();
     let string_to_sign = format!("PUT\n\n\n{}\n/{}", date, bucket);
@@ -80,7 +72,6 @@ async fn create_test_s3_bucket_impl(bucket: Arc<String>) -> IcebergResult<()> {
 }
 
 /// Creates the provided bucket with exponential backoff retry; this function assumes the bucket doesn't exist, otherwise it will return error.
-#[allow(dead_code)]
 pub(crate) async fn create_test_s3_bucket(bucket: String) -> IcebergResult<()> {
     let retry_strategy = ExponentialBackoff::from_millis(TEST_RETRY_INIT_MILLISEC)
         .map(jitter)
@@ -150,8 +141,7 @@ pub async fn delete_test_s3_bucket_impl(bucket: Arc<String>) -> IcebergResult<()
 }
 
 /// Delete the provided bucket with exponential backoff retry; this function assume bucket already exists and return error if not.
-#[allow(dead_code)]
-pub(crate) async fn delete_test_s3_bucket(bucket: String) -> IcebergResult<()> {
+pub(crate) async fn delete_test_s3_bucket(bucket: String) {
     let retry_strategy = ExponentialBackoff::from_millis(TEST_RETRY_INIT_MILLISEC)
         .map(jitter)
         .take(TEST_RETRY_COUNT);
@@ -167,6 +157,6 @@ pub(crate) async fn delete_test_s3_bucket(bucket: String) -> IcebergResult<()> {
             }
         }
     })
-    .await?;
-    Ok(())
+    .await
+    .unwrap();
 }

--- a/src/moonlink/src/storage/filesystem/s3/test_guard.rs
+++ b/src/moonlink/src/storage/filesystem/s3/test_guard.rs
@@ -1,0 +1,27 @@
+/// A RAII-style test guard, which creates bucket at construction, and deletes at destruction.
+use crate::storage::filesystem::s3::s3_test_utils;
+
+pub(crate) struct TestGuard {
+    /// Bucket name.n
+    bucket: String,
+}
+
+impl TestGuard {
+    pub(crate) async fn new(bucket: String) -> Self {
+        s3_test_utils::create_test_s3_bucket(bucket.clone())
+            .await
+            .unwrap();
+        Self { bucket }
+    }
+}
+
+impl Drop for TestGuard {
+    fn drop(&mut self) {
+        let bucket = std::mem::take(&mut self.bucket);
+        tokio::task::block_in_place(|| {
+            tokio::runtime::Handle::current().block_on(async move {
+                s3_test_utils::delete_test_s3_bucket(bucket).await;
+            });
+        });
+    }
+}

--- a/src/moonlink/src/storage/filesystem/s3/tests.rs
+++ b/src/moonlink/src/storage/filesystem/s3/tests.rs
@@ -2,8 +2,9 @@ use crate::storage::filesystem::accessor::base_filesystem_accessor::BaseFileSyst
 use crate::storage::filesystem::accessor::filesystem_accessor::FileSystemAccessor;
 use crate::storage::filesystem::accessor::test_utils::*;
 use crate::storage::filesystem::s3::s3_test_utils::*;
+use crate::storage::filesystem::s3::test_guard::TestGuard;
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_copy_from_local_to_remote() {
     // Prepare src file.
     let temp_dir = tempfile::tempdir().unwrap();
@@ -12,7 +13,7 @@ async fn test_copy_from_local_to_remote() {
     create_local_file(&src_filepath).await;
 
     let (bucket, warehouse_uri) = get_test_s3_bucket_and_warehouse();
-    create_test_s3_bucket(bucket.clone()).await.unwrap();
+    let _test_guard = TestGuard::new(bucket.clone()).await;
     let s3_filesystem_config = create_s3_filesystem_config(&warehouse_uri);
 
     // Copy from src to dst.
@@ -29,19 +30,16 @@ async fn test_copy_from_local_to_remote() {
         .await
         .unwrap();
     assert_eq!(actual_content, TEST_CONTEST);
-
-    // Clean up test bucket.
-    delete_test_s3_bucket(bucket.clone()).await.unwrap();
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_copy_from_remote_to_local() {
     let temp_dir = tempfile::tempdir().unwrap();
     let root_directory = temp_dir.path().to_str().unwrap().to_string();
     let dst_filepath = format!("{}/dst", &root_directory);
 
     let (bucket, warehouse_uri) = get_test_s3_bucket_and_warehouse();
-    create_test_s3_bucket(bucket.clone()).await.unwrap();
+    let _test_guard = TestGuard::new(bucket.clone()).await;
     let s3_filesystem_config = create_s3_filesystem_config(&warehouse_uri);
 
     // Prepare src file.
@@ -58,7 +56,4 @@ async fn test_copy_from_remote_to_local() {
     // Validate destination file content.
     let actual_content = tokio::fs::read_to_string(dst_filepath).await.unwrap();
     assert_eq!(actual_content, TEST_CONTEST);
-
-    // Clean up test bucket.
-    delete_test_s3_bucket(bucket.clone()).await.unwrap();
 }


### PR DESCRIPTION
## Summary

We need RAII-style test guard for object storage, otherwise have to do that manually which is easy to forget.
I tried another way: make deletion operation synchronous, so we could have blocking IO at drop trait, but that changeset is much bigger than this PR.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/770

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
