### PR TITLE
[storage] [5/N] Adapt moonlink backend interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2797,6 +2797,7 @@ version = "0.0.1"
 dependencies = [
  "clap",
  "moonlink_backend",
+ "moonlink_metadata_store",
  "moonlink_rpc",
  "thiserror 2.0.12",
  "tokio",

--- a/src/moonlink_backend/tests/test_initial_copy.rs
+++ b/src/moonlink_backend/tests/test_initial_copy.rs
@@ -3,8 +3,7 @@ mod common;
 #[cfg(test)]
 mod tests {
     use super::common::{
-        current_wal_lsn, ids_from_state, ids_from_state_with_deletes, TestGuard, DST_URI, SRC_URI,
-        TABLE_ID,
+        current_wal_lsn, ids_from_state, ids_from_state_with_deletes, TestGuard, SRC_URI, TABLE_ID,
     };
     use serial_test::serial;
     use std::collections::HashSet;
@@ -47,7 +46,6 @@ mod tests {
             .create_table(
                 guard.database_id,
                 TABLE_ID,
-                DST_URI.to_string(),
                 format!("public.{table_name}"),
                 SRC_URI.to_string(),
             )
@@ -118,7 +116,6 @@ mod tests {
             .create_table(
                 guard.database_id,
                 TABLE_ID,
-                DST_URI.to_string(),
                 format!("public.{table_name}"),
                 SRC_URI.to_string(),
             )
@@ -181,7 +178,6 @@ mod tests {
                 .create_table(
                     guard.database_id,
                     TABLE_ID,
-                    DST_URI.to_string(),
                     format!("public.{table_name}"),
                     SRC_URI.to_string(),
                 )
@@ -253,7 +249,6 @@ mod tests {
                 .create_table(
                     guard.database_id,
                     TABLE_ID,
-                    DST_URI.to_string(),
                     format!("public.{table_name}"),
                     SRC_URI.to_string(),
                 )
@@ -357,7 +352,6 @@ mod tests {
             .create_table(
                 guard.database_id,
                 TABLE_ID,
-                DST_URI.to_string(),
                 format!("public.{table_name}"),
                 SRC_URI.to_string(),
             )
@@ -431,7 +425,6 @@ mod tests {
             .create_table(
                 guard.database_id,
                 TABLE_ID,
-                DST_URI.to_string(),
                 format!("public.{table_name}"),
                 SRC_URI.to_string(),
             )
@@ -509,7 +502,6 @@ mod tests {
             .create_table(
                 guard.database_id,
                 TABLE_ID,
-                DST_URI.to_string(),
                 format!("public.{table_name}"),
                 SRC_URI.to_string(),
             )

--- a/src/moonlink_rpc/src/lib.rs
+++ b/src/moonlink_rpc/src/lib.rs
@@ -26,7 +26,7 @@ macro_rules! rpcs {
 
 rpcs! {
     create_snapshot(database_id: u32, table_id: u32, lsn: u64) -> ();
-    create_table(database_id: u32, table_id: u32, dst_uri: String, src: String, src_uri: String) -> ();
+    create_table(database_id: u32, table_id: u32, src: String, src_uri: String) -> ();
     drop_table(database_id: u32, table_id: u32) -> ();
     scan_table_begin(database_id: u32, table_id: u32, lsn: u64) -> Vec<u8>;
     scan_table_end(database_id: u32, table_id: u32) -> ();

--- a/src/moonlink_service/Cargo.toml
+++ b/src/moonlink_service/Cargo.toml
@@ -7,6 +7,7 @@ license = { workspace = true }
 [dependencies]
 clap = { workspace = true }
 moonlink_backend = { path = "../moonlink_backend" }
+moonlink_metadata_store = { path = "../moonlink_metadata_store" }
 moonlink_rpc = { path = "../moonlink_rpc" }
 thiserror = { workspace = true }
 tokio = { workspace = true }

--- a/src/moonlink_service/src/main.rs
+++ b/src/moonlink_service/src/main.rs
@@ -4,11 +4,10 @@ use moonlink_service::{start, Result};
 #[derive(Parser)]
 struct Cli {
     base_path: String,
-    metadata_store_uris: Vec<String>,
 }
 
 #[tokio::main]
 pub async fn main() -> Result<()> {
     let cli = Cli::parse();
-    start(cli.base_path, cli.metadata_store_uris).await
+    start(cli.base_path).await
 }


### PR DESCRIPTION
## Summary

Moonlink backend implementation has been adapted in the previous PRs, this PR simply updates the backend interface to take metadata storage accessors from pg_mooncake.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/894

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
