### PR TITLE
Async flush non streaming

### DIFF
--- a/src/moonlink/benches/bench_write.rs
+++ b/src/moonlink/benches/bench_write.rs
@@ -82,8 +82,7 @@ fn bench_write(c: &mut Criterion) {
                         values: row.values.clone(),
                     });
                 }
-                let handle = table.flush(100000);
-                handle.await.unwrap();
+                table.flush(100000).unwrap();
             });
         });
     });
@@ -125,8 +124,7 @@ fn bench_write(c: &mut Criterion) {
                         1,
                     );
                 }
-                let handle = table.flush(100000);
-                handle.await.unwrap();
+                table.flush(100000).unwrap();
             });
         });
     });

--- a/src/moonlink/src/storage/iceberg/tests.rs
+++ b/src/moonlink/src/storage/iceberg/tests.rs
@@ -1164,10 +1164,13 @@ async fn test_multiple_table_ids_for_deletion_vector() {
         table.delete(cur_row, /*lsn=*/ target_data_files_num).await;
     }
     table.commit(/*lsn=*/ target_data_files_num + 1);
-    table
-        .flush(/*lsn=*/ target_data_files_num + 1)
-        .await
-        .unwrap();
+    flush_table_and_sync(
+        &mut table,
+        &mut notify_rx,
+        /*lsn=*/ target_data_files_num + 1,
+    )
+    .await
+    .unwrap();
 
     // Create the second mooncake and iceberg snapshot, which include [`target_data_files_num`] number of deletion vector puffin files.
     create_mooncake_and_persist_for_test(&mut table, &mut notify_rx).await;

--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -45,7 +45,7 @@ use crate::NonEvictableHandle;
 use arrow::record_batch::RecordBatch;
 use arrow_schema::Schema;
 use delete_vector::BatchDeletionVector;
-pub(crate) use disk_slice::DiskSliceWriter;
+pub use disk_slice::DiskSliceWriter;
 use mem_slice::MemSlice;
 pub(crate) use snapshot::{PuffinDeletionBlobAtRead, SnapshotTableState};
 use std::collections::{HashMap, HashSet};
@@ -56,8 +56,8 @@ use table_snapshot::{IcebergSnapshotImportResult, IcebergSnapshotIndexMergeResul
 use tokio::sync::mpsc::Receiver;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::{watch, RwLock};
-use tracing::info_span;
 use tracing::Instrument;
+use tracing::{error, info_span};
 use transaction_stream::{TransactionStreamOutput, TransactionStreamState};
 
 /// Special transaction id used for initial copy append operation.
@@ -692,6 +692,24 @@ impl MooncakeTable {
         self.next_snapshot_task.data_compaction_result = data_compaction_res;
     }
 
+    /// Set flush result, which will append the flushed disk slice into current task.
+    pub(crate) fn set_flush_result(
+        &mut self,
+        flush_result: Option<Result<DiskSliceWriter>>,
+        lsn: u64,
+    ) {
+        self.next_snapshot_task.new_flush_lsn = Some(lsn);
+        match flush_result {
+            Some(Ok(disk_slice)) => {
+                self.next_snapshot_task.new_disk_slices.push(disk_slice);
+            }
+            Some(Err(err)) => {
+                error!(error = ?err, "failed to flush mem slice");
+            }
+            None => {}
+        }
+    }
+
     /// Get iceberg snapshot flush LSN.
     pub(crate) fn get_iceberg_snapshot_lsn(&self) -> Option<u64> {
         self.last_iceberg_snapshot_lsn
@@ -810,24 +828,61 @@ impl MooncakeTable {
     // This function
     // - tracks all record batches by current snapshot task
     // - persists all full batch records to local filesystem
-    pub async fn flush(&mut self, lsn: u64) -> Result<()> {
-        self.next_snapshot_task.new_flush_lsn = Some(lsn);
+    pub fn flush(&mut self, lsn: u64) -> Result<()> {
+        let table_notify_tx = self.table_notify.as_ref().unwrap().clone();
 
         if self.mem_slice.is_empty() {
+            self.next_snapshot_task.new_flush_lsn = Some(lsn);
+            tokio::task::spawn(async move {
+                table_notify_tx
+                    .send(TableEvent::FlushResult {
+                        flush_result: None,
+                        lsn,
+                    })
+                    .await
+                    .unwrap();
+            });
             return Ok(());
         }
 
         let next_file_id = self.next_file_id;
         self.next_file_id += 1;
-        let disk_slice = Self::flush_mem_slice(
-            &mut self.mem_slice,
-            &self.metadata,
-            next_file_id,
-            Some(lsn),
-            Some(&mut self.next_snapshot_task),
-        )
-        .await?;
-        self.next_snapshot_task.new_disk_slices.push(disk_slice);
+
+        // Drain mem slice and prepare information for background flush.
+        let (new_batch, batches, index) = self.mem_slice.drain().unwrap();
+        let index = Arc::new(index);
+
+        if let Some(batch) = new_batch {
+            self.next_snapshot_task.new_record_batches.push(batch);
+        }
+        self.next_snapshot_task.new_mem_indices.push(index.clone());
+
+        let path = self.metadata.path.clone();
+        let schema = self.metadata.schema.clone();
+        let parquet_flush_threshold_size = self.metadata.config.disk_slice_parquet_file_size;
+
+        tokio::task::spawn(
+            async move {
+                let mut disk_slice = DiskSliceWriter::new(
+                    schema,
+                    path,
+                    batches,
+                    Some(lsn),
+                    next_file_id,
+                    index,
+                    parquet_flush_threshold_size,
+                );
+                let res = disk_slice.write().await;
+                table_notify_tx
+                    .send(TableEvent::FlushResult {
+                        flush_result: Some(res.map(|_| disk_slice)),
+                        lsn,
+                    })
+                    .await
+                    .unwrap();
+            }
+            .instrument(info_span!("flush_mem_slice")),
+        );
 
         Ok(())
     }

--- a/src/moonlink/src/storage/mooncake_table/disk_slice.rs
+++ b/src/moonlink/src/storage/mooncake_table/disk_slice.rs
@@ -16,12 +16,13 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 /// Attributes for disk files.
+#[derive(Debug)]
 pub(crate) struct DiskFileAttrs {
     pub(crate) file_size: usize,
     pub(crate) row_num: usize,
 }
 
-pub(crate) struct DiskSliceWriter {
+pub struct DiskSliceWriter {
     /// The schema of the DiskSlice.
     ///
     schema: Arc<Schema>,
@@ -49,6 +50,12 @@ pub(crate) struct DiskSliceWriter {
 
     /// Records already flushed data files.
     files: Vec<(MooncakeDataFileRef, DiskFileAttrs)>,
+}
+
+impl std::fmt::Debug for DiskSliceWriter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("DiskSliceWriter").finish()
+    }
 }
 
 impl DiskSliceWriter {

--- a/src/moonlink/src/storage/mooncake_table/table_operation_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_operation_test_utils.rs
@@ -21,11 +21,17 @@ use crate::{ReadState, Result};
 #[cfg(test)]
 pub(crate) async fn flush_table_and_sync(
     table: &mut MooncakeTable,
-    _receiver: &mut Receiver<TableEvent>,
+    receiver: &mut Receiver<TableEvent>,
     lsn: u64,
 ) -> Result<()> {
-    // TODO(Nolan): Use receiver to block wait until table flush finishes.
-    table.flush(lsn).await
+    table.flush(lsn).unwrap();
+    let flush_result = receiver.recv().await.unwrap();
+    if let TableEvent::FlushResult { flush_result, lsn } = flush_result {
+        table.set_flush_result(flush_result, lsn);
+    } else {
+        panic!("Expected FlushResult as first event, but got others.");
+    }
+    Ok(())
 }
 
 /// ===============================

--- a/src/moonlink/src/table_handler.rs
+++ b/src/moonlink/src/table_handler.rs
@@ -407,7 +407,7 @@ impl TableHandler {
                             // Check whether a flush and force snapshot is needed.
                             if !table_handler_state.pending_force_snapshot_lsns.is_empty() {
                                 if let Some(commit_lsn) = table_handler_state.table_consistent_view_lsn {
-                                    table.flush(commit_lsn).await.unwrap();
+                                    table.flush(commit_lsn).unwrap();
                                     table_handler_state.reset_iceberg_state_at_mooncake_snapshot();
                                     assert!(table.create_snapshot(SnapshotOption {
                                         force_create: true,
@@ -525,6 +525,9 @@ impl TableHandler {
                             }
                             table_handler_state.maintainance_ongoing = false;
                         }
+                        TableEvent::FlushResult { flush_result, lsn} => {
+                            table.set_flush_result(flush_result, lsn);
+                        }
                         TableEvent::ReadRequest { cache_handles } => {
                             table.set_read_request_res(cache_handles);
                         }
@@ -636,7 +639,7 @@ impl TableHandler {
                     None => {
                         table.commit(lsn);
                         if table.should_flush() || force_snapshot {
-                            if let Err(e) = table.flush(lsn).await {
+                            if let Err(e) = table.flush(lsn) {
                                 error!(error = %e, "flush failed in commit");
                             }
                         }
@@ -658,7 +661,7 @@ impl TableHandler {
                 table.abort_in_stream_batch(xact_id);
             }
             TableEvent::Flush { lsn } => {
-                if let Err(e) = table.flush(lsn).await {
+                if let Err(e) = table.flush(lsn) {
                     error!(error = %e, "explicit flush failed");
                 }
             }

--- a/src/moonlink/src/table_handler/test_utils.rs
+++ b/src/moonlink/src/table_handler/test_utils.rs
@@ -224,6 +224,13 @@ impl TestEnvironment {
         self.send_event(TableEvent::StreamFlush { xact_id }).await;
     }
 
+    pub async fn snapshot_table(&self, lsn: Option<u64>) {
+        let (tx, mut rx) = mpsc::channel(1);
+        self.send_event(TableEvent::ForceSnapshot { lsn, tx: Some(tx) })
+            .await;
+        rx.recv().await.unwrap().unwrap();
+    }
+
     // --- LSN and Verification Helpers ---
 
     /// Sets both table commit and replication LSN to the same value.

--- a/src/moonlink/src/table_handler/tests.rs
+++ b/src/moonlink/src/table_handler/tests.rs
@@ -534,6 +534,7 @@ async fn test_drop_table_with_data() {
     .await;
     env.commit(/*lsn=*/ 1).await;
     env.flush_table(/*lsn=*/ 1).await;
+    env.snapshot_table(/*lsn=*/ Some(1)).await;
     env.set_readable_lsn(/*lsn=*/ 1);
 
     // Force mooncake and iceberg snapshot, and block wait until mooncake snapshot completion via getting a read state.

--- a/src/moonlink/src/table_notify.rs
+++ b/src/moonlink/src/table_notify.rs
@@ -3,6 +3,7 @@ use tokio::sync::mpsc::Sender;
 use crate::row::MoonlinkRow;
 use crate::storage::mooncake_table::DataCompactionPayload;
 use crate::storage::mooncake_table::DataCompactionResult;
+use crate::storage::mooncake_table::DiskSliceWriter;
 use crate::storage::mooncake_table::FileIndiceMergePayload;
 use crate::storage::mooncake_table::FileIndiceMergeResult;
 use crate::storage::mooncake_table::IcebergSnapshotPayload;
@@ -101,6 +102,13 @@ pub enum TableEvent {
     DataCompaction {
         /// Result for data compaction.
         data_compaction_result: Result<DataCompactionResult>,
+    },
+    /// Non-streaming flush completes.
+    FlushResult {
+        /// Result for mem slice flush.
+        flush_result: Option<Result<DiskSliceWriter>>,
+        /// LSN of the flush.
+        lsn: u64,
     },
     /// Read request completion.
     ReadRequest {


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

Spawn table flush as background task and send `TableEvent::FlushResult` on complete. There are some extra edge cases that need to be handled for the streaming case, so this is still handled by `flush_mem_slice`. We will unify these in a follow up PR. 

## Related Issues

Closes #<issue-number> or links to related issues.

## Changes

- Flush non streaming events in background
- Send `TableEvent::FlushResult`
- Add `set_flush_result` to set disk slices on complete
- Remove .await and update callers

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
