### PR TITLE
[storage] Reset mooncake table at schema update

### DIFF
--- a/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
@@ -195,10 +195,13 @@ impl TableManager for IcebergTableManager {
         mut snapshot_payload: IcebergSnapshotPayload,
         file_params: PersistenceFileParams,
     ) -> IcebergResult<PersistenceResult> {
+        // Persist data files, deletion vectors, and file indices.
         let new_table_schema = std::mem::take(&mut snapshot_payload.new_table_schema);
         let persistence_result = self
             .sync_snapshot_impl(snapshot_payload, file_params)
             .await?;
+
+        // Perform schema evolution if necessary.
         if let Some(new_table_schema) = new_table_schema {
             self.alter_table_schema_impl(new_table_schema).await?;
         }

--- a/src/moonlink/src/storage/iceberg/iceberg_table_syncer.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_syncer.rs
@@ -49,23 +49,6 @@ impl IcebergTableManager {
         _snapshot_payload: &IcebergSnapshotPayload,
     ) {
         schema_utils::assert_table_schema_id(self.iceberg_table.as_ref().unwrap());
-
-        // Perform expensive validations only at tests.
-        #[cfg(test)]
-        {
-            // Assert table schema matches iceberg table metadata.
-            schema_utils::assert_table_schema_consistent(
-                self.iceberg_table.as_ref().unwrap(),
-                &self.mooncake_table_metadata,
-            );
-
-            // Assert new data files schema matches table schema.
-            schema_utils::assert_payload_schema_consistent(
-                _snapshot_payload,
-                self.mooncake_table_metadata.as_ref(),
-            )
-            .await;
-        }
     }
 
     /// Util function to get unique table file id for the deletion vector puffin file.

--- a/src/moonlink/src/storage/iceberg/schema_utils.rs
+++ b/src/moonlink/src/storage/iceberg/schema_utils.rs
@@ -1,9 +1,5 @@
 #[cfg(test)]
-use crate::storage::mooncake_table::{
-    IcebergSnapshotPayload, TableMetadata as MooncakeTableMetadata,
-};
-#[cfg(test)]
-use crate::storage::storage_utils::MooncakeDataFileRef;
+use crate::storage::mooncake_table::TableMetadata as MooncakeTableMetadata;
 #[cfg(test)]
 use iceberg::spec::Schema as IcebergSchema;
 use iceberg::spec::DEFAULT_SCHEMA_ID;
@@ -21,44 +17,6 @@ pub(crate) fn assert_is_same_schema(lhs: IcebergSchema, rhs: IcebergSchema) {
         let lhs_name = lhs.name_by_field_id(cur_field_id);
         let rhs_name = rhs.name_by_field_id(cur_field_id);
         assert_eq!(lhs_name, rhs_name);
-    }
-}
-
-/// Validate the given parquet file matches the given schema.
-///
-/// Precondition: [`data_file`] is stored at local filesystem.
-#[cfg(test)]
-async fn assert_parquet_file_schema_consistent(
-    data_file: &MooncakeDataFileRef,
-    mooncake_table_metadata: &MooncakeTableMetadata,
-) {
-    let file = tokio::fs::File::open(data_file.file_path()).await.unwrap();
-    let stream_builder = parquet::arrow::async_reader::ParquetRecordBatchStreamBuilder::new(file)
-        .await
-        .unwrap();
-    let parquet_schema = stream_builder.parquet_schema();
-    let arrow_schema =
-        parquet::arrow::parquet_to_arrow_schema(parquet_schema, /*key_value_metadata=*/ None)
-            .unwrap();
-    assert_eq!(arrow_schema, *mooncake_table_metadata.schema);
-}
-
-/// Validate all data files within iceberg snapshot payload matches the given schema.
-#[cfg(test)]
-pub(crate) async fn assert_payload_schema_consistent(
-    snapshot_payload: &IcebergSnapshotPayload,
-    mooncake_table_metadata: &MooncakeTableMetadata,
-) {
-    // Assert import payload.
-    let import_payload = &snapshot_payload.import_payload;
-    for cur_data_file in import_payload.data_files.iter() {
-        assert_parquet_file_schema_consistent(cur_data_file, mooncake_table_metadata).await;
-    }
-
-    // Assert data compaction payload.
-    let data_compaction_payload = &snapshot_payload.data_compaction_payload;
-    for cur_data_file in data_compaction_payload.new_data_files_to_import.iter() {
-        assert_parquet_file_schema_consistent(cur_data_file, mooncake_table_metadata).await;
     }
 }
 

--- a/src/moonlink/src/storage/iceberg/tests.rs
+++ b/src/moonlink/src/storage/iceberg/tests.rs
@@ -1961,7 +1961,7 @@ async fn test_schema_update_impl(iceberg_table_config: IcebergTableConfig) {
     // Perform more data file with the new schema should go through with no issue.
     let row = test_row_with_updated_schema();
     table.append(row.clone()).unwrap();
-    table.commit(/*lsn=*/ 10);
+    table.commit(/*lsn=*/ 20);
     flush_table_and_sync(&mut table, &mut notify_rx, /*lsn=*/ 20)
         .await
         .unwrap();

--- a/src/moonlink/src/storage/iceberg/tests.rs
+++ b/src/moonlink/src/storage/iceberg/tests.rs
@@ -121,6 +121,14 @@ fn test_row_3() -> MoonlinkRow {
     ])
 }
 
+/// Test util function to create moonlink row with updated schema with [`create_test_updated_arrow_schema`].
+fn test_row_with_updated_schema() -> MoonlinkRow {
+    MoonlinkRow::new(vec![
+        RowValue::Int32(100),
+        RowValue::ByteArray("new_string".as_bytes().to_vec()),
+    ])
+}
+
 /// Test util function to write arrow record batch into local file.
 async fn write_arrow_record_batch_to_local<P: AsRef<std::path::Path>>(
     path: P,
@@ -1949,6 +1957,17 @@ async fn test_schema_update_impl(iceberg_table_config: IcebergTableConfig) {
     let expected_schema =
         arrow_schema_to_schema(updated_mooncake_table_metadata.schema.as_ref()).unwrap();
     assert_is_same_schema(actual_schema.as_ref().clone(), expected_schema);
+
+    // Perform more data file with the new schema should go through with no issue.
+    let row = test_row_with_updated_schema();
+    table.append(row.clone()).unwrap();
+    table.commit(/*lsn=*/ 10);
+    flush_table_and_sync(&mut table, &mut notify_rx, /*lsn=*/ 20)
+        .await
+        .unwrap();
+
+    // Create a mooncake and iceberg snapshot to reflect new data file changes.
+    create_mooncake_and_persist_for_test(&mut table, &mut notify_rx).await;
 }
 
 #[tokio::test]

--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -961,7 +961,12 @@ impl MooncakeTable {
 
         self.next_snapshot_task.new_rows = Some(self.mem_slice.get_latest_rows());
         let next_snapshot_task = std::mem::take(&mut self.next_snapshot_task);
+
+        // Re-initialize mooncake table fields.
         self.next_snapshot_task = SnapshotTask::new(self.metadata.config.clone());
+        // If table schema has been updated, re-initialize mem slice accordingly.
+        if 
+
         let cur_snapshot = self.snapshot.clone();
         // Create a detached task, whose completion will be notified separately.
         tokio::task::spawn(


### PR DESCRIPTION
## Summary

This PR fixes an existing issue: when table schema gets updated, schema-related fields should be reinitialized as well.

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
