### PR TITLE
[storage] Set wal metadata persistence result

### DIFF
--- a/src/moonlink/src/storage/iceberg/iceberg_table_loader.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_loader.rs
@@ -233,7 +233,7 @@ impl IcebergTableManager {
         // Fill in flush LSN.
         mooncake_snapshot.data_file_flush_lsn = flush_lsn;
         // Fill in wal persistence metadata.
-        mooncake_snapshot.wal_metadata = wal_metadata;
+        mooncake_snapshot.wal_persistence_metadata = wal_metadata;
 
         mooncake_snapshot
     }

--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -1034,7 +1034,7 @@ impl SnapshotTableState {
             {
                 iceberg_snapshot_payload = Some(self.get_iceberg_snapshot_payload(
                     flush_lsn,
-                    self.current_snapshot.wal_metadata.clone(),
+                    self.current_snapshot.wal_persistence_metadata.clone(),
                     aggregated_committed_deletion_logs,
                 ));
             }

--- a/src/moonlink/src/storage/mooncake_table/table_snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_snapshot.rs
@@ -187,6 +187,8 @@ pub struct IcebergSnapshotResult {
     pub(crate) table_manager: Box<dyn TableManager>,
     /// Iceberg flush LSN.
     pub(crate) flush_lsn: u64,
+    /// Iceberg WAL persistence.
+    pub(crate) wal_persisted_metadata: Option<WalPersistenceMetadata>,
     /// Iceberg import result.
     pub(crate) import_result: IcebergSnapshotImportResult,
     /// Iceberg index merge result.


### PR DESCRIPTION
## Summary

Followup for https://github.com/Mooncake-Labs/moonlink/pull/943, which sets iceberg persistence results for WAL metadata.

To @lohpaul9 , I think the interface for iceberg persistence on WAL is (mostly) completely, two things you need to do:
- Set WAL metadata after you persist WAL to storage, whether local filesystem or object storage;
- On recovery, WAL metadata will be stored at current snapshot, you need to get it out and replay WAL.

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
