### PR TITLE
[storage] Pass down filesystem config

### DIFF
--- a/src/moonlink_backend/src/lib.rs
+++ b/src/moonlink_backend/src/lib.rs
@@ -100,8 +100,8 @@ where
                     mooncake_table_id,
                     table_id,
                     &src_table_name,
-                    /*override_table_base_path=*/ None,
                     /*override_iceberg_filesystem_config=*/ None,
+                    /*is_recovery=*/ false,
                 )
                 .await?;
             manager.start_replication(&src_uri).await?;

--- a/src/moonlink_backend/src/recovery_utils.rs
+++ b/src/moonlink_backend/src/recovery_utils.rs
@@ -21,22 +21,20 @@ where
         database_id: D::from(database_id),
         table_id: T::from(metadata_entry.table_id),
     };
-    // TODO(hjiang): Need to populate real secret, which is fetched from secret table, if any.
     replication_manager
         .add_table(
             &metadata_entry.src_table_uri,
             mooncake_table_id,
             metadata_entry.table_id,
             &metadata_entry.src_table_name,
-            /*override_table_base_path=*/
+            /*iceberg_filesystem_config=*/
             Some(
-                &metadata_entry
+                metadata_entry
                     .moonlink_table_config
                     .iceberg_table_config
-                    .filesystem_config
-                    .get_root_path(),
+                    .filesystem_config,
             ),
-            /*iceberg_filesystem_config=*/ None,
+            /*is_recovery=*/ true,
         )
         .await?;
     Ok(())

--- a/src/moonlink_connectors/src/pg_replicate/table_init.rs
+++ b/src/moonlink_connectors/src/pg_replicate/table_init.rs
@@ -47,7 +47,7 @@ pub async fn build_table_components(
     mooncake_table_id: String,
     table_id: u32,
     table_schema: &TableSchema,
-    base_path: &Path,
+    base_path: &String,
     table_temp_files_directory: String,
     replication_state: &ReplicationState,
     object_storage_cache: ObjectStorageCache,
@@ -58,7 +58,7 @@ pub async fn build_table_components(
     let (arrow_schema, identity) = postgres_schema_to_moonlink_schema(table_schema);
     let iceberg_filesystem_config =
         iceberg_filesystem_config.unwrap_or(FileSystemConfig::FileSystem {
-            root_directory: base_path.to_str().unwrap().to_string(),
+            root_directory: base_path.to_string(),
         });
 
     let iceberg_table_config = IcebergTableConfig {

--- a/src/moonlink_connectors/src/replication_connection.rs
+++ b/src/moonlink_connectors/src/replication_connection.rs
@@ -23,7 +23,6 @@ use crate::pg_replicate::table::{SrcTableId, TableSchema};
 use futures::StreamExt;
 use moonlink::TableEvent;
 use std::collections::HashMap;
-use std::path::Path;
 use tokio::sync::{mpsc, watch};
 use tokio::task::JoinHandle;
 use tokio_postgres::{connect, Client, Config, NoTls};
@@ -278,8 +277,8 @@ impl ReplicationConnection {
         schema: &TableSchema,
         mooncake_table_id: &T,
         table_id: u32,
-        override_table_base_path: Option<&str>,
         iceberg_filesystem_config: Option<FileSystemConfig>,
+        is_recovery: bool,
     ) -> Result<MoonlinkTableConfig> {
         let src_table_id = schema.src_table_id;
         debug!(src_table_id, "adding table to replication");
@@ -287,7 +286,7 @@ impl ReplicationConnection {
             mooncake_table_id.to_string(),
             table_id,
             schema,
-            Path::new(override_table_base_path.unwrap_or(&self.table_base_path)),
+            &self.table_base_path,
             self.table_temp_files_directory.clone(),
             &self.replication_state,
             self.object_storage_cache.clone(),
@@ -315,9 +314,8 @@ impl ReplicationConnection {
             error!(error = ?e, "failed to enqueue AddTable command");
         }
 
-        // Only perform initial copy for new tables, not during recovery
-        // Recovery is indicated by override_table_base_path being Some(...)
-        if override_table_base_path.is_none() {
+        // Only perform initial copy for new tables, not during recovery.
+        if !is_recovery {
             // Notify the replication task we are starting a table copy and to begin buffering CDC events.
             let cmd_tx = self.cmd_tx.clone();
             if let Err(e) = cmd_tx
@@ -407,8 +405,8 @@ impl ReplicationConnection {
         table_name: &str,
         mooncake_table_id: &T,
         table_id: u32,
-        override_table_base_path: Option<&str>,
         iceberg_filesystem_config: Option<FileSystemConfig>,
+        is_recovery: bool,
     ) -> Result<(SrcTableId, MoonlinkTableConfig)> {
         debug!(table_name, "adding table");
         // TODO: We should not naively alter the replica identity of a table. We should only do this if we are sure that the table does not already have a FULL replica identity. [https://github.com/Mooncake-Labs/moonlink/issues/104]
@@ -420,8 +418,8 @@ impl ReplicationConnection {
                 &table_schema,
                 mooncake_table_id,
                 table_id,
-                override_table_base_path,
                 iceberg_filesystem_config,
+                is_recovery,
             )
             .await?;
 

--- a/src/moonlink_connectors/src/replication_manager.rs
+++ b/src/moonlink_connectors/src/replication_manager.rs
@@ -59,8 +59,8 @@ impl<T: Clone + Eq + Hash + std::fmt::Display> ReplicationManager<T> {
         mooncake_table_id: T,
         table_id: u32,
         table_name: &str,
-        override_table_base_path: Option<&str>,
         iceberg_filesystem_config: Option<FileSystemConfig>,
+        is_recovery: bool,
     ) -> Result<MoonlinkTableConfig> {
         debug!(%src_uri, table_name, "adding table through manager");
         if !self.connections.contains_key(src_uri) {
@@ -86,8 +86,8 @@ impl<T: Clone + Eq + Hash + std::fmt::Display> ReplicationManager<T> {
                 table_name,
                 &mooncake_table_id,
                 table_id,
-                override_table_base_path,
                 iceberg_filesystem_config,
+                is_recovery,
             )
             .await?;
         self.table_info

--- a/src/moonlink_metadata_store/src/postgres/config_utils.rs
+++ b/src/moonlink_metadata_store/src/postgres/config_utils.rs
@@ -8,6 +8,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Serialize, Deserialize)]
 struct IcebergTableConfigForPersistence {
     /// Table warehouse location.
+    /// TODO(hjiang): Store along with security as well.
     warehouse_uri: String,
     /// Namespace for the iceberg table.
     namespace: String,
@@ -52,7 +53,9 @@ pub(crate) fn deserialze_moonlink_table_config(
         iceberg_table_config: IcebergTableConfig {
             namespace: vec![parsed.iceberg_table_config.namespace],
             table_name: parsed.iceberg_table_config.table_name,
-            ..Default::default()
+            filesystem_config: moonlink::FileSystemConfig::FileSystem {
+                root_directory: parsed.iceberg_table_config.warehouse_uri,
+            },
         },
         mooncake_table_config: MooncakeTableConfig::default(),
     };


### PR DESCRIPTION
## Summary

This PR make preparations to pass down secret to table creation, will followup with security related PRs.
Also rename path-related variables, which we already have quite a few and hard to read without proper background:
- base_path: the base path for moonlink backend (all tables)
- write cache path
- read cache path: recreated everytime backend constructs
- temporary directory: recreated everytime backend constructs
- default iceberg warehouse: defaults to base_path
- override iceberg warehouse: deduced by persisted security (recovery); or passed by users (table creation)

Closes https://github.com/Mooncake-Labs/moonlink/issues/833

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
