### PR TITLE
[storage] Avoid mooncake snapshot when iceberg ongoing

### DIFF
--- a/src/moonlink/src/table_handler.rs
+++ b/src/moonlink/src/table_handler.rs
@@ -405,7 +405,7 @@ impl TableHandler {
                             }
 
                             // Check whether a flush and force snapshot is needed.
-                            if !table_handler_state.pending_force_snapshot_lsns.is_empty() {
+                            if !table_handler_state.pending_force_snapshot_lsns.is_empty() && !table_handler_state.iceberg_snapshot_ongoing {
                                 if let Some(commit_lsn) = table_handler_state.table_consistent_view_lsn {
                                     table.flush(commit_lsn).await.unwrap();
                                     table_handler_state.reset_iceberg_state_at_mooncake_snapshot();


### PR DESCRIPTION
## Summary

No need to force create a mooncake snapshot, when already an iceberg snapshot ongoing.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/860

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
