### PR TITLE
[storage] Avoid memset for IO operation buffer

### DIFF
--- a/src/moonlink/src/storage/filesystem/accessor/filesystem_accessor.rs
+++ b/src/moonlink/src/storage/filesystem/accessor/filesystem_accessor.rs
@@ -298,9 +298,13 @@ impl BaseFileSystemAccess for FileSystemAccessor {
         let src_path = src.to_string();
         let reader_task_handle = tokio::spawn(async move {
             let mut file = tokio::fs::File::open(&src_path).await?;
-            let mut buffer: Vec<u8> = Vec::with_capacity(IO_BLOCK_SIZE);
-            unsafe {
-                buffer.set_len(IO_BLOCK_SIZE);
+            #[allow(clippy::uninit_vec)]
+            let mut buffer: Vec<u8> = {
+                let mut buf = Vec::with_capacity(IO_BLOCK_SIZE);
+                unsafe {
+                    buf.set_len(IO_BLOCK_SIZE);
+                }
+                buf
             };
             loop {
                 let n = file.read(&mut buffer).await?;


### PR DESCRIPTION
## Summary

As titled, no need for initialization on buffer.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/783

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
