### PR TITLE
[storage] Create directory before canonicalization

### DIFF
--- a/src/moonlink_backend/src/lib.rs
+++ b/src/moonlink_backend/src/lib.rs
@@ -39,6 +39,7 @@ where
         logging::init_logging();
 
         // Canonicalize moonlink backend directory, so all paths stored are of absolute path.
+        tokio::fs::create_dir_all(&base_path).await?;
         let base_path = tokio::fs::canonicalize(base_path).await?;
         let base_path_str = base_path.to_str().unwrap();
 


### PR DESCRIPTION
## Summary

Make sure directory exists before canonlicalization.

Tested with pg_mooncake regression test on fresh devcontainer:
```sh
--- beginning regression test run ---
PASS setup 24ms
PASS partitioned_table 716ms
PASS sanity 690ms
passed=3 failed=0
```

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
