### PR TITLE
[minor] Extract out snapshot related functions

### DIFF
--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -6,6 +6,7 @@ mod persistence_buffer;
 mod shared_array;
 mod snapshot;
 mod snapshot_maintenance;
+mod snapshot_persistence;
 mod snapshot_read;
 pub mod snapshot_read_output;
 mod snapshot_validation;

--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -5,6 +5,7 @@ mod mem_slice;
 mod persistence_buffer;
 mod shared_array;
 mod snapshot;
+mod snapshot_cache_utils;
 mod snapshot_maintenance;
 mod snapshot_persistence;
 mod snapshot_read;

--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -6,6 +6,7 @@ mod persistence_buffer;
 mod shared_array;
 mod snapshot;
 mod snapshot_maintenance;
+mod snapshot_read;
 pub mod snapshot_read_output;
 mod snapshot_validation;
 pub mod table_config;

--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -1,4 +1,4 @@
-use super::data_batches::{create_batch_from_rows, InMemoryBatch};
+use super::data_batches::InMemoryBatch;
 use super::delete_vector::BatchDeletionVector;
 use super::{
     DiskFileEntry, IcebergSnapshotPayload, Snapshot, SnapshotTask,
@@ -17,13 +17,9 @@ use crate::storage::iceberg::puffin_utils::PuffinBlobRef;
 use crate::storage::index::{cache_utils as index_cache_utils, FileIndex};
 use crate::storage::mooncake_table::persistence_buffer::UnpersistedRecords;
 use crate::storage::mooncake_table::shared_array::SharedRowBufferSnapshot;
-use crate::storage::mooncake_table::snapshot_read_output::{
-    DataFileForRead, ReadOutput as SnapshotReadOutput,
-};
 use crate::storage::mooncake_table::table_snapshot::{
     FileIndiceMergePayload, IcebergSnapshotDataCompactionPayload,
 };
-use crate::storage::mooncake_table::table_state::TableSnapshotState;
 use crate::storage::mooncake_table::transaction_stream::TransactionStreamOutput;
 use crate::storage::mooncake_table::SnapshotOption;
 use crate::storage::mooncake_table::{
@@ -36,11 +32,7 @@ use crate::storage::storage_utils::{
 use crate::storage::wal::wal_persistence_metadata::WalPersistenceMetadata;
 use crate::table_notify::TableEvent;
 use crate::{create_data_file, NonEvictableHandle};
-use arrow_schema::Schema;
 use more_asserts as ma;
-use parquet::arrow::AsyncArrowWriter;
-use parquet::basic::{Compression, Encoding};
-use parquet::file::properties::WriterProperties;
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::mem::take;
@@ -54,10 +46,10 @@ pub(crate) struct SnapshotTableState {
     pub(super) current_snapshot: Snapshot,
 
     /// In memory RecordBatches, maps from batch id to in-memory batch.
-    batches: BTreeMap<u64, InMemoryBatch>,
+    pub(super) batches: BTreeMap<u64, InMemoryBatch>,
 
     /// Latest rows
-    rows: Option<SharedRowBufferSnapshot>,
+    pub(super) rows: Option<SharedRowBufferSnapshot>,
 
     // UNDONE(BATCH_INSERT):
     // Track uncommitted disk files/ batches from big batch insert
@@ -73,7 +65,7 @@ pub(crate) struct SnapshotTableState {
     pub(crate) uncommitted_deletion_log: Vec<Option<ProcessedDeletionRecord>>,
 
     /// Last commit point
-    last_commit: RecordLocation,
+    pub(super) last_commit: RecordLocation,
 
     /// Object storage cache.
     pub(super) object_storage_cache: ObjectStorageCache,
@@ -82,7 +74,7 @@ pub(crate) struct SnapshotTableState {
     pub(super) filesystem_accessor: Arc<dyn BaseFileSystemAccess>,
 
     /// Table notifier.
-    table_notify: Option<Sender<TableEvent>>,
+    pub(super) table_notify: Option<Sender<TableEvent>>,
 
     /// ---- Items not persisted to iceberg snapshot ----
     ///
@@ -141,7 +133,7 @@ impl SnapshotTableState {
     }
 
     /// Util function to get table unique file id.
-    fn get_table_unique_file_id(&self, file_id: FileId) -> TableUniqueFileId {
+    pub(super) fn get_table_unique_file_id(&self, file_id: FileId) -> TableUniqueFileId {
         TableUniqueFileId {
             table_id: TableId(self.mooncake_table_metadata.table_id),
             file_id,
@@ -1421,7 +1413,7 @@ impl SnapshotTableState {
     }
 
     /// Get committed deletion record for current snapshot.
-    async fn get_deletion_records(
+    pub(super) async fn get_deletion_records(
         &mut self,
     ) -> (
         Vec<NonEvictableHandle>,       /*puffin file cache handles*/
@@ -1477,122 +1469,5 @@ impl SnapshotTableState {
             }
         }
         (puffin_cache_handles, deletion_vector_blob_at_read, ret)
-    }
-
-    /// Util function to get read state, which returns all current data files information.
-    /// If a data file already has a pinned reference, increment the reference count directly to avoid unnecessary IO.
-    async fn get_read_files_for_read(&mut self) -> Vec<DataFileForRead> {
-        let mut data_files_for_read = Vec::with_capacity(self.current_snapshot.disk_files.len());
-        for (file, _) in self.current_snapshot.disk_files.iter() {
-            let unique_table_file_id = self.get_table_unique_file_id(file.file_id());
-            data_files_for_read.push(DataFileForRead::RemoteFilePath((
-                unique_table_file_id,
-                file.file_path().to_string(),
-            )));
-        }
-
-        data_files_for_read
-    }
-
-    pub(crate) fn get_table_schema(&self) -> Result<Arc<Schema>> {
-        Ok(self.mooncake_table_metadata.schema.clone())
-    }
-
-    pub(crate) fn get_table_snapshot_states(&self) -> Result<TableSnapshotState> {
-        Ok(TableSnapshotState {
-            table_commit_lsn: self.current_snapshot.snapshot_version,
-            iceberg_flush_lsn: self.current_snapshot.data_file_flush_lsn,
-        })
-    }
-
-    pub(crate) async fn request_read(&mut self) -> Result<SnapshotReadOutput> {
-        let mut data_file_paths = self.get_read_files_for_read().await;
-        let mut associated_files = Vec::new();
-        let (puffin_cache_handles, deletion_vectors_at_read, position_deletes) =
-            self.get_deletion_records().await;
-
-        // For committed but not persisted records, we create a temporary file for them, which gets deleted after query completion.
-        let file_path = self.current_snapshot.get_name_for_inmemory_file();
-        let filepath_exists = tokio::fs::try_exists(&file_path).await?;
-        if filepath_exists {
-            data_file_paths.push(DataFileForRead::TemporaryDataFile(
-                file_path.to_string_lossy().to_string(),
-            ));
-            associated_files.push(file_path.to_string_lossy().to_string());
-            return Ok(SnapshotReadOutput {
-                data_file_paths,
-                puffin_cache_handles,
-                deletion_vectors: deletion_vectors_at_read,
-                position_deletes,
-                associated_files,
-                object_storage_cache: Some(self.object_storage_cache.clone()),
-                filesystem_accessor: Some(self.filesystem_accessor.clone()),
-                table_notifier: Some(self.table_notify.as_ref().unwrap().clone()),
-            });
-        }
-
-        assert!(matches!(
-            self.last_commit,
-            RecordLocation::MemoryBatch(_, _)
-        ));
-        let (batch_id, row_id) = self.last_commit.clone().into();
-        if batch_id > 0 || row_id > 0 {
-            // add all batches
-            let mut filtered_batches = Vec::new();
-            let schema = self.current_snapshot.metadata.schema.clone();
-            for (id, batch) in self.batches.iter() {
-                if *id < batch_id {
-                    if let Some(filtered_batch) = batch.get_filtered_batch()? {
-                        filtered_batches.push(filtered_batch);
-                    }
-                } else if *id == batch_id && row_id > 0 {
-                    if batch.data.is_some() {
-                        if let Some(filtered_batch) = batch.get_filtered_batch_with_limit(row_id)? {
-                            filtered_batches.push(filtered_batch);
-                        }
-                    } else {
-                        let rows = self.rows.as_ref().unwrap().get_buffer(row_id);
-                        let deletions = &self
-                            .batches
-                            .values()
-                            .last()
-                            .expect("batch not found")
-                            .deletions;
-                        let batch = create_batch_from_rows(rows, schema.clone(), deletions);
-                        filtered_batches.push(batch);
-                    }
-                }
-            }
-
-            // TODO(hjiang): Check whether we could avoid IO operation inside of critical section.
-            if !filtered_batches.is_empty() {
-                // Build a parquet file from current record batches
-                let temp_file = tokio::fs::File::create(&file_path).await?;
-                let props = WriterProperties::builder()
-                    .set_compression(Compression::UNCOMPRESSED)
-                    .set_dictionary_enabled(false)
-                    .set_encoding(Encoding::PLAIN)
-                    .build();
-                let mut parquet_writer = AsyncArrowWriter::try_new(temp_file, schema, Some(props))?;
-                for batch in filtered_batches.iter() {
-                    parquet_writer.write(batch).await?;
-                }
-                parquet_writer.close().await?;
-                data_file_paths.push(DataFileForRead::TemporaryDataFile(
-                    file_path.to_string_lossy().to_string(),
-                ));
-                associated_files.push(file_path.to_string_lossy().to_string());
-            }
-        }
-        Ok(SnapshotReadOutput {
-            data_file_paths,
-            puffin_cache_handles,
-            deletion_vectors: deletion_vectors_at_read,
-            position_deletes,
-            associated_files,
-            object_storage_cache: Some(self.object_storage_cache.clone()),
-            filesystem_accessor: Some(self.filesystem_accessor.clone()),
-            table_notifier: Some(self.table_notify.as_ref().unwrap().clone()),
-        })
     }
 }

--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -13,7 +13,6 @@ use crate::storage::compaction::table_compaction::{
     CompactedDataEntry, DataCompactionPayload, RemappedRecordLocation,
 };
 use crate::storage::filesystem::accessor::base_filesystem_accessor::BaseFileSystemAccess;
-use crate::storage::iceberg::puffin_utils::PuffinBlobRef;
 use crate::storage::index::{cache_utils as index_cache_utils, FileIndex};
 use crate::storage::mooncake_table::persistence_buffer::UnpersistedRecords;
 use crate::storage::mooncake_table::shared_array::SharedRowBufferSnapshot;
@@ -31,7 +30,7 @@ use crate::storage::storage_utils::{
 };
 use crate::storage::wal::wal_persistence_metadata::WalPersistenceMetadata;
 use crate::table_notify::TableEvent;
-use crate::{create_data_file, NonEvictableHandle};
+use crate::NonEvictableHandle;
 use more_asserts as ma;
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, HashSet};
@@ -209,208 +208,6 @@ impl SnapshotTableState {
         self.committed_deletion_log = new_committed_deletion_log;
     }
 
-    /// Update current mooncake snapshot with persisted deletion vector.
-    /// Return the evicted files to delete.
-    async fn update_deletion_vector_to_persisted(
-        &mut self,
-        puffin_blob_ref: HashMap<FileId, PuffinBlobRef>,
-    ) -> Vec<String> {
-        // Aggregate the evicted files to delete.
-        let mut evicted_files_to_delete = vec![];
-
-        for (file_id, puffin_blob_ref) in puffin_blob_ref.into_iter() {
-            let entry = self.current_snapshot.disk_files.get_mut(&file_id).unwrap();
-            // Unreference and delete old cache handle if any.
-            let old_puffin_blob = entry.puffin_deletion_blob.take();
-            if let Some(mut old_puffin_blob) = old_puffin_blob {
-                let cur_evicted_files = old_puffin_blob
-                    .puffin_file_cache_handle
-                    .unreference_and_delete()
-                    .await;
-                evicted_files_to_delete.extend(cur_evicted_files);
-            }
-            entry.puffin_deletion_blob = Some(puffin_blob_ref);
-        }
-
-        evicted_files_to_delete
-    }
-
-    /// Update disk files in the current snapshot from local data files to remote ones, meanwile unpin write-through cache file from object storage cache.
-    /// Provide [`persisted_data_files`] could come from imported new files, or maintenance jobs like compaction.
-    /// Return cache evicted files to delete.
-    async fn update_data_files_to_persisted(
-        &mut self,
-        persisted_data_files: Vec<MooncakeDataFileRef>,
-    ) -> Vec<String> {
-        // Aggregate evicted files to delete.
-        let mut evicted_files_to_delete = vec![];
-
-        if persisted_data_files.is_empty() {
-            return evicted_files_to_delete;
-        }
-
-        // Update disk file from local write through cache to iceberg persisted remote path.
-        // TODO(hjiang): We should be able to save some copies here.
-        for cur_data_file in persisted_data_files.iter() {
-            // Removing entry with [`cur_data_file`] and insert with the same key might be confusing, but here we're only using file id as key, but not filepath.
-            // So the real operation is: remove the entry with <old filepath> and insert with <new filepath>.
-            let mut disk_file_entry = self
-                .current_snapshot
-                .disk_files
-                .remove(cur_data_file)
-                .unwrap();
-            let cur_evicted_files = disk_file_entry
-                .cache_handle
-                .as_mut()
-                .unwrap()
-                .unreference_and_replace_with_remote(cur_data_file.file_path())
-                .await;
-            evicted_files_to_delete.extend(cur_evicted_files);
-            disk_file_entry.cache_handle = None;
-
-            self.current_snapshot
-                .disk_files
-                .insert(cur_data_file.clone(), disk_file_entry);
-        }
-
-        evicted_files_to_delete
-    }
-
-    /// Update file indices in the current snapshot from local data files to remote ones.
-    /// Return evicted files to delete.
-    ///
-    /// # Arguments
-    ///
-    /// * updated_file_ids: file ids which are updated by data files update, used to identify which file indices to remove.
-    /// * new_file_indices: newly persisted file indices, need to reflect the update to mooncake snapshot.
-    async fn update_file_indices_to_persisted(
-        &mut self,
-        mut new_file_indices: Vec<FileIndex>,
-        updated_file_ids: HashSet<FileId>,
-    ) -> Vec<String> {
-        if new_file_indices.is_empty() && updated_file_ids.is_empty() {
-            return vec![];
-        }
-
-        // Update file indice from local write through cache to iceberg persisted remote path.
-        // TODO(hjiang): For better update performance, we might need to use hash set instead vector to store file indices.
-        let cur_file_indices = std::mem::take(&mut self.current_snapshot.indices.file_indices);
-        let mut updated_file_indices = Vec::with_capacity(cur_file_indices.len());
-        for cur_file_index in cur_file_indices.into_iter() {
-            let mut skip = false;
-            let referenced_data_files = &cur_file_index.files;
-            for cur_data_file in referenced_data_files.iter() {
-                if updated_file_ids.contains(&cur_data_file.file_id()) {
-                    skip = true;
-                    break;
-                }
-            }
-
-            // If one referenced file gets updated, all others should get updated.
-            #[cfg(test)]
-            if skip {
-                for cur_data_file in referenced_data_files.iter() {
-                    assert!(updated_file_ids.contains(&cur_data_file.file_id()));
-                }
-            }
-
-            if !skip {
-                updated_file_indices.push(cur_file_index);
-            }
-        }
-
-        // Aggregate evicted files to delete.
-        let mut evicted_files_to_delete = vec![];
-
-        // For newly persisted index block files, attempt local filesystem optimization to replace local cache filepath to remote if applicable.
-        // At this point, all index block files are at an inconsistent state, which have their
-        // - file path pointing to remote path
-        // - cache handle pinned and refers to local cache file path
-        for cur_file_index in new_file_indices.iter_mut() {
-            for cur_index_block in cur_file_index.index_blocks.iter_mut() {
-                // All index block files have their cache handle pinned in cache.
-                let cur_evicted_files = cur_index_block
-                    .cache_handle
-                    .as_mut()
-                    .unwrap()
-                    .replace_with_remote(cur_index_block.index_file.file_path())
-                    .await;
-                evicted_files_to_delete.extend(cur_evicted_files);
-
-                // Reset the index block to be local cache file, to keep it consistent.
-                cur_index_block.index_file = create_data_file(
-                    cur_index_block.index_file.file_id().0,
-                    cur_index_block
-                        .cache_handle
-                        .as_ref()
-                        .unwrap()
-                        .cache_entry
-                        .cache_filepath
-                        .to_string(),
-                );
-            }
-        }
-        updated_file_indices.extend(new_file_indices);
-        self.current_snapshot.indices.file_indices = updated_file_indices;
-
-        evicted_files_to_delete
-    }
-
-    /// Update current snapshot with iceberg persistence result.
-    /// Before iceberg snapshot, mooncake snapshot records local write through cache in disk file (which is local filepath).
-    /// After a successful iceberg snapshot, update current snapshot's disk files and file indices to reference to remote paths,
-    /// also import local write through cache to globally managed object storage cache, so they could be pinned and evicted when necessary.
-    ///
-    /// Return evicted data files to delete when unreference existing disk file entries.
-    async fn update_snapshot_by_iceberg_snapshot(&mut self, task: &SnapshotTask) -> Vec<String> {
-        // Aggregate evicted files to delete.
-        let mut evicted_files_to_delete = vec![];
-
-        // Get persisted data files and file indices.
-        // TODO(hjiang): Revisit whether we need separate fields in snapshot task.
-        let persisted_data_files = task
-            .iceberg_persisted_records
-            .get_data_files_to_reflect_persistence();
-        let (index_blocks_to_remove, persisted_file_indices) = task
-            .iceberg_persisted_records
-            .get_file_indices_to_reflect_persistence();
-
-        // Record data files number and file indices number for persistence reflection, which is not supposed to change.
-        let old_data_files_count = self.current_snapshot.disk_files.len();
-        let old_file_indices_count = self.current_snapshot.indices.file_indices.len();
-
-        // Step-1: Handle persisted data files.
-        let cur_evicted_files = self
-            .update_data_files_to_persisted(persisted_data_files)
-            .await;
-        evicted_files_to_delete.extend(cur_evicted_files);
-
-        // Step-2: Handle persisted file indices.
-        let cur_evicted_files = self
-            .update_file_indices_to_persisted(persisted_file_indices, index_blocks_to_remove)
-            .await;
-        evicted_files_to_delete.extend(cur_evicted_files);
-
-        // Step-3: Handle persisted deletion vector.
-        let cur_evicted_files = self
-            .update_deletion_vector_to_persisted(
-                task.iceberg_persisted_records
-                    .import_result
-                    .puffin_blob_ref
-                    .clone(),
-            )
-            .await;
-        evicted_files_to_delete.extend(cur_evicted_files);
-
-        // Check data files number and file indices number don't change after persistence reflection.
-        let new_data_files_count = self.current_snapshot.disk_files.len();
-        let new_file_indices_count = self.current_snapshot.indices.file_indices.len();
-        assert_eq!(old_data_files_count, new_data_files_count);
-        assert_eq!(old_file_indices_count, new_file_indices_count);
-
-        evicted_files_to_delete
-    }
-
     /// Util function to decide whether to create iceberg snapshot by deletion vectors.
     fn create_iceberg_snapshot_by_committed_logs(&self, force_create: bool) -> bool {
         let deletion_record_snapshot_threshold = if !force_create {
@@ -425,7 +222,7 @@ impl SnapshotTableState {
 
     /// Update current snapshot's file indices by adding and removing a few.
     #[allow(clippy::mutable_key_type)]
-    async fn update_file_indices_to_mooncake_snapshot_impl(
+    pub(super) async fn update_file_indices_to_mooncake_snapshot_impl(
         &mut self,
         mut old_file_indices: HashSet<FileIndex>,
         new_file_indices: Vec<FileIndex>,
@@ -474,7 +271,7 @@ impl SnapshotTableState {
     // Update current snapshot's data files by adding and removing a few, generated by data compaction.
     // Here new data files are all local data files, which will be uploaded to remote by importing into iceberg table.
     // Return evicted data files from the object storage cache to delete.
-    async fn update_data_files_to_mooncake_snapshot_impl(
+    pub(super) async fn update_data_files_to_mooncake_snapshot_impl(
         &mut self,
         old_data_files: HashSet<MooncakeDataFileRef>,
         new_data_files: Vec<(MooncakeDataFileRef, CompactedDataEntry)>,
@@ -589,62 +386,6 @@ impl SnapshotTableState {
         evicted_files_to_delete
     }
 
-    /// Return evicted files to delete.
-    async fn update_file_indices_merge_to_mooncake_snapshot(
-        &mut self,
-        task: &SnapshotTask,
-    ) -> Vec<String> {
-        self.update_file_indices_to_mooncake_snapshot_impl(
-            task.index_merge_result.old_file_indices.clone(),
-            task.index_merge_result.new_file_indices.clone(),
-        )
-        .await
-    }
-
-    /// Reflect data compaction results to mooncake snapshot.
-    /// Return evicted data files to delete due to data compaction.
-    async fn update_data_compaction_to_mooncake_snapshot(
-        &mut self,
-        task: &SnapshotTask,
-    ) -> Vec<String> {
-        // Aggregate evicted files to delete.
-        let mut evicted_files_to_delete = vec![];
-
-        if task.data_compaction_result.is_empty() {
-            return vec![];
-        }
-
-        // NOTICE: Update data files before file indices, so when update file indices, data files for new file indices already exist in disk files map.
-        let data_compaction_res = task.data_compaction_result.clone();
-        let cur_evicted_files = self
-            .update_data_files_to_mooncake_snapshot_impl(
-                data_compaction_res.old_data_files,
-                data_compaction_res.new_data_files,
-                data_compaction_res.remapped_data_files,
-            )
-            .await;
-        evicted_files_to_delete.extend(cur_evicted_files);
-
-        let cur_evicted_files = self
-            .update_file_indices_to_mooncake_snapshot_impl(
-                data_compaction_res.old_file_indices,
-                data_compaction_res.new_file_indices,
-            )
-            .await;
-        evicted_files_to_delete.extend(cur_evicted_files);
-
-        // Apply evicted data files to delete within data compaction process.
-        evicted_files_to_delete.extend(
-            task.data_compaction_result
-                .evicted_files_to_delete
-                .iter()
-                .cloned()
-                .to_owned(),
-        );
-
-        evicted_files_to_delete
-    }
-
     /// Remap single record location after compaction.
     /// Return if remap succeeds.
     fn remap_record_location_after_compaction(
@@ -754,7 +495,10 @@ impl SnapshotTableState {
 
     /// Unreference pinned cache handles used in read operations.
     /// Return evicted data files to delete.
-    async fn unreference_read_cache_handles(&mut self, task: &mut SnapshotTask) -> Vec<String> {
+    pub(super) async fn unreference_read_cache_handles(
+        &mut self,
+        task: &mut SnapshotTask,
+    ) -> Vec<String> {
         // Aggregate evicted data files to delete.
         let mut evicted_files_to_delete = vec![];
 
@@ -764,16 +508,6 @@ impl SnapshotTableState {
         }
 
         evicted_files_to_delete
-    }
-
-    /// Take read request result and update mooncake snapshot.
-    /// Return evicted data files to delete.
-    async fn update_snapshot_by_read_request_results(
-        &mut self,
-        task: &mut SnapshotTask,
-    ) -> Vec<String> {
-        // Unpin cached files used in the read request.
-        self.unreference_read_cache_handles(task).await
     }
 
     /// Unreference all pinned data files.

--- a/src/moonlink/src/storage/mooncake_table/snapshot_cache_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot_cache_utils.rs
@@ -1,0 +1,117 @@
+use crate::storage::index::cache_utils as index_cache_utils;
+/// This file contains cache related snapshot functions.
+use crate::storage::mooncake_table::transaction_stream::TransactionStreamOutput;
+use crate::storage::mooncake_table::SnapshotTableState;
+use crate::storage::mooncake_table::SnapshotTask;
+use crate::storage::storage_utils::TableId;
+
+impl SnapshotTableState {
+    /// Unreference pinned cache handles used in read operations.
+    /// Return evicted data files to delete.
+    pub(super) async fn unreference_read_cache_handles(
+        &mut self,
+        task: &mut SnapshotTask,
+    ) -> Vec<String> {
+        // Aggregate evicted data files to delete.
+        let mut evicted_files_to_delete = vec![];
+
+        for cur_cache_handle in task.read_cache_handles.iter_mut() {
+            let cur_evicted_files = cur_cache_handle.unreference().await;
+            evicted_files_to_delete.extend(cur_evicted_files);
+        }
+
+        evicted_files_to_delete
+    }
+
+    /// Unreference all pinned data files.
+    /// Return all evicted files to evict
+    pub(crate) async fn unreference_and_delete_all_cache_handles(&mut self) -> Vec<String> {
+        // Aggregate evicted files to delete.
+        let mut evicted_files_to_delete = vec![];
+
+        // Unreference and delete data files and puffin files.
+        for (_, disk_file_entry) in self.current_snapshot.disk_files.iter_mut() {
+            // Handle data files.
+            let cache_handle = &mut disk_file_entry.cache_handle;
+            if let Some(cache_handle) = cache_handle {
+                let cur_evicted_files = cache_handle.unreference_and_delete().await;
+                evicted_files_to_delete.extend(cur_evicted_files);
+            }
+            // Handle puffin files.
+            if let Some(puffin_file) = &mut disk_file_entry.puffin_deletion_blob {
+                let cur_evicted_files = puffin_file
+                    .puffin_file_cache_handle
+                    .unreference_and_delete()
+                    .await;
+                evicted_files_to_delete.extend(cur_evicted_files);
+            }
+        }
+
+        // Unreference and delete file indices.
+        for cur_file_index in self.current_snapshot.indices.file_indices.iter_mut() {
+            for cur_index_block in cur_file_index.index_blocks.iter_mut() {
+                let cur_evicted_files = cur_index_block
+                    .cache_handle
+                    .as_mut()
+                    .unwrap()
+                    .unreference_and_delete()
+                    .await;
+                evicted_files_to_delete.extend(cur_evicted_files);
+            }
+        }
+
+        evicted_files_to_delete
+    }
+
+    /// Import batch write and stream file indices into cache.
+    /// Return evicted files to delete.
+    pub(super) async fn import_file_indices_into_cache(
+        &mut self,
+        task: &mut SnapshotTask,
+    ) -> Vec<String> {
+        let table_id = TableId(self.mooncake_table_metadata.table_id);
+
+        // Aggregate evicted files to delete.
+        let mut evicted_files_to_delete = vec![];
+
+        // Import batch write file indices.
+        for cur_disk_slice in task.new_disk_slices.iter_mut() {
+            let cur_evicted_files = cur_disk_slice
+                .import_file_indices_to_cache(self.object_storage_cache.clone(), table_id)
+                .await;
+            evicted_files_to_delete.extend(cur_evicted_files);
+        }
+
+        // Import stream write file indices.
+        for cur_stream in task.new_streaming_xact.iter_mut() {
+            if let TransactionStreamOutput::Commit(commit) = cur_stream {
+                let cur_evicted_files = commit
+                    .import_file_index_into_cache(self.object_storage_cache.clone(), table_id)
+                    .await;
+                evicted_files_to_delete.extend(cur_evicted_files);
+            }
+        }
+
+        // Import new compacted file indices.
+        let new_file_indices_by_index_merge = &mut task.index_merge_result.new_file_indices;
+        let cur_evicted_files = index_cache_utils::import_file_indices_to_cache(
+            new_file_indices_by_index_merge,
+            self.object_storage_cache.clone(),
+            table_id,
+        )
+        .await;
+        evicted_files_to_delete.extend(cur_evicted_files);
+
+        // Import new merged file indices.
+        let new_file_indices_by_data_compaction = &mut task.data_compaction_result.new_file_indices;
+        let cur_evicted_files = index_cache_utils::import_file_indices_to_cache(
+            new_file_indices_by_data_compaction,
+            self.object_storage_cache.clone(),
+            table_id,
+        )
+        .await;
+        evicted_files_to_delete.extend(cur_evicted_files);
+
+        evicted_files_to_delete
+    }
+}

--- a/src/moonlink/src/storage/mooncake_table/snapshot_persistence.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot_persistence.rs
@@ -1,0 +1,216 @@
+use crate::create_data_file;
+use crate::storage::iceberg::puffin_utils::PuffinBlobRef;
+use crate::storage::index::FileIndex;
+use crate::storage::mooncake_table::SnapshotTask;
+use crate::storage::storage_utils::FileId;
+use crate::storage::storage_utils::MooncakeDataFileRef;
+/// This file stores snapshot persistence related features.
+use crate::storage::SnapshotTableState;
+use std::collections::{HashMap, HashSet};
+
+impl SnapshotTableState {
+    /// Update disk files in the current snapshot from local data files to remote ones, meanwile unpin write-through cache file from object storage cache.
+    /// Provide [`persisted_data_files`] could come from imported new files, or maintenance jobs like compaction.
+    /// Return cache evicted files to delete.
+    async fn update_data_files_to_persisted(
+        &mut self,
+        persisted_data_files: Vec<MooncakeDataFileRef>,
+    ) -> Vec<String> {
+        // Aggregate evicted files to delete.
+        let mut evicted_files_to_delete = vec![];
+
+        if persisted_data_files.is_empty() {
+            return evicted_files_to_delete;
+        }
+
+        // Update disk file from local write through cache to iceberg persisted remote path.
+        // TODO(hjiang): We should be able to save some copies here.
+        for cur_data_file in persisted_data_files.iter() {
+            // Removing entry with [`cur_data_file`] and insert with the same key might be confusing, but here we're only using file id as key, but not filepath.
+            // So the real operation is: remove the entry with <old filepath> and insert with <new filepath>.
+            let mut disk_file_entry = self
+                .current_snapshot
+                .disk_files
+                .remove(cur_data_file)
+                .unwrap();
+            let cur_evicted_files = disk_file_entry
+                .cache_handle
+                .as_mut()
+                .unwrap()
+                .unreference_and_replace_with_remote(cur_data_file.file_path())
+                .await;
+            evicted_files_to_delete.extend(cur_evicted_files);
+            disk_file_entry.cache_handle = None;
+
+            self.current_snapshot
+                .disk_files
+                .insert(cur_data_file.clone(), disk_file_entry);
+        }
+
+        evicted_files_to_delete
+    }
+
+    /// Update file indices in the current snapshot from local data files to remote ones.
+    /// Return evicted files to delete.
+    ///
+    /// # Arguments
+    ///
+    /// * updated_file_ids: file ids which are updated by data files update, used to identify which file indices to remove.
+    /// * new_file_indices: newly persisted file indices, need to reflect the update to mooncake snapshot.
+    async fn update_file_indices_to_persisted(
+        &mut self,
+        mut new_file_indices: Vec<FileIndex>,
+        updated_file_ids: HashSet<FileId>,
+    ) -> Vec<String> {
+        if new_file_indices.is_empty() && updated_file_ids.is_empty() {
+            return vec![];
+        }
+
+        // Update file indice from local write through cache to iceberg persisted remote path.
+        // TODO(hjiang): For better update performance, we might need to use hash set instead vector to store file indices.
+        let cur_file_indices = std::mem::take(&mut self.current_snapshot.indices.file_indices);
+        let mut updated_file_indices = Vec::with_capacity(cur_file_indices.len());
+        for cur_file_index in cur_file_indices.into_iter() {
+            let mut skip = false;
+            let referenced_data_files = &cur_file_index.files;
+            for cur_data_file in referenced_data_files.iter() {
+                if updated_file_ids.contains(&cur_data_file.file_id()) {
+                    skip = true;
+                    break;
+                }
+            }
+
+            // If one referenced file gets updated, all others should get updated.
+            #[cfg(test)]
+            if skip {
+                for cur_data_file in referenced_data_files.iter() {
+                    assert!(updated_file_ids.contains(&cur_data_file.file_id()));
+                }
+            }
+
+            if !skip {
+                updated_file_indices.push(cur_file_index);
+            }
+        }
+
+        // Aggregate evicted files to delete.
+        let mut evicted_files_to_delete = vec![];
+
+        // For newly persisted index block files, attempt local filesystem optimization to replace local cache filepath to remote if applicable.
+        // At this point, all index block files are at an inconsistent state, which have their
+        // - file path pointing to remote path
+        // - cache handle pinned and refers to local cache file path
+        for cur_file_index in new_file_indices.iter_mut() {
+            for cur_index_block in cur_file_index.index_blocks.iter_mut() {
+                // All index block files have their cache handle pinned in cache.
+                let cur_evicted_files = cur_index_block
+                    .cache_handle
+                    .as_mut()
+                    .unwrap()
+                    .replace_with_remote(cur_index_block.index_file.file_path())
+                    .await;
+                evicted_files_to_delete.extend(cur_evicted_files);
+
+                // Reset the index block to be local cache file, to keep it consistent.
+                cur_index_block.index_file = create_data_file(
+                    cur_index_block.index_file.file_id().0,
+                    cur_index_block
+                        .cache_handle
+                        .as_ref()
+                        .unwrap()
+                        .cache_entry
+                        .cache_filepath
+                        .to_string(),
+                );
+            }
+        }
+        updated_file_indices.extend(new_file_indices);
+        self.current_snapshot.indices.file_indices = updated_file_indices;
+
+        evicted_files_to_delete
+    }
+
+    /// Update current mooncake snapshot with persisted deletion vector.
+    /// Return the evicted files to delete.
+    async fn update_deletion_vector_to_persisted(
+        &mut self,
+        puffin_blob_ref: HashMap<FileId, PuffinBlobRef>,
+    ) -> Vec<String> {
+        // Aggregate the evicted files to delete.
+        let mut evicted_files_to_delete = vec![];
+
+        for (file_id, puffin_blob_ref) in puffin_blob_ref.into_iter() {
+            let entry = self.current_snapshot.disk_files.get_mut(&file_id).unwrap();
+            // Unreference and delete old cache handle if any.
+            let old_puffin_blob = entry.puffin_deletion_blob.take();
+            if let Some(mut old_puffin_blob) = old_puffin_blob {
+                let cur_evicted_files = old_puffin_blob
+                    .puffin_file_cache_handle
+                    .unreference_and_delete()
+                    .await;
+                evicted_files_to_delete.extend(cur_evicted_files);
+            }
+            entry.puffin_deletion_blob = Some(puffin_blob_ref);
+        }
+
+        evicted_files_to_delete
+    }
+
+    /// Update current snapshot with iceberg persistence result.
+    /// Before iceberg snapshot, mooncake snapshot records local write through cache in disk file (which is local filepath).
+    /// After a successful iceberg snapshot, update current snapshot's disk files and file indices to reference to remote paths,
+    /// also import local write through cache to globally managed object storage cache, so they could be pinned and evicted when necessary.
+    ///
+    /// Return evicted data files to delete when unreference existing disk file entries.
+    pub(super) async fn update_snapshot_by_iceberg_snapshot(
+        &mut self,
+        task: &SnapshotTask,
+    ) -> Vec<String> {
+        // Aggregate evicted files to delete.
+        let mut evicted_files_to_delete = vec![];
+
+        // Get persisted data files and file indices.
+        // TODO(hjiang): Revisit whether we need separate fields in snapshot task.
+        let persisted_data_files = task
+            .iceberg_persisted_records
+            .get_data_files_to_reflect_persistence();
+        let (index_blocks_to_remove, persisted_file_indices) = task
+            .iceberg_persisted_records
+            .get_file_indices_to_reflect_persistence();
+
+        // Record data files number and file indices number for persistence reflection, which is not supposed to change.
+        let old_data_files_count = self.current_snapshot.disk_files.len();
+        let old_file_indices_count = self.current_snapshot.indices.file_indices.len();
+
+        // Step-1: Handle persisted data files.
+        let cur_evicted_files = self
+            .update_data_files_to_persisted(persisted_data_files)
+            .await;
+        evicted_files_to_delete.extend(cur_evicted_files);
+
+        // Step-2: Handle persisted file indices.
+        let cur_evicted_files = self
+            .update_file_indices_to_persisted(persisted_file_indices, index_blocks_to_remove)
+            .await;
+        evicted_files_to_delete.extend(cur_evicted_files);
+
+        // Step-3: Handle persisted deletion vector.
+        let cur_evicted_files = self
+            .update_deletion_vector_to_persisted(
+                task.iceberg_persisted_records
+                    .import_result
+                    .puffin_blob_ref
+                    .clone(),
+            )
+            .await;
+        evicted_files_to_delete.extend(cur_evicted_files);
+
+        // Check data files number and file indices number don't change after persistence reflection.
+        let new_data_files_count = self.current_snapshot.disk_files.len();
+        let new_file_indices_count = self.current_snapshot.indices.file_indices.len();
+        assert_eq!(old_data_files_count, new_data_files_count);
+        assert_eq!(old_file_indices_count, new_file_indices_count);
+
+        evicted_files_to_delete
+    }
+}

--- a/src/moonlink/src/storage/mooncake_table/snapshot_persistence.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot_persistence.rs
@@ -18,6 +18,18 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 impl SnapshotTableState {
+    /// Util function to decide whether to create iceberg snapshot by deletion vectors.
+    pub(super) fn create_iceberg_snapshot_by_committed_logs(&self, force_create: bool) -> bool {
+        let deletion_record_snapshot_threshold = if !force_create {
+            self.mooncake_table_metadata
+                .config
+                .iceberg_snapshot_new_committed_deletion_log()
+        } else {
+            1
+        };
+        self.committed_deletion_log.len() >= deletion_record_snapshot_threshold
+    }
+
     pub(super) fn get_iceberg_snapshot_payload(
         &self,
         flush_lsn: u64,

--- a/src/moonlink/src/storage/mooncake_table/snapshot_read.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot_read.rs
@@ -1,0 +1,144 @@
+use super::data_batches::create_batch_from_rows;
+use crate::error::Result;
+use crate::storage::mooncake_table::snapshot::SnapshotTableState;
+use crate::storage::mooncake_table::snapshot_read_output::{
+    DataFileForRead, ReadOutput as SnapshotReadOutput,
+};
+use crate::storage::mooncake_table::table_state::TableSnapshotState;
+use crate::storage::storage_utils::RecordLocation;
+use arrow_schema::Schema;
+use parquet::arrow::AsyncArrowWriter;
+use parquet::basic::{Compression, Encoding};
+use parquet::file::properties::WriterProperties;
+use std::sync::Arc;
+
+impl SnapshotTableState {
+    /// =======================
+    /// Read snapshot schema
+    /// =======================
+    ///
+    pub(crate) fn get_table_schema(&self) -> Result<Arc<Schema>> {
+        Ok(self.mooncake_table_metadata.schema.clone())
+    }
+
+    /// =======================
+    /// Read snapshot states
+    /// =======================
+    ///
+    pub(crate) fn get_table_snapshot_states(&self) -> Result<TableSnapshotState> {
+        Ok(TableSnapshotState {
+            table_commit_lsn: self.current_snapshot.snapshot_version,
+            iceberg_flush_lsn: self.current_snapshot.data_file_flush_lsn,
+        })
+    }
+
+    /// =======================
+    /// Read snapshot
+    /// =======================
+    ///
+    /// Util function to get read state, which returns all current data files information.
+    /// If a data file already has a pinned reference, increment the reference count directly to avoid unnecessary IO.
+    async fn get_read_files_for_read(&mut self) -> Vec<DataFileForRead> {
+        let mut data_files_for_read = Vec::with_capacity(self.current_snapshot.disk_files.len());
+        for (file, _) in self.current_snapshot.disk_files.iter() {
+            let unique_table_file_id = self.get_table_unique_file_id(file.file_id());
+            data_files_for_read.push(DataFileForRead::RemoteFilePath((
+                unique_table_file_id,
+                file.file_path().to_string(),
+            )));
+        }
+
+        data_files_for_read
+    }
+
+    pub(crate) async fn request_read(&mut self) -> Result<SnapshotReadOutput> {
+        let mut data_file_paths = self.get_read_files_for_read().await;
+        let mut associated_files = Vec::new();
+        let (puffin_cache_handles, deletion_vectors_at_read, position_deletes) =
+            self.get_deletion_records().await;
+
+        // For committed but not persisted records, we create a temporary file for them, which gets deleted after query completion.
+        let file_path = self.current_snapshot.get_name_for_inmemory_file();
+        let filepath_exists = tokio::fs::try_exists(&file_path).await?;
+        if filepath_exists {
+            data_file_paths.push(DataFileForRead::TemporaryDataFile(
+                file_path.to_string_lossy().to_string(),
+            ));
+            associated_files.push(file_path.to_string_lossy().to_string());
+            return Ok(SnapshotReadOutput {
+                data_file_paths,
+                puffin_cache_handles,
+                deletion_vectors: deletion_vectors_at_read,
+                position_deletes,
+                associated_files,
+                object_storage_cache: Some(self.object_storage_cache.clone()),
+                filesystem_accessor: Some(self.filesystem_accessor.clone()),
+                table_notifier: Some(self.table_notify.as_ref().unwrap().clone()),
+            });
+        }
+
+        assert!(matches!(
+            self.last_commit,
+            RecordLocation::MemoryBatch(_, _)
+        ));
+        let (batch_id, row_id) = self.last_commit.clone().into();
+        if batch_id > 0 || row_id > 0 {
+            // add all batches
+            let mut filtered_batches = Vec::new();
+            let schema = self.current_snapshot.metadata.schema.clone();
+            for (id, batch) in self.batches.iter() {
+                if *id < batch_id {
+                    if let Some(filtered_batch) = batch.get_filtered_batch()? {
+                        filtered_batches.push(filtered_batch);
+                    }
+                } else if *id == batch_id && row_id > 0 {
+                    if batch.data.is_some() {
+                        if let Some(filtered_batch) = batch.get_filtered_batch_with_limit(row_id)? {
+                            filtered_batches.push(filtered_batch);
+                        }
+                    } else {
+                        let rows = self.rows.as_ref().unwrap().get_buffer(row_id);
+                        let deletions = &self
+                            .batches
+                            .values()
+                            .last()
+                            .expect("batch not found")
+                            .deletions;
+                        let batch = create_batch_from_rows(rows, schema.clone(), deletions);
+                        filtered_batches.push(batch);
+                    }
+                }
+            }
+
+            // TODO(hjiang): Check whether we could avoid IO operation inside of critical section.
+            if !filtered_batches.is_empty() {
+                // Build a parquet file from current record batches
+                let temp_file = tokio::fs::File::create(&file_path).await?;
+                let props = WriterProperties::builder()
+                    .set_compression(Compression::UNCOMPRESSED)
+                    .set_dictionary_enabled(false)
+                    .set_encoding(Encoding::PLAIN)
+                    .build();
+                let mut parquet_writer = AsyncArrowWriter::try_new(temp_file, schema, Some(props))?;
+                for batch in filtered_batches.iter() {
+                    parquet_writer.write(batch).await?;
+                }
+                parquet_writer.close().await?;
+                data_file_paths.push(DataFileForRead::TemporaryDataFile(
+                    file_path.to_string_lossy().to_string(),
+                ));
+                associated_files.push(file_path.to_string_lossy().to_string());
+            }
+        }
+        Ok(SnapshotReadOutput {
+            data_file_paths,
+            puffin_cache_handles,
+            deletion_vectors: deletion_vectors_at_read,
+            position_deletes,
+            associated_files,
+            object_storage_cache: Some(self.object_storage_cache.clone()),
+            filesystem_accessor: Some(self.filesystem_accessor.clone()),
+            table_notifier: Some(self.table_notify.as_ref().unwrap().clone()),
+        })
+    }
+}

--- a/src/moonlink/src/storage/mooncake_table/snapshot_read.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot_read.rs
@@ -5,6 +5,7 @@ use crate::storage::mooncake_table::snapshot_read_output::{
     DataFileForRead, ReadOutput as SnapshotReadOutput,
 };
 use crate::storage::mooncake_table::table_state::TableSnapshotState;
+use crate::storage::mooncake_table::SnapshotTask;
 use crate::storage::storage_utils::RecordLocation;
 use arrow_schema::Schema;
 use parquet::arrow::AsyncArrowWriter;
@@ -140,5 +141,15 @@ impl SnapshotTableState {
             filesystem_accessor: Some(self.filesystem_accessor.clone()),
             table_notifier: Some(self.table_notify.as_ref().unwrap().clone()),
         })
+    }
+
+    /// Take read request result and update mooncake snapshot.
+    /// Return evicted data files to delete.
+    pub(super) async fn update_snapshot_by_read_request_results(
+        &mut self,
+        task: &mut SnapshotTask,
+    ) -> Vec<String> {
+        // Unpin cached files used in the read request.
+        self.unreference_read_cache_handles(task).await
     }
 }


### PR DESCRIPTION
## Summary

This PR is a no-op refactoring PR.

Motivation: I'm trying to do some refactoring on snapshot code, but find it painful to jump between functions (`snapshot.rs` is ~1500LOC).
In this PR, I split snapshot update logic into several parts, like persistence related, table maintenance related, etc.
Each of these split components are roughly 200-300 loc, which is much much easier to read.

I might consider further to split them into separate classes, but the obstacle is several util functions and common functions.

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
