### PR TITLE
[1/N] Use backon for testing utils

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2573,6 +2573,7 @@ dependencies = [
  "arrow-array",
  "arrow-schema",
  "async-trait",
+ "backon",
  "base64 0.22.1",
  "bincode",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ arrow = { version = "55", default-features = false, features = [
 arrow-array = "55"
 arrow-schema = "55"
 async-trait = "0.1"
+backon = { version = "1.5.1" }
 bincode = { version = "2", features = ["serde"] }
 chrono = { version = "0.4", default-features = false }
 clap = { version = "4", features = ["derive"] }

--- a/src/moonlink/Cargo.toml
+++ b/src/moonlink/Cargo.toml
@@ -37,6 +37,7 @@ arrow = { workspace = true }
 arrow-array = { workspace = true }
 arrow-schema = { workspace = true }
 async-trait = { workspace = true }
+backon = { workspace = true }
 base64 = { version = "0.22", optional = true }
 bincode = { workspace = true }
 chrono = { workspace = true }

--- a/src/moonlink/src/storage/filesystem/gcs/gcs_test_utils.rs
+++ b/src/moonlink/src/storage/filesystem/gcs/gcs_test_utils.rs
@@ -1,18 +1,16 @@
 use crate::storage::filesystem::accessor::base_filesystem_accessor::BaseFileSystemAccess;
 use crate::storage::filesystem::filesystem_config::FileSystemConfig;
 use crate::storage::filesystem::test_utils::object_storage_test_utils::*;
-use crate::storage::iceberg::tokio_retry_utils;
 use crate::FileSystemAccessor;
 
 use std::sync::Arc;
+use std::time::Duration;
 
+use backon::{ExponentialBuilder, Retryable};
 use iceberg::{Error as IcebergError, Result as IcebergResult};
 use reqwest::StatusCode;
-use tokio_retry2::strategy::{jitter, ExponentialBackoff};
-use tokio_retry2::Retry;
 
 /// Fake GCS related constants.
-///
 pub(crate) static GCS_TEST_BUCKET_PREFIX: &str = "test-gcs-warehouse-";
 pub(crate) static GCS_TEST_WAREHOUSE_URI_PREFIX: &str = "gs://test-gcs-warehouse-";
 pub(crate) static GCS_TEST_ENDPOINT: &str = "http://gcs.local:4443";
@@ -25,14 +23,13 @@ pub(crate) fn create_gcs_filesystem_config(warehouse_uri: &str) -> FileSystemCon
         endpoint: Some(GCS_TEST_ENDPOINT.to_string()),
         disable_auth: true,
         project: GCS_TEST_PROJECT.to_string(),
-        // Fill other fields as empty.
         region: "".to_string(),
         access_key_id: "".to_string(),
         secret_access_key: "".to_string(),
     }
 }
 
-pub(crate) fn get_test_gcs_bucket_and_warehouse() -> (String /*bucket*/, String /*warehouse_uri*/) {
+pub(crate) fn get_test_gcs_bucket_and_warehouse() -> (String, String) {
     get_bucket_and_warehouse(GCS_TEST_BUCKET_PREFIX, GCS_TEST_WAREHOUSE_URI_PREFIX)
 }
 
@@ -57,27 +54,21 @@ async fn create_gcs_bucket_impl(bucket: Arc<String>) -> IcebergResult<()> {
     Ok(())
 }
 
-/// Util function to delete all objects in a GCS bucket.
 async fn delete_gcs_bucket_objects(bucket: &str) -> IcebergResult<()> {
-    let filesystem_config = create_gcs_filesystem_config(&format!("gs://{bucket}"));
-    let filesystem_accessor = FileSystemAccessor::new(filesystem_config);
-    filesystem_accessor
-        .remove_directory("/")
-        .await
-        .map_err(|e| {
-            IcebergError::new(
-                iceberg::ErrorKind::Unexpected,
-                format!("Failed to remove directory in bucket {bucket}: {e}"),
-            )
-        })?;
+    let config = create_gcs_filesystem_config(&format!("gs://{bucket}"));
+    let accessor = FileSystemAccessor::new(config);
+    accessor.remove_directory("/").await.map_err(|e| {
+        IcebergError::new(
+            iceberg::ErrorKind::Unexpected,
+            format!("Failed to remove directory in bucket {bucket}: {e}"),
+        )
+    })?;
     Ok(())
 }
 
 async fn delete_gcs_bucket_impl(bucket: Arc<String>) -> IcebergResult<()> {
-    // Fake GCS server doesn't support bucket deletion if it contains objects, so need to delete all objects first.
     delete_gcs_bucket_objects(&bucket).await?;
 
-    // Now delete the bucket.
     let client = reqwest::Client::new();
     let url = format!("{GCS_TEST_ENDPOINT}/storage/v1/b/{bucket}");
     let res = client.delete(&url).send().await.map_err(|e| {
@@ -101,41 +92,43 @@ async fn delete_gcs_bucket_impl(bucket: Arc<String>) -> IcebergResult<()> {
 }
 
 pub(crate) async fn create_test_gcs_bucket(bucket: String) -> IcebergResult<()> {
-    let retry_strategy = ExponentialBackoff::from_millis(TEST_RETRY_INIT_MILLISEC)
-        .map(jitter)
-        .take(TEST_RETRY_COUNT);
+    let bucket = Arc::new(bucket);
+    let backoff = ExponentialBuilder::default()
+        .with_min_delay(Duration::from_millis(TEST_RETRY_INIT_MILLISEC))
+        .with_max_times(TEST_RETRY_COUNT);
 
-    Retry::spawn(retry_strategy, {
-        let bucket_name = Arc::new(bucket);
-        move || {
-            let bucket_name = Arc::clone(&bucket_name);
-            async move {
-                create_gcs_bucket_impl(bucket_name)
-                    .await
-                    .map_err(tokio_retry_utils::iceberg_to_tokio_retry_error)
-            }
-        }
+    (move || {
+        let bucket = Arc::clone(&bucket);
+        async move { create_gcs_bucket_impl(bucket).await }
     })
-    .await?;
-    Ok(())
+    .retry(backoff)
+    .sleep(tokio::time::sleep)
+    .when(|e: &IcebergError| {
+        matches!(
+            e.kind(),
+            iceberg::ErrorKind::Unexpected | iceberg::ErrorKind::CatalogCommitConflicts
+        )
+    })
+    .await
 }
 
 pub(crate) async fn delete_test_gcs_bucket(bucket: String) {
-    let retry_strategy = ExponentialBackoff::from_millis(TEST_RETRY_INIT_MILLISEC)
-        .map(jitter)
-        .take(TEST_RETRY_COUNT);
+    let bucket = Arc::new(bucket);
+    let backoff = ExponentialBuilder::default()
+        .with_min_delay(Duration::from_millis(TEST_RETRY_INIT_MILLISEC))
+        .with_max_times(TEST_RETRY_COUNT);
 
-    Retry::spawn(retry_strategy, {
-        let bucket_name = Arc::new(bucket);
-        move || {
-            let bucket_name = Arc::clone(&bucket_name);
-            async move {
-                delete_gcs_bucket_impl(bucket_name)
-                    .await
-                    .map_err(tokio_retry_utils::iceberg_to_tokio_retry_error)
-            }
-        }
+    let _ = (move || {
+        let bucket = Arc::clone(&bucket);
+        async move { delete_gcs_bucket_impl(bucket).await }
     })
-    .await
-    .unwrap();
+    .retry(backoff)
+    .sleep(tokio::time::sleep)
+    .when(|e: &IcebergError| {
+        matches!(
+            e.kind(),
+            iceberg::ErrorKind::Unexpected | iceberg::ErrorKind::CatalogCommitConflicts
+        )
+    })
+    .await;
 }

--- a/src/moonlink/src/storage/filesystem/s3/s3_test_utils.rs
+++ b/src/moonlink/src/storage/filesystem/s3/s3_test_utils.rs
@@ -2,19 +2,19 @@ use crate::storage::filesystem::accessor::base_filesystem_accessor::BaseFileSyst
 use crate::storage::filesystem::accessor::filesystem_accessor::FileSystemAccessor;
 use crate::storage::filesystem::filesystem_config::FileSystemConfig;
 use crate::storage::filesystem::test_utils::object_storage_test_utils::*;
-use crate::storage::iceberg::tokio_retry_utils;
 
 use std::sync::Arc;
+use std::time::Duration;
 
 use base64::engine::general_purpose::STANDARD as base64;
 use base64::Engine;
 use chrono::Utc;
 use hmac::{Hmac, Mac};
-use iceberg::Error as IcebergError;
-use iceberg::Result as IcebergResult;
+use iceberg::{Error as IcebergError, Result as IcebergResult};
 use sha1::Sha1;
-use tokio_retry2::strategy::{jitter, ExponentialBackoff};
-use tokio_retry2::Retry;
+
+use backon::{ExponentialBuilder, Retryable};
+use tokio::time::sleep;
 
 type HmacSha1 = Hmac<Sha1>;
 
@@ -33,18 +33,16 @@ pub(crate) fn create_s3_filesystem_config(warehouse_uri: &str) -> FileSystemConf
     FileSystemConfig::S3 {
         access_key_id: S3_TEST_ACCESS_KEY_ID.to_string(),
         secret_access_key: S3_TEST_SECRET_ACCESS_KEY.to_string(),
-        region: "auto".to_string(), // minio doesn't care about region.
+        region: "auto".to_string(),
         bucket: bucket.to_string(),
         endpoint: Some(S3_TEST_ENDPOINT.to_string()),
     }
 }
 
-pub(crate) fn get_test_s3_bucket_and_warehouse(
-) -> (String /*bucket_name*/, String /*warehouse_url*/) {
+pub(crate) fn get_test_s3_bucket_and_warehouse() -> (String, String) {
     get_bucket_and_warehouse(S3_TEST_BUCKET_PREFIX, S3_TEST_WAREHOUSE_URI_PREFIX)
 }
 
-/// Create test bucket in minio server.
 async fn create_test_s3_bucket_impl(bucket: Arc<String>) -> IcebergResult<()> {
     let date = Utc::now().format("%a, %d %b %Y %T GMT").to_string();
     let string_to_sign = format!("PUT\n\n\n{date}\n/{bucket}");
@@ -56,6 +54,7 @@ async fn create_test_s3_bucket_impl(bucket: Arc<String>) -> IcebergResult<()> {
     let auth_header = format!("AWS {S3_TEST_ACCESS_KEY_ID}:{signature}");
     let url = format!("{S3_TEST_ENDPOINT}/{bucket}");
     let client = reqwest::Client::new();
+
     client
         .put(&url)
         .header("Authorization", auth_header)
@@ -68,62 +67,36 @@ async fn create_test_s3_bucket_impl(bucket: Arc<String>) -> IcebergResult<()> {
                 format!("Failed to create bucket {bucket} in minio with url {url}: {e}"),
             )
         })?;
+
     Ok(())
 }
 
-/// Creates the provided bucket with exponential backoff retry; this function assumes the bucket doesn't exist, otherwise it will return error.
-pub(crate) async fn create_test_s3_bucket(bucket: String) -> IcebergResult<()> {
-    let retry_strategy = ExponentialBackoff::from_millis(TEST_RETRY_INIT_MILLISEC)
-        .map(jitter)
-        .take(TEST_RETRY_COUNT);
-
-    Retry::spawn(retry_strategy, {
-        let bucket_name = Arc::new(bucket);
-        move || {
-            let bucket_name = Arc::clone(&bucket_name);
-            async move {
-                create_test_s3_bucket_impl(bucket_name)
-                    .await
-                    .map_err(tokio_retry_utils::iceberg_to_tokio_retry_error)
-            }
-        }
-    })
-    .await?;
-    Ok(())
-}
-
-/// Util function to delete all objects in a S3 bucket.
 async fn delete_s3_bucket_objects(bucket: &str) -> IcebergResult<()> {
-    let filesystem_config = create_s3_filesystem_config(&format!("s3://{bucket}"));
-    let filesystem_accessor = FileSystemAccessor::new(filesystem_config);
-    filesystem_accessor
-        .remove_directory("/")
-        .await
-        .map_err(|e| {
-            IcebergError::new(
-                iceberg::ErrorKind::Unexpected,
-                format!("Failed to remove directory in bucket {bucket}: {e}"),
-            )
-        })?;
+    let config = create_s3_filesystem_config(&format!("s3://{bucket}"));
+    let accessor = FileSystemAccessor::new(config);
+    accessor.remove_directory("/").await.map_err(|e| {
+        IcebergError::new(
+            iceberg::ErrorKind::Unexpected,
+            format!("Failed to remove directory in bucket {bucket}: {e}"),
+        )
+    })?;
     Ok(())
 }
 
-/// Delete test bucket in minio server.
-pub async fn delete_test_s3_bucket_impl(bucket: Arc<String>) -> IcebergResult<()> {
-    // Delete all objects in the bucket first.
+async fn delete_test_s3_bucket_impl(bucket: Arc<String>) -> IcebergResult<()> {
     delete_s3_bucket_objects(&bucket).await?;
 
-    // Now delete the bucket.
     let date = Utc::now().format("%a, %d %b %Y %T GMT").to_string();
     let string_to_sign = format!("DELETE\n\n\n{date}\n/{bucket}");
 
     let mut mac = HmacSha1::new_from_slice(S3_TEST_SECRET_ACCESS_KEY.as_bytes()).unwrap();
     mac.update(string_to_sign.as_bytes());
     let signature = base64.encode(mac.finalize().into_bytes());
+
     let auth_header = format!("AWS {S3_TEST_ACCESS_KEY_ID}:{signature}");
     let url = format!("{S3_TEST_ENDPOINT}/{bucket}");
-
     let client = reqwest::Client::new();
+
     client
         .delete(&url)
         .header("Authorization", auth_header)
@@ -133,30 +106,51 @@ pub async fn delete_test_s3_bucket_impl(bucket: Arc<String>) -> IcebergResult<()
         .map_err(|e| {
             IcebergError::new(
                 iceberg::ErrorKind::Unexpected,
-                format!("Failed to delete bucket {bucket} in minio {e}"),
+                format!("Failed to delete bucket {bucket} in minio: {e}"),
             )
         })?;
 
     Ok(())
 }
 
-/// Delete the provided bucket with exponential backoff retry; this function assume bucket already exists and return error if not.
-pub(crate) async fn delete_test_s3_bucket(bucket: String) {
-    let retry_strategy = ExponentialBackoff::from_millis(TEST_RETRY_INIT_MILLISEC)
-        .map(jitter)
-        .take(TEST_RETRY_COUNT);
+pub(crate) async fn create_test_s3_bucket(bucket: String) -> IcebergResult<()> {
+    let bucket = Arc::new(bucket);
+    let backoff = ExponentialBuilder::default()
+        .with_min_delay(Duration::from_millis(TEST_RETRY_INIT_MILLISEC))
+        .with_max_times(TEST_RETRY_COUNT);
 
-    Retry::spawn(retry_strategy, {
-        let bucket_name = Arc::new(bucket);
-        move || {
-            let bucket_name = Arc::clone(&bucket_name);
-            async move {
-                delete_test_s3_bucket_impl(bucket_name)
-                    .await
-                    .map_err(tokio_retry_utils::iceberg_to_tokio_retry_error)
-            }
-        }
+    (move || {
+        let bucket = Arc::clone(&bucket);
+        async move { create_test_s3_bucket_impl(bucket).await }
+    })
+    .retry(backoff)
+    .sleep(sleep)
+    .when(|e: &IcebergError| {
+        matches!(
+            e.kind(),
+            iceberg::ErrorKind::Unexpected | iceberg::ErrorKind::CatalogCommitConflicts
+        )
     })
     .await
-    .unwrap();
+}
+
+pub(crate) async fn delete_test_s3_bucket(bucket: String) {
+    let bucket = Arc::new(bucket);
+    let backoff = ExponentialBuilder::default()
+        .with_min_delay(Duration::from_millis(TEST_RETRY_INIT_MILLISEC))
+        .with_max_times(TEST_RETRY_COUNT);
+
+    let _ = (move || {
+        let bucket = Arc::clone(&bucket);
+        async move { delete_test_s3_bucket_impl(bucket).await }
+    })
+    .retry(backoff)
+    .sleep(sleep)
+    .when(|e: &IcebergError| {
+        matches!(
+            e.kind(),
+            iceberg::ErrorKind::Unexpected | iceberg::ErrorKind::CatalogCommitConflicts
+        )
+    })
+    .await;
 }


### PR DESCRIPTION
## Summary

Background:
- When checking dependency, I found we have two retry crates, one for tokio-retry, another for backon, which is an implicit dependency for opendal and iceberg-rust
- Checking the feature set and API, backon seems to be better; i.e. it's runtime agonostic

So I propose to replace tokio-retry with backon, will followup with another PRs.

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
