### PR TITLE
[storage] Use single channel for table maintenance

### DIFF
--- a/src/moonlink/src/event_sync.rs
+++ b/src/moonlink/src/event_sync.rs
@@ -9,11 +9,8 @@ pub struct EventSyncReceiver {
     pub drop_table_completion_rx: oneshot::Receiver<Result<()>>,
     /// Get notified when iceberg flush lsn advances.
     pub flush_lsn_rx: watch::Receiver<u64>,
-    /// Used to create notifier when index merge completes.
-    /// TODO(hjiang): Error status propagation.
-    pub index_merge_completion_tx: broadcast::Sender<()>,
-    /// Used to create notifier when data compaction completes.
-    pub data_compaction_completion_tx: broadcast::Sender<Result<()>>,
+    /// Used to create notifier when force table maintenance operation completes.
+    pub table_maintenance_completion_tx: broadcast::Sender<Result<()>>,
 }
 
 /// Contains a few senders, which notifies after certain iceberg events completion.
@@ -22,30 +19,24 @@ pub struct EventSyncSender {
     pub drop_table_completion_tx: oneshot::Sender<Result<()>>,
     /// Notifies when iceberg flush LSN advances.
     pub flush_lsn_tx: watch::Sender<u64>,
-    /// Notifies when index merge finishes.
-    /// TODO(hjiang): Error status propagation.
-    pub index_merge_completion_tx: broadcast::Sender<()>,
-    /// Notifies when data compaction finishes.
-    pub data_compaction_completion_tx: broadcast::Sender<Result<()>>,
+    /// Notifies when force table maintenance operation completes.
+    pub table_maintenance_completion_tx: broadcast::Sender<Result<()>>,
 }
 
 /// Create table event manager sender and receiver.
 pub fn create_table_event_syncer() -> (EventSyncSender, EventSyncReceiver) {
     let (drop_table_completion_tx, drop_table_completion_rx) = oneshot::channel();
     let (flush_lsn_tx, flush_lsn_rx) = watch::channel(0u64);
-    let (index_merge_completion_tx, _) = broadcast::channel(64usize);
-    let (data_compaction_completion_tx, _) = broadcast::channel(64usize);
+    let (table_maintenance_completion_tx, _) = broadcast::channel(64usize);
     let event_sync_sender = EventSyncSender {
         drop_table_completion_tx,
         flush_lsn_tx,
-        index_merge_completion_tx: index_merge_completion_tx.clone(),
-        data_compaction_completion_tx: data_compaction_completion_tx.clone(),
+        table_maintenance_completion_tx: table_maintenance_completion_tx.clone(),
     };
     let event_sync_receiver = EventSyncReceiver {
         drop_table_completion_rx,
         flush_lsn_rx,
-        index_merge_completion_tx,
-        data_compaction_completion_tx,
+        table_maintenance_completion_tx,
     };
     (event_sync_sender, event_sync_receiver)
 }

--- a/src/moonlink/src/table_handler/tests.rs
+++ b/src/moonlink/src/table_handler/tests.rs
@@ -1678,10 +1678,8 @@ async fn test_discard_duplicate_writes() {
 /// - replication lsn >= iceberg snapshot lsn, if assigned
 #[test]
 fn test_is_iceberg_snapshot_satisfy_force_snapshot() {
-    let (index_merge_completion_tx, _) = broadcast::channel(64usize);
-    let (data_compaction_completion_tx, _) = broadcast::channel(64usize);
-    let mut table_handler_state =
-        TableHandlerState::new(index_merge_completion_tx, data_compaction_completion_tx);
+    let (table_maintenance_completion_tx, _) = broadcast::channel(64usize);
+    let mut table_handler_state = TableHandlerState::new(table_maintenance_completion_tx);
     // Case-1: iceberg snapshot already satisfies requested lsn.
     {
         let requested_lsn = 0;

--- a/src/moonlink_connectors/src/pg_replicate/table_init.rs
+++ b/src/moonlink_connectors/src/pg_replicate/table_init.rs
@@ -32,19 +32,16 @@ pub struct TableResources {
 fn create_table_event_syncer() -> (EventSyncSender, EventSyncReceiver) {
     let (drop_table_completion_tx, drop_table_completion_rx) = oneshot::channel();
     let (flush_lsn_tx, flush_lsn_rx) = watch::channel(0u64);
-    let (index_merge_completion_tx, _) = broadcast::channel(64usize);
-    let (data_compaction_completion_tx, _) = broadcast::channel(64usize);
+    let (table_maintenance_completion_tx, _) = broadcast::channel(64usize);
     let event_sync_sender = EventSyncSender {
         drop_table_completion_tx,
         flush_lsn_tx,
-        index_merge_completion_tx: index_merge_completion_tx.clone(),
-        data_compaction_completion_tx: data_compaction_completion_tx.clone(),
+        table_maintenance_completion_tx: table_maintenance_completion_tx.clone(),
     };
     let event_sync_receiver = EventSyncReceiver {
         drop_table_completion_rx,
         flush_lsn_rx,
-        index_merge_completion_tx,
-        data_compaction_completion_tx,
+        table_maintenance_completion_tx,
     };
     (event_sync_sender, event_sync_receiver)
 }


### PR DESCRIPTION
## Summary

This PR should be a noop code cleanup, since we use force table maintenance commands for only testing, debugging, and admin purpose, we don't need to spend effort on supporting concurrent force operations.
This PR further simplifies code, by using one channel for all three types of maintenance commands and completion notifications.

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
