### PR TITLE
[storage] Implement unbuffered stream writer

### DIFF
--- a/src/moonlink/src/storage/filesystem/accessor.rs
+++ b/src/moonlink/src/storage/filesystem/accessor.rs
@@ -1,7 +1,10 @@
 pub(crate) mod base_filesystem_accessor;
+pub(crate) mod base_unbuffered_stream_writer;
 pub(crate) mod configs;
 pub(crate) mod filesystem_accessor;
 pub(crate) mod metadata;
+pub(crate) mod operator_utils;
+pub(crate) mod unbuffered_stream_writer;
 
 #[cfg(test)]
 pub(crate) mod test_utils;

--- a/src/moonlink/src/storage/filesystem/accessor/base_filesystem_accessor.rs
+++ b/src/moonlink/src/storage/filesystem/accessor/base_filesystem_accessor.rs
@@ -1,3 +1,4 @@
+use crate::storage::filesystem::accessor::base_unbuffered_stream_writer::BaseUnbufferedStreamWriter;
 /// This module defines the interface for filesystem accessor.
 use crate::storage::filesystem::accessor::metadata::ObjectMetadata;
 use crate::Result;
@@ -51,6 +52,15 @@ pub trait BaseFileSystemAccess: std::fmt::Debug + Send + Sync {
 
     /// Write the whole content to the given object.
     async fn write_object(&self, object_filepath: &str, content: Vec<u8>) -> Result<()>;
+
+    /// Return a writer, which used for stream writer.
+    /// Notice: no IO operation is performed under the hood.
+    ///
+    /// TODO(hjiang): Consider to take a [`config`]
+    async fn create_unbuffered_stream_writer(
+        &self,
+        object_filepath: &str,
+    ) -> Result<Box<dyn BaseUnbufferedStreamWriter>>;
 
     /// Delete the given object.
     async fn delete_object(&self, object_filepath: &str) -> Result<()>;

--- a/src/moonlink/src/storage/filesystem/accessor/base_unbuffered_stream_writer.rs
+++ b/src/moonlink/src/storage/filesystem/accessor/base_unbuffered_stream_writer.rs
@@ -1,0 +1,22 @@
+/// This module defines the interface for unbuffered stream writer.
+///
+/// There're two modes for the writer:
+/// - non-blocking write, which returns immediately without waiting for the IO operation to complete.
+/// - blocking write, which blocks wait until completion.
+/// WARNING: These two modes cannot be used together.
+use async_trait::async_trait;
+
+use crate::Result;
+
+#[cfg(test)]
+use mockall::*;
+
+#[async_trait]
+#[cfg_attr(test, automock)]
+pub trait BaseUnbufferedStreamWriter: Send {
+    /// Append the given buffer to the writer in non-blocking style.
+    async fn append_non_blocking(&mut self, data: Vec<u8>) -> Result<()>;
+
+    /// Flush all pending writes.
+    async fn finalize(mut self) -> Result<()>;
+}

--- a/src/moonlink/src/storage/filesystem/accessor/base_unbuffered_stream_writer.rs
+++ b/src/moonlink/src/storage/filesystem/accessor/base_unbuffered_stream_writer.rs
@@ -3,6 +3,7 @@
 /// There're two modes for the writer:
 /// - non-blocking write, which returns immediately without waiting for the IO operation to complete.
 /// - blocking write, which blocks wait until completion.
+///
 /// WARNING: These two modes cannot be used together.
 use async_trait::async_trait;
 
@@ -18,5 +19,5 @@ pub trait BaseUnbufferedStreamWriter: Send {
     async fn append_non_blocking(&mut self, data: Vec<u8>) -> Result<()>;
 
     /// Flush all pending writes.
-    async fn finalize(mut self) -> Result<()>;
+    async fn finalize(self: Box<Self>) -> Result<()>;
 }

--- a/src/moonlink/src/storage/filesystem/accessor/filesystem_accessor.rs
+++ b/src/moonlink/src/storage/filesystem/accessor/filesystem_accessor.rs
@@ -3,8 +3,6 @@ use async_trait::async_trait;
 #[cfg(feature = "storage-gcs")]
 use futures::TryStreamExt;
 use futures::{Stream, StreamExt};
-use opendal::layers::RetryLayer;
-use opendal::services;
 use opendal::Operator;
 #[cfg(test)]
 use tempfile::TempDir;
@@ -15,8 +13,10 @@ use tokio::sync::mpsc;
 use tokio::sync::OnceCell;
 
 use crate::storage::filesystem::accessor::base_filesystem_accessor::BaseFileSystemAccess;
+use crate::storage::filesystem::accessor::base_unbuffered_stream_writer::BaseUnbufferedStreamWriter;
 use crate::storage::filesystem::accessor::metadata::ObjectMetadata;
 use crate::storage::filesystem::accessor::operator_utils;
+use crate::storage::filesystem::accessor::unbuffered_stream_writer::UnbufferedStreamWriter;
 use crate::storage::filesystem::filesystem_config::FileSystemConfig;
 use crate::Result;
 
@@ -262,6 +262,18 @@ impl BaseFileSystemAccess for FileSystemAccessor {
         Ok(())
     }
 
+    async fn create_unbuffered_stream_writer(
+        &self,
+        object_filepath: &str,
+    ) -> Result<Box<dyn BaseUnbufferedStreamWriter>> {
+        let sanitized_object = self.sanitize_path(object_filepath);
+        let operator = self.get_operator().await?;
+        Ok(Box::new(UnbufferedStreamWriter::new(
+            operator.clone(),
+            sanitized_object.to_string(),
+        )?))
+    }
+
     async fn delete_object(&self, object: &str) -> Result<()> {
         let sanitized_object = self.sanitize_path(object);
         let operator = self.get_operator().await?;
@@ -383,7 +395,9 @@ impl BaseFileSystemAccess for FileSystemAccessor {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::storage::filesystem::accessor::test_utils::*;
+    use crate::storage::filesystem::{
+        accessor::test_utils::*, test_utils::writer_test_utils::test_unbuffered_stream_writer_impl,
+    };
     use rstest::rstest;
 
     #[tokio::test]
@@ -481,5 +495,23 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(actual_content, expected_content);
+    }
+
+    #[tokio::test]
+    async fn test_unbuffered_stream_write() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let root_directory = temp_dir.path().to_str().unwrap().to_string();
+        let filesystem_config = FileSystemConfig::FileSystem {
+            root_directory: root_directory.clone(),
+        };
+        let filesystem_accessor = FileSystemAccessor::new(filesystem_config.clone());
+
+        let dst_filename = "dst".to_string();
+        let dst_filepath = format!("{}/{}", &root_directory, dst_filename);
+        let writer = filesystem_accessor
+            .create_unbuffered_stream_writer(&dst_filepath)
+            .await
+            .unwrap();
+        test_unbuffered_stream_writer_impl(writer, dst_filename, filesystem_config).await;
     }
 }

--- a/src/moonlink/src/storage/filesystem/accessor/filesystem_accessor.rs
+++ b/src/moonlink/src/storage/filesystem/accessor/filesystem_accessor.rs
@@ -15,8 +15,8 @@ use tokio::sync::mpsc;
 use tokio::sync::OnceCell;
 
 use crate::storage::filesystem::accessor::base_filesystem_accessor::BaseFileSystemAccess;
-use crate::storage::filesystem::accessor::configs::*;
 use crate::storage::filesystem::accessor::metadata::ObjectMetadata;
+use crate::storage::filesystem::accessor::operator_utils;
 use crate::storage::filesystem::filesystem_config::FileSystemConfig;
 use crate::Result;
 
@@ -62,76 +62,8 @@ impl FileSystemAccessor {
 
     /// Get IO operator from the catalog.
     async fn get_operator(&self) -> Result<&Operator> {
-        let retry_layer = RetryLayer::new()
-            .with_max_times(MAX_RETRY_COUNT)
-            .with_jitter()
-            .with_factor(RETRY_DELAY_FACTOR)
-            .with_min_delay(MIN_RETRY_DELAY)
-            .with_max_delay(MAX_RETRY_DELAY);
-
         self.operator
-            .get_or_try_init(|| async {
-                match &self.config {
-                    #[cfg(feature = "storage-fs")]
-                    FileSystemConfig::FileSystem { root_directory } => {
-                        let builder = services::Fs::default().root(root_directory);
-                        let op = Operator::new(builder)?.layer(retry_layer).finish();
-                        Ok(op)
-                    }
-                    #[cfg(feature = "storage-gcs")]
-                    FileSystemConfig::Gcs {
-                        region,
-                        bucket,
-                        endpoint,
-                        access_key_id,
-                        secret_access_key,
-                        disable_auth,
-                        ..
-                    } => {
-                        // Test environment.
-                        if *disable_auth {
-                            let builder = services::Gcs::default()
-                                .root("/")
-                                .bucket(bucket)
-                                .endpoint(endpoint.as_ref().unwrap())
-                                .disable_config_load()
-                                .disable_vm_metadata()
-                                .allow_anonymous();
-                            let op = Operator::new(builder)?.layer(retry_layer).finish();
-                            return Ok(op);
-                        }
-
-                        let builder = services::S3::default()
-                            .root("/")
-                            .region(region)
-                            .bucket(bucket)
-                            .endpoint("https://storage.googleapis.com")
-                            .access_key_id(access_key_id)
-                            .secret_access_key(secret_access_key);
-                        let op = Operator::new(builder)?.layer(retry_layer).finish();
-                        Ok(op)
-                    }
-                    #[cfg(feature = "storage-s3")]
-                    FileSystemConfig::S3 {
-                        access_key_id,
-                        secret_access_key,
-                        region,
-                        bucket,
-                        endpoint,
-                    } => {
-                        let mut builder = services::S3::default()
-                            .bucket(bucket)
-                            .region(region)
-                            .access_key_id(access_key_id)
-                            .secret_access_key(secret_access_key);
-                        if let Some(endpoint) = endpoint {
-                            builder = builder.endpoint(endpoint);
-                        }
-                        let op = Operator::new(builder)?.layer(retry_layer).finish();
-                        Ok(op)
-                    }
-                }
-            })
+            .get_or_try_init(|| async { operator_utils::create_opendal_operator(&self.config) })
             .await
     }
 

--- a/src/moonlink/src/storage/filesystem/accessor/operator_utils.rs
+++ b/src/moonlink/src/storage/filesystem/accessor/operator_utils.rs
@@ -1,0 +1,78 @@
+use crate::storage::filesystem::accessor::configs::*;
+use crate::FileSystemConfig;
+use crate::Result;
+
+use opendal::layers::RetryLayer;
+use opendal::services;
+use opendal::Operator;
+
+/// Util function to create opendal operator from filesystem config.
+pub(crate) fn create_opendal_operator(filesystem_config: &FileSystemConfig) -> Result<Operator> {
+    let retry_layer = RetryLayer::new()
+        .with_max_times(MAX_RETRY_COUNT)
+        .with_jitter()
+        .with_factor(RETRY_DELAY_FACTOR)
+        .with_min_delay(MIN_RETRY_DELAY)
+        .with_max_delay(MAX_RETRY_DELAY);
+
+    match filesystem_config {
+        #[cfg(feature = "storage-fs")]
+        FileSystemConfig::FileSystem { root_directory } => {
+            let builder = services::Fs::default().root(root_directory);
+            let op = Operator::new(builder)?.layer(retry_layer).finish();
+            Ok(op)
+        }
+        #[cfg(feature = "storage-gcs")]
+        FileSystemConfig::Gcs {
+            region,
+            bucket,
+            endpoint,
+            access_key_id,
+            secret_access_key,
+            disable_auth,
+            ..
+        } => {
+            // Test environment.
+            if *disable_auth {
+                let builder = services::Gcs::default()
+                    .root("/")
+                    .bucket(bucket)
+                    .endpoint(endpoint.as_ref().unwrap())
+                    .disable_config_load()
+                    .disable_vm_metadata()
+                    .allow_anonymous();
+                let op = Operator::new(builder)?.layer(retry_layer).finish();
+                return Ok(op);
+            }
+
+            let builder = services::S3::default()
+                .root("/")
+                .region(region)
+                .bucket(bucket)
+                .endpoint("https://storage.googleapis.com")
+                .access_key_id(access_key_id)
+                .secret_access_key(secret_access_key);
+            let op = Operator::new(builder)?.layer(retry_layer).finish();
+            Ok(op)
+        }
+        #[cfg(feature = "storage-s3")]
+        FileSystemConfig::S3 {
+            access_key_id,
+            secret_access_key,
+            region,
+            bucket,
+            endpoint,
+        } => {
+            let mut builder = services::S3::default()
+                .bucket(bucket)
+                .region(region)
+                .access_key_id(access_key_id)
+                .secret_access_key(secret_access_key);
+            if let Some(endpoint) = endpoint {
+                builder = builder.endpoint(endpoint);
+            }
+            let op = Operator::new(builder)?.layer(retry_layer).finish();
+            Ok(op)
+        }
+    }
+}

--- a/src/moonlink/src/storage/filesystem/accessor/unbuffered_stream_writer.rs
+++ b/src/moonlink/src/storage/filesystem/accessor/unbuffered_stream_writer.rs
@@ -1,0 +1,109 @@
+/// A stream writer, which doesn't maintain a buffer inside.
+use crate::storage::filesystem::accessor::base_unbuffered_stream_writer::BaseUnbufferedStreamWriter;
+use crate::Result;
+
+use async_trait::async_trait;
+use futures::io::WriteAll;
+use futures::AsyncWriteExt;
+use opendal::raw::oio::MultipartWriter;
+use opendal::raw::AccessDyn;
+use opendal::raw::AccessorInfo;
+use opendal::FuturesAsyncWriter;
+use opendal::Operator;
+use opendal::Writer;
+use tokio::sync::mpsc::{Receiver, Sender};
+
+use futures::FutureExt;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+/// Max number of outstanding multipart writes.
+const MAX_CONCURRENT_WRITRS: usize = 32;
+/// Channel size for foreground/background communication.
+const CHANNEL_SIZE: usize = 32;
+
+pub struct UnbufferedStreamWriter {
+    request_tx: Sender<Vec<u8>>,
+    background_task: tokio::task::JoinHandle<Result<()>>,
+}
+
+impl UnbufferedStreamWriter {
+    /// # Arguments
+    ///
+    /// * object_filepath: filepath relative to operator root path.
+    pub async fn new(operator: Operator, object_filepath: String) -> Result<Self> {
+        let (tx, mut rx) = tokio::sync::mpsc::channel(CHANNEL_SIZE);
+        let background_task = tokio::spawn(async move {
+            let mut writer = operator
+                .writer_with(&object_filepath)
+                .concurrent(MAX_CONCURRENT_WRITRS)
+                .await?;
+            while let Some(buf) = rx.recv().await {
+                writer.write(buf).await?;
+            }
+            writer.close().await?;
+            Ok(())
+        });
+
+        Ok(Self {
+            request_tx: tx,
+            background_task,
+        })
+    }
+}
+
+#[async_trait]
+impl BaseUnbufferedStreamWriter for UnbufferedStreamWriter {
+    async fn append_non_blocking(&mut self, data: Vec<u8>) -> Result<()> {
+        self.request_tx.send(data).await.unwrap();
+        Ok(())
+    }
+
+    async fn finalize(mut self) -> Result<()> {
+        drop(self.request_tx);
+        self.background_task.await??;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::filesystem::accessor::{operator_utils, test_utils::*};
+
+    #[tokio::test]
+    async fn test_unbuffered_stream_writer() {
+        const FILE_SIZE: usize = 10;
+
+        let temp_dir = tempfile::tempdir().unwrap();
+        let root_directory = temp_dir.path().to_str().unwrap().to_string();
+
+        // Prepare src file.
+        let src_filename = "src".to_string();
+        let src_filepath = format!("{}/{}", &root_directory, src_filename);
+        let expected_content = create_local_file(&src_filepath, FILE_SIZE).await;
+
+        // Create an operator.
+        let filesystem_config = &crate::FileSystemConfig::FileSystem { root_directory };
+        let operator = operator_utils::create_opendal_operator(filesystem_config).unwrap();
+
+        // Create writer and append in blocks.
+        let mut writer = UnbufferedStreamWriter::new(operator.clone(), src_filename)
+            .await
+            .unwrap();
+        writer
+            .append_non_blocking(expected_content[..FILE_SIZE / 2].as_bytes().to_vec())
+            .await
+            .unwrap();
+        writer
+            .append_non_blocking(expected_content[FILE_SIZE / 2..].as_bytes().to_vec())
+            .await
+            .unwrap();
+        writer.finalize().await.unwrap();
+
+        // Verify content.
+        let actual_content = tokio::fs::read(&src_filepath).await.unwrap();
+        assert_eq!(actual_content, expected_content.into_bytes());
+    }
+}

--- a/src/moonlink/src/storage/filesystem/gcs/tests.rs
+++ b/src/moonlink/src/storage/filesystem/gcs/tests.rs
@@ -1,11 +1,11 @@
 use crate::storage::filesystem::accessor::base_filesystem_accessor::BaseFileSystemAccess;
-use crate::storage::filesystem::accessor::base_unbuffered_stream_writer::BaseUnbufferedStreamWriter;
 use crate::storage::filesystem::accessor::filesystem_accessor::FileSystemAccessor;
 use crate::storage::filesystem::accessor::operator_utils;
 use crate::storage::filesystem::accessor::test_utils::*;
 use crate::storage::filesystem::accessor::unbuffered_stream_writer::UnbufferedStreamWriter;
 use crate::storage::filesystem::gcs::gcs_test_utils::*;
 use crate::storage::filesystem::gcs::test_guard::TestGuard;
+use crate::storage::filesystem::test_utils::writer_test_utils::*;
 
 use futures::StreamExt;
 use rstest::rstest;
@@ -105,34 +105,30 @@ async fn test_copy_from_remote_to_local(#[case] file_size: usize) {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_unbuffered_stream_writer() {
-    const FILE_SIZE: usize = 10;
-    const CONTENT: &str = "helloworld";
     let dst_filename = "dst".to_string();
-
     let (bucket, warehouse_uri) = get_test_gcs_bucket_and_warehouse();
     let _test_guard = TestGuard::new(bucket.clone()).await;
     let gcs_filesystem_config = create_gcs_filesystem_config(&warehouse_uri);
     let operator = operator_utils::create_opendal_operator(&gcs_filesystem_config).unwrap();
 
     // Create writer and append in blocks.
-    let mut writer = UnbufferedStreamWriter::new(operator.clone(), dst_filename.clone())
-        .await
-        .unwrap();
-    writer
-        .append_non_blocking(CONTENT[..FILE_SIZE / 2].as_bytes().to_vec())
-        .await
-        .unwrap();
-    writer
-        .append_non_blocking(CONTENT[FILE_SIZE / 2..].as_bytes().to_vec())
-        .await
-        .unwrap();
-    writer.finalize().await.unwrap();
+    let writer =
+        Box::new(UnbufferedStreamWriter::new(operator.clone(), dst_filename.clone()).unwrap());
+    test_unbuffered_stream_writer_impl(writer, dst_filename, gcs_filesystem_config).await;
+}
 
-    // Verify content.
-    let filesystem_accessor = FileSystemAccessor::new(gcs_filesystem_config);
-    let actual_content = filesystem_accessor
-        .read_object_as_string(&dst_filename)
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_unbuffered_stream_write_with_filesystem_accessor() {
+    let (bucket, warehouse_uri) = get_test_gcs_bucket_and_warehouse();
+    let _test_guard = TestGuard::new(bucket.clone()).await;
+    let gcs_filesystem_config = create_gcs_filesystem_config(&warehouse_uri);
+    let filesystem_accessor = FileSystemAccessor::new(gcs_filesystem_config.clone());
+
+    let dst_filename = "dst".to_string();
+    let dst_filepath = format!("{}/{}", &warehouse_uri, dst_filename);
+    let writer = filesystem_accessor
+        .create_unbuffered_stream_writer(&dst_filepath)
         .await
         .unwrap();
-    assert_eq!(actual_content, CONTENT);
+    test_unbuffered_stream_writer_impl(writer, dst_filename, gcs_filesystem_config).await;
 }

--- a/src/moonlink/src/storage/filesystem/gcs/tests.rs
+++ b/src/moonlink/src/storage/filesystem/gcs/tests.rs
@@ -1,6 +1,9 @@
 use crate::storage::filesystem::accessor::base_filesystem_accessor::BaseFileSystemAccess;
+use crate::storage::filesystem::accessor::base_unbuffered_stream_writer::BaseUnbufferedStreamWriter;
 use crate::storage::filesystem::accessor::filesystem_accessor::FileSystemAccessor;
+use crate::storage::filesystem::accessor::operator_utils;
 use crate::storage::filesystem::accessor::test_utils::*;
+use crate::storage::filesystem::accessor::unbuffered_stream_writer::UnbufferedStreamWriter;
 use crate::storage::filesystem::gcs::gcs_test_utils::*;
 use crate::storage::filesystem::gcs::test_guard::TestGuard;
 
@@ -98,4 +101,38 @@ async fn test_copy_from_remote_to_local(#[case] file_size: usize) {
     // Validate destination file content.
     let actual_content = tokio::fs::read_to_string(dst_filepath).await.unwrap();
     assert_eq!(actual_content, expected_content);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_unbuffered_stream_writer() {
+    const FILE_SIZE: usize = 10;
+    const CONTENT: &str = "helloworld";
+    let dst_filename = "dst".to_string();
+
+    let (bucket, warehouse_uri) = get_test_gcs_bucket_and_warehouse();
+    let _test_guard = TestGuard::new(bucket.clone()).await;
+    let gcs_filesystem_config = create_gcs_filesystem_config(&warehouse_uri);
+    let operator = operator_utils::create_opendal_operator(&gcs_filesystem_config).unwrap();
+
+    // Create writer and append in blocks.
+    let mut writer = UnbufferedStreamWriter::new(operator.clone(), dst_filename.clone())
+        .await
+        .unwrap();
+    writer
+        .append_non_blocking(CONTENT[..FILE_SIZE / 2].as_bytes().to_vec())
+        .await
+        .unwrap();
+    writer
+        .append_non_blocking(CONTENT[FILE_SIZE / 2..].as_bytes().to_vec())
+        .await
+        .unwrap();
+    writer.finalize().await.unwrap();
+
+    // Verify content.
+    let filesystem_accessor = FileSystemAccessor::new(gcs_filesystem_config);
+    let actual_content = filesystem_accessor
+        .read_object_as_string(&dst_filename)
+        .await
+        .unwrap();
+    assert_eq!(actual_content, CONTENT);
 }

--- a/src/moonlink/src/storage/filesystem/s3/tests.rs
+++ b/src/moonlink/src/storage/filesystem/s3/tests.rs
@@ -1,11 +1,11 @@
 use crate::storage::filesystem::accessor::base_filesystem_accessor::BaseFileSystemAccess;
-use crate::storage::filesystem::accessor::base_unbuffered_stream_writer::BaseUnbufferedStreamWriter;
 use crate::storage::filesystem::accessor::filesystem_accessor::FileSystemAccessor;
 use crate::storage::filesystem::accessor::operator_utils;
 use crate::storage::filesystem::accessor::test_utils::*;
 use crate::storage::filesystem::accessor::unbuffered_stream_writer::UnbufferedStreamWriter;
 use crate::storage::filesystem::s3::s3_test_utils::*;
 use crate::storage::filesystem::s3::test_guard::TestGuard;
+use crate::storage::filesystem::test_utils::writer_test_utils::*;
 
 use futures::StreamExt;
 use rstest::rstest;
@@ -105,34 +105,30 @@ async fn test_copy_from_remote_to_local(#[case] file_size: usize) {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_unbuffered_stream_writer() {
-    const FILE_SIZE: usize = 10;
-    const CONTENT: &str = "helloworld";
     let dst_filename = "dst".to_string();
-
     let (bucket, warehouse_uri) = get_test_s3_bucket_and_warehouse();
     let _test_guard = TestGuard::new(bucket.clone()).await;
     let s3_filesystem_config = create_s3_filesystem_config(&warehouse_uri);
     let operator = operator_utils::create_opendal_operator(&s3_filesystem_config).unwrap();
 
     // Create writer and append in blocks.
-    let mut writer = UnbufferedStreamWriter::new(operator.clone(), dst_filename.clone())
-        .await
-        .unwrap();
-    writer
-        .append_non_blocking(CONTENT[..FILE_SIZE / 2].as_bytes().to_vec())
-        .await
-        .unwrap();
-    writer
-        .append_non_blocking(CONTENT[FILE_SIZE / 2..].as_bytes().to_vec())
-        .await
-        .unwrap();
-    writer.finalize().await.unwrap();
+    let writer =
+        Box::new(UnbufferedStreamWriter::new(operator.clone(), dst_filename.clone()).unwrap());
+    test_unbuffered_stream_writer_impl(writer, dst_filename, s3_filesystem_config).await;
+}
 
-    // Verify content.
-    let filesystem_accessor = FileSystemAccessor::new(s3_filesystem_config);
-    let actual_content = filesystem_accessor
-        .read_object_as_string(&dst_filename)
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_unbuffered_stream_write_with_filesystem_accessor() {
+    let (bucket, warehouse_uri) = get_test_s3_bucket_and_warehouse();
+    let _test_guard = TestGuard::new(bucket.clone()).await;
+    let s3_filesystem_config = create_s3_filesystem_config(&warehouse_uri);
+    let filesystem_accessor = FileSystemAccessor::new(s3_filesystem_config.clone());
+
+    let dst_filename = "dst".to_string();
+    let dst_filepath = format!("{}/{}", &warehouse_uri, dst_filename);
+    let writer = filesystem_accessor
+        .create_unbuffered_stream_writer(&dst_filepath)
         .await
         .unwrap();
-    assert_eq!(actual_content, CONTENT);
+    test_unbuffered_stream_writer_impl(writer, dst_filename, s3_filesystem_config).await;
 }

--- a/src/moonlink/src/storage/filesystem/test_utils.rs
+++ b/src/moonlink/src/storage/filesystem/test_utils.rs
@@ -1,2 +1,4 @@
 #[cfg(test)]
 pub(crate) mod object_storage_test_utils;
+#[cfg(test)]
+pub(crate) mod writer_test_utils;

--- a/src/moonlink/src/storage/filesystem/test_utils/object_storage_test_utils.rs
+++ b/src/moonlink/src/storage/filesystem/test_utils/object_storage_test_utils.rs
@@ -9,7 +9,6 @@ pub(crate) const TEST_BUCKET_NAME_LEN: usize = 10;
 use rand::Rng;
 
 /// Get object storage bucket name from warehouse uri.
-#[allow(dead_code)]
 pub(crate) fn get_bucket_from_warehouse_uri(warehouse_uri: &str) -> String {
     // Try to parse with url::Url
     if let Ok(url) = url::Url::parse(warehouse_uri) {
@@ -27,7 +26,7 @@ pub(crate) fn get_bucket_from_warehouse_uri(warehouse_uri: &str) -> String {
         .to_string()
 }
 
-#[allow(dead_code)]
+#[cfg(any(feature = "storage-gcs", feature = "storage-s3"))]
 pub(crate) fn get_bucket_and_warehouse(
     bucket_prefix: &str,
     warehouse_uri_prefix: &str,

--- a/src/moonlink/src/storage/filesystem/test_utils/object_storage_test_utils.rs
+++ b/src/moonlink/src/storage/filesystem/test_utils/object_storage_test_utils.rs
@@ -1,11 +1,10 @@
 /// Testing utils for object storage.
-#[allow(dead_code)]
+#[cfg(any(feature = "storage-gcs", feature = "storage-s3"))]
 pub(crate) const TEST_RETRY_COUNT: usize = 2;
-#[allow(dead_code)]
+#[cfg(any(feature = "storage-gcs", feature = "storage-s3"))]
 pub(crate) const TEST_RETRY_INIT_MILLISEC: u64 = 100;
-#[allow(dead_code)]
-pub(crate) const TEST_BUCKET_NAME_LEN: usize = 10;
 
+#[cfg(any(feature = "storage-gcs", feature = "storage-s3"))]
 use rand::Rng;
 
 /// Get object storage bucket name from warehouse uri.

--- a/src/moonlink/src/storage/filesystem/test_utils/writer_test_utils.rs
+++ b/src/moonlink/src/storage/filesystem/test_utils/writer_test_utils.rs
@@ -13,11 +13,11 @@ pub(crate) async fn test_unbuffered_stream_writer_impl(
     const CONTENT: &str = "helloworld";
 
     writer
-        .append_non_blocking(CONTENT.as_bytes()[FILE_SIZE / 2..].to_vec())
+        .append_non_blocking(CONTENT.as_bytes()[..FILE_SIZE / 2].to_vec())
         .await
         .unwrap();
     writer
-        .append_non_blocking(CONTENT.as_bytes()[..FILE_SIZE / 2].to_vec())
+        .append_non_blocking(CONTENT.as_bytes()[FILE_SIZE / 2..].to_vec())
         .await
         .unwrap();
     writer.finalize().await.unwrap();

--- a/src/moonlink/src/storage/filesystem/test_utils/writer_test_utils.rs
+++ b/src/moonlink/src/storage/filesystem/test_utils/writer_test_utils.rs
@@ -1,0 +1,32 @@
+use crate::storage::filesystem::accessor::base_filesystem_accessor::BaseFileSystemAccess;
+use crate::storage::filesystem::accessor::base_unbuffered_stream_writer::BaseUnbufferedStreamWriter;
+use crate::storage::filesystem::accessor::filesystem_accessor::FileSystemAccessor;
+use crate::storage::FileSystemConfig;
+
+/// Util function to test stream writer.
+pub(crate) async fn test_unbuffered_stream_writer_impl(
+    mut writer: Box<dyn BaseUnbufferedStreamWriter>,
+    dst_filename: String,
+    filesystem_config: FileSystemConfig,
+) {
+    const FILE_SIZE: usize = 10;
+    const CONTENT: &str = "helloworld";
+
+    writer
+        .append_non_blocking(CONTENT.as_bytes()[FILE_SIZE / 2..].to_vec())
+        .await
+        .unwrap();
+    writer
+        .append_non_blocking(CONTENT.as_bytes()[..FILE_SIZE / 2].to_vec())
+        .await
+        .unwrap();
+    writer.finalize().await.unwrap();
+
+    // Verify content.
+    let filesystem_accessor = FileSystemAccessor::new(filesystem_config);
+    let actual_content = filesystem_accessor
+        .read_object_as_string(&dst_filename)
+        .await
+        .unwrap();
+    assert_eq!(actual_content, CONTENT);
+}


### PR DESCRIPTION
## Summary

This PR implements stream writer, with no buffer support; mainly for WAL usage. Some key features:
- Append is non-blocking, so it could be used in eventloop
- User needs to explicit flush and close

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/914

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [x] Documentation updated if necessary
- [x] I have reviewed my own changes
