### PR TITLE
[storage] Only drop table when no background task

### DIFF
--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -187,7 +187,7 @@ pub struct TableMetadata {
     /// function to get lookup key from row
     pub(crate) identity: IdentityProp,
 }
-#[derive(Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct AlterTableRequest {
     pub(crate) new_columns: Vec<arrow_schema::FieldRef>,
     pub(crate) dropped_columns: Vec<String>,

--- a/src/moonlink/src/table_handler/test_utils.rs
+++ b/src/moonlink/src/table_handler/test_utils.rs
@@ -303,7 +303,7 @@ impl TestEnvironment {
 
     // --- Lifecycle Helper ---
     pub async fn shutdown(&mut self) {
-        self.send_event(TableEvent::Shutdown).await;
+        self.send_event(TableEvent::DropTable).await;
         if let Some(handle) = self.handler._event_handle.take() {
             handle.await.expect("TableHandler task panicked");
         }

--- a/src/moonlink/src/table_notify.rs
+++ b/src/moonlink/src/table_notify.rs
@@ -45,8 +45,6 @@ pub enum TableEvent {
     Flush { lsn: u64 },
     /// Flush the transaction stream with given xact_id
     StreamFlush { xact_id: u32 },
-    /// Shutdown the handler
-    Shutdown,
     /// ==============================
     /// Interactive blocking events
     /// ==============================


### PR DESCRIPTION
## Summary

... table only dropped and shutdown when no background task.
I found we only use shutdown in one test, so I remove it directly. We could add it back if necessary.
Also add assertion when we set special table events.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/970

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
