### PR TITLE
[storage] Rework retry transaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1921,7 +1921,7 @@ dependencies = [
 [[package]]
 name = "iceberg"
 version = "0.5.1"
-source = "git+https://github.com/apache/iceberg-rust.git?rev=3fa902789dae510acb0bd3e9e57e9f7b92a0677d#3fa902789dae510acb0bd3e9e57e9f7b92a0677d"
+source = "git+https://github.com/apache/iceberg-rust.git?rev=e47b268a6d58a58b8d79263d13cded55ff93fcff#e47b268a6d58a58b8d79263d13cded55ff93fcff"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -1936,6 +1936,7 @@ dependencies = [
  "arrow-string",
  "as-any",
  "async-trait",
+ "backon",
  "base64 0.22.1",
  "bimap",
  "bytes",
@@ -1945,6 +1946,7 @@ dependencies = [
  "fnv",
  "futures",
  "itertools 0.13.0",
+ "mockall",
  "moka",
  "murmur3",
  "num-bigint",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ crc32fast = "1"
 fastbloom = "0.12.0"
 futures = { version = "0.3", default-features = false }
 hashbrown = "0.15.3"
-iceberg = { git = "https://github.com/apache/iceberg-rust.git", rev = "3fa902789dae510acb0bd3e9e57e9f7b92a0677d", default-features = false, features = [
+iceberg = { git = "https://github.com/apache/iceberg-rust.git", rev = "e47b268a6d58a58b8d79263d13cded55ff93fcff", default-features = false, features = [
   "storage-fs",
 ] }
 itertools = { version = "0.14" }

--- a/src/moonlink/src/storage/iceberg/file_catalog.rs
+++ b/src/moonlink/src/storage/iceberg/file_catalog.rs
@@ -465,7 +465,7 @@ impl Catalog for FileCatalog {
         _namespace_ident: &NamespaceIdent,
         _properties: HashMap<String, String>,
     ) -> IcebergResult<()> {
-        todo!()
+        todo!("Update namespace is not supported yet!")
     }
 
     /// Create a new table inside the namespace.
@@ -580,7 +580,7 @@ impl Catalog for FileCatalog {
 
     /// Rename a table in the catalog.
     async fn rename_table(&self, _src: &TableIdent, _dest: &TableIdent) -> IcebergResult<()> {
-        todo!()
+        todo!("rename table is not supported yet!")
     }
 
     /// Update a table to the catalog, which writes metadata file and version hint file.

--- a/src/moonlink/src/storage/iceberg/file_catalog.rs
+++ b/src/moonlink/src/storage/iceberg/file_catalog.rs
@@ -153,6 +153,7 @@ impl FileCatalog {
                     iceberg::ErrorKind::Unexpected,
                     format!("Failed to read version hint file on load table: {e}"),
                 )
+                .with_retryable(true)
             })?;
         let version = version_str
             .trim()
@@ -176,6 +177,7 @@ impl FileCatalog {
                     iceberg::ErrorKind::Unexpected,
                     format!("Failed to read table metadata file on load table: {e}"),
                 )
+                .with_retryable(true)
             })?;
         let metadata = serde_json::from_slice::<TableMetadata>(&metadata_bytes)
             .map_err(|e| IcebergError::new(iceberg::ErrorKind::DataInvalid, e.to_string()))?;
@@ -302,6 +304,7 @@ impl Catalog for FileCatalog {
                     iceberg::ErrorKind::Unexpected,
                     format!("Failed to list namespaces: {e}"),
                 )
+                .with_retryable(true)
             })?;
 
         // Start multiple async functions in parallel to check whether namespace.
@@ -369,6 +372,7 @@ impl Catalog for FileCatalog {
                     iceberg::ErrorKind::Unexpected,
                     format!("Failed to write metadata file at namespace creation: {e}"),
                 )
+                .with_retryable(true)
             })?;
 
         Ok(Namespace::new(namespace_ident.clone()))
@@ -398,6 +402,7 @@ impl Catalog for FileCatalog {
                     iceberg::ErrorKind::Unexpected,
                     format!("Failed to check namespace {namespace_ident:?} existence: {e:?}"),
                 )
+                .with_retryable(true)
             })?;
         Ok(exists)
     }
@@ -413,6 +418,7 @@ impl Catalog for FileCatalog {
                     iceberg::ErrorKind::Unexpected,
                     format!("Failed to drop namespace {namespace_ident:?} existence: {e:?}"),
                 )
+                .with_retryable(true)
             })?;
         Ok(())
     }
@@ -487,6 +493,7 @@ impl Catalog for FileCatalog {
                     iceberg::ErrorKind::Unexpected,
                     format!("Failed to write version hint file at table creation: {e}"),
                 )
+                .with_retryable(true)
             })?;
 
         // Create metadata file.
@@ -507,6 +514,7 @@ impl Catalog for FileCatalog {
                     iceberg::ErrorKind::Unexpected,
                     format!("Failed to write metadata file at table creation: {e}"),
                 )
+                .with_retryable(true)
             })?;
 
         let table = Table::builder()
@@ -543,6 +551,7 @@ impl Catalog for FileCatalog {
                     iceberg::ErrorKind::Unexpected,
                     format!("Failed to delete directory {directory}: {e:?}"),
                 )
+                .with_retryable(true)
             })?;
         Ok(())
     }
@@ -564,7 +573,7 @@ impl Catalog for FileCatalog {
                     format!(
                         "Failed to check version hint file existence {version_hint_filepath:?}: {e:?}"
                     ),
-                )
+                ).with_retryable(true)
             })?;
         Ok(exists)
     }
@@ -607,6 +616,7 @@ impl Catalog for FileCatalog {
                     iceberg::ErrorKind::Unexpected,
                     format!("Failed to write metadata file at table update: {e}"),
                 )
+                .with_retryable(true)
             })?;
 
         // Manifest files and manifest list has persisted into storage, make modifications based on puffin blobs.
@@ -633,6 +643,7 @@ impl Catalog for FileCatalog {
                         "Failed to write version hint file existencee {version_hint_path}: {e:?}"
                     ),
                 )
+                .with_retryable(true)
             })?;
 
         Table::builder()

--- a/src/moonlink/src/storage/iceberg/iceberg_table_loader.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_loader.rs
@@ -17,6 +17,7 @@ use std::vec;
 
 use iceberg::io::FileIO;
 use iceberg::spec::{DataFileFormat, ManifestEntry};
+use iceberg::Error as IcebergError;
 use iceberg::Result as IcebergResult;
 
 /// Results for recovering file indices from iceberg table.
@@ -137,10 +138,29 @@ impl IcebergTableManager {
                 self.filesystem_accessor.as_ref(),
             )
             .await
-            .map_err(utils::to_iceberg_error)?;
-        io_utils::delete_local_files(evicted_files_to_delete)
+            .map_err(|e| {
+                IcebergError::new(
+                    iceberg::ErrorKind::Unexpected,
+                    format!(
+                        "Failed to get cache entry for {}: {:?}",
+                        data_file.file_path(),
+                        e
+                    ),
+                )
+                .with_retryable(true)
+            })?;
+        io_utils::delete_local_files(evicted_files_to_delete.clone())
             .await
-            .map_err(utils::to_iceberg_error)?;
+            .map_err(|e| {
+                IcebergError::new(
+                    iceberg::ErrorKind::Unexpected,
+                    format!(
+                        "Failed to delete files for {:?}: {:?}",
+                        evicted_files_to_delete, e
+                    ),
+                )
+                .with_retryable(true)
+            })?;
 
         data_file_entry.persisted_deletion_vector = Some(PuffinBlobRef {
             // Deletion vector should be pinned on cache.

--- a/src/moonlink/src/storage/iceberg/iceberg_table_loader.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_loader.rs
@@ -154,10 +154,7 @@ impl IcebergTableManager {
             .map_err(|e| {
                 IcebergError::new(
                     iceberg::ErrorKind::Unexpected,
-                    format!(
-                        "Failed to delete files for {:?}: {:?}",
-                        evicted_files_to_delete, e
-                    ),
+                    format!("Failed to delete files for {evicted_files_to_delete:?}: {e:?}"),
                 )
                 .with_retryable(true)
             })?;

--- a/src/moonlink/src/storage/iceberg/iceberg_table_syncer.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_syncer.rs
@@ -26,10 +26,8 @@ use crate::storage::{io_utils, storage_utils};
 use std::collections::{HashMap, HashSet};
 use std::vec;
 
-use backon::{ExponentialBuilder, Retryable};
 use iceberg::puffin::CompressionCodec;
 use iceberg::spec::DataFile;
-use iceberg::table::Table as IcebergTable;
 use iceberg::transaction::{ApplyTransactionAction, Transaction};
 use iceberg::{Error as IcebergError, Result as IcebergResult};
 
@@ -127,7 +125,7 @@ impl IcebergTableManager {
             .map_err(|e| {
                 IcebergError::new(
                     iceberg::ErrorKind::Unexpected,
-                    format!("Failed to get cache entry for {}: {:?}", puffin_filepath, e),
+                    format!("Failed to get cache entry for {puffin_filepath}: {e:?}"),
                 )
                 .with_retryable(true)
             })?;
@@ -136,10 +134,7 @@ impl IcebergTableManager {
             .map_err(|e| {
                 IcebergError::new(
                     iceberg::ErrorKind::Unexpected,
-                    format!(
-                        "Failed to delete files for {:?}: {:?}",
-                        evicted_files_to_delete, e
-                    ),
+                    format!("Failed to delete files for {evicted_files_to_delete:?}: {e:?}"),
                 )
                 .with_retryable(true)
             })?;

--- a/src/moonlink/src/storage/iceberg/index.rs
+++ b/src/moonlink/src/storage/iceberg/index.rs
@@ -3,7 +3,6 @@ use std::collections::HashMap;
 use crate::storage::cache::object_storage::base_cache::CacheTrait;
 use crate::storage::filesystem::accessor::base_filesystem_accessor::BaseFileSystemAccess;
 use crate::storage::iceberg::puffin_utils;
-use crate::storage::iceberg::utils::to_iceberg_error;
 use crate::storage::index::persisted_bucket_hash_map::IndexBlock as MooncakeIndexBlock;
 /// This module defines the file index struct used for iceberg, which corresponds to in-memory mooncake table file index structs, and supports the serde between mooncake table format and iceberg format.
 use crate::storage::index::FileIndex as MooncakeFileIndex;
@@ -135,6 +134,7 @@ impl FileIndex {
                             cur_index_block.filepath, e
                         ),
                     )
+                    .with_retryable(true)
                 })?;
             evicted_files_to_delete.extend(cur_evicted_files);
 
@@ -172,9 +172,18 @@ impl FileIndex {
         };
 
         // Delete all evicted files inline.
-        io_utils::delete_local_files(evicted_files_to_delete)
+        io_utils::delete_local_files(evicted_files_to_delete.clone())
             .await
-            .map_err(to_iceberg_error)?;
+            .map_err(|e| {
+                IcebergError::new(
+                    iceberg::ErrorKind::Unexpected,
+                    format!(
+                        "Failed to delete files for {:?}: {:?}",
+                        evicted_files_to_delete, e
+                    ),
+                )
+                .with_retryable(true)
+            })?;
 
         Ok(file_indice)
     }

--- a/src/moonlink/src/storage/iceberg/index.rs
+++ b/src/moonlink/src/storage/iceberg/index.rs
@@ -177,10 +177,7 @@ impl FileIndex {
             .map_err(|e| {
                 IcebergError::new(
                     iceberg::ErrorKind::Unexpected,
-                    format!(
-                        "Failed to delete files for {:?}: {:?}",
-                        evicted_files_to_delete, e
-                    ),
+                    format!("Failed to delete files for {evicted_files_to_delete:?}: {e:?}"),
                 )
                 .with_retryable(true)
             })?;

--- a/src/moonlink/src/storage/iceberg/io_utils.rs
+++ b/src/moonlink/src/storage/iceberg/io_utils.rs
@@ -38,6 +38,7 @@ pub(crate) async fn write_record_batch_to_iceberg(
                 iceberg::ErrorKind::Unexpected,
                 format!("Failed to copy from {local_filepath} to {remote_filepath}: {e:?}"),
             )
+            .with_retryable(true)
         })?;
 
     // Get data file from local parquet file.
@@ -72,6 +73,7 @@ pub(crate) async fn upload_index_file(
                 iceberg::ErrorKind::Unexpected,
                 format!("Failed to copy from {local_index_filepath} to {remote_filepath}: {e:?}"),
             )
+            .with_retryable(true)
         })?;
     Ok(remote_filepath)
 }

--- a/src/moonlink/src/storage/iceberg/table_property.rs
+++ b/src/moonlink/src/storage/iceberg/table_property.rs
@@ -23,8 +23,6 @@ pub(crate) const TABLE_COMMIT_RETRY_MAX_MS_DEFAULT: u64 = 30000; // 30 second
 pub(crate) const TABLE_COMMIT_RETRY_TIMEOUT_MS: &str = "commit.retry.total-timeout-ms";
 pub(crate) const TABLE_COMMIT_RETRY_TIMEOUT_MS_DEFAULT: u64 = 120000; // 2 min
 
-pub(crate) const TABLE_COMMIT_RETRY_FACTOR: u64 = 2;
-
 // Create iceberg table properties from table config.
 pub(crate) fn create_iceberg_table_properties() -> HashMap<String, String> {
     let mut props = HashMap::with_capacity(6);

--- a/src/moonlink/src/storage/iceberg/utils.rs
+++ b/src/moonlink/src/storage/iceberg/utils.rs
@@ -138,8 +138,3 @@ pub(crate) async fn get_table_if_exists<C: MoonlinkCatalog + ?Sized>(
     let table = catalog.load_table(&table_ident).await?;
     Ok(Some(table))
 }
-
-/// Util function to convert the given error to iceberg "unexpected" error.
-pub(crate) fn to_iceberg_error<E: std::fmt::Debug>(err: E) -> IcebergError {
-    IcebergError::new(iceberg::ErrorKind::Unexpected, format!("Error: {err:?}"))
-}

--- a/src/moonlink/src/storage/iceberg/utils.rs
+++ b/src/moonlink/src/storage/iceberg/utils.rs
@@ -7,9 +7,7 @@ use arrow_schema::Schema as ArrowSchema;
 use iceberg::arrow as IcebergArrow;
 use iceberg::spec::{DataContentType, DataFileFormat, ManifestEntry};
 use iceberg::table::Table as IcebergTable;
-use iceberg::{
-    Error as IcebergError, NamespaceIdent, Result as IcebergResult, TableCreation, TableIdent,
-};
+use iceberg::{NamespaceIdent, Result as IcebergResult, TableCreation, TableIdent};
 
 /// Return whether the given manifest entry represents data files.
 pub fn is_data_file_entry(entry: &ManifestEntry) -> bool {


### PR DESCRIPTION
## Summary

iceberg-rust supports transaction retry internally, so I don't need to implement myself.

A few changes in the PR:
- Upgrade iceberg-rust to the latest version
- Update transaction commit logic and discard self-implemented retry
- Explicit propagate iceberg error, instead of using a util function
- Revisit and correctly mark errors as retryable or not

I tested the retry feature manually, and confirmed it works.
It's not easy to add unit tests because IO operations performed by opendal is not easy to mock.

Followup items would be rework on moonlink error type: https://github.com/Mooncake-Labs/moonlink/issues/852

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/851

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
