### PR TITLE
[storage] Refactor deletion record remapping for compaction

### DIFF
--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -464,11 +464,9 @@ impl SnapshotTableState {
             .await;
         evicted_data_files_to_delete.extend(compaction_evicted_files);
 
-        // Remap uncommitted deletion logs.
+        // Remap deletion logs.
         self.remap_uncommitted_deletion_logs_after_compaction(&mut task);
-        // Extract remapped committed deletion logs, so they don't get pruned, because data compaction doesn't update flush LSN.
-        let remapped_committed_deletion_log =
-            self.extract_remapped_committed_deletion_log(&mut task);
+        self.remap_committed_deletion_logs_after_compaction(&mut task);
 
         // Prune unpersisted records.
         //
@@ -490,9 +488,6 @@ impl SnapshotTableState {
         // After data compaction and index merge changes have been applied to snapshot, processed deletion record will point to the new record location.
         self.rows = take(&mut task.new_rows);
         self.process_deletion_log(&mut task).await;
-
-        // Re-queue unpersisted committed deletion logs.
-        self.requeue_committed_deletion_logs(remapped_committed_deletion_log);
 
         // Assert and update flush LSN.
         if let Some(new_flush_lsn) = task.new_flush_lsn {


### PR DESCRIPTION
## Summary

This PR refactors deletion record remapping after compaction.
Since https://github.com/Mooncake-Labs/moonlink/pull/1045 we only prune persisted deletion logs, instead of relying on flush LSN, we're safe to remap both committed / uncommitted together.

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
