### PR TITLE
[chaos] Add streaming transaction to chaos test

### DIFF
--- a/src/moonlink/src/storage/mooncake_table/table_creation_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_creation_test_utils.rs
@@ -145,6 +145,16 @@ pub(crate) fn create_test_table_metadata_with_index_merge(
     create_test_table_metadata_with_config(local_table_directory, config)
 }
 
+/// Test util function to create mooncake table metadata, which disables flush at commit.
+#[cfg(feature = "chaos-test")]
+pub(crate) fn create_test_table_metadata_disable_flush(
+    local_table_directory: String,
+) -> Arc<MooncakeTableMetadata> {
+    let mut config = MooncakeTableConfig::new(local_table_directory.clone());
+    config.mem_slice_size = usize::MAX; // Disable flush at commit if not force flush.
+    create_test_table_metadata_with_config(local_table_directory, config)
+}
+
 /// Test util function to create mooncake table metadata, with (1) index merge enabled whenever there're two index blocks; and (2) flush at commit is disabled.
 #[cfg(feature = "chaos-test")]
 pub(crate) fn create_test_table_metadata_with_index_merge_disable_flush(


### PR DESCRIPTION
## Summary

This PR does three things for chaos test:
- Add initial streaming transaction into test suite;
- Increase default test event number from 1000 to 3000, which should finish within ~5 minutes
- Add a new test mode, with no background index merge and data compaction

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/998
Closes https://github.com/Mooncake-Labs/moonlink/issues/1064

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [x] Documentation updated if necessary
- [x] I have reviewed my own changes
