### PR TITLE
[storage] Use absolute path everywhere

### DIFF
--- a/src/moonlink/src/table_handler.rs
+++ b/src/moonlink/src/table_handler.rs
@@ -754,7 +754,6 @@ impl TableHandler {
                                     error!(error = ?err, "failed to perform compaction");
                                 }
                             }
-                            table_handler_state.maintenance_ongoing = false;
                         }
                         TableEvent::ReadRequestCompletion { cache_handles } => {
                             table.set_read_request_res(cache_handles);


### PR DESCRIPTION
## Summary

This PR canonicalizes relative moolink backend path into absolute path, so all paths built upon will be absolute one.
Likely needs some cleanups for path / pathbuf / string usage, I will followup.

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
