### PR TITLE
Unique batch id allocations per table

### DIFF
--- a/src/moonlink/src/storage/mooncake_table/batch_id_counter.rs
+++ b/src/moonlink/src/storage/mooncake_table/batch_id_counter.rs
@@ -1,0 +1,178 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+/// Batch ID counter for the two-counter allocation strategy.
+///
+/// The system uses two separate atomic counters to partition the 64-bit batch ID space:
+/// - **Streaming Counter**: Range 0 -> 2^32-1, used for streaming transactions
+/// - **Non-Streaming Counter**: Range 2^32+, used for regular operations
+///
+/// We give streaming batches the smaller range so that they are always behind the commit point, which points to the most recently added batch of the non-streaming batches.
+/// This ensures batch IDs are always monotonically increasing and unique across all transactions.
+pub(super) struct BatchIdCounter {
+    counter: Arc<AtomicU64>,
+    is_streaming: bool,
+}
+
+impl BatchIdCounter {
+    pub fn new(is_streaming: bool) -> Self {
+        Self {
+            counter: Arc::new(AtomicU64::new(if is_streaming { 0 } else { 1u64 << 32 })),
+            is_streaming,
+        }
+    }
+
+    pub fn load(&self) -> u64 {
+        self.counter.load(Ordering::Relaxed)
+    }
+
+    pub fn next(&self) -> u64 {
+        let current = self.counter.load(Ordering::Relaxed);
+
+        // Check limits before incrementing
+        if self.is_streaming {
+            assert!(
+                current < (1u64 << 32),
+                "Streaming batch ID counter overflow: exceeded 2^32-1"
+            );
+        } else {
+            assert!(
+                current < u64::MAX,
+                "Non-streaming batch ID counter overflow"
+            );
+        }
+
+        self.counter.fetch_add(1, Ordering::Relaxed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread;
+
+    #[test]
+    fn test_streaming_counter_creation() {
+        let counter = BatchIdCounter::new(true);
+        assert_eq!(counter.load(), 0);
+        assert!(counter.is_streaming);
+    }
+
+    #[test]
+    fn test_non_streaming_counter_creation() {
+        let counter = BatchIdCounter::new(false);
+        assert_eq!(counter.load(), 1u64 << 32);
+        assert!(!counter.is_streaming);
+    }
+
+    #[test]
+    fn test_streaming_counter_next() {
+        let counter = BatchIdCounter::new(true);
+
+        // First call should return 0, then increment to 1
+        assert_eq!(counter.next(), 0);
+        assert_eq!(counter.load(), 1);
+
+        // Second call should return 1, then increment to 2
+        assert_eq!(counter.next(), 1);
+        assert_eq!(counter.load(), 2);
+    }
+
+    #[test]
+    fn test_non_streaming_counter_next() {
+        let counter = BatchIdCounter::new(false);
+        let expected_start = 1u64 << 32;
+
+        // First call should return 2^32, then increment to 2^32 + 1
+        assert_eq!(counter.next(), expected_start);
+        assert_eq!(counter.load(), expected_start + 1);
+
+        // Second call should return 2^32 + 1, then increment to 2^32 + 2
+        assert_eq!(counter.next(), expected_start + 1);
+        assert_eq!(counter.load(), expected_start + 2);
+    }
+
+    #[test]
+    #[should_panic(expected = "Streaming batch ID counter overflow: exceeded 2^32-1")]
+    fn test_streaming_counter_overflow() {
+        let counter = BatchIdCounter::new(true);
+
+        // Manually set counter to the limit
+        let limit = 1u64 << 32;
+        counter.counter.store(limit, Ordering::Relaxed);
+
+        // This should panic
+        counter.next();
+    }
+
+    #[test]
+    #[should_panic(expected = "Non-streaming batch ID counter overflow")]
+    fn test_non_streaming_counter_overflow() {
+        let counter = BatchIdCounter::new(false);
+
+        // Manually set counter to u64::MAX
+        counter.counter.store(u64::MAX, Ordering::Relaxed);
+
+        // This should panic
+        counter.next();
+    }
+
+    #[test]
+    fn test_streaming_counter_near_limit() {
+        let counter = BatchIdCounter::new(true);
+        let near_limit = (1u64 << 32) - 2;
+
+        // Set counter near the limit
+        counter.counter.store(near_limit, Ordering::Relaxed);
+
+        // These should work
+        assert_eq!(counter.next(), near_limit);
+        assert_eq!(counter.next(), near_limit + 1);
+
+        // The next call should panic - test this separately to ensure it panics
+    }
+
+    #[test]
+    fn test_concurrent_access() {
+        let counter = Arc::new(BatchIdCounter::new(true));
+        let num_threads = 10;
+        let increments_per_thread = 100;
+
+        let handles: Vec<_> = (0..num_threads)
+            .map(|_| {
+                let counter_clone = Arc::clone(&counter);
+                thread::spawn(move || {
+                    let mut ids = Vec::new();
+                    for _ in 0..increments_per_thread {
+                        ids.push(counter_clone.next());
+                    }
+                    ids
+                })
+            })
+            .collect();
+
+        // Collect all IDs from all threads
+        let mut all_ids = Vec::new();
+        for handle in handles {
+            all_ids.extend(handle.join().unwrap());
+        }
+
+        // All IDs should be unique
+        all_ids.sort_unstable();
+        let mut unique_ids = all_ids.clone();
+        unique_ids.dedup();
+
+        assert_eq!(all_ids.len(), unique_ids.len(), "All IDs should be unique");
+        assert_eq!(all_ids.len(), num_threads * increments_per_thread);
+
+        // All IDs should be in streaming range
+        for id in &all_ids {
+            assert!(*id < (1u64 << 32), "ID {} should be in streaming range", id);
+        }
+
+        // IDs should be consecutive starting from 0
+        for (i, &id) in all_ids.iter().enumerate() {
+            assert_eq!(id, i as u64, "IDs should be consecutive");
+        }
+    }
+}

--- a/src/moonlink/src/storage/mooncake_table/batch_id_counter.rs
+++ b/src/moonlink/src/storage/mooncake_table/batch_id_counter.rs
@@ -167,7 +167,7 @@ mod tests {
 
         // All IDs should be in streaming range
         for id in &all_ids {
-            assert!(*id < (1u64 << 32), "ID {} should be in streaming range", id);
+            assert!(*id < (1u64 << 32), "ID {id} should be in streaming range");
         }
 
         // IDs should be consecutive starting from 0

--- a/src/moonlink/src/storage/mooncake_table/disk_slice.rs
+++ b/src/moonlink/src/storage/mooncake_table/disk_slice.rs
@@ -262,7 +262,7 @@ mod tests {
     use crate::row::{IdentityProp, MoonlinkRow, RowValue};
     use crate::storage::index::persisted_bucket_hash_map::test_get_hashes_for_index;
     use crate::storage::mooncake_table::mem_slice::MemSlice;
-    use crate::storage::mooncake_table::MooncakeTableConfig;
+    use crate::storage::mooncake_table::{BatchIdCounter, MooncakeTableConfig};
     use crate::storage::storage_utils::RawDeletionRecord;
     use arrow::datatypes::{DataType, Field};
     use arrow_array::{Int32Array, StringArray};
@@ -293,7 +293,12 @@ mod tests {
 
         let identity = IdentityProp::SinglePrimitiveKey(0);
         // Create a MemSlice with test data
-        let mut mem_slice = MemSlice::new(schema.clone(), 100, identity);
+        let mut mem_slice = MemSlice::new(
+            schema.clone(),
+            100,
+            identity,
+            Arc::new(BatchIdCounter::new(false)),
+        );
 
         // Add some test rows
         let row1 = MoonlinkRow::new(vec![
@@ -361,7 +366,12 @@ mod tests {
         let identity = IdentityProp::SinglePrimitiveKey(0);
 
         // Create a MemSlice with test data - more rows this time
-        let mut mem_slice = MemSlice::new(schema.clone(), 3, identity);
+        let mut mem_slice = MemSlice::new(
+            schema.clone(),
+            3,
+            identity,
+            Arc::new(BatchIdCounter::new(false)),
+        );
 
         // Add several test rows
         let rows = [

--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -570,7 +570,7 @@ impl SnapshotTableState {
         // Use the counter to ensure unique ID and follow proper allocation strategy
         let next_id = self.non_streaming_batch_id_counter.next();
 
-        // Assert that the batch is not already in the map.
+        // Add to batch and assert that the batch is not already in the map.
         assert!(self
             .batches
             .insert(next_id, InMemoryBatch::new(batch_size))
@@ -660,7 +660,7 @@ impl SnapshotTableState {
                 .delete_memory_index(slice.old_index());
 
             slice.input_batches().iter().for_each(|b| {
-                // Assert that the batch is in the map.
+                // Remove from batch and assert that the batch is in the map.
                 assert!(self.batches.remove(&b.id).is_some());
             });
         }

--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -589,8 +589,7 @@ impl SnapshotTableState {
                         }
                     )
                     .is_none(),
-                "Batch ID {} already exists in self.batches",
-                id
+                "Batch ID {id} already exists in self.batches"
             );
         }
     }

--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -14,6 +14,7 @@ use crate::storage::filesystem::accessor::base_filesystem_accessor::BaseFileSyst
 use crate::storage::index::{cache_utils as index_cache_utils, FileIndex};
 use crate::storage::mooncake_table::persistence_buffer::UnpersistedRecords;
 use crate::storage::mooncake_table::shared_array::SharedRowBufferSnapshot;
+use crate::storage::mooncake_table::BatchIdCounter;
 use crate::storage::mooncake_table::MoonlinkRow;
 use crate::storage::mooncake_table::SnapshotOption;
 use crate::storage::storage_utils::{FileId, TableId, TableUniqueFileId};
@@ -73,6 +74,9 @@ pub(crate) struct SnapshotTableState {
     /// Iceberg snapshot is created in an async style, which means it doesn't correspond 1-1 to mooncake snapshot, so we need to ensure idempotency for iceberg snapshot payload.
     /// The following fields record unpersisted content, which will be placed in iceberg payload everytime.
     pub(super) unpersisted_records: UnpersistedRecords,
+
+    /// Batch ID counter for non-streaming operations
+    pub(super) non_streaming_batch_id_counter: Arc<BatchIdCounter>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -104,9 +108,15 @@ impl SnapshotTableState {
         object_storage_cache: ObjectStorageCache,
         filesystem_accessor: Arc<dyn BaseFileSystemAccess>,
         current_snapshot: Snapshot,
+        non_streaming_batch_id_counter: Arc<BatchIdCounter>,
     ) -> Result<Self> {
         let mut batches = BTreeMap::new();
-        batches.insert(0, InMemoryBatch::new(metadata.config.batch_size));
+        // Properly consume a batch ID from the counter to avoid collision with main MemSlice
+        let initial_batch_id = non_streaming_batch_id_counter.next();
+        batches.insert(
+            initial_batch_id,
+            InMemoryBatch::new(metadata.config.batch_size),
+        );
 
         let table_config = metadata.config.clone();
         Ok(Self {
@@ -114,22 +124,30 @@ impl SnapshotTableState {
             current_snapshot,
             batches,
             rows: None,
-            last_commit: RecordLocation::MemoryBatch(0, 0),
+            last_commit: RecordLocation::MemoryBatch(initial_batch_id, 0),
             object_storage_cache,
             filesystem_accessor,
             table_notify: None,
             committed_deletion_log: Vec::new(),
             uncommitted_deletion_log: Vec::new(),
             unpersisted_records: UnpersistedRecords::new(table_config),
+            non_streaming_batch_id_counter,
         })
     }
 
     pub(crate) fn reset_for_alter(&mut self, new_metadata: Arc<MooncakeTableMetadata>) {
         self.batches = BTreeMap::new();
-        self.batches
-            .insert(0, InMemoryBatch::new(new_metadata.config.batch_size));
+        // Initialize with a proper batch ID from the counter to avoid collisions
+        let initial_batch_id = self.non_streaming_batch_id_counter.load();
+        assert!(self
+            .batches
+            .insert(
+                initial_batch_id,
+                InMemoryBatch::new(new_metadata.config.batch_size)
+            )
+            .is_none());
         self.rows = None;
-        self.last_commit = RecordLocation::MemoryBatch(0, 0);
+        self.last_commit = RecordLocation::MemoryBatch(initial_batch_id, 0);
         self.current_snapshot.metadata = new_metadata.clone();
         self.mooncake_table_metadata = new_metadata;
     }
@@ -549,20 +567,32 @@ impl SnapshotTableState {
 
         // start a fresh empty batch after the newest data
         let batch_size = self.current_snapshot.metadata.config.batch_size;
-        let next_id = incoming.last().unwrap().0 + 1;
-        self.batches.insert(next_id, InMemoryBatch::new(batch_size));
+        // Use the counter to ensure unique ID and follow proper allocation strategy
+        let next_id = self.non_streaming_batch_id_counter.next();
 
-        // add completed batches
-        self.batches
-            .extend(incoming.into_iter().skip(1).map(|(id, rb)| {
-                (
-                    id,
-                    InMemoryBatch {
-                        data: Some(rb.clone()),
-                        deletions: BatchDeletionVector::new(rb.num_rows()),
-                    },
-                )
-            }));
+        // Assert that the batch is not already in the map.
+        assert!(self
+            .batches
+            .insert(next_id, InMemoryBatch::new(batch_size))
+            .is_none());
+
+        // Add completed batches
+        // Assert that no incoming batch ID is already present in the map.
+        for (id, rb) in incoming.into_iter().skip(1) {
+            assert!(
+                self.batches
+                    .insert(
+                        id,
+                        InMemoryBatch {
+                            data: Some(rb.clone()),
+                            deletions: BatchDeletionVector::new(rb.num_rows()),
+                        }
+                    )
+                    .is_none(),
+                "Batch ID {} already exists in self.batches",
+                id
+            );
+        }
     }
 
     /// Return files evicted from object storage cache.
@@ -631,7 +661,8 @@ impl SnapshotTableState {
                 .delete_memory_index(slice.old_index());
 
             slice.input_batches().iter().for_each(|b| {
-                self.batches.remove(&b.id);
+                // Assert that the batch is in the map.
+                assert!(self.batches.remove(&b.id).is_some());
             });
         }
 


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

In order to support async flush batches from both streaming and non-streaming transactions will need to be added to the snapshot. in order to support this, we must ensure batch ids are globally unique across all transactions. 

Previous behavior would start the `batch_ids` at 0 for each new mem slice. This means streaming transaction batch ids overlap with other streaming transactions and the main table mem slice. 

We do this by splitting the `u64` range in two, assigning streaming transactions the range `[0, 21^63)` and non-streaming `[2^63, 2^64)`. It's important that streaming batch id's are always strictly less than non-streaming batch id's since we use the commit point from the non-streaming mem slice to determine read visibility. As soon as a streaming transaction commits it will become visible since its always less than commit point.  

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1030

## Changes

- 
- 
- 

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
