### PR TITLE
Coordinate `pg_current_wal_lsn` with initial copy

### DIFF
--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -17,7 +17,7 @@ use super::iceberg::puffin_utils::PuffinBlobRef;
 use super::index::index_merge_config::FileIndexMergeConfig;
 use super::index::{FileIndex, MemIndex, MooncakeIndex};
 use super::storage_utils::{MooncakeDataFileRef, RawDeletionRecord, RecordLocation};
-use crate::error::{Error, Result};
+use crate::error::Result;
 use crate::row::{IdentityProp, MoonlinkRow};
 use crate::storage::cache::object_storage::object_storage_cache::ObjectStorageCache;
 use crate::storage::compaction::compaction_config::DataCompactionConfig;

--- a/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
+++ b/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
@@ -293,7 +293,10 @@ impl MooncakeTable {
             snapshot_task.new_flush_lsn = Some(lsn);
             Ok(())
         } else {
-            Err(Error::TransactionNotFound(xact_id))
+            panic!(
+                "Transaction stream state not found for xact_id: {}",
+                xact_id
+            );
         }
     }
 }

--- a/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
+++ b/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
@@ -293,10 +293,7 @@ impl MooncakeTable {
             snapshot_task.new_flush_lsn = Some(lsn);
             Ok(())
         } else {
-            panic!(
-                "Transaction stream state not found for xact_id: {}",
-                xact_id
-            );
+            panic!("Transaction stream state not found for xact_id: {xact_id}");
         }
     }
 }

--- a/src/moonlink/src/table_handler/tests.rs
+++ b/src/moonlink/src/table_handler/tests.rs
@@ -1221,7 +1221,7 @@ async fn test_initial_copy_basic() {
 
     // Start initial copy workflow.
     sender
-        .send(TableEvent::StartInitialCopy { start_lsn: 0 })
+        .send(TableEvent::StartInitialCopy)
         .await
         .expect("send start initial copy");
 

--- a/src/moonlink/src/table_handler/tests.rs
+++ b/src/moonlink/src/table_handler/tests.rs
@@ -1221,7 +1221,7 @@ async fn test_initial_copy_basic() {
 
     // Start initial copy workflow.
     sender
-        .send(TableEvent::StartInitialCopy)
+        .send(TableEvent::StartInitialCopy { start_lsn: 0 })
         .await
         .expect("send start initial copy");
 
@@ -1251,7 +1251,7 @@ async fn test_initial_copy_basic() {
 
     // Finish the copy which applies buffered changes.
     sender
-        .send(TableEvent::FinishInitialCopy)
+        .send(TableEvent::FinishInitialCopy { start_lsn: 0 })
         .await
         .expect("send finish initial copy");
 

--- a/src/moonlink/src/table_notify.rs
+++ b/src/moonlink/src/table_notify.rs
@@ -67,9 +67,11 @@ pub enum TableEvent {
     /// Alter table,
     AlterTable { columns_to_drop: Vec<String> },
     /// Start initial table copy.
-    StartInitialCopy,
+    /// `start_lsn` is the `pg_current_wal_lsn` when the initial copy starts.
+    StartInitialCopy { start_lsn: u64 },
     /// Finish initial table copy and merge buffered changes.
-    FinishInitialCopy,
+    /// `start_lsn` is the `pg_current_wal_lsn` when the initial copy starts. We want this in FinishInitialCopy so we can set the commit LSN correctly.
+    FinishInitialCopy { start_lsn: u64 },
     /// ==============================
     /// Table internal events
     /// ==============================

--- a/src/moonlink/src/table_notify.rs
+++ b/src/moonlink/src/table_notify.rs
@@ -68,7 +68,7 @@ pub enum TableEvent {
     AlterTable { columns_to_drop: Vec<String> },
     /// Start initial table copy.
     /// `start_lsn` is the `pg_current_wal_lsn` when the initial copy starts.
-    StartInitialCopy { start_lsn: u64 },
+    StartInitialCopy,
     /// Finish initial table copy and merge buffered changes.
     /// `start_lsn` is the `pg_current_wal_lsn` when the initial copy starts. We want this in FinishInitialCopy so we can set the commit LSN correctly.
     FinishInitialCopy { start_lsn: u64 },

--- a/src/moonlink_connectors/src/pg_replicate/clients/postgres.rs
+++ b/src/moonlink_connectors/src/pg_replicate/clients/postgres.rs
@@ -61,11 +61,14 @@ impl ReplicationClient {
     /// Connect to a postgres database in logical replication mode without TLS
     pub async fn connect_no_tls(
         uri: &str,
+        replication_mode: bool,
     ) -> Result<(ReplicationClient, Connection<Socket, NoTlsStream>), ReplicationClientError> {
         debug!("connecting to postgres");
 
         let mut config = uri.parse::<Config>()?;
-        config.replication_mode(ReplicationMode::Logical);
+        if replication_mode {
+            config.replication_mode(ReplicationMode::Logical);
+        }
         let (postgres_client, connection) = config.connect(NoTls).await?;
 
         debug!("successfully connected to postgres");
@@ -89,6 +92,14 @@ impl ReplicationClient {
         Ok(())
     }
 
+    // Gets the current wal lsn
+    pub async fn get_current_wal_lsn(&mut self) -> Result<PgLsn, ReplicationClientError> {
+        let query = "SELECT pg_current_wal_lsn();";
+        let result = self.postgres_client.query_one(query, &[]).await?;
+        let lsn = result.get(0);
+        Ok(lsn)
+    }
+
     /// Commits a transaction
     pub async fn commit_txn(&mut self) -> Result<(), ReplicationClientError> {
         if self.in_txn {
@@ -106,26 +117,69 @@ impl ReplicationClient {
         Ok(())
     }
 
+    pub async fn add_table_to_publication(
+        &mut self,
+        table_name: &TableName,
+    ) -> Result<(), ReplicationClientError> {
+        self.postgres_client.simple_query("BEGIN;").await?;
+        self.in_txn = true;
+        let query = format!(
+            "ALTER PUBLICATION moonlink_pub ADD TABLE {};",
+            table_name.as_quoted_identifier()
+        );
+        self.postgres_client.simple_query(&query).await?;
+        self.postgres_client.simple_query("COMMIT;").await?;
+        self.in_txn = false;
+        Ok(())
+    }
+
+    pub async fn get_row_count(
+        &mut self,
+        table_name: &TableName,
+    ) -> Result<i64, ReplicationClientError> {
+        let query = format!(
+            "SELECT COUNT(*) FROM {};",
+            table_name.as_quoted_identifier()
+        );
+        let result = self.postgres_client.query_one(&query, &[]).await?;
+        let row_count = result.get(0);
+        Ok(row_count)
+    }
+
     /// Returns a [CopyOutStream] for a table
     pub async fn get_table_copy_stream(
-        &self,
+        &mut self,
         table_name: &TableName,
         column_schemas: &[ColumnSchema],
-    ) -> Result<CopyOutStream, ReplicationClientError> {
+    ) -> Result<(CopyOutStream, PgLsn), ReplicationClientError> {
         let column_list = column_schemas
             .iter()
             .map(|col| quote_identifier(&col.name))
             .collect::<Vec<_>>()
             .join(", ");
 
+        // start a transaction
+        self.postgres_client.simple_query("BEGIN;").await?;
+        self.in_txn = true;
+
+        // Get the current LSN
+        let current_wal_lsn = self.get_current_wal_lsn().await?;
+
+        // TODO(nbiscaro): Use binary format instead of text.
         let copy_query = format!(
             r#"COPY {} ({column_list}) TO STDOUT WITH (FORMAT text);"#,
             table_name.as_quoted_identifier(),
         );
 
+        // self.postgres_client.simple_query("COMMIT;").await?;
+        // self.in_txn = false;
+
         let stream = self.postgres_client.copy_out_simple(&copy_query).await?;
 
-        Ok(stream)
+        // Note that we keep the transaction open
+        // Once we are done consuming the stream, we will commit the transaction
+
+        Ok((stream, current_wal_lsn))
     }
 
     /// Returns a vector of columns of a table, optionally filtered by a publication's column list

--- a/src/moonlink_connectors/src/pg_replicate/clients/postgres.rs
+++ b/src/moonlink_connectors/src/pg_replicate/clients/postgres.rs
@@ -158,7 +158,7 @@ impl ReplicationClient {
         self.postgres_client.simple_query("BEGIN;").await?;
         self.in_txn = true;
 
-        // Get the current LSN
+        // Get the current LSN before we start the copy
         let current_wal_lsn = self.get_current_wal_lsn().await?;
 
         // TODO(nbiscaro): Use binary format instead of text.

--- a/src/moonlink_connectors/src/pg_replicate/clients/postgres.rs
+++ b/src/moonlink_connectors/src/pg_replicate/clients/postgres.rs
@@ -167,9 +167,6 @@ impl ReplicationClient {
             table_name.as_quoted_identifier(),
         );
 
-        // self.postgres_client.simple_query("COMMIT;").await?;
-        // self.in_txn = false;
-
         let stream = self.postgres_client.copy_out_simple(&copy_query).await?;
 
         // Note that we keep the transaction open

--- a/src/moonlink_connectors/src/pg_replicate/clients/postgres.rs
+++ b/src/moonlink_connectors/src/pg_replicate/clients/postgres.rs
@@ -121,15 +121,11 @@ impl ReplicationClient {
         &mut self,
         table_name: &TableName,
     ) -> Result<(), ReplicationClientError> {
-        self.postgres_client.simple_query("BEGIN;").await?;
-        self.in_txn = true;
         let query = format!(
             "ALTER PUBLICATION moonlink_pub ADD TABLE {};",
             table_name.as_quoted_identifier()
         );
         self.postgres_client.simple_query(&query).await?;
-        self.postgres_client.simple_query("COMMIT;").await?;
-        self.in_txn = false;
         Ok(())
     }
 

--- a/src/moonlink_connectors/src/pg_replicate/initial_copy.rs
+++ b/src/moonlink_connectors/src/pg_replicate/initial_copy.rs
@@ -19,22 +19,8 @@ pub struct CopyProgress {
     pub rows_copied: u64,
 }
 
-/// Start the copy for `table_id` using `event_sender`
-/// to deliver the copied rows.
-pub async fn initial_table_copy(
-    table_id: SrcTableId,
-    schema: TableSchema,
-    source: PostgresSource,
-    event_sender: &Sender<TableEvent>,
-) -> Result<CopyProgress> {
-    let stream = source
-        .get_table_copy_stream(&schema.table_name, &schema.column_schemas)
-        .await?;
-    copy_table_stream_impl(schema, stream, event_sender).await
-}
-
 /// Reads rows from `stream` and sends them to the provided `event_sender`.
-async fn copy_table_stream_impl(
+pub async fn copy_table_stream_impl(
     table_schema: TableSchema,
     mut stream: TableCopyStream,
     event_sender: &Sender<TableEvent>,
@@ -51,7 +37,7 @@ async fn copy_table_stream_impl(
             .send(TableEvent::Append {
                 row: PostgresTableRow(row).into(),
                 xact_id: None,
-                lsn: 0,
+                lsn: stream.start_lsn.into(),
                 is_copied: true,
             })
             .await

--- a/src/moonlink_connectors/src/pg_replicate/initial_copy.rs
+++ b/src/moonlink_connectors/src/pg_replicate/initial_copy.rs
@@ -37,7 +37,7 @@ pub async fn copy_table_stream_impl(
             .send(TableEvent::Append {
                 row: PostgresTableRow(row).into(),
                 xact_id: None,
-                lsn: stream.start_lsn.into(),
+                lsn: 0,
                 is_copied: true,
             })
             .await

--- a/src/moonlink_connectors/src/replication_connection.rs
+++ b/src/moonlink_connectors/src/replication_connection.rs
@@ -1,6 +1,6 @@
 use crate::pg_replicate::clients::postgres::ReplicationClient;
 use crate::pg_replicate::conversions::cdc_event::CdcEventConversionError;
-use crate::pg_replicate::initial_copy::initial_table_copy;
+use crate::pg_replicate::initial_copy::copy_table_stream_impl;
 use crate::pg_replicate::moonlink_sink::Sink;
 use crate::pg_replicate::postgres_source::{
     CdcStreamConfig, CdcStreamError, PostgresSource, PostgresSourceError, TableNamesFrom,
@@ -109,6 +109,7 @@ impl ReplicationConnection {
             &uri,
             Some(slot_name.clone()),
             TableNamesFrom::Publication("moonlink_pub".to_string()),
+            true,
         )
         .await?;
 
@@ -143,15 +144,6 @@ impl ReplicationConnection {
     async fn alter_table_replica_identity(&self, table_name: &str) -> Result<()> {
         self.postgres_client
             .simple_query(&format!("ALTER TABLE {table_name} REPLICA IDENTITY FULL;"))
-            .await?;
-        Ok(())
-    }
-
-    async fn add_table_to_publication(&self, table_name: &str) -> Result<()> {
-        self.postgres_client
-            .simple_query(&format!(
-                "ALTER PUBLICATION moonlink_pub ADD TABLE {table_name};"
-            ))
             .await?;
         Ok(())
     }
@@ -255,7 +247,7 @@ impl ReplicationConnection {
         let cfg = self.source.get_cdc_stream_config().unwrap();
 
         tokio::spawn(async move {
-            let (client, connection) = ReplicationClient::connect_no_tls(&uri)
+            let (client, connection) = ReplicationClient::connect_no_tls(&uri, true)
                 .await
                 .map_err(PostgresSourceError::from)?;
 
@@ -290,13 +282,6 @@ impl ReplicationConnection {
 
         let event_sender_clone = table_resources.event_sender.clone();
 
-        // Mark the table as being in initial copy, before receiving any events.
-        if !is_recovery {
-            if let Err(e) = event_sender_clone.send(TableEvent::StartInitialCopy).await {
-                error!(error = ?e, "failed to send StartInitialCopy event");
-            }
-        }
-
         self.table_readers
             .insert(src_table_id, table_resources.read_state_manager);
         self.table_event_managers
@@ -315,28 +300,54 @@ impl ReplicationConnection {
             error!(error = ?e, "failed to enqueue AddTable command");
         }
 
-        // Only perform initial copy for new tables, not during recovery.
-        if !is_recovery {
-            // Create a dedicated source for the copy and register and snapshot the table.
-            let copy_source = PostgresSource::new(
-                &self.uri,
-                Some(self.slot_name.clone()),
-                TableNamesFrom::Vec(vec![schema.table_name.clone()]),
-            )
+        // Create a dedicated source for the copy and register and snapshot the table.
+        let mut copy_source = PostgresSource::new(
+            &self.uri,
+            Some(self.slot_name.clone()),
+            TableNamesFrom::Vec(vec![schema.table_name.clone()]),
+            false,
+        )
+        .await?;
+
+        // Add table to publication first to begin accumulating any cdc events.
+        // We can check where our initial copy started from and discard any rows we have already seen.
+        // We should add to publication regardless of whether we are recovering or not.
+        copy_source
+            .add_table_to_publication(&schema.table_name)
             .await?;
+
+        // Check if there are existing rows
+        let row_count = copy_source.get_row_count(&schema.table_name).await?;
+
+        // Only perform initial copy for new tables, not during recovery.
+        // Early return if there are no rows to copy.
+        if !is_recovery && row_count > 0 {
+            let stream = copy_source
+                .get_table_copy_stream(&schema.table_name, &schema.column_schemas)
+                .await?;
+            let start_lsn = stream.start_lsn.into();
+            if let Err(e) = event_sender_clone
+                .send(TableEvent::StartInitialCopy { start_lsn })
+                .await
+            {
+                error!(error = ?e, "failed to send StartInitialCopy event");
+            }
+
             let schema_clone = schema.clone();
             tokio::spawn(async move {
-                let res = initial_table_copy(
-                    src_table_id,
-                    schema_clone,
-                    copy_source,
-                    &event_sender_clone,
-                )
-                .await;
+                let res = copy_table_stream_impl(schema_clone, stream, &event_sender_clone).await;
+                // We have finsihed consuming the stream, so commit the transaction
+                // We keep the transaction open since the COMMIT will block until the COPY TO is complete.
+                if let Err(e) = copy_source.commit_transaction().await {
+                    error!(error = ?e, "failed to commit transaction");
+                }
                 if let Err(e) = res {
                     error!(error = ?e, table_id = src_table_id, "failed to copy table");
                 }
-                if let Err(e) = event_sender_clone.send(TableEvent::FinishInitialCopy).await {
+                if let Err(e) = event_sender_clone
+                    .send(TableEvent::FinishInitialCopy { start_lsn })
+                    .await
+                {
                     error!(error = ?e, table_id = src_table_id, "failed to send FinishTableCopy command");
                 }
             });
@@ -405,8 +416,6 @@ impl ReplicationConnection {
                 is_recovery,
             )
             .await?;
-
-        self.add_table_to_publication(table_name).await?;
 
         debug!(src_table_id = table_schema.src_table_id, "table added");
 

--- a/src/moonlink_connectors/src/replication_connection.rs
+++ b/src/moonlink_connectors/src/replication_connection.rs
@@ -303,7 +303,7 @@ impl ReplicationConnection {
         // Create a dedicated source for the copy
         let mut copy_source = PostgresSource::new(
             &self.uri,
-            Some(self.slot_name.clone()),
+            None,
             TableNamesFrom::Vec(vec![schema.table_name.clone()]),
             false,
         )

--- a/src/moonlink_connectors/src/replication_connection.rs
+++ b/src/moonlink_connectors/src/replication_connection.rs
@@ -300,7 +300,7 @@ impl ReplicationConnection {
             error!(error = ?e, "failed to enqueue AddTable command");
         }
 
-        // Create a dedicated source for the copy and register and snapshot the table.
+        // Create a dedicated source for the copy
         let mut copy_source = PostgresSource::new(
             &self.uri,
             Some(self.slot_name.clone()),


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

In order to better coordinate initial copy with incoming CDC events, we
1) Alter the publication with the new table
2) Fetch the `pg_current_wal_lsn` and start the `COPY TO` within the same transaction
3) Discard any events that have LSN < `pg_current_wal_lsn`

Since we add to the publication first and then start the copy we are at risk of having events both in the initial copy and sent as CDC event. We use the current_wal_lsn to dedup as it allows us to determine which events are already included in the initial copy. This was previously done in the reverse order, starting the initial copy and then altering the publication, however there is a window between when the copy starts and when the publication is altered where we may drop events. 

There are some other QOL improvements here such as a check for early return on initial copy (there are no rows). 

## Related Issues

Closes #<issue-number> or links to related issues.

Follow up: https://github.com/Mooncake-Labs/moonlink/issues/917
Follow up: https://github.com/Mooncake-Labs/moonlink/issues/916


## Changes

- Coordinate LSN with initial copy
- Early return if no rows

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
