### PR TITLE
Fix opendal s3 dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2007,8 +2007,8 @@ dependencies = [
 
 [[package]]
 name = "iceberg"
-version = "0.5.1"
-source = "git+https://github.com/apache/iceberg-rust.git?rev=36af3f7ae5202c0d10ef97d35387fa32ec796371#36af3f7ae5202c0d10ef97d35387fa32ec796371"
+version = "0.6.0"
+source = "git+https://github.com/apache/iceberg-rust.git?rev=593d49efd0b41de2a1af38eae1a492848b95ffd0#593d49efd0b41de2a1af38eae1a492848b95ffd0"
 dependencies = [
  "anyhow",
  "apache-avro",
@@ -2037,7 +2037,7 @@ dependencies = [
  "murmur3",
  "num-bigint",
  "once_cell",
- "opendal 0.53.3",
+ "opendal",
  "ordered-float 4.6.0",
  "parquet",
  "rand 0.8.5",
@@ -2692,7 +2692,7 @@ dependencies = [
  "multimap",
  "num-bigint",
  "num-traits",
- "opendal 0.54.0",
+ "opendal",
  "parquet",
  "pprof",
  "rand 0.9.1",
@@ -3023,35 +3023,6 @@ name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
-
-[[package]]
-name = "opendal"
-version = "0.53.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f947c4efbca344c1a125753366033c8107f552b2e3f8251815ed1908f116ca3e"
-dependencies = [
- "anyhow",
- "async-trait",
- "backon",
- "base64 0.22.1",
- "bytes",
- "chrono",
- "crc32c",
- "futures",
- "getrandom 0.2.16",
- "http 1.3.1",
- "http-body 1.0.1",
- "log",
- "md-5",
- "percent-encoding",
- "quick-xml 0.37.5",
- "reqsign",
- "reqwest",
- "serde",
- "serde_json",
- "tokio",
- "uuid",
-]
 
 [[package]]
 name = "opendal"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2037,7 +2037,7 @@ dependencies = [
  "murmur3",
  "num-bigint",
  "once_cell",
- "opendal",
+ "opendal 0.53.3",
  "ordered-float 4.6.0",
  "parquet",
  "rand 0.8.5",
@@ -2692,7 +2692,7 @@ dependencies = [
  "multimap",
  "num-bigint",
  "num-traits",
- "opendal",
+ "opendal 0.54.0",
  "parquet",
  "pprof",
  "rand 0.9.1",
@@ -3032,6 +3032,34 @@ checksum = "f947c4efbca344c1a125753366033c8107f552b2e3f8251815ed1908f116ca3e"
 dependencies = [
  "anyhow",
  "async-trait",
+ "backon",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "crc32c",
+ "futures",
+ "getrandom 0.2.16",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "log",
+ "md-5",
+ "percent-encoding",
+ "quick-xml 0.37.5",
+ "reqsign",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
+name = "opendal"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb9838d0575c6dbaf3fcec7255af8d5771996d4af900bbb6fa9a314dec00a1a"
+dependencies = [
+ "anyhow",
  "backon",
  "base64 0.22.1",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ crc32fast = "1"
 fastbloom = "0.12.0"
 futures = { version = "0.3", default-features = false }
 hashbrown = "0.15.3"
-iceberg = { git = "https://github.com/apache/iceberg-rust.git", rev = "36af3f7ae5202c0d10ef97d35387fa32ec796371", default-features = false, features = [
+iceberg = { git = "https://github.com/apache/iceberg-rust.git", rev = "593d49efd0b41de2a1af38eae1a492848b95ffd0", default-features = false, features = [
   "storage-fs",
 ] }
 itertools = { version = "0.14" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,9 +41,7 @@ multimap = { version = "0.10", default-features = false }
 nix = { version = "0.27", default-features = false, features = ["fs"] }
 num-bigint = { version = "0.4" }
 num-traits = "0.2"
-opendal = { version = "0.53", default-features = false, features = [
-  "services-s3",
-] }
+opendal = { version = "0.54", default-features = false }
 parquet = { version = "55", default-features = false, features = [
   "arrow",
   "async",

--- a/src/moonlink/Cargo.toml
+++ b/src/moonlink/Cargo.toml
@@ -18,11 +18,13 @@ storage-s3 = [
     "sha1",
     "reqwest",
 ]
+
+# iceberg gcs io doesn't support HMAC key, so have to leverage S3 sdk.
 storage-gcs = [
     "opendal/services-gcs",
+    "opendal/services-s3",
     "iceberg/storage-gcs",
     "iceberg/storage-s3",
-    # iceberg gcs io doesn't support HMAC key, so have to leverage S3 sdk.
     "base64",
     "hmac",
     "sha1",

--- a/src/moonlink/src/storage/iceberg/file_catalog.rs
+++ b/src/moonlink/src/storage/iceberg/file_catalog.rs
@@ -653,4 +653,12 @@ impl Catalog for FileCatalog {
             .metadata_location(metadata_filepath)
             .build()
     }
+
+    async fn register_table(
+        &self,
+        _table: &TableIdent,
+        _metadata_location: String,
+    ) -> IcebergResult<Table> {
+        todo!("register existing table is not supported")
+    }
 }


### PR DESCRIPTION
## Summary

Currently s3 dependency is included in library and executable by default, but we only need to include under `storage-s3` feature.

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
