### PR TITLE
[storage] Only prune committed deletion logs

### DIFF
--- a/src/moonlink/src/storage/compaction/compactor.rs
+++ b/src/moonlink/src/storage/compaction/compactor.rs
@@ -3,7 +3,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use arrow_array::{Int32Array, RecordBatch};
+use arrow_array::RecordBatch;
 use arrow_schema::SchemaRef;
 use futures::TryStreamExt;
 use more_asserts as ma;

--- a/src/moonlink/src/storage/iceberg/tests.rs
+++ b/src/moonlink/src/storage/iceberg/tests.rs
@@ -66,15 +66,14 @@ fn test_committed_deletion_log_1(
     let mut deletion_vector = BatchDeletionVector::new(MooncakeTableConfig::DEFAULT_BATCH_SIZE);
     deletion_vector.delete_row(0);
 
-    HashMap::<MooncakeDataFileRef, BatchDeletionVector>::from([(
-        data_file,
-        deletion_vector,
-    )])
+    HashMap::<MooncakeDataFileRef, BatchDeletionVector>::from([(data_file, deletion_vector)])
 }
 /// Corresponds to [`test_committed_deletion_log_1`].
-fn test_committed_deletion_logs_to_persist_1(data_file: MooncakeDataFileRef) -> HashSet<(FileId, usize)> {
+fn test_committed_deletion_logs_to_persist_1(
+    data_file: MooncakeDataFileRef,
+) -> HashSet<(FileId, usize)> {
     let mut committed_deletion_logs = HashSet::new();
-    committed_deletion_logs.insert((data_file.file_id(), /*row_idx=*/0));
+    committed_deletion_logs.insert((data_file.file_id(), /*row_idx=*/ 0));
     committed_deletion_logs
 }
 fn test_committed_deletion_log_2(
@@ -90,10 +89,12 @@ fn test_committed_deletion_log_2(
     )])
 }
 /// Corresponds to [`test_committed_deletion_log_2`].
-fn test_committed_deletion_logs_to_persist_2(data_file: MooncakeDataFileRef) -> HashSet<(FileId, usize)> {
+fn test_committed_deletion_logs_to_persist_2(
+    data_file: MooncakeDataFileRef,
+) -> HashSet<(FileId, usize)> {
     let mut committed_deletion_logs = HashSet::new();
-    committed_deletion_logs.insert((data_file.file_id(), /*row_idx=*/1));
-    committed_deletion_logs.insert((data_file.file_id(), /*row_idx=*/2));
+    committed_deletion_logs.insert((data_file.file_id(), /*row_idx=*/ 1));
+    committed_deletion_logs.insert((data_file.file_id(), /*row_idx=*/ 2));
     committed_deletion_logs
 }
 

--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -820,7 +820,8 @@ impl MooncakeTable {
 
         // ---- Buffer iceberg persisted content to next snapshot task ---
         assert!(self.next_snapshot_task.committed_deletion_logs.is_empty());
-        self.next_snapshot_task.committed_deletion_logs = iceberg_snapshot_res.committed_deletion_logs;
+        self.next_snapshot_task.committed_deletion_logs =
+            iceberg_snapshot_res.committed_deletion_logs;
 
         assert!(self
             .next_snapshot_task

--- a/src/moonlink/src/storage/mooncake_table/snapshot_persistence.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot_persistence.rs
@@ -1,7 +1,6 @@
 use crate::create_data_file;
 use crate::storage::iceberg::puffin_utils::PuffinBlobRef;
 use crate::storage::index::FileIndex;
-use crate::storage::mooncake_table::delete_vector::BatchDeletionVector;
 use crate::storage::mooncake_table::snapshot::CommittedDeletionToPersist;
 use crate::storage::mooncake_table::table_snapshot::IcebergSnapshotDataCompactionPayload;
 use crate::storage::mooncake_table::IcebergSnapshotPayload;

--- a/src/moonlink/src/storage/mooncake_table/table_snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_snapshot.rs
@@ -122,7 +122,10 @@ impl std::fmt::Debug for IcebergSnapshotPayload {
             .field("uuid", &self.uuid)
             .field("flush_lsn", &self.flush_lsn)
             .field("wal_persistence_metadata", &self.wal_persistence_metadata)
-            .field("committed deletion logs count", &self.committed_deletion_logs.len())
+            .field(
+                "committed deletion logs count",
+                &self.committed_deletion_logs.len(),
+            )
             .field("import payload", &self.import_payload)
             .field("index merge payload", &self.index_merge_payload)
             .field("data compaction payload", &self.data_compaction_payload)


### PR DESCRIPTION
## Summary

This PR is a no-op change, to resolve compaction related snapshot operations.
For details, see https://github.com/Mooncake-Labs/moonlink/issues/1044#issuecomment-3116904158
The solution is to record all committed deletion logs to persist, and only prune those committed, but not generated by compaction.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1044

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
