### PR TITLE
[storage] Add basic chaos test

### DIFF
--- a/src/moonlink/Cargo.toml
+++ b/src/moonlink/Cargo.toml
@@ -33,6 +33,8 @@ storage-gcs = [
 
 bench = []
 
+chaos-test = []
+
 [dependencies]
 ahash = "0.8.11"
 arrow = { workspace = true }

--- a/src/moonlink/src/row/moonlink_row.rs
+++ b/src/moonlink/src/row/moonlink_row.rs
@@ -8,7 +8,7 @@ use parquet::arrow::ProjectionMask;
 use std::hash::{Hash, Hasher};
 use std::mem::take;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct MoonlinkRow {
     pub values: Vec<RowValue>,
 }
@@ -182,9 +182,7 @@ impl MoonlinkRow {
         let batch = batch_reader.next().unwrap().unwrap();
         self.equals_record_batch_at_offset_impl(&batch, 0)
     }
-}
 
-impl MoonlinkRow {
     pub fn equals_moonlink_row(&self, other: &Self, identity: &IdentityProp) -> bool {
         match identity {
             IdentityProp::Keys(keys) => {
@@ -297,12 +295,6 @@ mod tests {
     use arrow_array::{Int32Array, Int64Array};
     use parquet::{arrow::AsyncArrowWriter, file::properties::WriterProperties};
     use tempfile::tempdir;
-
-    impl Clone for MoonlinkRow {
-        fn clone(&self) -> Self {
-            MoonlinkRow::new(self.values.clone())
-        }
-    }
 
     #[test]
     fn test_equals_full_row_with_identity() {

--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -737,7 +737,7 @@ impl MooncakeTable {
         }
 
         assert!(self.iceberg_table_manager.is_none());
-        self.iceberg_table_manager = Some(iceberg_snapshot_res.table_manager);
+        self.iceberg_table_manager = Some(iceberg_snapshot_res.table_manager.unwrap());
 
         // ---- Buffer iceberg persisted content to next snapshot task ---
         assert!(self
@@ -1177,7 +1177,7 @@ impl MooncakeTable {
         );
 
         let snapshot_result = IcebergSnapshotResult {
-            table_manager: iceberg_table_manager,
+            table_manager: Some(iceberg_table_manager),
             flush_lsn,
             wal_persisted_metadata,
             new_table_schema,

--- a/src/moonlink/src/storage/mooncake_table/table_creation_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_creation_test_utils.rs
@@ -272,13 +272,13 @@ pub(crate) async fn create_mooncake_table_and_notify_for_compaction(
     (table, notify_rx)
 }
 
-/// Test util function to create mooncake table and table notify.
-pub(crate) async fn create_mooncake_table_and_notify(
+/// Test util function to create mooncake table.
+pub(crate) async fn create_mooncake_table(
     mooncake_table_metadata: Arc<MooncakeTableMetadata>,
     iceberg_table_config: IcebergTableConfig,
     object_storage_cache: ObjectStorageCache,
-) -> (MooncakeTable, Receiver<TableEvent>) {
-    let mut table = MooncakeTable::new(
+) -> MooncakeTable {
+    let table = MooncakeTable::new(
         create_test_arrow_schema().as_ref().clone(),
         ICEBERG_TEST_TABLE.to_string(),
         /*version=*/ TEST_TABLE_ID.0,
@@ -292,6 +292,21 @@ pub(crate) async fn create_mooncake_table_and_notify(
     .await
     .unwrap();
 
+    table
+}
+
+/// Test util function to create mooncake table and table notify.
+pub(crate) async fn create_mooncake_table_and_notify(
+    mooncake_table_metadata: Arc<MooncakeTableMetadata>,
+    iceberg_table_config: IcebergTableConfig,
+    object_storage_cache: ObjectStorageCache,
+) -> (MooncakeTable, Receiver<TableEvent>) {
+    let mut table = create_mooncake_table(
+        mooncake_table_metadata,
+        iceberg_table_config,
+        object_storage_cache,
+    )
+    .await;
     let (notify_tx, notify_rx) = mpsc::channel(100);
     table.register_table_notify(notify_tx).await;
 

--- a/src/moonlink/src/storage/mooncake_table/table_snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_snapshot.rs
@@ -323,6 +323,20 @@ pub struct IcebergSnapshotResult {
     pub(crate) data_compaction_result: IcebergSnapshotDataCompactionResult,
 }
 
+impl Clone for IcebergSnapshotResult {
+    fn clone(&self) -> Self {
+        IcebergSnapshotResult {
+            table_manager: None,
+            flush_lsn: self.flush_lsn,
+            wal_persisted_metadata: self.wal_persisted_metadata.clone(),
+            new_table_schema: self.new_table_schema.clone(),
+            import_result: self.import_result.clone(),
+            index_merge_result: self.index_merge_result.clone(),
+            data_compaction_result: self.data_compaction_result.clone(),
+        }
+    }
+}
+
 impl IcebergSnapshotResult {
     /// Return whether iceberg snapshot result contains table maintenance persistence result.
     pub fn contains_maintanence_result(&self) -> bool {

--- a/src/moonlink/src/storage/mooncake_table/table_snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_snapshot.rs
@@ -32,7 +32,7 @@ fn get_index_block_files_impl(file_indices: &Vec<MooncakeFileIndex>) -> Vec<Moon
 ////////////////////////////
 ///
 /// Iceberg snapshot payload by write operations.
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct IcebergSnapshotImportPayload {
     /// New data files to introduce to the iceberg table.
     pub(crate) data_files: Vec<MooncakeDataFileRef>,
@@ -59,7 +59,7 @@ impl std::fmt::Debug for IcebergSnapshotImportPayload {
 }
 
 /// Iceberg snapshot payload by index merge operations.
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct IcebergSnapshotIndexMergePayload {
     /// New file indices to import to the iceberg table.
     pub(crate) new_file_indices_to_import: Vec<MooncakeFileIndex>,
@@ -135,7 +135,7 @@ impl IcebergSnapshotDataCompactionPayload {
     }
 }
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct IcebergSnapshotPayload {
     /// Flush LSN.
     pub(crate) flush_lsn: u64,
@@ -308,7 +308,7 @@ impl std::fmt::Debug for IcebergSnapshotDataCompactionResult {
 
 pub struct IcebergSnapshotResult {
     /// Table manager is (1) not `Sync` safe; (2) only used at iceberg snapshot creation, so we `move` it around every snapshot.
-    pub(crate) table_manager: Box<dyn TableManager>,
+    pub(crate) table_manager: Option<Box<dyn TableManager>>,
     /// Iceberg flush LSN.
     pub(crate) flush_lsn: u64,
     /// Iceberg WAL persistence.

--- a/src/moonlink/src/table_handler.rs
+++ b/src/moonlink/src/table_handler.rs
@@ -911,3 +911,6 @@ mod test_utils;
 
 #[cfg(test)]
 mod failure_tests;
+
+#[cfg(test)]
+mod chaos_test;

--- a/src/moonlink/src/table_handler/chaos_test.rs
+++ b/src/moonlink/src/table_handler/chaos_test.rs
@@ -17,7 +17,6 @@ use rand::prelude::*;
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 use std::collections::VecDeque;
-use std::panic::{catch_unwind, AssertUnwindSafe};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tempfile::{tempdir, TempDir};
 use tokio::sync::mpsc::{self, Sender};

--- a/src/moonlink/src/table_handler/chaos_test.rs
+++ b/src/moonlink/src/table_handler/chaos_test.rs
@@ -229,7 +229,7 @@ async fn test_chaos() {
     if let Err(e) = task_result {
         // Display all enqueued events for debugging and replay.
         while let Some(cur_event) = env.event_replay_rx.recv().await {
-            println!("{:?}", cur_event);
+            println!("{cur_event:?}");
         }
         // Propagate the panic to fail the test.
         if let Ok(panic) = e.try_into_panic() {

--- a/src/moonlink/src/table_handler/chaos_test.rs
+++ b/src/moonlink/src/table_handler/chaos_test.rs
@@ -1,0 +1,205 @@
+/// This file implements chaos test for table handler.
+///
+/// System invariants:
+/// - Begin events happen only after end events
+/// - End events happen only after begin events
+/// - Rows to delete comes from appended ones
+/// - LSN always increases
+use crate::event_sync::create_table_event_syncer;
+use crate::row::{MoonlinkRow, RowValue};
+use crate::storage::mooncake_table::table_creation_test_utils::*;
+use crate::table_handler::{TableEvent, TableHandler};
+use crate::union_read::ReadStateManager;
+use crate::ObjectStorageCache;
+use crate::TableEventManager;
+
+use rand::prelude::*;
+use rand::Rng;
+use std::collections::VecDeque;
+use tempfile::{tempdir, TempDir};
+use tokio::sync::mpsc::Sender;
+use tokio::sync::watch;
+
+#[derive(Debug)]
+struct ChaosState {
+    current_lsn: u64,
+    has_begun: bool,
+    // Used to generate rows to insert.
+    next_id: i32,
+    inserted_rows: VecDeque<MoonlinkRow>,
+}
+
+fn create_row(id: i32, name: &str, age: i32) -> MoonlinkRow {
+    MoonlinkRow::new(vec![
+        RowValue::Int32(id),
+        RowValue::ByteArray(name.as_bytes().to_vec()),
+        RowValue::Int32(age),
+    ])
+}
+
+impl ChaosState {
+    fn new() -> Self {
+        Self {
+            current_lsn: 0,
+            has_begun: false,
+            next_id: 0,
+            inserted_rows: VecDeque::new(),
+        }
+    }
+
+    fn next_lsn(&mut self) -> u64 {
+        self.current_lsn += 1;
+        self.current_lsn
+    }
+
+    fn next_row(&mut self) -> MoonlinkRow {
+        let row = create_row(self.next_id, /*name=*/ "user", self.next_id % 5);
+        self.next_id += 1;
+        row
+    }
+}
+
+fn generate_random_events(state: &mut ChaosState, rng: &mut impl Rng) -> Vec<TableEvent> {
+    #[derive(Debug, Clone)]
+    enum EventKind {
+        Begin,
+        Append,
+        Delete,
+        EndWithFlush,
+        EndNoFlush,
+    }
+
+    let mut choices = vec![];
+
+    if !state.has_begun {
+        choices.push(EventKind::Begin);
+    } else {
+        choices.push(EventKind::Append);
+        if !state.inserted_rows.is_empty() {
+            choices.push(EventKind::Delete);
+        }
+        choices.push(EventKind::EndWithFlush);
+        choices.push(EventKind::EndNoFlush);
+    }
+
+    match *choices.choose(rng).unwrap() {
+        EventKind::Begin => {
+            state.has_begun = true;
+            vec![TableEvent::Append {
+                row: state.next_row(),
+                xact_id: None,
+                lsn: state.next_lsn(),
+                is_copied: false,
+            }]
+        }
+        EventKind::Append => {
+            let row = state.next_row();
+            state.inserted_rows.push_back(row.clone());
+            vec![TableEvent::Append {
+                row,
+                xact_id: None,
+                lsn: state.next_lsn(),
+                is_copied: false,
+            }]
+        }
+        EventKind::Delete => {
+            let idx = rng.random_range(0..state.inserted_rows.len());
+            let row = state.inserted_rows.remove(idx).unwrap();
+            vec![TableEvent::Delete {
+                row,
+                xact_id: None,
+                lsn: state.next_lsn(),
+            }]
+        }
+        EventKind::EndWithFlush => {
+            let lsn = state.next_lsn();
+            state.has_begun = false;
+            vec![
+                TableEvent::Commit { lsn, xact_id: None },
+                TableEvent::Flush { lsn },
+            ]
+        }
+        EventKind::EndNoFlush => {
+            let lsn = state.next_lsn();
+            state.has_begun = false;
+            vec![TableEvent::Commit { lsn, xact_id: None }]
+        }
+    }
+}
+
+#[allow(dead_code)]
+struct TestEnvironment {
+    iceberg_temp_dir: TempDir,
+    cache_temp_dir: TempDir,
+    table_temp_dir: TempDir,
+    object_storage_cache: ObjectStorageCache,
+    read_state_manager: ReadStateManager,
+    table_event_manager: TableEventManager,
+    table_handler: TableHandler,
+    event_sender: Sender<TableEvent>,
+}
+
+impl TestEnvironment {
+    async fn new() -> Self {
+        let iceberg_temp_dir = tempdir().unwrap();
+        let iceberg_table_config = get_iceberg_table_config(&iceberg_temp_dir);
+
+        let table_temp_dir = tempdir().unwrap();
+        let mooncake_table_metadata = create_test_table_metadata_with_index_merge(
+            table_temp_dir.path().to_str().unwrap().to_string(),
+        );
+
+        // Local filesystem to store read-through cache.
+        let cache_temp_dir = tempdir().unwrap();
+        let object_storage_cache = ObjectStorageCache::default_for_test(&cache_temp_dir);
+
+        // Create mooncake table and table event notification receiver.
+        let table = create_mooncake_table(
+            mooncake_table_metadata,
+            iceberg_table_config,
+            object_storage_cache.clone(),
+        )
+        .await;
+        let (_, replication_rx) = watch::channel(0u64);
+        let (_, last_commit_rx) = watch::channel(0u64);
+        let read_state_manager =
+            ReadStateManager::new(&table, replication_rx.clone(), last_commit_rx);
+        let (table_event_sync_sender, table_event_sync_receiver) = create_table_event_syncer();
+        let table_handler =
+            TableHandler::new(table, table_event_sync_sender, replication_rx.clone()).await;
+        let table_event_manager =
+            TableEventManager::new(table_handler.get_event_sender(), table_event_sync_receiver);
+        let event_sender = table_handler.get_event_sender();
+
+        Self {
+            iceberg_temp_dir,
+            cache_temp_dir,
+            table_temp_dir,
+            object_storage_cache,
+            table_event_manager,
+            read_state_manager,
+            table_handler,
+            event_sender,
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_chaos() {
+    let mut rng = rand::rng();
+    let mut state = ChaosState::new();
+    let env = TestEnvironment::new().await;
+    let event_sender = env.event_sender.clone();
+
+    // TODO(hjiang): Hard-coded times, should better use a CLI flag.
+    for _ in 0..100 {
+        let events = generate_random_events(&mut state, &mut rng);
+        for cur_event in events.into_iter() {
+            event_sender.send(cur_event).await.unwrap();
+        }
+    }
+
+    // TODO(hjiang): Hard-coded wait time, should issue shutdown table event after exit bug resolved.
+    // Ref: https://github.com/Mooncake-Labs/moonlink/issues/970
+    tokio::time::sleep(std::time::Duration::from_secs(60)).await;
+}

--- a/src/moonlink/src/table_handler/test_utils.rs
+++ b/src/moonlink/src/table_handler/test_utils.rs
@@ -92,6 +92,7 @@ impl TestEnvironment {
             mooncake_table,
             table_event_sync_sender,
             replication_rx.clone(),
+            /*event_replay_tx=*/ None,
         )
         .await;
         let table_event_manager =

--- a/src/moonlink/src/table_notify.rs
+++ b/src/moonlink/src/table_notify.rs
@@ -154,4 +154,38 @@ impl TableEvent {
             _ => None,
         }
     }
+
+    fn clone_impl(&self) -> Self {
+        match self {
+            TableEvent::IcebergSnapshotResult {
+                iceberg_snapshot_result,
+            } => match iceberg_snapshot_result {
+                Err(e) => TableEvent::IcebergSnapshotResult {
+                    iceberg_snapshot_result: Err(e.clone()),
+                },
+                Ok(iceberg_snapshot_result) => TableEvent::IcebergSnapshotResult {
+                    iceberg_snapshot_result: Ok(IcebergSnapshotResult {
+                        table_manager: None,
+                        flush_lsn: iceberg_snapshot_result.flush_lsn,
+                        wal_persisted_metadata: iceberg_snapshot_result
+                            .wal_persisted_metadata
+                            .clone(),
+                        new_table_schema: iceberg_snapshot_result.new_table_schema.clone(),
+                        import_result: iceberg_snapshot_result.import_result.clone(),
+                        index_merge_result: iceberg_snapshot_result.index_merge_result.clone(),
+                        data_compaction_result: iceberg_snapshot_result
+                            .data_compaction_result
+                            .clone(),
+                    }),
+                },
+            },
+            _ => self.clone(),
+        }
+    }
+}
+
+impl Clone for TableEvent {
+    fn clone(&self) -> Self {
+        self.clone_impl()
+    }
 }

--- a/src/moonlink/src/table_notify.rs
+++ b/src/moonlink/src/table_notify.rs
@@ -14,7 +14,7 @@ use crate::Result;
 /// TODO(hjiang): Revisit whether we need to place the payload into box.
 #[allow(clippy::large_enum_variant)]
 /// Event types that can be processed by the TableHandler
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub enum TableEvent {
     /// ==============================
     /// Replication events
@@ -153,39 +153,5 @@ impl TableEvent {
             TableEvent::Flush { lsn } => Some(*lsn),
             _ => None,
         }
-    }
-
-    fn clone_impl(&self) -> Self {
-        match self {
-            TableEvent::IcebergSnapshotResult {
-                iceberg_snapshot_result,
-            } => match iceberg_snapshot_result {
-                Err(e) => TableEvent::IcebergSnapshotResult {
-                    iceberg_snapshot_result: Err(e.clone()),
-                },
-                Ok(iceberg_snapshot_result) => TableEvent::IcebergSnapshotResult {
-                    iceberg_snapshot_result: Ok(IcebergSnapshotResult {
-                        table_manager: None,
-                        flush_lsn: iceberg_snapshot_result.flush_lsn,
-                        wal_persisted_metadata: iceberg_snapshot_result
-                            .wal_persisted_metadata
-                            .clone(),
-                        new_table_schema: iceberg_snapshot_result.new_table_schema.clone(),
-                        import_result: iceberg_snapshot_result.import_result.clone(),
-                        index_merge_result: iceberg_snapshot_result.index_merge_result.clone(),
-                        data_compaction_result: iceberg_snapshot_result
-                            .data_compaction_result
-                            .clone(),
-                    }),
-                },
-            },
-            _ => self.clone(),
-        }
-    }
-}
-
-impl Clone for TableEvent {
-    fn clone(&self) -> Self {
-        self.clone_impl()
     }
 }

--- a/src/moonlink_connectors/src/pg_replicate/table_init.rs
+++ b/src/moonlink_connectors/src/pg_replicate/table_init.rs
@@ -89,8 +89,13 @@ pub async fn build_table_components(
         ReadStateManager::new(&table, replication_state.subscribe(), commit_lsn_rx);
     let table_state_reader = TableStateReader::new(table_id, &iceberg_table_config, &table);
     let (event_sync_sender, event_sync_receiver) = create_table_event_syncer();
-    let table_handler =
-        TableHandler::new(table, event_sync_sender, replication_state.subscribe()).await;
+    let table_handler = TableHandler::new(
+        table,
+        event_sync_sender,
+        replication_state.subscribe(),
+        /*event_replay_tx=*/ None,
+    )
+    .await;
     let flush_lsn_rx = event_sync_receiver.flush_lsn_rx.clone();
     let table_event_manager =
         TableEventManager::new(table_handler.get_event_sender(), event_sync_receiver);


### PR DESCRIPTION
## Summary

This PR introduces the very basic chaos test to moonlink eventloop, which is known to lack extensive testing and hard to test due to timing issues.
As of now, it has discovered two bugs with table handler.

A few other things included in the PR:
- Make table events clone-able, so it could be sent to the replay channel;
- Update display formatter, otherwise it's very verbose and spammy to print file index out.

The implementation here is very coarse, quite a few TODO items; I pause it because it doesn't make sense to keep adding new feature when we already detected a few issues.
- Add snapshot read, to check whether read content is correct
- Check iceberg snapshot persistence
- Add streaming events
- Add table maintenance events
- Add chaos test into CI pipeline

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/967

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [x] Documentation updated if necessary
- [x] I have reviewed my own changes
