### PR TITLE
[storage] Assert schema consistency for new persisted files

### DIFF
--- a/src/moonlink/src/storage/iceberg/iceberg_table_syncer.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_syncer.rs
@@ -9,6 +9,8 @@ use crate::storage::iceberg::index::FileIndexBlob;
 use crate::storage::iceberg::io_utils as iceberg_io_utils;
 use crate::storage::iceberg::puffin_utils;
 use crate::storage::iceberg::puffin_utils::PuffinBlobRef;
+#[cfg(test)]
+use crate::storage::iceberg::schema_utils;
 use crate::storage::iceberg::table_manager::{PersistenceFileParams, PersistenceResult};
 use crate::storage::index::FileIndex as MooncakeFileIndex;
 use crate::storage::mooncake_table::delete_vector::BatchDeletionVector;
@@ -431,6 +433,15 @@ impl IcebergTableManager {
         mut snapshot_payload: IcebergSnapshotPayload,
         file_params: PersistenceFileParams,
     ) -> IcebergResult<PersistenceResult> {
+        #[cfg(test)]
+        {
+            schema_utils::assert_iceberg_payload_schema_consistent(
+                &snapshot_payload,
+                self.mooncake_table_metadata.as_ref(),
+            )
+            .await;
+        }
+
         // Initialize iceberg table on access.
         self.initialize_iceberg_table_for_once().await?;
 

--- a/src/moonlink/src/storage/iceberg/schema_utils.rs
+++ b/src/moonlink/src/storage/iceberg/schema_utils.rs
@@ -1,4 +1,10 @@
 #[cfg(test)]
+use crate::storage::mooncake_table::{
+    IcebergSnapshotPayload, TableMetadata as MooncakeTableMetadata,
+};
+#[cfg(test)]
+use crate::storage::storage_utils::MooncakeDataFileRef;
+#[cfg(test)]
 use iceberg::spec::Schema as IcebergSchema;
 
 /// Schema related utils.
@@ -13,5 +19,43 @@ pub(crate) fn assert_is_same_schema(lhs: IcebergSchema, rhs: IcebergSchema) {
         let lhs_name = lhs.name_by_field_id(cur_field_id);
         let rhs_name = rhs.name_by_field_id(cur_field_id);
         assert_eq!(lhs_name, rhs_name);
+    }
+}
+
+/// Validate the given parquet file matches the given schema.
+///
+/// Precondition: [`data_file`] is stored at local filesystem.
+#[cfg(test)]
+async fn assert_schema_consistent(
+    data_file: &MooncakeDataFileRef,
+    mooncake_table_metadata: &MooncakeTableMetadata,
+) {
+    let file = tokio::fs::File::open(data_file.file_path()).await.unwrap();
+    let stream_builder = parquet::arrow::async_reader::ParquetRecordBatchStreamBuilder::new(file)
+        .await
+        .unwrap();
+    let parquet_schema = stream_builder.parquet_schema();
+    let arrow_schema =
+        parquet::arrow::parquet_to_arrow_schema(parquet_schema, /*key_value_metadata=*/ None)
+            .unwrap();
+    assert_eq!(arrow_schema, *mooncake_table_metadata.schema);
+}
+
+/// Validate all data files within iceberg snapshot payload matches the given schema.
+#[cfg(test)]
+pub(crate) async fn assert_iceberg_payload_schema_consistent(
+    snapshot_payload: &IcebergSnapshotPayload,
+    mooncake_table_metadata: &MooncakeTableMetadata,
+) {
+    // Assert import payload.
+    let import_payload = &snapshot_payload.import_payload;
+    for cur_data_file in import_payload.data_files.iter() {
+        assert_schema_consistent(cur_data_file, mooncake_table_metadata).await;
+    }
+
+    // Assert data compaction payload.
+    let data_compaction_payload = &snapshot_payload.data_compaction_payload;
+    for cur_data_file in data_compaction_payload.new_data_files_to_import.iter() {
+        assert_schema_consistent(cur_data_file, mooncake_table_metadata).await;
     }
 }


### PR DESCRIPTION
## Summary

This PR adds schema consistency check (under test), to make sure new data files to persist is consistent with mooncake table schema.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/927

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
