### PR TITLE
[storage] Attach id to background events

### DIFF
--- a/src/moonlink/src/storage/compaction/compactor.rs
+++ b/src/moonlink/src/storage/compaction/compactor.rs
@@ -386,6 +386,7 @@ impl CompactionBuilder {
         if old_record_loc_to_new_mapping.is_empty() {
             assert!(record_loc_to_data_file_index.is_empty());
             return Ok(DataCompactionResult {
+                uuid: self.compaction_payload.uuid,
                 remapped_data_files: old_record_loc_to_new_mapping,
                 old_data_files,
                 old_file_indices,
@@ -410,6 +411,7 @@ impl CompactionBuilder {
             .await;
 
         Ok(DataCompactionResult {
+            uuid: self.compaction_payload.uuid,
             remapped_data_files: old_record_loc_to_new_mapping,
             old_data_files,
             old_file_indices,

--- a/src/moonlink/src/storage/compaction/table_compaction.rs
+++ b/src/moonlink/src/storage/compaction/table_compaction.rs
@@ -25,6 +25,8 @@ pub struct SingleFileToCompact {
 /// Payload to trigger a compaction operation.
 #[derive(Clone)]
 pub struct DataCompactionPayload {
+    /// UUID for current compaction operation, used for observability purpose.
+    pub(crate) uuid: uuid::Uuid,
     /// Object storage cache.
     pub(crate) object_storage_cache: ObjectStorageCache,
     /// Filesystem accessor.
@@ -38,6 +40,7 @@ pub struct DataCompactionPayload {
 impl std::fmt::Debug for DataCompactionPayload {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("DataCompactionPayload")
+            .field("uuid", &self.uuid)
             .field("object_storage_cache", &self.object_storage_cache)
             .field("filesystem_accessor", &self.filesystem_accessor)
             .field("disk file number", &self.disk_files.len())
@@ -73,6 +76,8 @@ pub(crate) struct RemappedRecordLocation {
 /// Result for a compaction operation.
 #[derive(Clone, Default, PartialEq)]
 pub struct DataCompactionResult {
+    /// UUID for current compaction operation, used for observability purpose.
+    pub(crate) uuid: uuid::Uuid,
     /// Data files which get compacted, maps from old record location to new one.
     pub(crate) remapped_data_files: HashMap<RecordLocation, RemappedRecordLocation>,
     /// Old compacted data files, which maps to their corresponding compacted data file.
@@ -110,6 +115,7 @@ impl DataCompactionResult {
 impl std::fmt::Debug for DataCompactionResult {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("DataCompactionResult")
+            .field("uuid", &self.uuid)
             .field("remapped data files count", &self.remapped_data_files.len())
             .field("old data files count", &self.old_data_files.len())
             .field("old file indices count", &self.old_file_indices.len())

--- a/src/moonlink/src/storage/compaction/tests.rs
+++ b/src/moonlink/src/storage/compaction/tests.rs
@@ -66,6 +66,7 @@ async fn test_data_file_compaction_1() {
 
     // Prepare compaction payload.
     let payload = DataCompactionPayload {
+        uuid: uuid::Uuid::new_v4(),
         object_storage_cache: ObjectStorageCache::default_for_test(&temp_dir),
         filesystem_accessor: FileSystemAccessor::default_for_test(&temp_dir),
         disk_files: vec![get_single_file_to_compact(
@@ -149,6 +150,7 @@ async fn test_data_file_compaction_2() {
 
     // Prepare compaction payload.
     let payload = DataCompactionPayload {
+        uuid: uuid::Uuid::new_v4(),
         object_storage_cache: ObjectStorageCache::default_for_test(&temp_dir),
         filesystem_accessor: filesystem_accessor.clone(),
         disk_files: vec![get_single_file_to_compact(
@@ -236,6 +238,7 @@ async fn test_data_file_compaction_3() {
 
     // Prepare compaction payload.
     let payload = DataCompactionPayload {
+        uuid: uuid::Uuid::new_v4(),
         object_storage_cache: ObjectStorageCache::default_for_test(&temp_dir),
         filesystem_accessor: filesystem_accessor.clone(),
         disk_files: vec![get_single_file_to_compact(
@@ -312,6 +315,7 @@ async fn test_data_file_compaction_4() {
 
     // Prepare compaction payload.
     let payload = DataCompactionPayload {
+        uuid: uuid::Uuid::new_v4(),
         object_storage_cache: ObjectStorageCache::default_for_test(&temp_dir),
         filesystem_accessor: FileSystemAccessor::default_for_test(&temp_dir),
         disk_files: vec![
@@ -427,6 +431,7 @@ async fn test_data_file_compaction_5() {
 
     // Prepare compaction payload.
     let payload = DataCompactionPayload {
+        uuid: uuid::Uuid::new_v4(),
         object_storage_cache: ObjectStorageCache::default_for_test(&temp_dir),
         filesystem_accessor: filesystem_accessor.clone(),
         disk_files: vec![
@@ -549,6 +554,7 @@ async fn test_data_file_compaction_6() {
 
     // Prepare compaction payload.
     let payload = DataCompactionPayload {
+        uuid: uuid::Uuid::new_v4(),
         object_storage_cache: ObjectStorageCache::default_for_test(&temp_dir),
         filesystem_accessor: filesystem_accessor.clone(),
         disk_files: vec![
@@ -659,6 +665,7 @@ async fn test_multiple_compacted_data_files_1() {
 
     // Prepare compaction payload.
     let payload = DataCompactionPayload {
+        uuid: uuid::Uuid::new_v4(),
         object_storage_cache: ObjectStorageCache::default_for_test(&temp_dir),
         filesystem_accessor: filesystem_accessor.clone(),
         disk_files: vec![
@@ -794,6 +801,7 @@ async fn test_multiple_compacted_data_files_2() {
 
     // Prepare compaction payload.
     let payload = DataCompactionPayload {
+        uuid: uuid::Uuid::new_v4(),
         object_storage_cache: ObjectStorageCache::default_for_test(&temp_dir),
         filesystem_accessor: filesystem_accessor.clone(),
         disk_files: vec![
@@ -856,6 +864,7 @@ async fn test_large_number_of_data_files() {
 
     // Prepare compaction payload.
     let payload = DataCompactionPayload {
+        uuid: uuid::Uuid::new_v4(),
         object_storage_cache: ObjectStorageCache::default_for_test(&temp_dir),
         filesystem_accessor: FileSystemAccessor::default_for_test(&temp_dir),
         disk_files: old_data_files_to_compact,

--- a/src/moonlink/src/storage/iceberg/tests.rs
+++ b/src/moonlink/src/storage/iceberg/tests.rs
@@ -312,6 +312,7 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
     let file_index_1 = create_file_index(vec![data_file_1.clone()]);
 
     let iceberg_snapshot_payload = IcebergSnapshotPayload {
+        uuid: uuid::Uuid::new_v4(),
         flush_lsn: 0,
         wal_persistence_metadata: None,
         new_table_schema: None,
@@ -364,6 +365,7 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
     let file_index_2 = create_file_index(vec![data_file_2.clone()]);
 
     let iceberg_snapshot_payload = IcebergSnapshotPayload {
+        uuid: uuid::Uuid::new_v4(),
         flush_lsn: 1,
         wal_persistence_metadata: None,
         new_table_schema: None,
@@ -440,6 +442,7 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
     // Write third snapshot to iceberg table, with file indices to add and remove.
     let merged_file_index = create_file_index(remote_data_files.clone());
     let iceberg_snapshot_payload = IcebergSnapshotPayload {
+        uuid: uuid::Uuid::new_v4(),
         flush_lsn: 2,
         wal_persistence_metadata: Some(WalPersistenceMetadata {
             persisted_file_num: 10,
@@ -530,6 +533,7 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
     //
     // Attempt a fourth snapshot persistence, which goes after data file compaction.
     let iceberg_snapshot_payload = IcebergSnapshotPayload {
+        uuid: uuid::Uuid::new_v4(),
         flush_lsn: 3,
         wal_persistence_metadata: None,
         new_table_schema: None,
@@ -599,6 +603,7 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
     //
     // Remove all existing data files and file indices.
     let iceberg_snapshot_payload = IcebergSnapshotPayload {
+        uuid: uuid::Uuid::new_v4(),
         flush_lsn: 4,
         wal_persistence_metadata: None,
         new_table_schema: None,
@@ -978,6 +983,7 @@ async fn test_empty_content_snapshot_creation_impl(iceberg_table_config: Iceberg
     )
     .unwrap();
     let iceberg_snapshot_payload = IcebergSnapshotPayload {
+        uuid: uuid::Uuid::new_v4(),
         flush_lsn: 0,
         wal_persistence_metadata: None,
         new_table_schema: None,

--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -1091,6 +1091,7 @@ impl MooncakeTable {
                 .build_from_merge(file_indice_merge_payload.file_indices.clone(), cur_file_id)
                 .await;
             let index_merge_result = FileIndiceMergeResult {
+                uuid: file_indice_merge_payload.uuid,
                 old_file_indices: file_indice_merge_payload.file_indices,
                 new_file_indices: vec![merged],
             };
@@ -1162,6 +1163,7 @@ impl MooncakeTable {
         let flush_lsn = snapshot_payload.flush_lsn;
         let wal_persisted_metadata = snapshot_payload.wal_persistence_metadata.clone();
         let new_table_schema = snapshot_payload.new_table_schema.clone();
+        let uuid = snapshot_payload.uuid;
 
         let new_imported_data_files_count = snapshot_payload.import_payload.data_files.len();
         let new_compacted_data_files_count = snapshot_payload
@@ -1234,6 +1236,7 @@ impl MooncakeTable {
         );
 
         let snapshot_result = IcebergSnapshotResult {
+            uuid,
             table_manager: Some(iceberg_table_manager),
             flush_lsn,
             wal_persisted_metadata,

--- a/src/moonlink/src/storage/mooncake_table/snapshot_maintenance.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot_maintenance.rs
@@ -139,6 +139,7 @@ impl SnapshotTableState {
         }
 
         let payload = DataCompactionPayload {
+            uuid: uuid::Uuid::new_v4(),
             object_storage_cache: self.object_storage_cache.clone(),
             filesystem_accessor: self.filesystem_accessor.clone(),
             disk_files: tentative_data_files_to_compact,
@@ -208,6 +209,7 @@ impl SnapshotTableState {
         // To avoid too many small IO operations, only attempt an index merge when accumulated small indices exceeds the threshold.
         if file_indices_to_merge.len() >= index_merge_file_num_threshold {
             let payload = FileIndiceMergePayload {
+                uuid: uuid::Uuid::new_v4(),
                 file_indices: file_indices_to_merge,
             };
             return IndexMergeMaintenanceStatus::Payload(payload);

--- a/src/moonlink/src/storage/mooncake_table/snapshot_persistence.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot_persistence.rs
@@ -35,6 +35,7 @@ impl SnapshotTableState {
         new_committed_deletion_logs: HashMap<MooncakeDataFileRef, BatchDeletionVector>,
     ) -> IcebergSnapshotPayload {
         IcebergSnapshotPayload {
+            uuid: uuid::Uuid::new_v4(),
             flush_lsn,
             wal_persistence_metadata,
             new_table_schema: None,

--- a/src/moonlink/src/storage/mooncake_table/table_snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_snapshot.rs
@@ -98,6 +98,8 @@ impl IcebergSnapshotDataCompactionPayload {
 
 #[derive(Clone)]
 pub struct IcebergSnapshotPayload {
+    /// UUID for the current persistence operation, used for observability purpose.
+    pub(crate) uuid: uuid::Uuid,
     /// Flush LSN.
     pub(crate) flush_lsn: u64,
     /// WAL persistence metadata.
@@ -115,6 +117,7 @@ pub struct IcebergSnapshotPayload {
 impl std::fmt::Debug for IcebergSnapshotPayload {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("IcebergSnapshotPayload")
+            .field("uuid", &self.uuid)
             .field("flush_lsn", &self.flush_lsn)
             .field("wal_persistence_metadata", &self.wal_persistence_metadata)
             .finish()
@@ -238,6 +241,8 @@ impl std::fmt::Debug for IcebergSnapshotDataCompactionResult {
 }
 
 pub struct IcebergSnapshotResult {
+    /// UUID for the current persistence operation, used for observability purpose.
+    pub(crate) uuid: uuid::Uuid,
     /// Table manager is (1) not `Sync` safe; (2) only used at iceberg snapshot creation, so we `move` it around every snapshot.
     pub(crate) table_manager: Option<Box<dyn TableManager>>,
     /// Iceberg flush LSN.
@@ -257,6 +262,7 @@ pub struct IcebergSnapshotResult {
 impl Clone for IcebergSnapshotResult {
     fn clone(&self) -> Self {
         IcebergSnapshotResult {
+            uuid: self.uuid,
             table_manager: None,
             flush_lsn: self.flush_lsn,
             wal_persisted_metadata: self.wal_persisted_metadata.clone(),
@@ -284,6 +290,7 @@ impl IcebergSnapshotResult {
 impl std::fmt::Debug for IcebergSnapshotResult {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("IcebergSnapshotResult")
+            .field("uuid", &self.uuid)
             .field("flush_lsn", &self.flush_lsn)
             .finish()
     }
@@ -295,18 +302,24 @@ impl std::fmt::Debug for IcebergSnapshotResult {
 ///
 #[derive(Clone)]
 pub struct FileIndiceMergePayload {
+    /// UUID for current index merge operation, used for observability purpose.
+    pub(crate) uuid: uuid::Uuid,
     /// File indices to merge.
     pub(crate) file_indices: HashSet<GlobalIndex>,
 }
 
 impl std::fmt::Debug for FileIndiceMergePayload {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("FileIndiceMergePayload").finish()
+        f.debug_struct("FileIndiceMergePayload")
+            .field("uuid", &self.uuid)
+            .finish()
     }
 }
 
 #[derive(Clone, Default)]
 pub struct FileIndiceMergeResult {
+    /// UUID for current index merge operation, used for observability purpose.
+    pub(crate) uuid: uuid::Uuid,
     /// Old file indices being merged.
     pub(crate) old_file_indices: HashSet<GlobalIndex>,
     /// New file indice merged.
@@ -326,7 +339,9 @@ impl FileIndiceMergeResult {
 
 impl std::fmt::Debug for FileIndiceMergeResult {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("FileIndiceMergeResult").finish()
+        f.debug_struct("FileIndiceMergeResult")
+            .field("uuid", &self.uuid)
+            .finish()
     }
 }
 


### PR DESCRIPTION
## Summary

Certain bugs only surface after injecting 20K events, making it hard to debug with certain ways to "locate" the start and end for multiple concurrent background tasks.
Later event UUID is also helpful for observability, like logging and tracing.

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
