### PR TITLE
Add storage-gcs and storage-s3 into CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,11 @@ jobs:
             sleep 2
           done
 
+      - name: Run gcs tests
+        timeout-minutes: 5
+        run: |
+          cargo test -p moonlink --features=storage-gcs
+
       - name: Run tests via llvm-cov/nextest
         timeout-minutes: 5
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Start Fake GCS Server (HTTP mode)
+      # ─────────────────────── Start Fake GCS Server ──────────────────────────
+      - name: Start Fake GCS Server
         run: |
           docker run -d \
             --name fake-gcs \
@@ -69,20 +70,47 @@ jobs:
             fsouza/fake-gcs-server:latest \
             -scheme http -port 4443
 
-      - name: Add gcs.local to /etc/hosts
-        run: echo "127.0.0.1 gcs.local" | sudo tee -a /etc/hosts
+      # ─────────────────────── Start Fake S3 Server ──────────────────────────
+      - name: Start MinIO Server
+        run: |
+          docker run -d \
+            --name minio \
+            -p 9000:9000 \
+            -e MINIO_ROOT_USER=minioadmin \
+            -e MINIO_ROOT_PASSWORD=minioadmin \
+            minio/minio:latest server /data
 
-      - name: Wait for Fake GCS to be ready
+      # ─────────────── Add hostnames to /etc/hosts ──────────────────────────
+      - name: Add gcs.local and s3.local to /etc/hosts
+        run: |
+          echo "127.0.0.1 gcs.local" | sudo tee -a /etc/hosts
+          echo "127.0.0.1 s3.local"  | sudo tee -a /etc/hosts
+
+      # ───────────────────── Wait for Fake GCS to be ready ───────────────────
+      - name: Wait for Fake GCS
         run: |
           for i in {1..10}; do
             if curl -sf http://gcs.local:4443/storage/v1/b; then
-              echo "Fake GCS is up!"
+              echo "Fake GCS is ready!"
               break
             fi
             echo "Waiting for Fake GCS..."
             sleep 2
           done
 
+      # ───────────────────── Wait for Fake S3 to be ready ───────────────────
+      - name: Wait for Fake S3
+        run: |
+          for i in {1..10}; do
+            if curl -sf http://s3.local:9000/minio/health/ready; then
+              echo "Fake S3 is ready!"
+              break
+            fi
+            echo "Waiting for Fake GCS..."
+            sleep 2
+          done
+
+      # ────────────────────── Toolchain + Test Tools ─────────────────────────
       - uses: dtolnay/rust-toolchain@stable
         id: toolchain
         with:
@@ -97,25 +125,15 @@ jobs:
       - uses: taiki-e/install-action@v2
         with: { tool: nextest }
 
-      - name: Add gcs.local to /etc/hosts
-        run: |
-          echo "127.0.0.1 gcs.local" | sudo tee -a /etc/hosts
-
-      - name: Wait for Fake GCS to be ready
-        run: |
-          for i in {1..10}; do
-            if curl -sf http://gcs.local:4443/storage/v1/b; then
-              echo "Fake GCS is up!"
-              break
-            fi
-            echo "Waiting for Fake GCS..."
-            sleep 2
-          done
-
-      - name: Run gcs tests
+      - name: Run GCS feature tests
         timeout-minutes: 5
         run: |
           cargo test -p moonlink --features=storage-gcs
+
+      - name: Run S3 feature tests
+        timeout-minutes: 5
+        run: |
+          cargo test -p moonlink --features=storage-s3
 
       - name: Run tests via llvm-cov/nextest
         timeout-minutes: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,22 +57,31 @@ jobs:
     name: Unit Tests + Coverage (llvm-cov + nextest)
     runs-on: ubuntu-latest
 
-    services:
-      fake-gcs:
-        image: fsouza/fake-gcs-server:latest
-        ports:
-          - 4443:4443
-        env:
-          STORAGE_DIR: /data
-        options: >-
-          --hostname gcs
-          --health-cmd "curl -f http://localhost:4443/storage/v1/b || exit 1"
-          --health-interval 3s
-          --health-timeout 3s
-          --health-retries 10
-
     steps:
       - uses: actions/checkout@v4
+
+      - name: Start Fake GCS Server (HTTP mode)
+        run: |
+          docker run -d \
+            --name fake-gcs \
+            -p 4443:4443 \
+            -e STORAGE_DIR=/data \
+            fsouza/fake-gcs-server:latest \
+            -scheme http -port 4443
+
+      - name: Add gcs.local to /etc/hosts
+        run: echo "127.0.0.1 gcs.local" | sudo tee -a /etc/hosts
+
+      - name: Wait for Fake GCS to be ready
+        run: |
+          for i in {1..10}; do
+            if curl -sf http://gcs.local:4443/storage/v1/b; then
+              echo "Fake GCS is up!"
+              break
+            fi
+            echo "Waiting for Fake GCS..."
+            sleep 2
+          done
 
       - uses: dtolnay/rust-toolchain@stable
         id: toolchain

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,9 +81,10 @@ jobs:
             minio/minio:latest server /data
 
       # ─────────────── Add hostnames to /etc/hosts ──────────────────────────
-      - name: Add gcs.local and to /etc/hosts
+      - name: Add gcs.local and s3.local to /etc/hosts
         run: |
           echo "127.0.0.1 gcs.local" | sudo tee -a /etc/hosts
+          echo "127.0.0.1 s3.local" | sudo tee -a /etc/hosts
 
       # ───────────────────── Wait for Fake GCS to be ready ───────────────────
       - name: Wait for Fake GCS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,21 @@ jobs:
   coverage:
     name: Unit Tests + Coverage (llvm-cov + nextest)
     runs-on: ubuntu-latest
+
+    services:
+      fake-gcs:
+        image: fsouza/fake-gcs-server:latest
+        ports:
+          - 4443:4443
+        env:
+          STORAGE_DIR: /data
+        options: >-
+          --hostname gcs
+          --health-cmd "curl -f http://localhost:4443/storage/v1/b || exit 1"
+          --health-interval 3s
+          --health-timeout 3s
+          --health-retries 10
+
     steps:
       - uses: actions/checkout@v4
 
@@ -73,7 +88,21 @@ jobs:
       - uses: taiki-e/install-action@v2
         with: { tool: nextest }
 
-      # ---------- Run the suite through llvm-cov and nextest ----------
+      - name: Add gcs.local to /etc/hosts
+        run: |
+          echo "127.0.0.1 gcs.local" | sudo tee -a /etc/hosts
+
+      - name: Wait for Fake GCS to be ready
+        run: |
+          for i in {1..10}; do
+            if curl -sf http://gcs.local:4443/storage/v1/b; then
+              echo "Fake GCS is up!"
+              break
+            fi
+            echo "Waiting for Fake GCS..."
+            sleep 2
+          done
+
       - name: Run tests via llvm-cov/nextest
         timeout-minutes: 5
         run: |
@@ -104,4 +133,3 @@ jobs:
         with:
           files: lcov.info
           fail_ci_if_error: true
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
             -scheme http -port 4443
 
       # ─────────────────────── Start Fake S3 Server ──────────────────────────
-      - name: Start MinIO Server
+      - name: Start Fake S3 Server
         run: |
           docker run -d \
             --name minio \
@@ -81,10 +81,9 @@ jobs:
             minio/minio:latest server /data
 
       # ─────────────── Add hostnames to /etc/hosts ──────────────────────────
-      - name: Add gcs.local and s3.local to /etc/hosts
+      - name: Add gcs.local and to /etc/hosts
         run: |
           echo "127.0.0.1 gcs.local" | sudo tee -a /etc/hosts
-          echo "127.0.0.1 s3.local"  | sudo tee -a /etc/hosts
 
       # ───────────────────── Wait for Fake GCS to be ready ───────────────────
       - name: Wait for Fake GCS
@@ -102,7 +101,7 @@ jobs:
       - name: Wait for Fake S3
         run: |
           for i in {1..10}; do
-            if curl -sf http://s3.local:9000/minio/health/ready; then
+            if curl -sf http://minio:9000/minio/health/ready; then
               echo "Fake S3 is ready!"
               break
             fi

--- a/src/moonlink/src/storage/filesystem/s3/s3_test_utils.rs
+++ b/src/moonlink/src/storage/filesystem/s3/s3_test_utils.rs
@@ -25,7 +25,7 @@ pub(crate) static S3_TEST_BUCKET_PREFIX: &str = "test-minio-warehouse-";
 pub(crate) static S3_TEST_WAREHOUSE_URI_PREFIX: &str = "s3://test-minio-warehouse-";
 pub(crate) static S3_TEST_ACCESS_KEY_ID: &str = "minioadmin";
 pub(crate) static S3_TEST_SECRET_ACCESS_KEY: &str = "minioadmin";
-pub(crate) static S3_TEST_ENDPOINT: &str = "http://minio:9000";
+pub(crate) static S3_TEST_ENDPOINT: &str = "http://s3.local:9000";
 
 /// Create a S3 catalog config.
 pub(crate) fn create_s3_filesystem_config(warehouse_uri: &str) -> FileSystemConfig {
@@ -65,7 +65,10 @@ async fn create_test_s3_bucket_impl(bucket: Arc<String>) -> IcebergResult<()> {
         .map_err(|e| {
             IcebergError::new(
                 iceberg::ErrorKind::Unexpected,
-                format!("Failed to create bucket {} in minio {}", bucket, e),
+                format!(
+                    "Failed to create bucket {} in minio with url {}: {}",
+                    bucket, url, e
+                ),
             )
         })?;
     Ok(())


### PR DESCRIPTION
## Summary

I have added a few object storage related features into unit tests, which relies on 
(1) local minio server as S3 backend
(2) local fake GCS server as gcs backend.

In this PR, I added both into CI.

There're two concerns and followups left for the PR:
- Triple compilation time and CI execution time, which is hard to avoid (maybe caching on CI?), because different features actually generates different libraries and executables. I could followup with potential caching capability, but haven't seen a quick solution.
  + It's still acceptable CI speed from my perspective, could also try to parallelize GCS/S3/normal testing.
- Another is somewhat repeated unit tests; I don't see cargo solutions to only run unit tests annotated with one specific feature.
  + SO link: https://stackoverflow.com/questions/77529267/how-to-run-only-tests-marked-with-a-specific-feature-and-ignoring-the-rest

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/774

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
