### PR TITLE
[storage] Fix stream abort

### DIFF
--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -54,6 +54,8 @@ pub(crate) struct SnapshotTableState {
     // Type-3, committed but not yet persisted deletion logs.
     pub(crate) committed_deletion_log: Vec<ProcessedDeletionRecord>,
     // Type-1: uncommitted deletion logs.
+    //
+    // Invariant: all processed deletion records are valid, here we use `Option` simply for an easy way to `move` the record out.
     pub(crate) uncommitted_deletion_log: Vec<Option<ProcessedDeletionRecord>>,
 
     /// Last commit point

--- a/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
+++ b/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
@@ -367,13 +367,9 @@ impl SnapshotTableState {
                     });
                 }
                 TransactionStreamOutput::Abort(xact_id) => {
-                    for row in self.uncommitted_deletion_log.iter_mut() {
-                        if let Some(deletion) = row {
-                            if deletion.lsn == get_lsn_for_pending_xact(xact_id) {
-                                *row = None;
-                            }
-                        }
-                    }
+                    self.uncommitted_deletion_log.retain(|deletion| {
+                        deletion.as_ref().unwrap().lsn != get_lsn_for_pending_xact(xact_id)
+                    });
                     task.new_deletions
                         .retain(|deletion| deletion.lsn != get_lsn_for_pending_xact(xact_id));
                 }


### PR DESCRIPTION
## Summary

Uncommitted deletion log, though of type `Option`, actually holds the invariant that all records are valid.
So to unset an uncommitted record at abort, we should remove the element out instead of marking it as none.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1071

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [x] Documentation updated if necessary
- [x] I have reviewed my own changes
