### PR TITLE
[storage] Persist wal metadata at iceberg

### DIFF
--- a/src/moonlink/src/storage.rs
+++ b/src/moonlink/src/storage.rs
@@ -9,6 +9,7 @@ pub(crate) mod mooncake_table;
 pub(crate) mod parquet_utils;
 pub(crate) mod path_utils;
 pub(crate) mod storage_utils;
+mod wal;
 
 pub use crate::event_sync::EventSyncReceiver;
 pub use cache::object_storage::cache_config::ObjectStorageCacheConfig;

--- a/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
@@ -25,8 +25,12 @@ use iceberg::writer::file_writer::location_generator::LocationGenerator;
 use iceberg::{NamespaceIdent, Result as IcebergResult, TableIdent};
 use uuid::Uuid;
 
-/// Key for iceberg table property, to record flush lsn.
+/// TODO(hjiang): store snapshot property in snapshot summary, instead of table property.
+///
+/// Key for iceberg snapshot property, to record flush lsn.
 pub(super) const MOONCAKE_TABLE_FLUSH_LSN: &str = "moonlink.table-flush-lsn";
+/// Key for iceberg snapshot property, to record WAL persistence metadata.
+pub(super) const MOONCAKE_WAL_METADATA: &str = "moonlink.wal-metadata";
 /// Used to represent uninitialized deletion vector.
 /// TODO(hjiang): Consider using `Option<>` to represent uninitialized, which is more rust-idiometic.
 pub(super) const UNINITIALIZED_BATCH_DELETION_VECTOR_MAX_ROW: usize = 0;

--- a/src/moonlink/src/storage/iceberg/tests.rs
+++ b/src/moonlink/src/storage/iceberg/tests.rs
@@ -304,6 +304,7 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
 
     let iceberg_snapshot_payload = IcebergSnapshotPayload {
         flush_lsn: 0,
+        wal_persistence_metadata: None,
         import_payload: IcebergSnapshotImportPayload {
             data_files: vec![data_file_1.clone()],
             new_deletion_vector: test_committed_deletion_log_1(data_file_1.clone()),
@@ -354,6 +355,7 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
 
     let iceberg_snapshot_payload = IcebergSnapshotPayload {
         flush_lsn: 1,
+        wal_persistence_metadata: None,
         import_payload: IcebergSnapshotImportPayload {
             data_files: vec![data_file_2.clone()],
             new_deletion_vector: test_committed_deletion_log_2(data_file_2.clone()),
@@ -428,6 +430,7 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
     let merged_file_index = create_file_index(remote_data_files.clone());
     let iceberg_snapshot_payload = IcebergSnapshotPayload {
         flush_lsn: 2,
+        wal_persistence_metadata: None,
         import_payload: IcebergSnapshotImportPayload {
             data_files: vec![],
             new_deletion_vector: HashMap::new(),
@@ -506,6 +509,7 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
     // Attempt a fourth snapshot persistence, which goes after data file compaction.
     let iceberg_snapshot_payload = IcebergSnapshotPayload {
         flush_lsn: 3,
+        wal_persistence_metadata: None,
         import_payload: IcebergSnapshotImportPayload {
             data_files: vec![],
             new_deletion_vector: HashMap::new(),
@@ -573,6 +577,7 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
     // Remove all existing data files and file indices.
     let iceberg_snapshot_payload = IcebergSnapshotPayload {
         flush_lsn: 4,
+        wal_persistence_metadata: None,
         import_payload: IcebergSnapshotImportPayload {
             data_files: vec![],
             new_deletion_vector: HashMap::new(),
@@ -950,6 +955,7 @@ async fn test_empty_content_snapshot_creation_impl(iceberg_table_config: Iceberg
     .unwrap();
     let iceberg_snapshot_payload = IcebergSnapshotPayload {
         flush_lsn: 0,
+        wal_persistence_metadata: None,
         import_payload: IcebergSnapshotImportPayload::default(),
         index_merge_payload: IcebergSnapshotIndexMergePayload::default(),
         data_compaction_payload: IcebergSnapshotDataCompactionPayload::default(),

--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -723,6 +723,7 @@ impl SnapshotTableState {
     ) -> IcebergSnapshotPayload {
         IcebergSnapshotPayload {
             flush_lsn,
+            wal_persistence_metadata: None,
             import_payload: IcebergSnapshotImportPayload {
                 data_files: self.unpersisted_records.get_unpersisted_data_files(),
                 new_deletion_vector: new_committed_deletion_logs,

--- a/src/moonlink/src/storage/mooncake_table/table_snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_snapshot.rs
@@ -5,6 +5,7 @@ use crate::storage::index::FileIndex as MooncakeFileIndex;
 use crate::storage::mooncake_table::delete_vector::BatchDeletionVector;
 use crate::storage::storage_utils::FileId;
 use crate::storage::storage_utils::MooncakeDataFileRef;
+use crate::storage::wal::wal_persistence_metadata::WalPersistenceMetadata;
 use crate::storage::TableManager;
 
 use std::collections::{HashMap, HashSet};
@@ -78,6 +79,8 @@ impl IcebergSnapshotDataCompactionPayload {
 pub struct IcebergSnapshotPayload {
     /// Flush LSN.
     pub(crate) flush_lsn: u64,
+    /// WAL persistence metadata.
+    pub(crate) wal_persistence_metadata: Option<WalPersistenceMetadata>,
     /// Payload by import operations.
     pub(crate) import_payload: IcebergSnapshotImportPayload,
     /// Payload by index merge operations.

--- a/src/moonlink/src/storage/wal.rs
+++ b/src/moonlink/src/storage/wal.rs
@@ -1,0 +1,1 @@
+pub(crate) mod wal_persistence_metadata;

--- a/src/moonlink/src/storage/wal/wal_persistence_metadata.rs
+++ b/src/moonlink/src/storage/wal/wal_persistence_metadata.rs
@@ -1,0 +1,10 @@
+/// Metadata on WAL persistence information.
+use serde::{Deserialize, Serialize};
+
+/// WAL persistence metadata, which will be persisted into iceberg snapshot property.
+/// WARNING: it's supposed to be small.
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct WalPersistenceMetadata {
+    /// Persisted WAL file number.
+    pub(crate) persisted_file_num: u32,
+}


### PR DESCRIPTION
## Summary

so on recovery we could load WAL metadata from iceberg; for flexibility I store a struct instead a single field.
Currently I store it in the table property, which is BAD; 
the ideal place should be snapshot summary, but due to the limitation of iceberg-rust I don't find better solution.

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
