### PR TITLE
[CI] Parallelize object storage tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,9 +52,9 @@ jobs:
       - name: cargo deny check
         run: cargo deny check
 
-  # ───────────────────────── 2 · TEST & COVERAGE ────────────────────────────
-  coverage:
-    name: Unit Tests + Coverage (llvm-cov + nextest)
+  # ──────────────────────── 2 · GCS feature test ────────────────────────────
+  gcs_test:
+    name: Unit tests with GCS feature enabled
     runs-on: ubuntu-latest
 
     steps:
@@ -69,6 +69,37 @@ jobs:
             -e STORAGE_DIR=/data \
             fsouza/fake-gcs-server:latest \
             -scheme http -port 4443
+      
+      # ─────────────── Add hostnames to /etc/hosts ──────────────────────────
+      - name: Add gcs.local to /etc/hosts
+        run: |
+          echo "127.0.0.1 gcs.local" | sudo tee -a /etc/hosts
+
+      # ───────────────────── Wait for Fake GCS to be ready ───────────────────
+      - name: Wait for Fake GCS ready
+        run: |
+          for i in {1..10}; do
+            if curl -sf http://gcs.local:4443/storage/v1/b; then
+              echo "Fake GCS is ready!"
+              break
+            fi
+            echo "Waiting for Fake GCS..."
+            sleep 2
+          done
+
+      # ────────────────────── Toolchain + Test Tools ─────────────────────────
+      - name: Run GCS feature tests
+        timeout-minutes: 5
+        run: |
+          cargo test -p moonlink --features=storage-gcs
+
+  # ──────────────────────── 3 · S3 feature test ────────────────────────────
+  s3_test:
+    name: Unit tests with S3 feature enabled
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
 
       # ─────────────────────── Start Fake S3 Server ──────────────────────────
       - name: Start Fake S3 Server
@@ -79,24 +110,11 @@ jobs:
             -e MINIO_ROOT_USER=minioadmin \
             -e MINIO_ROOT_PASSWORD=minioadmin \
             minio/minio:latest server /data
-
+      
       # ─────────────── Add hostnames to /etc/hosts ──────────────────────────
-      - name: Add gcs.local and s3.local to /etc/hosts
+      - name: Add s3.local to /etc/hosts
         run: |
-          echo "127.0.0.1 gcs.local" | sudo tee -a /etc/hosts
           echo "127.0.0.1 s3.local" | sudo tee -a /etc/hosts
-
-      # ───────────────────── Wait for Fake GCS to be ready ───────────────────
-      - name: Wait for Fake GCS
-        run: |
-          for i in {1..10}; do
-            if curl -sf http://gcs.local:4443/storage/v1/b; then
-              echo "Fake GCS is ready!"
-              break
-            fi
-            echo "Waiting for Fake GCS..."
-            sleep 2
-          done
 
       # ───────────────────── Wait for Fake S3 to be ready ───────────────────
       - name: Wait for Fake S3
@@ -109,6 +127,20 @@ jobs:
             echo "Waiting for Fake GCS..."
             sleep 2
           done
+
+      # ────────────────────── Toolchain + Test Tools ─────────────────────────
+      - name: Run S3 feature tests
+        timeout-minutes: 5
+        run: |
+          cargo test -p moonlink --features=storage-s3
+
+  # ───────────────────────── 4 · TEST & COVERAGE ────────────────────────────
+  coverage:
+    name: Unit Tests + Coverage (llvm-cov + nextest)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
 
       # ────────────────────── Toolchain + Test Tools ─────────────────────────
       - uses: dtolnay/rust-toolchain@stable
@@ -124,16 +156,6 @@ jobs:
         with: { tool: cargo-llvm-cov }
       - uses: taiki-e/install-action@v2
         with: { tool: nextest }
-
-      - name: Run GCS feature tests
-        timeout-minutes: 5
-        run: |
-          cargo test -p moonlink --features=storage-gcs
-
-      - name: Run S3 feature tests
-        timeout-minutes: 5
-        run: |
-          cargo test -p moonlink --features=storage-s3
 
       - name: Run tests via llvm-cov/nextest
         timeout-minutes: 5


### PR DESCRIPTION
## Summary

This PR parallelizes object storage test with normal unit tests, so CI runtime reduces from 6 minutes to 3 minutes.

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
