### PR TITLE
[storage] Rework recovery on streaming

### DIFF
--- a/src/moonlink/src/table_handler/table_handler_state.rs
+++ b/src/moonlink/src/table_handler/table_handler_state.rs
@@ -169,6 +169,11 @@ impl TableHandlerState {
         if self.initial_persistence_lsn.is_none() {
             return false;
         }
+        // Streaming events cannot be discarded, whose LSN is sent at commit phase.
+        if event.is_streaming_update() {
+            return false;
+        }
+        // For non-streaming events, discard if LSN is less than flush LSN.
         let initial_persistence_lsn = self.initial_persistence_lsn.unwrap();
         if let Some(lsn) = event.get_lsn_for_ingest_event() {
             lsn <= initial_persistence_lsn

--- a/src/moonlink/src/table_handler/tests.rs
+++ b/src/moonlink/src/table_handler/tests.rs
@@ -1543,7 +1543,7 @@ async fn test_full_maintenance_with_sufficient_data_files() {
     assert_eq!(snapshot.indices.file_indices.len(), 1); // one compacted file index
 }
 
-/// Testing scenario: write operations no later than persisted LSN shall be discarded.
+/// Testing scenario: non-streaming write operations no later than persisted LSN shall be discarded.
 #[tokio::test]
 async fn test_discard_duplicate_writes() {
     let temp_dir = tempdir().unwrap();
@@ -1626,7 +1626,7 @@ async fn test_discard_duplicate_writes() {
         /*id=*/ 40,
         /*name=*/ "Dog",
         /*age=*/ 40,
-        /*lsn=*/ 25,
+        /*lsn=*/ 0,
         /*xact_id=*/ Some(40),
     )
     .await;

--- a/src/moonlink/src/table_handler/tests.rs
+++ b/src/moonlink/src/table_handler/tests.rs
@@ -1543,7 +1543,7 @@ async fn test_full_maintenance_with_sufficient_data_files() {
     assert_eq!(snapshot.indices.file_indices.len(), 1); // one compacted file index
 }
 
-/// Testing scenario: non-streaming write operations no later than persisted LSN shall be discarded.
+/// Testing scenario: write operations no later than persisted LSN shall be discarded.
 #[tokio::test]
 async fn test_discard_duplicate_writes() {
     let temp_dir = tempdir().unwrap();

--- a/src/moonlink/src/table_notify.rs
+++ b/src/moonlink/src/table_notify.rs
@@ -142,6 +142,19 @@ impl TableEvent {
         }
     }
 
+    /// Whether current table event indicates a streaming write transaction.
+    pub fn is_streaming_update(&self) -> bool {
+        match &self {
+            TableEvent::Append { xact_id, .. } => xact_id.is_some(),
+            TableEvent::Delete { xact_id, .. } => xact_id.is_some(),
+            TableEvent::StreamAbort { .. } => true,
+            TableEvent::Commit { xact_id, .. } => xact_id.is_some(),
+            TableEvent::CommitFlush { xact_id, .. } => xact_id.is_some(),
+            TableEvent::StreamFlush { .. } => true,
+            _ => false,
+        }
+    }
+
     pub fn get_lsn_for_ingest_event(&self) -> Option<u64> {
         match self {
             TableEvent::Append { lsn, .. } => Some(*lsn),


### PR DESCRIPTION
## Summary

This PR rework recovery on streaming. 
Current implementation doesn't work for streaming write, whose LSN is only assigned at commit/abort.

This PR keeps everything unchanged for non-streaming write, but not discard streaming write events until commit/abort.

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
