### PR TITLE
[storage] Fix multi maintenance requests

### DIFF
--- a/src/moonlink/src/table_handler.rs
+++ b/src/moonlink/src/table_handler.rs
@@ -217,7 +217,7 @@ impl TableHandler {
                         // Branch to trigger a force regular index merge request.
                         TableEvent::ForceRegularIndexMerge => {
                             // TODO(hjiang): If there's already table maintenance ongoing, skip.
-                            if table_handler_state.table_maintenance_process_status.is_maintenance_ongoing() {
+                            if !table_handler_state.can_start_new_maintenance() {
                                 let _ = table_handler_state.table_maintenance_completion_tx.send(Ok(()));
                                 continue;
                             }
@@ -227,7 +227,7 @@ impl TableHandler {
                         }
                         // Branch to trigger a force regular data compaction request.
                         TableEvent::ForceRegularDataCompaction => {
-                            if table_handler_state.table_maintenance_process_status.is_maintenance_ongoing() {
+                            if !table_handler_state.can_start_new_maintenance() {
                                 let _ = table_handler_state.table_maintenance_completion_tx.send(Ok(()));
                                 continue;
                             }
@@ -237,7 +237,7 @@ impl TableHandler {
                         }
                         // Branch to trigger a force full index merge request.
                         TableEvent::ForceFullMaintenance => {
-                            if table_handler_state.table_maintenance_process_status.is_maintenance_ongoing() {
+                            if !table_handler_state.can_start_new_maintenance() {
                                 let _ = table_handler_state.table_maintenance_completion_tx.send(Ok(()));
                                 continue;
                             }


### PR DESCRIPTION
## Summary

This issue is:
- It's possible to have multiple table maintenance requested, but none gets started;
- When the second request starts, we check current status is `UNREQUESTED`, which fails the assertion.

So in this PR, I directly acks back when there's already ongoing maintenance.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1027

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
