### PR TITLE
[storage] Overwrite iceberg-rust schema

### DIFF
--- a/src/moonlink/src/storage/iceberg.rs
+++ b/src/moonlink/src/storage/iceberg.rs
@@ -5,6 +5,7 @@ mod iceberg_table_loader;
 pub(super) mod iceberg_table_manager;
 mod iceberg_table_syncer;
 pub(super) mod index;
+pub(super) mod io_utils;
 pub(super) mod moonlink_catalog;
 pub(super) mod parquet_metadata_utils;
 pub(super) mod parquet_stats_utils;

--- a/src/moonlink/src/storage/iceberg.rs
+++ b/src/moonlink/src/storage/iceberg.rs
@@ -12,6 +12,8 @@ pub(super) mod parquet_stats_utils;
 pub(super) mod parquet_utils;
 pub(super) mod puffin_utils;
 pub(super) mod puffin_writer_proxy;
+#[cfg(test)]
+pub(super) mod schema_utils;
 pub(super) mod table_event_manager;
 pub(super) mod table_manager;
 pub(super) mod table_property;

--- a/src/moonlink/src/storage/iceberg/catalog_utils.rs
+++ b/src/moonlink/src/storage/iceberg/catalog_utils.rs
@@ -1,10 +1,14 @@
 #[cfg(test)]
 use crate::storage::filesystem::accessor::base_filesystem_accessor::BaseFileSystemAccess;
+use crate::storage::filesystem::filesystem_config::FileSystemConfig;
 use crate::storage::iceberg::file_catalog::FileCatalog;
 use crate::storage::iceberg::moonlink_catalog::MoonlinkCatalog;
-use crate::FileSystemConfig;
 
+use arrow_schema::Schema as ArrowSchema;
+use iceberg::spec::Schema as IcebergSchema;
 use iceberg::Result as IcebergResult;
+
+use std::sync::Arc;
 
 /// Create a catelog based on the provided type.
 ///
@@ -12,16 +16,22 @@ use iceberg::Result as IcebergResult;
 /// Here we simply deduce catalog type from warehouse because both filesystem and object storage catalog are only able to handle certain scheme.
 pub fn create_catalog(
     filesystem_config: FileSystemConfig,
+    iceberg_schema: IcebergSchema,
 ) -> IcebergResult<Box<dyn MoonlinkCatalog>> {
-    Ok(Box::new(FileCatalog::new(filesystem_config)?))
+    Ok(Box::new(FileCatalog::new(
+        filesystem_config,
+        iceberg_schema,
+    )?))
 }
 
 /// Test util function to create catalog with provided filesystem accessor.
 #[cfg(test)]
 pub fn create_catalog_with_filesystem_accessor(
     filesystem_accessor: std::sync::Arc<dyn BaseFileSystemAccess>,
+    iceberg_schema: IcebergSchema,
 ) -> IcebergResult<Box<dyn MoonlinkCatalog>> {
     Ok(Box::new(FileCatalog::new_with_filesystem_accessor(
         filesystem_accessor,
+        iceberg_schema,
     )?))
 }

--- a/src/moonlink/src/storage/iceberg/catalog_utils.rs
+++ b/src/moonlink/src/storage/iceberg/catalog_utils.rs
@@ -4,11 +4,8 @@ use crate::storage::filesystem::filesystem_config::FileSystemConfig;
 use crate::storage::iceberg::file_catalog::FileCatalog;
 use crate::storage::iceberg::moonlink_catalog::MoonlinkCatalog;
 
-use arrow_schema::Schema as ArrowSchema;
 use iceberg::spec::Schema as IcebergSchema;
 use iceberg::Result as IcebergResult;
-
-use std::sync::Arc;
 
 /// Create a catelog based on the provided type.
 ///

--- a/src/moonlink/src/storage/iceberg/file_catalog.rs
+++ b/src/moonlink/src/storage/iceberg/file_catalog.rs
@@ -41,10 +41,14 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::vec;
 
+use arrow_schema::Schema as ArrowSchema;
 use async_trait::async_trait;
+use iceberg::arrow as IcebergArrow;
 use iceberg::io::FileIO;
 use iceberg::puffin::PuffinWriter;
-use iceberg::spec::{TableMetadata, TableMetadataBuilder};
+use iceberg::spec::{
+    Schema as IcebergSchema, TableMetadata, TableMetadataBuildResult, TableMetadataBuilder,
+};
 use iceberg::table::Table;
 use iceberg::Result as IcebergResult;
 use iceberg::{
@@ -67,6 +71,8 @@ pub struct FileCatalog {
     file_io: FileIO,
     /// Table location.
     warehouse_location: String,
+    /// Used to overwrite iceberg metadata at table creation.
+    iceberg_schema: IcebergSchema,
     /// Used to record puffin blob metadata in one transaction, and cleaned up after transaction commits.
     ///
     /// Maps from "puffin filepath" to "puffin blob metadata".
@@ -79,13 +85,14 @@ pub struct FileCatalog {
 
 impl FileCatalog {
     /// Create a file catalog, which gets initialized lazily.
-    pub fn new(config: FileSystemConfig) -> IcebergResult<Self> {
+    pub fn new(config: FileSystemConfig, iceberg_schema: IcebergSchema) -> IcebergResult<Self> {
         let file_io = iceberg_io_utils::create_file_io(&config)?;
         let warehouse_location = get_root_path(&config);
         Ok(Self {
             filesystem_accessor: Arc::new(FileSystemAccessor::new(config)),
             file_io,
             warehouse_location,
+            iceberg_schema,
             puffin_blobs_to_add: HashMap::new(),
             puffin_blobs_to_remove: HashSet::new(),
             data_files_to_remove: HashSet::new(),
@@ -96,12 +103,14 @@ impl FileCatalog {
     #[cfg(test)]
     pub fn new_with_filesystem_accessor(
         filesystem_accessor: Arc<dyn BaseFileSystemAccess>,
+        iceberg_schema: IcebergSchema,
     ) -> IcebergResult<Self> {
         use iceberg::io::FileIOBuilder;
         let file_io = FileIOBuilder::new_fs_io().build()?;
         Ok(Self {
             filesystem_accessor,
             file_io,
+            iceberg_schema,
             warehouse_location: String::new(),
             puffin_blobs_to_add: HashMap::new(),
             puffin_blobs_to_remove: HashSet::new(),
@@ -216,6 +225,20 @@ impl FileCatalog {
             }
         }
         Ok(builder)
+    }
+
+    /// This is a hack function to work-around iceberg-rust.
+    /// iceberg-rust somehow reassign field id at table creation, which means it leads to inconsistency between iceberg table metadata and parquet metadata; query engines is possible to suffer schema inconsistency error.
+    /// Here we overwrite iceberg schema with correctly populated field id.
+    fn get_iceberg_table_metadata(
+        &self,
+        table_metadata: TableMetadataBuildResult,
+    ) -> IcebergResult<TableMetadata> {
+        let metadata = table_metadata.metadata;
+        let mut metadata_builder = metadata.into_builder(/*current_file_location=*/ None);
+        metadata_builder = metadata_builder.add_current_schema(self.iceberg_schema.clone())?;
+        let new_table_metadata = metadata_builder.build()?;
+        Ok(new_table_metadata.metadata)
     }
 }
 
@@ -490,7 +513,8 @@ impl Catalog for FileCatalog {
         );
 
         let table_metadata = TableMetadataBuilder::from_table_creation(creation)?.build()?;
-        let metadata_json = serde_json::to_vec(&table_metadata.metadata)?;
+        let metadata = self.get_iceberg_table_metadata(table_metadata)?;
+        let metadata_json = serde_json::to_vec(&metadata)?;
         self.filesystem_accessor
             .write_object(&metadata_filepath, /*content=*/ metadata_json)
             .await
@@ -502,7 +526,7 @@ impl Catalog for FileCatalog {
             })?;
 
         let table = Table::builder()
-            .metadata(table_metadata.metadata)
+            .metadata(metadata)
             .identifier(table_ident)
             .file_io(self.file_io.clone())
             .build()?;

--- a/src/moonlink/src/storage/iceberg/file_catalog.rs
+++ b/src/moonlink/src/storage/iceberg/file_catalog.rs
@@ -3,11 +3,11 @@ use crate::storage::filesystem::accessor::base_filesystem_accessor::BaseFileSyst
 use crate::storage::filesystem::accessor::filesystem_accessor::FileSystemAccessor;
 use crate::storage::filesystem::filesystem_config::FileSystemConfig;
 use crate::storage::filesystem::utils::path_utils::get_root_path;
+use crate::storage::iceberg::io_utils as iceberg_io_utils;
 use crate::storage::iceberg::moonlink_catalog::PuffinWrite;
 use crate::storage::iceberg::puffin_writer_proxy::{
     get_puffin_metadata_and_close, PuffinBlobMetadataProxy,
 };
-use crate::storage::iceberg::utils;
 
 use futures::future::join_all;
 use std::collections::{HashMap, HashSet};
@@ -80,7 +80,7 @@ pub struct FileCatalog {
 impl FileCatalog {
     /// Create a file catalog, which gets initialized lazily.
     pub fn new(config: FileSystemConfig) -> IcebergResult<Self> {
-        let file_io = utils::create_file_io(&config)?;
+        let file_io = iceberg_io_utils::create_file_io(&config)?;
         let warehouse_location = get_root_path(&config);
         Ok(Self {
             filesystem_accessor: Arc::new(FileSystemAccessor::new(config)),

--- a/src/moonlink/src/storage/iceberg/file_catalog.rs
+++ b/src/moonlink/src/storage/iceberg/file_catalog.rs
@@ -41,9 +41,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::vec;
 
-use arrow_schema::Schema as ArrowSchema;
 use async_trait::async_trait;
-use iceberg::arrow as IcebergArrow;
 use iceberg::io::FileIO;
 use iceberg::puffin::PuffinWriter;
 use iceberg::spec::{

--- a/src/moonlink/src/storage/iceberg/file_catalog_test.rs
+++ b/src/moonlink/src/storage/iceberg/file_catalog_test.rs
@@ -57,7 +57,7 @@ async fn test_local_iceberg_table_creation() {
         FileSystemConfig::FileSystem {
             root_directory: warehouse_path.to_string(),
         },
-        get_test_schema().await.unwrap(),
+        get_test_schema(),
     )
     .unwrap();
     let namespace_ident = NamespaceIdent::from_strs([NAMESPACE]).unwrap();
@@ -112,7 +112,7 @@ async fn create_test_table(catalog: &FileCatalog) -> IcebergResult<()> {
     let namespace = NamespaceIdent::from_strs(["default"])?;
     let table_name = "test_table".to_string();
 
-    let schema = get_test_schema().await?;
+    let schema = get_test_schema();
     let table_creation = TableCreation::builder()
         .name(table_name.clone())
         .location(format!(
@@ -183,7 +183,7 @@ async fn test_catalog_table_operations_impl(catalog: FileCatalog) -> IcebergResu
 
     // Load table and check.
     let table = catalog.load_table(&table_ident).await?;
-    let expected_schema = get_test_schema().await?;
+    let expected_schema = get_test_schema();
     assert_eq!(table.identifier(), &table_ident,);
     assert_eq!(*table.metadata().current_schema().as_ref(), expected_schema,);
 
@@ -298,7 +298,7 @@ async fn test_list_operation_impl(catalog: FileCatalog) -> IcebergResult<()> {
 #[tokio::test]
 async fn test_update_table_with_requirement_check_failed() {
     let temp_dir = TempDir::new().unwrap();
-    let catalog = create_test_file_catalog(&temp_dir, get_test_schema().await.unwrap());
+    let catalog = create_test_file_catalog(&temp_dir, get_test_schema());
     create_test_table(&catalog).await.unwrap();
 
     let namespace = NamespaceIdent::from_strs(["default"]).unwrap();
@@ -379,10 +379,7 @@ async fn test_update_table_impl(mut catalog: FileCatalog) -> IcebergResult<()> {
     catalog.clear_puffin_metadata();
 
     let table_metadata = table.metadata();
-    assert_eq!(
-        **table_metadata.current_schema(),
-        get_test_schema().await.unwrap(),
-    );
+    assert_eq!(**table_metadata.current_schema(), get_test_schema(),);
     assert_eq!(table.identifier(), &table_ident,);
     assert_eq!(table_metadata.current_snapshot_id(), Some(1),);
 
@@ -394,7 +391,7 @@ async fn test_update_table_impl(mut catalog: FileCatalog) -> IcebergResult<()> {
 #[tokio::test]
 async fn test_catalog_namespace_operations_filesystem() {
     let temp_dir = TempDir::new().unwrap();
-    let catalog = create_test_file_catalog(&temp_dir, get_test_schema().await.unwrap());
+    let catalog = create_test_file_catalog(&temp_dir, get_test_schema());
     test_catalog_namespace_operations_impl(catalog)
         .await
         .unwrap();
@@ -416,7 +413,7 @@ async fn test_catalog_namespace_operations_gcs() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_catalog_table_operations_filesystem() {
     let temp_dir = TempDir::new().unwrap();
-    let catalog = create_test_file_catalog(&temp_dir, get_test_schema().await.unwrap());
+    let catalog = create_test_file_catalog(&temp_dir, get_test_schema());
     test_catalog_table_operations_impl(catalog).await.unwrap();
 }
 #[tokio::test]
@@ -436,7 +433,7 @@ async fn test_catalog_table_operations_gcs() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_list_operation_filesystem() {
     let temp_dir = TempDir::new().unwrap();
-    let catalog = create_test_file_catalog(&temp_dir, get_test_schema().await.unwrap());
+    let catalog = create_test_file_catalog(&temp_dir, get_test_schema());
     test_list_operation_impl(catalog).await.unwrap();
 }
 #[tokio::test]
@@ -456,7 +453,7 @@ async fn test_list_operation_gcs() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_update_table_filesystem() {
     let temp_dir = TempDir::new().unwrap();
-    let catalog = create_test_file_catalog(&temp_dir, get_test_schema().await.unwrap());
+    let catalog = create_test_file_catalog(&temp_dir, get_test_schema());
     test_update_table_impl(catalog).await.unwrap();
 }
 #[tokio::test]

--- a/src/moonlink/src/storage/iceberg/file_catalog_test.rs
+++ b/src/moonlink/src/storage/iceberg/file_catalog_test.rs
@@ -53,9 +53,12 @@ async fn test_local_iceberg_table_creation() {
 
     let temp_dir = TempDir::new().unwrap();
     let warehouse_path = temp_dir.path().to_str().unwrap();
-    let catalog = FileCatalog::new(FileSystemConfig::FileSystem {
-        root_directory: warehouse_path.to_string(),
-    })
+    let catalog = FileCatalog::new(
+        FileSystemConfig::FileSystem {
+            root_directory: warehouse_path.to_string(),
+        },
+        get_test_schema().await.unwrap(),
+    )
     .unwrap();
     let namespace_ident = NamespaceIdent::from_strs([NAMESPACE]).unwrap();
     let _ = catalog
@@ -295,7 +298,7 @@ async fn test_list_operation_impl(catalog: FileCatalog) -> IcebergResult<()> {
 #[tokio::test]
 async fn test_update_table_with_requirement_check_failed() {
     let temp_dir = TempDir::new().unwrap();
-    let catalog = create_test_file_catalog(&temp_dir);
+    let catalog = create_test_file_catalog(&temp_dir, get_test_schema().await.unwrap());
     create_test_table(&catalog).await.unwrap();
 
     let namespace = NamespaceIdent::from_strs(["default"]).unwrap();
@@ -391,7 +394,7 @@ async fn test_update_table_impl(mut catalog: FileCatalog) -> IcebergResult<()> {
 #[tokio::test]
 async fn test_catalog_namespace_operations_filesystem() {
     let temp_dir = TempDir::new().unwrap();
-    let catalog = create_test_file_catalog(&temp_dir);
+    let catalog = create_test_file_catalog(&temp_dir, get_test_schema().await.unwrap());
     test_catalog_namespace_operations_impl(catalog)
         .await
         .unwrap();
@@ -413,7 +416,7 @@ async fn test_catalog_namespace_operations_gcs() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_catalog_table_operations_filesystem() {
     let temp_dir = TempDir::new().unwrap();
-    let catalog = create_test_file_catalog(&temp_dir);
+    let catalog = create_test_file_catalog(&temp_dir, get_test_schema().await.unwrap());
     test_catalog_table_operations_impl(catalog).await.unwrap();
 }
 #[tokio::test]
@@ -433,7 +436,7 @@ async fn test_catalog_table_operations_gcs() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_list_operation_filesystem() {
     let temp_dir = TempDir::new().unwrap();
-    let catalog = create_test_file_catalog(&temp_dir);
+    let catalog = create_test_file_catalog(&temp_dir, get_test_schema().await.unwrap());
     test_list_operation_impl(catalog).await.unwrap();
 }
 #[tokio::test]
@@ -453,7 +456,7 @@ async fn test_list_operation_gcs() -> IcebergResult<()> {
 #[tokio::test]
 async fn test_update_table_filesystem() {
     let temp_dir = TempDir::new().unwrap();
-    let catalog = create_test_file_catalog(&temp_dir);
+    let catalog = create_test_file_catalog(&temp_dir, get_test_schema().await.unwrap());
     test_update_table_impl(catalog).await.unwrap();
 }
 #[tokio::test]

--- a/src/moonlink/src/storage/iceberg/file_catalog_test_utils.rs
+++ b/src/moonlink/src/storage/iceberg/file_catalog_test_utils.rs
@@ -1,6 +1,5 @@
 use iceberg::spec::PrimitiveType;
 use iceberg::spec::Type as IcebergType;
-use iceberg::Result as IcebergResult;
 use iceberg::{
     spec::{NestedField, Schema},
     TableIdent, TableUpdate,
@@ -32,16 +31,16 @@ pub(crate) fn create_test_file_catalog(tmp_dir: &TempDir, iceberg_schema: Schema
 }
 
 // Test util function to get iceberg schema,
-pub(crate) async fn get_test_schema() -> IcebergResult<Schema> {
+pub(crate) fn get_test_schema() -> Schema {
     let field = NestedField::required(
         /*id=*/ 1,
         "field_name".to_string(),
         IcebergType::Primitive(PrimitiveType::Int),
     );
-    let schema = Schema::builder()
+
+    Schema::builder()
         .with_schema_id(0)
         .with_fields(vec![Arc::new(field)])
-        .build()?;
-
-    Ok(schema)
+        .build()
+        .unwrap()
 }

--- a/src/moonlink/src/storage/iceberg/file_catalog_test_utils.rs
+++ b/src/moonlink/src/storage/iceberg/file_catalog_test_utils.rs
@@ -20,11 +20,14 @@ pub(crate) struct TableCommitProxy {
 }
 
 /// Test util to create file catalog.
-pub(crate) fn create_test_file_catalog(tmp_dir: &TempDir) -> FileCatalog {
+pub(crate) fn create_test_file_catalog(tmp_dir: &TempDir, iceberg_schema: Schema) -> FileCatalog {
     let warehouse_path = tmp_dir.path().to_str().unwrap();
-    FileCatalog::new(FileSystemConfig::FileSystem {
-        root_directory: warehouse_path.to_string(),
-    })
+    FileCatalog::new(
+        FileSystemConfig::FileSystem {
+            root_directory: warehouse_path.to_string(),
+        },
+        iceberg_schema,
+    )
     .unwrap()
 }
 

--- a/src/moonlink/src/storage/iceberg/gcs_test_utils.rs
+++ b/src/moonlink/src/storage/iceberg/gcs_test_utils.rs
@@ -1,8 +1,9 @@
 use crate::storage::filesystem::gcs::gcs_test_utils::*;
 use crate::storage::iceberg::file_catalog::FileCatalog;
+use crate::storage::iceberg::file_catalog_test_utils::*;
 
 #[allow(dead_code)]
 pub(crate) fn create_gcs_catalog(warehouse_uri: &str) -> FileCatalog {
     let filesystem_config = create_gcs_filesystem_config(warehouse_uri);
-    FileCatalog::new(filesystem_config).unwrap()
+    FileCatalog::new(filesystem_config, get_test_schema()).unwrap()
 }

--- a/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
@@ -114,7 +114,10 @@ impl IcebergTableManager {
         filesystem_accessor: Arc<dyn BaseFileSystemAccess>,
         config: IcebergTableConfig,
     ) -> IcebergResult<IcebergTableManager> {
-        let catalog = catalog_utils::create_catalog(config.filesystem_config.clone())?;
+        let iceberg_schema =
+            iceberg::arrow::arrow_schema_to_schema(mooncake_table_metadata.schema.as_ref())?;
+        let catalog =
+            catalog_utils::create_catalog(config.filesystem_config.clone(), iceberg_schema)?;
         Ok(Self {
             snapshot_loaded: false,
             config,
@@ -136,8 +139,12 @@ impl IcebergTableManager {
         filesystem_accessor: Arc<dyn BaseFileSystemAccess>,
         config: IcebergTableConfig,
     ) -> IcebergResult<IcebergTableManager> {
-        let catalog =
-            catalog_utils::create_catalog_with_filesystem_accessor(filesystem_accessor.clone())?;
+        let iceberg_schema =
+            iceberg::arrow::arrow_schema_to_schema(mooncake_table_metadata.schema.as_ref())?;
+        let catalog = catalog_utils::create_catalog_with_filesystem_accessor(
+            filesystem_accessor.clone(),
+            iceberg_schema,
+        )?;
         Ok(Self {
             snapshot_loaded: false,
             config,

--- a/src/moonlink/src/storage/iceberg/iceberg_table_syncer.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_syncer.rs
@@ -6,6 +6,7 @@ use crate::storage::iceberg::deletion_vector::{
 };
 use crate::storage::iceberg::iceberg_table_manager::*;
 use crate::storage::iceberg::index::FileIndexBlob;
+use crate::storage::iceberg::io_utils as iceberg_io_utils;
 use crate::storage::iceberg::puffin_utils::PuffinBlobRef;
 use crate::storage::iceberg::table_manager::{PersistenceFileParams, PersistenceResult};
 use crate::storage::iceberg::table_property::{
@@ -155,7 +156,7 @@ impl IcebergTableManager {
         // Handle imported new data files.
         let mut new_iceberg_data_files = Vec::with_capacity(new_data_files.len());
         for local_data_file in new_data_files.into_iter() {
-            let iceberg_data_file = utils::write_record_batch_to_iceberg(
+            let iceberg_data_file = iceberg_io_utils::write_record_batch_to_iceberg(
                 self.iceberg_table.as_ref().unwrap(),
                 local_data_file.file_path(),
                 self.iceberg_table.as_ref().unwrap().metadata(),
@@ -340,7 +341,7 @@ impl IcebergTableManager {
             new_file_indices.push(cur_file_index);
             // Upload new index file to iceberg table.
             for cur_index_block in cur_file_index.index_blocks.iter() {
-                let remote_index_block = utils::upload_index_file(
+                let remote_index_block = iceberg_io_utils::upload_index_file(
                     self.iceberg_table.as_ref().unwrap(),
                     cur_index_block.index_file.file_path(),
                     self.filesystem_accessor.as_ref(),

--- a/src/moonlink/src/storage/iceberg/io_utils.rs
+++ b/src/moonlink/src/storage/iceberg/io_utils.rs
@@ -1,0 +1,144 @@
+use crate::storage::filesystem::accessor::base_filesystem_accessor::BaseFileSystemAccess;
+use crate::storage::filesystem::filesystem_config::FileSystemConfig;
+#[cfg(feature = "storage-gcs")]
+use crate::storage::filesystem::gcs::cred_utils as gcs_cred_utils;
+use crate::storage::iceberg::parquet_utils;
+
+use std::path::Path;
+
+use iceberg::io::{FileIO, FileIOBuilder};
+use iceberg::spec::DataFile;
+use iceberg::spec::TableMetadata as IcebergTableMetadata;
+use iceberg::table::Table as IcebergTable;
+use iceberg::writer::file_writer::location_generator::{
+    DefaultLocationGenerator, LocationGenerator,
+};
+use iceberg::{Error as IcebergError, Result as IcebergResult};
+
+/// Write the given record batch in the given local file to the iceberg table (parquet file keeps unchanged).
+pub(crate) async fn write_record_batch_to_iceberg(
+    table: &IcebergTable,
+    local_filepath: &String,
+    table_metadata: &IcebergTableMetadata,
+    filesystem_accessor: &dyn BaseFileSystemAccess,
+) -> IcebergResult<DataFile> {
+    let filename = Path::new(local_filepath)
+        .file_name()
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string();
+    let location_generator = DefaultLocationGenerator::new(table.metadata().clone())?;
+    let remote_filepath = location_generator.generate_location(&filename);
+
+    // Import local parquet file to remote.
+    filesystem_accessor
+        .copy_from_local_to_remote(local_filepath, &remote_filepath)
+        .await
+        .map_err(|e| {
+            IcebergError::new(
+                iceberg::ErrorKind::Unexpected,
+                format!(
+                    "Failed to copy from {} to {}: {:?}",
+                    local_filepath, remote_filepath, e
+                ),
+            )
+        })?;
+
+    // Get data file from local parquet file.
+    let data_file = parquet_utils::get_data_file_from_local_parquet_file(
+        local_filepath,
+        remote_filepath,
+        table_metadata,
+    )
+    .await?;
+    Ok(data_file)
+}
+
+/// Copy the given local index file to iceberg table, and return filepath within iceberg table.
+pub(crate) async fn upload_index_file(
+    table: &IcebergTable,
+    local_index_filepath: &str,
+    filesystem_accessor: &dyn BaseFileSystemAccess,
+) -> IcebergResult<String> {
+    let filename = Path::new(local_index_filepath)
+        .file_name()
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string();
+    let location_generator = DefaultLocationGenerator::new(table.metadata().clone()).unwrap();
+    let remote_filepath = location_generator.generate_location(&filename);
+    filesystem_accessor
+        .copy_from_local_to_remote(local_index_filepath, &remote_filepath)
+        .await
+        .map_err(|e| {
+            IcebergError::new(
+                iceberg::ErrorKind::Unexpected,
+                format!(
+                    "Failed to copy from {} to {}: {:?}",
+                    local_index_filepath, remote_filepath, e
+                ),
+            )
+        })?;
+    Ok(remote_filepath)
+}
+
+/// Create iceberg [`FileIO`].
+pub(crate) fn create_file_io(config: &FileSystemConfig) -> IcebergResult<FileIO> {
+    match config {
+        #[cfg(feature = "storage-fs")]
+        FileSystemConfig::FileSystem { .. } => FileIOBuilder::new_fs_io().build(),
+        #[cfg(feature = "storage-gcs")]
+        FileSystemConfig::Gcs {
+            endpoint,
+            disable_auth,
+            cred_path,
+            ..
+        } => {
+            if *disable_auth {
+                assert!(cred_path.is_none());
+            }
+
+            let mut file_io_builder = FileIOBuilder::new("GCS")
+                .with_prop(iceberg::io::GCS_PROJECT_ID, "coral-ring-465417-r0");
+            if let Some(endpoint) = endpoint {
+                file_io_builder =
+                    file_io_builder.with_prop(iceberg::io::GCS_SERVICE_PATH, endpoint);
+            }
+            if *disable_auth {
+                file_io_builder = file_io_builder
+                    .with_prop(iceberg::io::GCS_NO_AUTH, "true")
+                    .with_prop(iceberg::io::GCS_ALLOW_ANONYMOUS, "true")
+                    .with_prop(iceberg::io::GCS_DISABLE_CONFIG_LOAD, "true");
+            } else {
+                let cred_json = gcs_cred_utils::load_gcs_credentials(cred_path).map_err(|e| {
+                    IcebergError::new(
+                        iceberg::ErrorKind::Unexpected,
+                        format!("Failed to load GCS credential {:?}: {:?}", cred_path, e),
+                    )
+                })?;
+                file_io_builder =
+                    file_io_builder.with_prop(iceberg::io::GCS_CREDENTIALS_JSON, cred_json);
+            }
+            file_io_builder.build()
+        }
+        #[cfg(feature = "storage-s3")]
+        FileSystemConfig::S3 {
+            access_key_id,
+            secret_access_key,
+            region,
+            endpoint,
+            ..
+        } => {
+            let mut file_io_builder = FileIOBuilder::new("s3")
+                .with_prop(iceberg::io::S3_REGION, region)
+                .with_prop(iceberg::io::S3_ACCESS_KEY_ID, access_key_id)
+                .with_prop(iceberg::io::S3_SECRET_ACCESS_KEY, secret_access_key);
+            if let Some(endpoint) = endpoint {
+                file_io_builder = file_io_builder.with_prop(iceberg::io::S3_ENDPOINT, endpoint);
+            }
+            file_io_builder.build()
+        }
+    }
+}

--- a/src/moonlink/src/storage/iceberg/s3_test_utils.rs
+++ b/src/moonlink/src/storage/iceberg/s3_test_utils.rs
@@ -1,9 +1,10 @@
 use crate::storage::filesystem::s3::s3_test_utils::*;
 /// This module provides a few test util functions.
 use crate::storage::iceberg::file_catalog::FileCatalog;
+use crate::storage::iceberg::file_catalog_test_utils::*;
 
 /// Create a S3 catalog, which communicates with local minio server.
 pub(crate) fn create_test_s3_catalog(warehouse_uri: &str) -> FileCatalog {
     let filesystem_config = create_s3_filesystem_config(warehouse_uri);
-    FileCatalog::new(filesystem_config).unwrap()
+    FileCatalog::new(filesystem_config, get_test_schema()).unwrap()
 }

--- a/src/moonlink/src/storage/iceberg/schema_utils.rs
+++ b/src/moonlink/src/storage/iceberg/schema_utils.rs
@@ -1,0 +1,17 @@
+#[cfg(test)]
+use iceberg::spec::Schema as IcebergSchema;
+
+/// Schema related utils.
+///
+#[cfg(test)]
+pub(crate) fn assert_is_same_schema(lhs: IcebergSchema, rhs: IcebergSchema) {
+    let lhs_highest_field_id = lhs.highest_field_id();
+    let rhs_highest_field_id = rhs.highest_field_id();
+    assert_eq!(lhs_highest_field_id, rhs_highest_field_id);
+
+    for cur_field_id in 0..=lhs_highest_field_id {
+        let lhs_name = lhs.name_by_field_id(cur_field_id);
+        let rhs_name = rhs.name_by_field_id(cur_field_id);
+        assert_eq!(lhs_name, rhs_name);
+    }
+}

--- a/src/moonlink/src/storage/iceberg/utils.rs
+++ b/src/moonlink/src/storage/iceberg/utils.rs
@@ -1,24 +1,12 @@
-use crate::storage::filesystem::accessor::base_filesystem_accessor::BaseFileSystemAccess;
-use crate::storage::filesystem::filesystem_config::FileSystemConfig;
-#[cfg(feature = "storage-gcs")]
-use crate::storage::filesystem::gcs::cred_utils as gcs_cred_utils;
 use crate::storage::iceberg::moonlink_catalog::MoonlinkCatalog;
-use crate::storage::iceberg::parquet_utils;
 use crate::storage::iceberg::table_property;
 
 use std::collections::HashMap;
-use std::path::Path;
 
 use arrow_schema::Schema as ArrowSchema;
 use iceberg::arrow as IcebergArrow;
-use iceberg::io::{FileIO, FileIOBuilder};
-use iceberg::spec::DataFile;
-use iceberg::spec::TableMetadata as IcebergTableMetadata;
 use iceberg::spec::{DataContentType, DataFileFormat, ManifestEntry};
 use iceberg::table::Table as IcebergTable;
-use iceberg::writer::file_writer::location_generator::{
-    DefaultLocationGenerator, LocationGenerator,
-};
 use iceberg::{
     Error as IcebergError, NamespaceIdent, Result as IcebergResult, TableCreation, TableIdent,
 };
@@ -149,134 +137,6 @@ pub(crate) async fn get_table_if_exists<C: MoonlinkCatalog + ?Sized>(
 
     let table = catalog.load_table(&table_ident).await?;
     Ok(Some(table))
-}
-
-/// Write the given record batch in the given local file to the iceberg table (parquet file keeps unchanged).
-pub(crate) async fn write_record_batch_to_iceberg(
-    table: &IcebergTable,
-    local_filepath: &String,
-    table_metadata: &IcebergTableMetadata,
-    filesystem_accessor: &dyn BaseFileSystemAccess,
-) -> IcebergResult<DataFile> {
-    let filename = Path::new(local_filepath)
-        .file_name()
-        .unwrap()
-        .to_str()
-        .unwrap()
-        .to_string();
-    let location_generator = DefaultLocationGenerator::new(table.metadata().clone())?;
-    let remote_filepath = location_generator.generate_location(&filename);
-
-    // Import local parquet file to remote.
-    filesystem_accessor
-        .copy_from_local_to_remote(local_filepath, &remote_filepath)
-        .await
-        .map_err(|e| {
-            IcebergError::new(
-                iceberg::ErrorKind::Unexpected,
-                format!(
-                    "Failed to copy from {} to {}: {:?}",
-                    local_filepath, remote_filepath, e
-                ),
-            )
-        })?;
-
-    // Get data file from local parquet file.
-    let data_file = parquet_utils::get_data_file_from_local_parquet_file(
-        local_filepath,
-        remote_filepath,
-        table_metadata,
-    )
-    .await?;
-    Ok(data_file)
-}
-
-/// Copy the given local index file to iceberg table, and return filepath within iceberg table.
-pub(crate) async fn upload_index_file(
-    table: &IcebergTable,
-    local_index_filepath: &str,
-    filesystem_accessor: &dyn BaseFileSystemAccess,
-) -> IcebergResult<String> {
-    let filename = Path::new(local_index_filepath)
-        .file_name()
-        .unwrap()
-        .to_str()
-        .unwrap()
-        .to_string();
-    let location_generator = DefaultLocationGenerator::new(table.metadata().clone()).unwrap();
-    let remote_filepath = location_generator.generate_location(&filename);
-    filesystem_accessor
-        .copy_from_local_to_remote(local_index_filepath, &remote_filepath)
-        .await
-        .map_err(|e| {
-            IcebergError::new(
-                iceberg::ErrorKind::Unexpected,
-                format!(
-                    "Failed to copy from {} to {}: {:?}",
-                    local_index_filepath, remote_filepath, e
-                ),
-            )
-        })?;
-    Ok(remote_filepath)
-}
-
-/// Create iceberg [`FileIO`].
-pub(crate) fn create_file_io(config: &FileSystemConfig) -> IcebergResult<FileIO> {
-    match config {
-        #[cfg(feature = "storage-fs")]
-        FileSystemConfig::FileSystem { .. } => FileIOBuilder::new_fs_io().build(),
-        #[cfg(feature = "storage-gcs")]
-        FileSystemConfig::Gcs {
-            endpoint,
-            disable_auth,
-            cred_path,
-            ..
-        } => {
-            if *disable_auth {
-                assert!(cred_path.is_none());
-            }
-
-            let mut file_io_builder = FileIOBuilder::new("GCS")
-                .with_prop(iceberg::io::GCS_PROJECT_ID, "coral-ring-465417-r0");
-            if let Some(endpoint) = endpoint {
-                file_io_builder =
-                    file_io_builder.with_prop(iceberg::io::GCS_SERVICE_PATH, endpoint);
-            }
-            if *disable_auth {
-                file_io_builder = file_io_builder
-                    .with_prop(iceberg::io::GCS_NO_AUTH, "true")
-                    .with_prop(iceberg::io::GCS_ALLOW_ANONYMOUS, "true")
-                    .with_prop(iceberg::io::GCS_DISABLE_CONFIG_LOAD, "true");
-            } else {
-                let cred_json = gcs_cred_utils::load_gcs_credentials(cred_path).map_err(|e| {
-                    IcebergError::new(
-                        iceberg::ErrorKind::Unexpected,
-                        format!("Failed to load GCS credential {:?}: {:?}", cred_path, e),
-                    )
-                })?;
-                file_io_builder =
-                    file_io_builder.with_prop(iceberg::io::GCS_CREDENTIALS_JSON, cred_json);
-            }
-            file_io_builder.build()
-        }
-        #[cfg(feature = "storage-s3")]
-        FileSystemConfig::S3 {
-            access_key_id,
-            secret_access_key,
-            region,
-            endpoint,
-            ..
-        } => {
-            let mut file_io_builder = FileIOBuilder::new("s3")
-                .with_prop(iceberg::io::S3_REGION, region)
-                .with_prop(iceberg::io::S3_ACCESS_KEY_ID, access_key_id)
-                .with_prop(iceberg::io::S3_SECRET_ACCESS_KEY, secret_access_key);
-            if let Some(endpoint) = endpoint {
-                file_io_builder = file_io_builder.with_prop(iceberg::io::S3_ENDPOINT, endpoint);
-            }
-            file_io_builder.build()
-        }
-    }
 }
 
 /// Util function to convert the given error to iceberg "unexpected" error.


### PR DESCRIPTION
## Summary

On iceberg table creation, iceberg-rust somehow reassigns field id, which leads to inconsistency between parquet field id vs iceberg metadata field id, and fails duckdb query.

This PR workaround (before upstream has a better explanation or solution) by overwriting iceberg schema at catalog.

After this PR, duckdb query works for data files:
```sql
[/tmp/duckdb_iceberg] (hjiang/ignore-puffin-blob) 
vscode@54ca2001a79b$ ./build/reldebug/duckdb
DuckDB v1.3.2 (Ossivalis) 0b83e5d2f6
Enter ".help" for usage hints.
Connected to a transient in-memory database.
Use ".open FILENAME" to reopen on a persistent database.
D SELECT * FROM iceberg_scan('/tmp/.tmpFGSFJd/namespace/test_table/');
┌───────┬─────────┬───────┐
│  id   │  name   │  age  │
│ int32 │ varchar │ int32 │
├───────┼─────────┼───────┤
│   1   │ John    │  30   │
└───────┴─────────┴───────┘
```

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/801
Closes https://github.com/Mooncake-Labs/moonlink/issues/804
Closes https://github.com/Mooncake-Labs/moonlink/issues/803

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [x] Documentation updated if necessary
- [x] I have reviewed my own changes
