### PR TITLE
Make moonlink error cloneable

### DIFF
--- a/src/moonlink/src/error.rs
+++ b/src/moonlink/src/error.rs
@@ -3,20 +3,21 @@ use iceberg::Error as IcebergError;
 use parquet::errors::ParquetError;
 use std::io;
 use std::result;
+use std::sync::Arc;
 use thiserror::Error;
 use tokio::sync::watch;
 
 /// Custom error type for moonlink
-#[derive(Debug, Error)]
+#[derive(Clone, Debug, Error)]
 pub enum Error {
     #[error("Arrow error: {source}")]
-    Arrow { source: ArrowError },
+    Arrow { source: Arc<ArrowError> },
 
-    #[error("IO error: {0}")]
-    Io(#[from] io::Error),
+    #[error("IO error: {source}")]
+    Io { source: Arc<io::Error> },
 
     #[error("Parquet error: {0}")]
-    Parquet(#[from] ParquetError),
+    Parquet(#[from] Arc<ParquetError>),
 
     #[error("Transaction {0} not found")]
     TransactionNotFound(u32),
@@ -31,31 +32,61 @@ pub enum Error {
     TokioJoinError(String),
 
     #[error("Iceberg error: {source}")]
-    IcebergError { source: IcebergError },
+    IcebergError { source: Arc<IcebergError> },
 
     #[error("Iceberg error: {0}")]
     IcebergMessage(String),
 
     #[error("OpenDAL error: {0}")]
-    OpenDal(#[from] opendal::Error),
+    OpenDal(#[from] Arc<opendal::Error>),
 
     #[error("UTF-8 conversion error: {0}")]
     Utf8(#[from] std::string::FromUtf8Error),
 
     #[error("Join error: {0}")]
-    JoinError(#[from] tokio::task::JoinError),
+    JoinError(#[from] Arc<tokio::task::JoinError>),
 }
 
 pub type Result<T> = result::Result<T, Error>;
 
 impl From<ArrowError> for Error {
     fn from(source: ArrowError) -> Self {
-        Error::Arrow { source }
+        Error::Arrow {
+            source: Arc::new(source),
+        }
     }
 }
 
 impl From<IcebergError> for Error {
     fn from(source: IcebergError) -> Self {
-        Error::IcebergError { source }
+        Error::IcebergError {
+            source: Arc::new(source),
+        }
+    }
+}
+
+impl From<io::Error> for Error {
+    fn from(source: io::Error) -> Self {
+        Error::Io {
+            source: Arc::new(source),
+        }
+    }
+}
+
+impl From<opendal::Error> for Error {
+    fn from(source: opendal::Error) -> Self {
+        Error::OpenDal(Arc::new(source))
+    }
+}
+
+impl From<tokio::task::JoinError> for Error {
+    fn from(source: tokio::task::JoinError) -> Self {
+        Error::JoinError(Arc::new(source))
+    }
+}
+
+impl From<ParquetError> for Error {
+    fn from(source: ParquetError) -> Self {
+        Error::Parquet(Arc::new(source))
     }
 }

--- a/src/moonlink/src/error.rs
+++ b/src/moonlink/src/error.rs
@@ -16,8 +16,8 @@ pub enum Error {
     #[error("IO error: {source}")]
     Io { source: Arc<io::Error> },
 
-    #[error("Parquet error: {0}")]
-    Parquet(#[from] Arc<ParquetError>),
+    #[error("Parquet error: {source}")]
+    Parquet { source: Arc<ParquetError> },
 
     #[error("Transaction {0} not found")]
     TransactionNotFound(u32),
@@ -37,14 +37,14 @@ pub enum Error {
     #[error("Iceberg error: {0}")]
     IcebergMessage(String),
 
-    #[error("OpenDAL error: {0}")]
-    OpenDal(#[from] Arc<opendal::Error>),
+    #[error("OpenDAL error: {source}")]
+    OpenDal { source: Arc<opendal::Error> },
 
     #[error("UTF-8 conversion error: {0}")]
     Utf8(#[from] std::string::FromUtf8Error),
 
-    #[error("Join error: {0}")]
-    JoinError(#[from] Arc<tokio::task::JoinError>),
+    #[error("Join error: {source}")]
+    JoinError { source: Arc<tokio::task::JoinError> },
 }
 
 pub type Result<T> = result::Result<T, Error>;
@@ -75,18 +75,24 @@ impl From<io::Error> for Error {
 
 impl From<opendal::Error> for Error {
     fn from(source: opendal::Error) -> Self {
-        Error::OpenDal(Arc::new(source))
+        Error::OpenDal {
+            source: Arc::new(source),
+        }
     }
 }
 
 impl From<tokio::task::JoinError> for Error {
     fn from(source: tokio::task::JoinError) -> Self {
-        Error::JoinError(Arc::new(source))
+        Error::JoinError {
+            source: Arc::new(source),
+        }
     }
 }
 
 impl From<ParquetError> for Error {
     fn from(source: ParquetError) -> Self {
-        Error::Parquet(Arc::new(source))
+        Error::Parquet {
+            source: Arc::new(source),
+        }
     }
 }

--- a/src/moonlink/src/storage/mooncake_table/disk_slice.rs
+++ b/src/moonlink/src/storage/mooncake_table/disk_slice.rs
@@ -180,7 +180,7 @@ impl DiskSliceWriter {
                 let file =
                     tokio::fs::File::create(dir_path.join(data_file.as_ref().unwrap().file_path()))
                         .await
-                        .map_err(Error::Io)?;
+                        .map_err(Into::<Error>::into)?;
                 let properties = parquet_utils::get_default_parquet_properties();
                 writer = Some(AsyncArrowWriter::try_new(
                     file,
@@ -294,7 +294,7 @@ mod tests {
     #[tokio::test]
     async fn test_disk_slice_builder() -> Result<()> {
         // Create a temporary directory for the test
-        let temp_dir = tempdir().map_err(Error::Io)?;
+        let temp_dir = tempdir().map_err(Into::<Error>::into)?;
         // Create a schema for testing
         let schema = get_test_schema();
 
@@ -352,7 +352,7 @@ mod tests {
             assert_eq!(record_batch, expected_record_batch);
         }
         // Clean up temporary directory
-        temp_dir.close().map_err(Error::Io)?;
+        temp_dir.close().map_err(Into::<Error>::into)?;
 
         Ok(())
     }
@@ -360,7 +360,7 @@ mod tests {
     #[tokio::test]
     async fn test_index_remapping() -> Result<()> {
         // Create a temporary directory for the test
-        let temp_dir = tempdir().map_err(Error::Io)?;
+        let temp_dir = tempdir().map_err(Into::<Error>::into)?;
 
         // Create a schema for testing
         let schema = get_test_schema();
@@ -478,7 +478,7 @@ mod tests {
         );
 
         // Clean up temporary directory
-        temp_dir.close().map_err(Error::Io)?;
+        temp_dir.close().map_err(Into::<Error>::into)?;
 
         Ok(())
     }


### PR DESCRIPTION
## Summary

We're using `tokio::sync::broadcast` in multiple places for synchronization, for example, index merge command, data compaction command, force snapshot command, etc.

One requirement for the receiver is cloneable type, for us is `moonlink::Result<()>`.
This PR achieves so by wrapping non-cloneable error types with `Arc`; no performance concern since it only happens on error path.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/869

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
