### PR TITLE
Hermetic git hook installation

### DIFF
--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -5,4 +5,5 @@ git config devcontainers-theme.show-dirty 1
 echo "alias psql='PGPASSWORD=postgres psql -h postgres -p 5432 -U postgres -d postgres'" >> ~/.bashrc
 
 # precommit hook requirement.
+rm -f .git/hooks/*
 pre-commit install -t pre-push


### PR DESCRIPTION
## Summary

Git hook is installed at moonlink repo, so it's persisted across devcontainers, if start command doesn't touch it.
In this PR I reinstall everything so installation is hermetic.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/810

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
