### PR TITLE
[storage] Update test flush command

### DIFF
--- a/src/moonlink/src/table_handler/test_utils.rs
+++ b/src/moonlink/src/table_handler/test_utils.rs
@@ -234,7 +234,8 @@ impl TestEnvironment {
     }
 
     pub async fn flush_table_and_sync(&mut self, lsn: u64) {
-        self.send_event(TableEvent::Flush { lsn }).await;
+        self.send_event(TableEvent::CommitFlush { lsn, xact_id: None })
+            .await;
         self.send_event(TableEvent::ForceSnapshot { lsn: Some(lsn) })
             .await;
         TableEventManager::synchronize_force_snapshot_request(
@@ -246,7 +247,8 @@ impl TestEnvironment {
     }
 
     pub async fn flush_table(&self, lsn: u64) {
-        self.send_event(TableEvent::Flush { lsn }).await;
+        self.send_event(TableEvent::CommitFlush { lsn, xact_id: None })
+            .await;
     }
 
     pub async fn stream_flush(&self, xact_id: u32) {

--- a/src/moonlink/src/table_notify.rs
+++ b/src/moonlink/src/table_notify.rs
@@ -41,8 +41,8 @@ pub enum TableEvent {
     /// Test events
     /// ==============================
     ///
-    /// Flush the table to disk
-    Flush { lsn: u64 },
+    /// Commit and flush the table to disk
+    CommitFlush { lsn: u64, xact_id: Option<u32> },
     /// Flush the transaction stream with given xact_id
     StreamFlush { xact_id: u32 },
     /// ==============================
@@ -126,7 +126,7 @@ impl TableEvent {
                     | TableEvent::Delete { .. }
                     | TableEvent::Commit { .. }
                     | TableEvent::StreamAbort { .. }
-                    | TableEvent::Flush { .. }
+                    | TableEvent::CommitFlush { .. }
                     | TableEvent::StreamFlush { .. }
             )
         }
@@ -148,7 +148,7 @@ impl TableEvent {
             TableEvent::Delete { lsn, .. } => Some(*lsn),
             TableEvent::Commit { lsn, .. } => Some(*lsn),
             TableEvent::StreamAbort { .. } => None,
-            TableEvent::Flush { lsn } => Some(*lsn),
+            TableEvent::CommitFlush { lsn, .. } => Some(*lsn),
             _ => None,
         }
     }


### PR DESCRIPTION
## Summary

Currently we use `TableEvent::Flush` in tests, to deterministically flush the pending updates.
But if there're other events kicking in between commit and flush, it breaks one of the invariants that flush LSN always progresses. So in theory, all tests relying on flush event is flaky.

This PR combines both commit and flush into one event. It has no effect to production env.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1002

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
