### PR TITLE
[minor] Rename table events

### DIFF
--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -921,7 +921,7 @@ impl MooncakeTable {
                 new_file_indices: vec![merged],
             };
             table_notify_tx_copy
-                .send(TableEvent::IndexMerge { index_merge_result })
+                .send(TableEvent::IndexMergeResult { index_merge_result })
                 .await
                 .unwrap();
         });
@@ -952,7 +952,7 @@ impl MooncakeTable {
                 let builder = CompactionBuilder::new(compaction_payload, schema_ref, file_params);
                 let data_compaction_result = builder.build().await;
                 table_notify_tx_copy
-                    .send(TableEvent::DataCompaction {
+                    .send(TableEvent::DataCompactionResult {
                         data_compaction_result,
                     })
                     .await
@@ -1019,7 +1019,7 @@ impl MooncakeTable {
         // Notify on event error.
         if iceberg_persistence_res.is_err() {
             table_notify
-                .send(TableEvent::IcebergSnapshot {
+                .send(TableEvent::IcebergSnapshotResult {
                     iceberg_snapshot_result: Err(iceberg_persistence_res.unwrap_err().into()),
                 })
                 .await
@@ -1080,7 +1080,7 @@ impl MooncakeTable {
             },
         };
         table_notify
-            .send(TableEvent::IcebergSnapshot {
+            .send(TableEvent::IcebergSnapshotResult {
                 iceberg_snapshot_result: Ok(snapshot_result),
             })
             .await

--- a/src/moonlink/src/storage/mooncake_table/table_operation_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_operation_test_utils.rs
@@ -151,7 +151,7 @@ pub(crate) async fn sync_mooncake_snapshot(
 }
 async fn sync_iceberg_snapshot(receiver: &mut Receiver<TableEvent>) -> IcebergSnapshotResult {
     let notification = receiver.recv().await.unwrap();
-    if let TableEvent::IcebergSnapshot {
+    if let TableEvent::IcebergSnapshotResult {
         iceberg_snapshot_result,
     } = notification
     {
@@ -162,7 +162,7 @@ async fn sync_iceberg_snapshot(receiver: &mut Receiver<TableEvent>) -> IcebergSn
 }
 async fn sync_index_merge(receiver: &mut Receiver<TableEvent>) -> FileIndiceMergeResult {
     let notification = receiver.recv().await.unwrap();
-    if let TableEvent::IndexMerge { index_merge_result } = notification {
+    if let TableEvent::IndexMergeResult { index_merge_result } = notification {
         index_merge_result
     } else {
         panic!("Expected index merge completion notification, but get another one.");
@@ -170,7 +170,7 @@ async fn sync_index_merge(receiver: &mut Receiver<TableEvent>) -> FileIndiceMerg
 }
 async fn sync_data_compaction(receiver: &mut Receiver<TableEvent>) -> DataCompactionResult {
     let notification = receiver.recv().await.unwrap();
-    if let TableEvent::DataCompaction {
+    if let TableEvent::DataCompactionResult {
         data_compaction_result,
     } = notification
     {
@@ -263,7 +263,7 @@ pub(crate) async fn create_iceberg_snapshot(
     table.persist_iceberg_snapshot(iceberg_snapshot_payload.unwrap());
     let notification = notify_rx.recv().await.unwrap();
     match notification {
-        TableEvent::IcebergSnapshot {
+        TableEvent::IcebergSnapshotResult {
             iceberg_snapshot_result,
         } => iceberg_snapshot_result,
         _ => {
@@ -441,7 +441,7 @@ pub(crate) async fn sync_read_request_for_test(
     receiver: &mut Receiver<TableEvent>,
 ) {
     let notification = receiver.recv().await.unwrap();
-    if let TableEvent::ReadRequest { cache_handles } = notification {
+    if let TableEvent::ReadRequestCompletion { cache_handles } = notification {
         table.set_read_request_res(cache_handles);
     } else {
         panic!("Receive other notifications other than read request")

--- a/src/moonlink/src/table_handler.rs
+++ b/src/moonlink/src/table_handler.rs
@@ -559,7 +559,7 @@ impl TableHandler {
 
                             table_handler_state.mooncake_snapshot_ongoing = false;
                         }
-                        TableEvent::IcebergSnapshot { iceberg_snapshot_result } => {
+                        TableEvent::IcebergSnapshotResult { iceberg_snapshot_result } => {
                             table_handler_state.iceberg_snapshot_ongoing = false;
                             match iceberg_snapshot_result {
                                 Ok(snapshot_res) => {
@@ -594,11 +594,11 @@ impl TableHandler {
                                 return;
                             }
                         }
-                        TableEvent::IndexMerge { index_merge_result } => {
+                        TableEvent::IndexMergeResult { index_merge_result } => {
                             table.set_file_indices_merge_res(index_merge_result);
                             table_handler_state.mark_index_merge_completed().await;
                         }
-                        TableEvent::DataCompaction { data_compaction_result } => {
+                        TableEvent::DataCompactionResult { data_compaction_result } => {
                             table_handler_state.mark_data_compaction_completed(&data_compaction_result).await;
                             match data_compaction_result {
                                 Ok(data_compaction_res) => {
@@ -610,7 +610,7 @@ impl TableHandler {
                             }
                             table_handler_state.maintenance_ongoing = false;
                         }
-                        TableEvent::ReadRequest { cache_handles } => {
+                        TableEvent::ReadRequestCompletion { cache_handles } => {
                             table.set_read_request_res(cache_handles);
                         }
                         TableEvent::EvictedDataFilesToDelete { evicted_data_files } => {

--- a/src/moonlink/src/table_notify.rs
+++ b/src/moonlink/src/table_notify.rs
@@ -96,22 +96,22 @@ pub enum TableEvent {
         evicted_data_files_to_delete: Vec<String>,
     },
     /// Iceberg snapshot completes.
-    IcebergSnapshot {
+    IcebergSnapshotResult {
         /// Result for iceberg snapshot.
         iceberg_snapshot_result: Result<IcebergSnapshotResult>,
     },
     /// Index merge completes.
-    IndexMerge {
+    IndexMergeResult {
         /// Result for index merge.
         index_merge_result: FileIndiceMergeResult,
     },
     /// Data compaction completes.
-    DataCompaction {
+    DataCompactionResult {
         /// Result for data compaction.
         data_compaction_result: Result<DataCompactionResult>,
     },
     /// Read request completion.
-    ReadRequest {
+    ReadRequestCompletion {
         /// Cache handles, which are pinned before query.
         cache_handles: Vec<NonEvictableHandle>,
     },

--- a/src/moonlink/src/union_read/read_state.rs
+++ b/src/moonlink/src/union_read/read_state.rs
@@ -36,7 +36,7 @@ impl Drop for ReadState {
         if let Some(table_notify) = self.table_notify.clone() {
             tokio::spawn(async move {
                 table_notify
-                    .send(TableEvent::ReadRequest { cache_handles })
+                    .send(TableEvent::ReadRequestCompletion { cache_handles })
                     .await
                     .unwrap();
             });


### PR DESCRIPTION
## Summary

A pretty minor change. I find we have multiple index merge / data compaction events, which even confuses me, who write these code... Rename a few of them as "Result" or "Completion", hopefully it's clearer.

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
