### PR TITLE
[storage] Overwrite over delete for manifest list

### DIFF
--- a/src/moonlink/src/storage/iceberg/puffin_writer_proxy.rs
+++ b/src/moonlink/src/storage/iceberg/puffin_writer_proxy.rs
@@ -294,7 +294,6 @@ async fn create_new_manifest_list_writer(
     cur_snapshot: &Snapshot,
     file_io: &FileIO,
 ) -> IcebergResult<ManifestListWriter> {
-    file_io.delete(cur_snapshot.manifest_list()).await?;
     let manifest_list_outfile = file_io.new_output(cur_snapshot.manifest_list())?;
 
     let latest_seq_no = table_metadata.last_sequence_number();


### PR DESCRIPTION
## Summary

I suffer deletion failure when committing iceberg transaction due to insufficient permission, see https://github.com/Mooncake-Labs/moonlink/issues/840#issuecomment-3066016996
The issue is:
- To add customized puffin blob, I rewrite the existing manifest list file
- Implementation-wise, I did a delete + write, which requires "object deletion" + "object write" permission
- While directly overwrite only requires the later

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
