### PR TITLE
[storage] Remove cardinality from metadata store

### DIFF
--- a/src/moonlink_metadata_store/src/postgres/sql/create_tables.sql
+++ b/src/moonlink_metadata_store/src/postgres/sql/create_tables.sql
@@ -5,6 +5,5 @@ CREATE TABLE tables (
     table_name text NOT NULL,     -- source table name
     uri text,                     -- source URI
     config json,                  -- mooncake and persistence configurations
-    cardinality bigint,           -- estimated row count or similar
     PRIMARY KEY (database_id, table_id)
 );

--- a/src/moonlink_metadata_store/src/sqlite/sql/create_tables.sql
+++ b/src/moonlink_metadata_store/src/sqlite/sql/create_tables.sql
@@ -5,6 +5,5 @@ CREATE TABLE tables (
     table_name text NOT NULL,   -- source table name
     uri text,                   -- source URI
     config TEXT,                -- mooncake and persistence configurations
-    cardinality INTEGER,        -- estimated row count or similar
     PRIMARY KEY (database_id, table_id)
 );


### PR DESCRIPTION
## Summary

This PR removes cardinality from metadata storage table, because moonlink manages metadata storage its own, instead of sharing with pg_mooncake.

**NOTICE:
I directly remove the schema row because moonlink hasn't been released officially.
Changing DB schema requires schema evolution in normal cases.**

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
