### PR TITLE
[storage] Fix maintenance task notification data race

### DIFF
--- a/src/moonlink/src/storage/iceberg/table_event_manager.rs
+++ b/src/moonlink/src/storage/iceberg/table_event_manager.rs
@@ -51,29 +51,32 @@ impl TableEventManager {
     /// Initiate an index merge event, return the channel for synchronization.
     /// TODO(hjiang): Error status propagation.
     pub async fn initiate_index_merge(&mut self) -> broadcast::Receiver<Result<()>> {
+        let subscriber = self.table_maintenance_completion_tx.subscribe();
         self.table_event_tx
             .send(TableEvent::ForceRegularIndexMerge)
             .await
             .unwrap();
-        self.table_maintenance_completion_tx.subscribe()
+        subscriber
     }
 
     /// Initialte a data compaction event, return the channel for synchronization.
     pub async fn initiate_data_compaction(&mut self) -> broadcast::Receiver<Result<()>> {
+        let subscriber = self.table_maintenance_completion_tx.subscribe();
         self.table_event_tx
             .send(TableEvent::ForceRegularDataCompaction)
             .await
             .unwrap();
-        self.table_maintenance_completion_tx.subscribe()
+        subscriber
     }
 
     /// Initialte full table maintenance event, return the channel for synchronization.
     pub async fn initiate_full_compaction(&mut self) -> broadcast::Receiver<Result<()>> {
+        let subscriber = self.table_maintenance_completion_tx.subscribe();
         self.table_event_tx
             .send(TableEvent::ForceFullMaintenance)
             .await
             .unwrap();
-        self.table_maintenance_completion_tx.subscribe()
+        subscriber
     }
 
     /// Drop a mooncake table.


### PR DESCRIPTION
## Summary

This PR fixes data race for maintenance task notification.

The issue is:
- `broadcast::send` only notifies active handlers, so it's possible that before new receiver handler creation, maintenance task has already finished and send to other uninteresting receivers.

Reference: https://docs.rs/tokio/latest/tokio/sync/broadcast/struct.Sender.html#method.send

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
