### PR TITLE
Async flush snapshot order

### DIFF
--- a/src/moonlink/src/table_handler/tests.rs
+++ b/src/moonlink/src/table_handler/tests.rs
@@ -1702,3 +1702,21 @@ fn test_is_iceberg_snapshot_satisfy_force_snapshot() {
         );
     }
 }
+
+#[test]
+fn test_can_initiate_iceberg_snapshot_pending_flush() {
+    let mut state = TableHandlerState::new();
+
+    // Normal conditions with no pending snapshot and result consumed
+    state.iceberg_snapshot_result_consumed = true;
+    state.iceberg_snapshot_ongoing = false;
+
+    // Pending flush with lower LSN should block
+    assert!(!state.can_initiate_iceberg_snapshot(10, 5));
+
+    // Pending flush with equal LSN should also block
+    assert!(!state.can_initiate_iceberg_snapshot(5, 5));
+
+    // When the lowest pending flush is higher than the snapshot flush LSN, snapshot can proceed
+    assert!(state.can_initiate_iceberg_snapshot(5, 6));
+}

--- a/src/moonlink/src/table_handler/tests.rs
+++ b/src/moonlink/src/table_handler/tests.rs
@@ -1705,7 +1705,8 @@ fn test_is_iceberg_snapshot_satisfy_force_snapshot() {
 
 #[test]
 fn test_can_initiate_iceberg_snapshot_pending_flush() {
-    let mut state = TableHandlerState::new();
+    let (index_merge_completion_tx, _) = broadcast::channel(64usize);
+    let mut state = TableHandlerState::new(index_merge_completion_tx);
 
     // Normal conditions with no pending snapshot and result consumed
     state.iceberg_snapshot_result_consumed = true;


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

Given flush is now async it's possible for LSNs to complete out of order. This is fine in the mooncake snapshot case but we need to guarantee order when creating iceberg snapshot. 

To do this we maintain a set of pending flush LSNs and only allow iceberg snapshot if there are no pending flush LSNs < requested LSN. 

This needs more integration/unit testing and will be done as part of https://github.com/Mooncake-Labs/moonlink/issues/857, but would like to get in for correctness. 

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/858

## Changes

- 
- 
- 

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
