### PR TITLE
[minor] Provide a sync flush API for testing

### DIFF
--- a/src/moonlink/src/storage/mooncake_table/file_index_state_tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/file_index_state_tests.rs
@@ -63,7 +63,7 @@ async fn prepare_test_disk_file(
     temp_dir: &TempDir,
     object_storage_cache: ObjectStorageCache,
 ) -> (MooncakeTable, Receiver<TableEvent>) {
-    let (mut table, table_notify) =
+    let (mut table, mut table_notify) =
         create_mooncake_table_and_notify_for_read(temp_dir, object_storage_cache).await;
 
     let row = MoonlinkRow::new(vec![
@@ -73,7 +73,9 @@ async fn prepare_test_disk_file(
     ]);
     table.append(row.clone()).unwrap();
     table.commit(/*lsn=*/ 1);
-    table.flush(/*lsn=*/ 1).await.unwrap();
+    flush_table_and_sync(&mut table, &mut table_notify, /*lsn=*/ 1)
+        .await
+        .unwrap();
 
     (table, table_notify)
 }
@@ -231,7 +233,7 @@ async fn prepare_test_disk_files_for_index_merge(
     temp_dir: &TempDir,
     object_storage_cache: ObjectStorageCache,
 ) -> (MooncakeTable, Receiver<TableEvent>) {
-    let (mut table, table_notify) =
+    let (mut table, mut table_notify) =
         create_mooncake_table_and_notify_for_index_merge(temp_dir, object_storage_cache).await;
 
     // Append, commit and flush the first row.
@@ -242,7 +244,9 @@ async fn prepare_test_disk_files_for_index_merge(
     ]);
     table.append(row.clone()).unwrap();
     table.commit(/*lsn=*/ 1);
-    table.flush(/*lsn=*/ 1).await.unwrap();
+    flush_table_and_sync(&mut table, &mut table_notify, /*lsn=*/ 1)
+        .await
+        .unwrap();
 
     // Append, commit and flush the second row.
     let row = MoonlinkRow::new(vec![
@@ -252,7 +256,9 @@ async fn prepare_test_disk_files_for_index_merge(
     ]);
     table.append(row.clone()).unwrap();
     table.commit(/*lsn=*/ 2);
-    table.flush(/*lsn=*/ 2).await.unwrap();
+    flush_table_and_sync(&mut table, &mut table_notify, /*lsn=*/ 2)
+        .await
+        .unwrap();
 
     (table, table_notify)
 }

--- a/src/moonlink/src/storage/mooncake_table/table_operation_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_operation_test_utils.rs
@@ -14,6 +14,21 @@ use crate::{MooncakeTable, SnapshotReadOutput};
 use crate::{ReadState, Result};
 
 /// ===============================
+/// Flush
+/// ===============================
+///
+/// Flush mooncake and block wait its completio.
+#[cfg(test)]
+pub(crate) async fn flush_table_and_sync(
+    table: &mut MooncakeTable,
+    _receiver: &mut Receiver<TableEvent>,
+    lsn: u64,
+) -> Result<()> {
+    // TODO(Nolan): Use receiver to block wait until table flush finishes.
+    table.flush(lsn).await
+}
+
+/// ===============================
 /// Delete evicted files
 /// ===============================
 ///
@@ -33,30 +48,6 @@ pub(crate) async fn sync_delete_evicted_files(
         assert_eq!(evicted_data_files, expected_files_to_delete);
     } else {
         panic!("Receive other notifications other than delete evicted files")
-    }
-}
-
-/// ===============================
-/// Request read
-/// ===============================
-///
-/// Perform a read request for the given table.
-pub(crate) async fn perform_read_request_for_test(table: &mut MooncakeTable) -> SnapshotReadOutput {
-    let mut guard = table.snapshot.write().await;
-    guard.request_read().await.unwrap()
-}
-
-/// Block wait read request to finish, and set the result to the snapshot buffer.
-/// Precondition: there's ongoing read request.
-pub(crate) async fn sync_read_request_for_test(
-    table: &mut MooncakeTable,
-    receiver: &mut Receiver<TableEvent>,
-) {
-    let notification = receiver.recv().await.unwrap();
-    if let TableEvent::ReadRequest { cache_handles } = notification {
-        table.set_read_request_res(cache_handles);
-    } else {
-        panic!("Receive other notifications other than read request")
     }
 }
 
@@ -435,4 +426,24 @@ pub(crate) async fn drop_read_states_and_create_mooncake_snapshot(
     drop_read_states(read_states, table, receiver).await;
     let (_, _, _, _, files_to_delete) = create_mooncake_snapshot_for_test(table, receiver).await;
     files_to_delete
+}
+
+/// Perform a read request for the given table.
+pub(crate) async fn perform_read_request_for_test(table: &mut MooncakeTable) -> SnapshotReadOutput {
+    let mut guard = table.snapshot.write().await;
+    guard.request_read().await.unwrap()
+}
+
+/// Block wait read request to finish, and set the result to the snapshot buffer.
+/// Precondition: there's ongoing read request.
+pub(crate) async fn sync_read_request_for_test(
+    table: &mut MooncakeTable,
+    receiver: &mut Receiver<TableEvent>,
+) {
+    let notification = receiver.recv().await.unwrap();
+    if let TableEvent::ReadRequest { cache_handles } = notification {
+        table.set_read_request_res(cache_handles);
+    } else {
+        panic!("Receive other notifications other than read request")
+    }
 }

--- a/src/moonlink/src/storage/mooncake_table/table_operation_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_operation_test_utils.rs
@@ -17,7 +17,7 @@ use crate::{ReadState, Result};
 /// Flush
 /// ===============================
 ///
-/// Flush mooncake and block wait its completio.
+/// Flush mooncake, block wait its completion and reflect result to mooncake table.
 #[cfg(test)]
 pub(crate) async fn flush_table_and_sync(
     table: &mut MooncakeTable,

--- a/src/moonlink/src/storage/mooncake_table/test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/test_utils.rs
@@ -147,7 +147,7 @@ pub async fn append_commit_flush_create_mooncake_snapshot_for_test(
 ) -> Result<()> {
     append_rows(table, rows)?;
     table.commit(lsn);
-    table.flush(lsn).await?;
+    flush_table_and_sync(table, completion_rx, lsn).await?;
     create_mooncake_snapshot_for_test(table, completion_rx).await;
     Ok(())
 }


### PR DESCRIPTION
## Summary

This PR adds a new API to flush synchronously, so when flush becomes async, we only have to modify one test util function, but not everywhere.

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
