### PR TITLE
Coordinate batch id's between mem slice and snapshot 

### DIFF
--- a/src/moonlink/src/storage/mooncake_table/batch_id_counter.rs
+++ b/src/moonlink/src/storage/mooncake_table/batch_id_counter.rs
@@ -22,10 +22,12 @@ impl BatchIdCounter {
         }
     }
 
+    // Relaxed ordering is used here because the counter is only used for internal state tracking, not for synchronization.
     pub fn load(&self) -> u64 {
         self.counter.load(Ordering::Relaxed)
     }
 
+    // Relaxed ordering is used here because the counter is only used for internal state tracking, not for synchronization.
     pub fn next(&self) -> u64 {
         let current = self.counter.load(Ordering::Relaxed);
 

--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -567,8 +567,7 @@ impl SnapshotTableState {
 
         // start a fresh empty batch after the newest data
         let batch_size = self.current_snapshot.metadata.config.batch_size;
-        // Use the counter to ensure unique ID and follow proper allocation strategy
-        let next_id = self.non_streaming_batch_id_counter.next();
+        let next_id = incoming.last().unwrap().0 + 1;
 
         // Add to batch and assert that the batch is not already in the map.
         assert!(self

--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -567,6 +567,7 @@ impl SnapshotTableState {
 
         // start a fresh empty batch after the newest data
         let batch_size = self.current_snapshot.metadata.config.batch_size;
+        // Use the ID from the incoming batches rather than the counter, since the counter may have been further advanced elsewhere.
         let next_id = incoming.last().unwrap().0 + 1;
 
         // Add to batch and assert that the batch is not already in the map.

--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -111,8 +111,8 @@ impl SnapshotTableState {
         non_streaming_batch_id_counter: Arc<BatchIdCounter>,
     ) -> Result<Self> {
         let mut batches = BTreeMap::new();
-        // Properly consume a batch ID from the counter to avoid collision with main MemSlice
-        let initial_batch_id = non_streaming_batch_id_counter.load();
+        // Properly load a batch ID from the counter to ensure correspondence with MemSlice.
+        let initial_batch_id = non_streaming_batch_id_counter.next();
         batches.insert(
             initial_batch_id,
             InMemoryBatch::new(metadata.config.batch_size),

--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -112,7 +112,7 @@ impl SnapshotTableState {
     ) -> Result<Self> {
         let mut batches = BTreeMap::new();
         // Properly consume a batch ID from the counter to avoid collision with main MemSlice
-        let initial_batch_id = non_streaming_batch_id_counter.next();
+        let initial_batch_id = non_streaming_batch_id_counter.load();
         batches.insert(
             initial_batch_id,
             InMemoryBatch::new(metadata.config.batch_size),


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

We should use the same initial batch id in `SnapshotTableState` constructor as we do in `MemSlice` constructor to start with a 1-1 mapping. 

Also, during `finalize_batches` we should use the id from the actual incoming batches, not the shared counter since it's possible that the shared counter was further incremented. 

 

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1035

## Changes

- 
- 
- 

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
