### PR TITLE
Remove warn for missing schema

### DIFF
--- a/src/moonlink_connectors/src/replication_connection.rs
+++ b/src/moonlink_connectors/src/replication_connection.rs
@@ -568,7 +568,6 @@ async fn run_event_loop(
 
                 match event_result {
                     Err(CdcStreamError::CdcEventConversion(CdcEventConversionError::MissingSchema(_))) => {
-                        warn!("missing schema for replication event");
                         continue;
                     }
                     Err(CdcStreamError::CdcEventConversion(CdcEventConversionError::MessageNotSupported)) => {


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

When replaying from `confirmed_flush_lsn` it's possible and valid to replay events from tables that have since been dropped. We should drop the `warn!` to avoid spamming. 

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/787

## Changes

- 
- 
- 

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
