### PR TITLE
Fix precision and scale for Decimal128

### DIFF
--- a/src/moonlink/src/row/column_array_builder.rs
+++ b/src/moonlink/src/row/column_array_builder.rs
@@ -84,8 +84,10 @@ impl ColumnArrayBuilder {
                     array_builder,
                 )
             }
-            DataType::Decimal128(_, _) => ColumnArrayBuilder::Decimal128(
-                PrimitiveBuilder::<Decimal128Type>::with_capacity(capacity),
+            DataType::Decimal128(precision, scale) => ColumnArrayBuilder::Decimal128(
+                PrimitiveBuilder::<Decimal128Type>::with_capacity(capacity)
+                    .with_precision_and_scale(*precision, *scale)
+                    .expect("Failed to create Decimal128Type"),
                 array_builder,
             ),
             DataType::Binary => ColumnArrayBuilder::Binary(

--- a/src/moonlink_connectors/src/pg_replicate/util.rs
+++ b/src/moonlink_connectors/src/pg_replicate/util.rs
@@ -23,7 +23,7 @@ fn numeric_precision_scale(modifier: i32) -> Option<(u8, i8)> {
     // Derived from: [https://github.com/postgres/postgres/blob/4fbb46f61271f4b7f46ecad3de608fc2f4d7d80f/src/backend/utils/adt/numeric.c#L929v]
     let precision = ((typmod >> 16) & 0xffff) as u8;
     // Derived from: [https://github.com/postgres/postgres/blob/4fbb46f61271f4b7f46ecad3de608fc2f4d7d80f/src/backend/utils/adt/numeric.c#L944]
-    let raw_scale = (typmod & 0x7fff);
+    let raw_scale = (typmod & 0x7ff);
     let scale = ((raw_scale ^ 1024) - 1024) as i8;
     Some((precision, scale))
 }

--- a/src/moonlink_connectors/src/pg_replicate/util.rs
+++ b/src/moonlink_connectors/src/pg_replicate/util.rs
@@ -364,16 +364,8 @@ impl From<PostgresTableRow> for MoonlinkRow {
                 Cell::Numeric(value) => {
                     match value {
                         PgNumeric::Value(bigdecimal) => {
-                            let (int_val, scale) = bigdecimal.as_bigint_and_exponent();
-                            let multiplier = 10_i128.pow(scale as u32);
-                            if let Some(scaled_integer) =
-                                int_val.to_i128().and_then(|v| v.checked_mul(multiplier))
-                            {
-                                values.push(RowValue::Decimal(scaled_integer));
-                            } else {
-                                values.push(RowValue::Null); // handle overflow safely
-                                warn!("Decimal value too large to fit in i128; storing as NULL");
-                            }
+                            let (int_val, _) = bigdecimal.into_bigint_and_exponent();
+                            values.push(RowValue::Decimal(int_val.to_i128().unwrap()));
                         }
                         _ => {
                             // DevNote:

--- a/src/moonlink_connectors/src/pg_replicate/util.rs
+++ b/src/moonlink_connectors/src/pg_replicate/util.rs
@@ -242,7 +242,8 @@ fn convert_array_cell(cell: ArrayCell) -> Vec<RowValue> {
             .map(|v| {
                 v.map(|n| match n {
                     PgNumeric::Value(bigdecimal) => {
-                        RowValue::Decimal(bigdecimal.to_i128().unwrap())
+                        let (int_val, _) = bigdecimal.into_bigint_and_exponent();
+                        RowValue::Decimal(int_val.to_i128().unwrap())
                     }
                     _ => RowValue::Null,
                 })


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

There are a few issues with the current implementation. 

When building the Decimal128 type in `column_array_builder` we were silently dropping the precision and scale. It would then use the defaults of `(38, 10)`.
We are applying the scale to the `int_val` from `bigdecimal`, but this is already scaled. We can directly append the `int_val`.
We were using an incorrect mask when parsing `typmod` (although this seemed to have no impact)
We weren't using the scaled value in the `ArrayCell` case. 

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/789

## Changes

- Pass precision and scale when building `Decimal128Type
- Avoid double scale
- Fix mask
- Use scaled val in ArrayCell 

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
