### PR TITLE
Add stream state to snapshot task

### DIFF
--- a/src/moonlink/benches/bench_write.rs
+++ b/src/moonlink/benches/bench_write.rs
@@ -181,7 +181,7 @@ fn bench_write(c: &mut Criterion) {
                             1,
                         );
                     }
-                    let disk_slice = table.prepare_stream_disk_slice(1);
+                    let mut disk_slice = table.prepare_stream_disk_slice(1);
                     table
                         .flush_stream_disk_slice(1, &mut disk_slice)
                         .await
@@ -202,7 +202,7 @@ fn bench_write(c: &mut Criterion) {
                             )
                             .await;
                     }
-                    let disk_slice = table.prepare_stream_disk_slice(1);
+                    let mut disk_slice = table.prepare_stream_disk_slice(1);
                     table
                         .flush_stream_disk_slice(1, &mut disk_slice)
                         .await

--- a/src/moonlink/benches/bench_write.rs
+++ b/src/moonlink/benches/bench_write.rs
@@ -181,12 +181,7 @@ fn bench_write(c: &mut Criterion) {
                             1,
                         );
                     }
-                    let mut disk_slice = table.prepare_stream_disk_slice(1).unwrap();
-                    table
-                        .flush_stream_disk_slice(1, &mut disk_slice)
-                        .await
-                        .unwrap();
-                    table.apply_stream_flush_result(1, disk_slice);
+                    table.flush_stream(1, None).await.unwrap();
                 });
                 table
             },
@@ -202,12 +197,7 @@ fn bench_write(c: &mut Criterion) {
                             )
                             .await;
                     }
-                    let mut disk_slice = table.prepare_stream_disk_slice(1).unwrap();
-                    table
-                        .flush_stream_disk_slice(1, &mut disk_slice)
-                        .await
-                        .unwrap();
-                    table.apply_stream_flush_result(1, disk_slice);
+                    table.flush_stream(1, None).await.unwrap();
                     //let handle = table.create_snapshot();
                     //let _ = handle.unwrap().await.unwrap();
                 });

--- a/src/moonlink/benches/bench_write.rs
+++ b/src/moonlink/benches/bench_write.rs
@@ -181,7 +181,7 @@ fn bench_write(c: &mut Criterion) {
                             1,
                         );
                     }
-                    let mut disk_slice = table.prepare_stream_disk_slice(1);
+                    let mut disk_slice = table.prepare_stream_disk_slice(1).unwrap();
                     table
                         .flush_stream_disk_slice(1, &mut disk_slice)
                         .await
@@ -202,7 +202,7 @@ fn bench_write(c: &mut Criterion) {
                             )
                             .await;
                     }
-                    let mut disk_slice = table.prepare_stream_disk_slice(1);
+                    let mut disk_slice = table.prepare_stream_disk_slice(1).unwrap();
                     table
                         .flush_stream_disk_slice(1, &mut disk_slice)
                         .await

--- a/src/moonlink/benches/bench_write.rs
+++ b/src/moonlink/benches/bench_write.rs
@@ -181,8 +181,12 @@ fn bench_write(c: &mut Criterion) {
                             1,
                         );
                     }
-                    let handle = table.flush_transaction_stream(1);
-                    handle.await.unwrap();
+                    let disk_slice = table.prepare_stream_disk_slice(1);
+                    table
+                        .flush_stream_disk_slice(1, &mut disk_slice)
+                        .await
+                        .unwrap();
+                    table.apply_stream_flush_result(1, disk_slice);
                 });
                 table
             },
@@ -198,8 +202,12 @@ fn bench_write(c: &mut Criterion) {
                             )
                             .await;
                     }
-                    let handle = table.flush_transaction_stream(1);
-                    handle.await.unwrap();
+                    let disk_slice = table.prepare_stream_disk_slice(1);
+                    table
+                        .flush_stream_disk_slice(1, &mut disk_slice)
+                        .await
+                        .unwrap();
+                    table.apply_stream_flush_result(1, disk_slice);
                     //let handle = table.create_snapshot();
                     //let _ = handle.unwrap().await.unwrap();
                 });

--- a/src/moonlink/src/storage/index.rs
+++ b/src/moonlink/src/storage/index.rs
@@ -43,6 +43,12 @@ pub type FileIndex = GlobalIndex; // key -> (file, row_offset)
 #[derive(Clone)]
 pub(crate) struct IndexPtr(Arc<MemIndex>);
 
+impl IndexPtr {
+    pub fn arc_ptr(&self) -> Arc<MemIndex> {
+        self.0.clone()
+    }
+}
+
 impl PartialEq for IndexPtr {
     fn eq(&self, other: &Self) -> bool {
         Arc::as_ptr(&self.0) == Arc::as_ptr(&other.0)

--- a/src/moonlink/src/storage/mooncake_table/delete_vector.rs
+++ b/src/moonlink/src/storage/mooncake_table/delete_vector.rs
@@ -5,7 +5,7 @@ use arrow::record_batch::RecordBatch;
 use arrow::util::bit_util;
 use more_asserts as ma;
 
-#[derive(Clone, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq, Default)]
 pub struct BatchDeletionVector {
     /// Boolean array tracking deletions (false = deleted, true = active)
     deletion_vector: Option<Vec<u8>>,

--- a/src/moonlink/src/storage/mooncake_table/disk_slice.rs
+++ b/src/moonlink/src/storage/mooncake_table/disk_slice.rs
@@ -106,10 +106,6 @@ impl DiskSliceWriter {
         self.writer_lsn
     }
 
-    pub(crate) fn set_lsn(&mut self, lsn: u64) {
-        self.writer_lsn = Some(lsn);
-    }
-
     pub(super) fn input_batches(&self) -> &Vec<BatchEntry> {
         &self.batches
     }

--- a/src/moonlink/src/storage/mooncake_table/disk_slice.rs
+++ b/src/moonlink/src/storage/mooncake_table/disk_slice.rs
@@ -21,7 +21,7 @@ pub(crate) struct DiskFileAttrs {
     pub(crate) row_num: usize,
 }
 
-pub(crate) struct DiskSliceWriter {
+pub struct DiskSliceWriter {
     /// The schema of the DiskSlice.
     ///
     schema: Arc<Schema>,
@@ -104,6 +104,10 @@ impl DiskSliceWriter {
 
     pub(super) fn lsn(&self) -> Option<u64> {
         self.writer_lsn
+    }
+
+    pub(crate) fn set_lsn(&mut self, lsn: u64) {
+        self.writer_lsn = Some(lsn);
     }
 
     pub(super) fn input_batches(&self) -> &Vec<BatchEntry> {

--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -601,24 +601,33 @@ impl SnapshotTableState {
         }
 
         let incoming = take(&mut task.new_record_batches);
-        // close previously‐open batch
-        assert!(self.batches.values().last().unwrap().data.is_none());
-        self.batches.last_entry().unwrap().get_mut().data = Some(incoming[0].1.clone());
+        let (streaming_batches, mut non_streaming_batches): (Vec<_>, Vec<_>) =
+            incoming.into_iter().partition(|(id, _)| *id < (1u64 << 63));
 
-        // start a fresh empty batch after the newest data
-        let batch_size = self.current_snapshot.metadata.config.batch_size;
-        // Use the ID from the incoming batches rather than the counter, since the counter may have been further advanced elsewhere.
-        let next_id = incoming.last().unwrap().0 + 1;
+        if !non_streaming_batches.is_empty() {
+            // close previously‐open batch
+            assert!(self.batches.values().last().unwrap().data.is_none());
+            // Use the ID from the incoming batches rather than the counter, since the counter may have been further advanced elsewhere.
+            let next_id = non_streaming_batches.last().unwrap().0 + 1;
+            self.batches.last_entry().unwrap().get_mut().data =
+                Some(non_streaming_batches.remove(0).1.clone());
 
-        // Add to batch and assert that the batch is not already in the map.
-        assert!(self
-            .batches
-            .insert(next_id, InMemoryBatch::new(batch_size))
-            .is_none());
+            // start a fresh empty batch after the newest data
+            let batch_size = self.current_snapshot.metadata.config.batch_size;
+
+            // Add to batch and assert that the batch is not already in the map.
+            assert!(self
+                .batches
+                .insert(next_id, InMemoryBatch::new(batch_size))
+                .is_none());
+        }
 
         // Add completed batches
         // Assert that no incoming batch ID is already present in the map.
-        for (id, rb) in incoming.into_iter().skip(1) {
+        for (id, rb) in streaming_batches
+            .into_iter()
+            .chain(non_streaming_batches.into_iter())
+        {
             assert!(
                 self.batches
                     .insert(

--- a/src/moonlink/src/storage/mooncake_table/tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/tests.rs
@@ -717,7 +717,7 @@ async fn test_streaming_begin_flush_commit_end_flush() {
 
     // Begin the flush
     // This will drain the mem slice and add its relevant state to the stream state
-    let mut disk_slice = table.prepare_stream_disk_slice(xact_id);
+    let mut disk_slice = table.prepare_stream_disk_slice(xact_id).unwrap();
     table
         .flush_stream_disk_slice(xact_id, &mut disk_slice)
         .await
@@ -786,7 +786,7 @@ async fn test_streaming_begin_flush_commit_end_flush_multiple() {
 
     // Begin the flush
     // This will drain the mem slice and add its relevant state to the stream state
-    let mut disk_slice1 = table.prepare_stream_disk_slice(xact_id);
+    let mut disk_slice1 = table.prepare_stream_disk_slice(xact_id).unwrap();
     table
         .flush_stream_disk_slice(xact_id, &mut disk_slice1)
         .await
@@ -797,7 +797,7 @@ async fn test_streaming_begin_flush_commit_end_flush_multiple() {
 
     // Begin the flush
     // This will drain the mem slice and add its relevant state to the stream state
-    let mut disk_slice2 = table.prepare_stream_disk_slice(xact_id);
+    let mut disk_slice2 = table.prepare_stream_disk_slice(xact_id).unwrap();
     table
         .flush_stream_disk_slice(xact_id, &mut disk_slice2)
         .await
@@ -883,7 +883,7 @@ async fn test_streaming_begin_flush_commit_delete_end_flush() {
 
     // Begin the flush
     // This will drain the mem slice and add its relevant state to the stream state
-    let mut disk_slice = table.prepare_stream_disk_slice(xact_id);
+    let mut disk_slice = table.prepare_stream_disk_slice(xact_id).unwrap();
     table
         .flush_stream_disk_slice(xact_id, &mut disk_slice)
         .await
@@ -921,7 +921,7 @@ async fn test_streaming_begin_flush_commit_delete_end_flush() {
         .await
         .unwrap();
 
-    let mut disk_slice2 = table.prepare_stream_disk_slice(xact_id2);
+    let mut disk_slice2 = table.prepare_stream_disk_slice(xact_id2).unwrap();
     table
         .flush_stream_disk_slice(xact_id2, &mut disk_slice2)
         .await
@@ -975,7 +975,7 @@ async fn test_streaming_begin_flush_abort_end_flush() {
 
     // Begin the flush
     // This will drain the mem slice and add its relevant state to the stream state
-    let mut disk_slice = table.prepare_stream_disk_slice(xact_id);
+    let mut disk_slice = table.prepare_stream_disk_slice(xact_id).unwrap();
     table
         .flush_stream_disk_slice(xact_id, &mut disk_slice)
         .await
@@ -1022,13 +1022,13 @@ async fn test_streaming_begin_flush_abort_end_flush_multiple() {
 
     // Begin the flush
     // This will drain the mem slice and add its relevant state to the stream state
-    let mut disk_slice1 = table.prepare_stream_disk_slice(xact_id);
+    let mut disk_slice1 = table.prepare_stream_disk_slice(xact_id).unwrap();
     table
         .flush_stream_disk_slice(xact_id, &mut disk_slice1)
         .await
         .unwrap();
 
-    let mut disk_slice2 = table.prepare_stream_disk_slice(xact_id);
+    let mut disk_slice2 = table.prepare_stream_disk_slice(xact_id).unwrap();
     table
         .flush_stream_disk_slice(xact_id, &mut disk_slice2)
         .await

--- a/src/moonlink/src/storage/mooncake_table/tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/tests.rs
@@ -851,12 +851,12 @@ async fn test_streaming_begin_flush_commit_end_flush_multiple() {
     {
         let mut snapshot = table.snapshot.write().await;
         let SnapshotReadOutput {
-            data_file_paths, ..
+            mut data_file_paths,
+            ..
         } = snapshot.request_read().await.unwrap();
-        // First file contains first row
-        verify_file_contents(&data_file_paths[0].get_file_path(), &[1], Some(1));
-        // Second file contains second row
-        verify_file_contents(&data_file_paths[1].get_file_path(), &[2], Some(1));
+        data_file_paths.sort_by_key(|data_file| data_file.get_file_path());
+        verify_file_contents(&data_file_paths[1].get_file_path(), &[1], Some(1));
+        verify_file_contents(&data_file_paths[2].get_file_path(), &[2], Some(1));
     }
 }
 

--- a/src/moonlink/src/storage/mooncake_table/tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/tests.rs
@@ -717,7 +717,7 @@ async fn test_streaming_begin_flush_commit_end_flush() {
 
     // Begin the flush
     // This will drain the mem slice and add its relevant state to the stream state
-    let mut disk_slice = table.prepare_stream_disk_slice(xact_id).unwrap();
+    let mut disk_slice = table.prepare_stream_disk_slice(xact_id, Some(lsn)).unwrap();
     table
         .flush_stream_disk_slice(xact_id, &mut disk_slice)
         .await
@@ -786,7 +786,7 @@ async fn test_streaming_begin_flush_commit_end_flush_multiple() {
 
     // Begin the flush
     // This will drain the mem slice and add its relevant state to the stream state
-    let mut disk_slice1 = table.prepare_stream_disk_slice(xact_id).unwrap();
+    let mut disk_slice1 = table.prepare_stream_disk_slice(xact_id, Some(lsn)).unwrap();
     table
         .flush_stream_disk_slice(xact_id, &mut disk_slice1)
         .await
@@ -797,7 +797,7 @@ async fn test_streaming_begin_flush_commit_end_flush_multiple() {
 
     // Begin the flush
     // This will drain the mem slice and add its relevant state to the stream state
-    let mut disk_slice2 = table.prepare_stream_disk_slice(xact_id).unwrap();
+    let mut disk_slice2 = table.prepare_stream_disk_slice(xact_id, Some(lsn)).unwrap();
     table
         .flush_stream_disk_slice(xact_id, &mut disk_slice2)
         .await
@@ -883,7 +883,7 @@ async fn test_streaming_begin_flush_commit_delete_end_flush() {
 
     // Begin the flush
     // This will drain the mem slice and add its relevant state to the stream state
-    let mut disk_slice = table.prepare_stream_disk_slice(xact_id).unwrap();
+    let mut disk_slice = table.prepare_stream_disk_slice(xact_id, Some(lsn)).unwrap();
     table
         .flush_stream_disk_slice(xact_id, &mut disk_slice)
         .await
@@ -921,7 +921,9 @@ async fn test_streaming_begin_flush_commit_delete_end_flush() {
         .await
         .unwrap();
 
-    let mut disk_slice2 = table.prepare_stream_disk_slice(xact_id2).unwrap();
+    let mut disk_slice2 = table
+        .prepare_stream_disk_slice(xact_id2, Some(lsn2))
+        .unwrap();
     table
         .flush_stream_disk_slice(xact_id2, &mut disk_slice2)
         .await
@@ -968,6 +970,7 @@ async fn test_streaming_begin_flush_abort_end_flush() {
     table.register_table_notify(event_completion_tx).await;
 
     let xact_id = 1;
+    let lsn = 1;
 
     // Append a row to streaming mem slice
     let row = test_row(1, "A", 20);
@@ -975,7 +978,7 @@ async fn test_streaming_begin_flush_abort_end_flush() {
 
     // Begin the flush
     // This will drain the mem slice and add its relevant state to the stream state
-    let mut disk_slice = table.prepare_stream_disk_slice(xact_id).unwrap();
+    let mut disk_slice = table.prepare_stream_disk_slice(xact_id, Some(lsn)).unwrap();
     table
         .flush_stream_disk_slice(xact_id, &mut disk_slice)
         .await
@@ -1013,6 +1016,7 @@ async fn test_streaming_begin_flush_abort_end_flush_multiple() {
     table.register_table_notify(event_completion_tx).await;
 
     let xact_id = 1;
+    let lsn = 1;
 
     // Append a row to streaming mem slice
     let row1 = test_row(1, "A", 20);
@@ -1022,13 +1026,13 @@ async fn test_streaming_begin_flush_abort_end_flush_multiple() {
 
     // Begin the flush
     // This will drain the mem slice and add its relevant state to the stream state
-    let mut disk_slice1 = table.prepare_stream_disk_slice(xact_id).unwrap();
+    let mut disk_slice1 = table.prepare_stream_disk_slice(xact_id, Some(lsn)).unwrap();
     table
         .flush_stream_disk_slice(xact_id, &mut disk_slice1)
         .await
         .unwrap();
 
-    let mut disk_slice2 = table.prepare_stream_disk_slice(xact_id).unwrap();
+    let mut disk_slice2 = table.prepare_stream_disk_slice(xact_id, Some(lsn)).unwrap();
     table
         .flush_stream_disk_slice(xact_id, &mut disk_slice2)
         .await

--- a/src/moonlink/src/storage/mooncake_table/tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/tests.rs
@@ -695,3 +695,369 @@ async fn test_alter_table_with_operations() {
     )
     .await;
 }
+
+#[tokio::test]
+async fn test_streaming_begin_flush_commit_end_flush() {
+    let context = TestContext::new("streaming_begin_flush_commit_end_flush");
+    let mut table = test_table(
+        &context,
+        "streaming_begin_flush_commit_end_flush",
+        IdentityProp::Keys(vec![0]),
+    )
+    .await;
+    let (event_completion_tx, mut event_completion_rx) = mpsc::channel(100);
+    table.register_table_notify(event_completion_tx).await;
+
+    let xact_id = 1;
+    let lsn = 1;
+
+    // Append a row to streaming mem slice
+    let row = test_row(1, "A", 20);
+    table.append_in_stream_batch(row, xact_id).unwrap();
+
+    // Begin the flush
+    // This will drain the mem slice and add its relevant state to the stream state
+    let mut disk_slice = table.prepare_stream_disk_slice(xact_id);
+    table
+        .flush_stream_disk_slice(xact_id, &mut disk_slice)
+        .await
+        .unwrap();
+
+    // Wait to apply the flush to simulate an async flush that hasn't returned
+    // Commit the transaction while the flush is pending
+    // This will move the state from the stream state to the snapshot task
+    table
+        .commit_transaction_stream(xact_id, lsn + 1)
+        .await
+        .unwrap();
+
+    // Make sure the row is visible in snapshot before flush finishes
+    create_mooncake_snapshot_for_test(&mut table, &mut event_completion_rx).await;
+    // Read the snapshot
+    {
+        let mut snapshot = table.snapshot.write().await;
+        let SnapshotReadOutput {
+            data_file_paths, ..
+        } = snapshot.request_read().await.unwrap();
+        verify_file_contents(&data_file_paths[0].get_file_path(), &[1], Some(1));
+    }
+
+    // Apply the flush
+    table.apply_stream_flush_result(xact_id, disk_slice);
+
+    // Make sure we can still read the row after flush
+    {
+        let mut snapshot = table.snapshot.write().await;
+        let SnapshotReadOutput {
+            data_file_paths, ..
+        } = snapshot.request_read().await.unwrap();
+        verify_file_contents(&data_file_paths[0].get_file_path(), &[1], Some(1));
+    }
+
+    // Make sure we can still read the row after snapshot
+    create_mooncake_snapshot_for_test(&mut table, &mut event_completion_rx).await;
+    {
+        let mut snapshot = table.snapshot.write().await;
+        let SnapshotReadOutput {
+            data_file_paths, ..
+        } = snapshot.request_read().await.unwrap();
+        verify_file_contents(&data_file_paths[0].get_file_path(), &[1], Some(1));
+    }
+}
+
+#[tokio::test]
+async fn test_streaming_begin_flush_commit_end_flush_multiple() {
+    let context = TestContext::new("streaming_begin_flush_commit_end_flush");
+    let mut table = test_table(
+        &context,
+        "streaming_begin_flush_commit_end_flush",
+        IdentityProp::Keys(vec![0]),
+    )
+    .await;
+    let (event_completion_tx, mut event_completion_rx) = mpsc::channel(100);
+    table.register_table_notify(event_completion_tx).await;
+
+    let xact_id = 1;
+    let lsn = 1;
+
+    // Append a row to streaming mem slice
+    let row1 = test_row(1, "A", 20);
+    table.append_in_stream_batch(row1, xact_id).unwrap();
+
+    // Begin the flush
+    // This will drain the mem slice and add its relevant state to the stream state
+    let mut disk_slice1 = table.prepare_stream_disk_slice(xact_id);
+    table
+        .flush_stream_disk_slice(xact_id, &mut disk_slice1)
+        .await
+        .unwrap();
+
+    let row2 = test_row(2, "B", 21);
+    table.append_in_stream_batch(row2, xact_id).unwrap();
+
+    // Begin the flush
+    // This will drain the mem slice and add its relevant state to the stream state
+    let mut disk_slice2 = table.prepare_stream_disk_slice(xact_id);
+    table
+        .flush_stream_disk_slice(xact_id, &mut disk_slice2)
+        .await
+        .unwrap();
+
+    // Wait to apply the flush to simulate an async flush that hasn't returned
+    // Commit the transaction while the flush is pending
+    // This will move the state from the stream state to the snapshot task
+    table
+        .commit_transaction_stream(xact_id, lsn + 1)
+        .await
+        .unwrap();
+
+    // Make sure the rows are visible in snapshot before flush finishes
+    create_mooncake_snapshot_for_test(&mut table, &mut event_completion_rx).await;
+    // Read the snapshot
+    // (Should use the in memory file)
+    {
+        let mut snapshot = table.snapshot.write().await;
+        let SnapshotReadOutput {
+            data_file_paths, ..
+        } = snapshot.request_read().await.unwrap();
+        verify_file_contents(&data_file_paths[0].get_file_path(), &[1, 2], Some(2));
+    }
+
+    // Apply the flush
+    table.apply_stream_flush_result(xact_id, disk_slice1);
+
+    // Make sure the stream state is still present since we have outstanding flush
+    assert!(table.transaction_stream_states.contains_key(&xact_id));
+
+    // Apply the second flush
+    table.apply_stream_flush_result(xact_id, disk_slice2);
+
+    // Assert the stream state is removed
+    assert!(!table.transaction_stream_states.contains_key(&xact_id));
+
+    // Make sure we can still read the rows after flush
+    // (Should still use the in memory file)
+    {
+        let mut snapshot = table.snapshot.write().await;
+        let SnapshotReadOutput {
+            data_file_paths, ..
+        } = snapshot.request_read().await.unwrap();
+        verify_file_contents(&data_file_paths[0].get_file_path(), &[1, 2], Some(2));
+    }
+
+    // Make sure we can still read the rows after snapshot
+    // (Should now read the rows from disk)
+    create_mooncake_snapshot_for_test(&mut table, &mut event_completion_rx).await;
+    {
+        let mut snapshot = table.snapshot.write().await;
+        let SnapshotReadOutput {
+            data_file_paths, ..
+        } = snapshot.request_read().await.unwrap();
+        // First file contains first row
+        verify_file_contents(&data_file_paths[0].get_file_path(), &[1], Some(1));
+        // Second file contains second row
+        verify_file_contents(&data_file_paths[1].get_file_path(), &[2], Some(1));
+    }
+}
+
+#[tokio::test]
+async fn test_streaming_begin_flush_commit_delete_end_flush() {
+    let context = TestContext::new("streaming_begin_flush_commit_delete_end_flush");
+    let mut table = test_table(
+        &context,
+        "streaming_begin_flush_commit_delete_end_flush",
+        IdentityProp::Keys(vec![0]),
+    )
+    .await;
+    let (event_completion_tx, mut event_completion_rx) = mpsc::channel(100);
+    table.register_table_notify(event_completion_tx).await;
+
+    let xact_id = 1;
+    let lsn = 1;
+
+    // Append a row to streaming mem slice
+    let row1 = test_row(1, "A", 20);
+    table.append_in_stream_batch(row1, xact_id).unwrap();
+    let row2 = test_row(2, "B", 21);
+    table.append_in_stream_batch(row2.clone(), xact_id).unwrap();
+
+    // Begin the flush
+    // This will drain the mem slice and add its relevant state to the stream state
+    let mut disk_slice = table.prepare_stream_disk_slice(xact_id);
+    table
+        .flush_stream_disk_slice(xact_id, &mut disk_slice)
+        .await
+        .unwrap();
+
+    // Wait to apply the flush to simulate an async flush that hasn't returned
+    // Commit the transaction while the flush is pending
+    // This will move the state from the stream state to the snapshot task
+    table
+        .commit_transaction_stream(xact_id, lsn + 1)
+        .await
+        .unwrap();
+
+    // Make sure the rows are visible in snapshot before flush finishes
+    create_mooncake_snapshot_for_test(&mut table, &mut event_completion_rx).await;
+    // Read the snapshot
+    {
+        let mut snapshot = table.snapshot.write().await;
+        let SnapshotReadOutput {
+            data_file_paths, ..
+        } = snapshot.request_read().await.unwrap();
+        verify_file_contents(&data_file_paths[0].get_file_path(), &[1, 2], Some(2));
+    }
+
+    // Start a new transaction
+    let xact_id2 = 2;
+    let lsn2 = 2;
+
+    // Delete the row from the previous transaction (has not been flushed yet)
+    table.delete_in_stream_batch(row2, xact_id2).await;
+
+    // Commit the new transaction
+    table
+        .commit_transaction_stream(xact_id2, lsn2 + 1)
+        .await
+        .unwrap();
+
+    let mut disk_slice2 = table.prepare_stream_disk_slice(xact_id2);
+    table
+        .flush_stream_disk_slice(xact_id2, &mut disk_slice2)
+        .await
+        .unwrap();
+
+    // Apply the flush for both transactions
+    table.apply_stream_flush_result(xact_id, disk_slice);
+    table.apply_stream_flush_result(xact_id2, disk_slice2);
+
+    // Make sure we only have one row in the snapshot
+    create_mooncake_snapshot_for_test(&mut table, &mut event_completion_rx).await;
+
+    // Read the snapshot
+    {
+        let mut snapshot = table.snapshot.write().await;
+        let SnapshotReadOutput {
+            data_file_paths,
+            puffin_cache_handles,
+            position_deletes,
+            deletion_vectors,
+            ..
+        } = snapshot.request_read().await.unwrap();
+        verify_files_and_deletions(
+            get_data_files_for_read(&data_file_paths).as_slice(),
+            get_deletion_puffin_files_for_read(&puffin_cache_handles).as_slice(),
+            position_deletes,
+            deletion_vectors,
+            &[1],
+        )
+        .await;
+    }
+}
+
+#[tokio::test]
+async fn test_streaming_begin_flush_abort_end_flush() {
+    let context = TestContext::new("streaming_begin_flush_abort_end_flush");
+    let mut table = test_table(
+        &context,
+        "streaming_begin_flush_abort_end_flush",
+        IdentityProp::Keys(vec![0]),
+    )
+    .await;
+    let (event_completion_tx, mut event_completion_rx) = mpsc::channel(100);
+    table.register_table_notify(event_completion_tx).await;
+
+    let xact_id = 1;
+
+    // Append a row to streaming mem slice
+    let row = test_row(1, "A", 20);
+    table.append_in_stream_batch(row, xact_id).unwrap();
+
+    // Begin the flush
+    // This will drain the mem slice and add its relevant state to the stream state
+    let mut disk_slice = table.prepare_stream_disk_slice(xact_id);
+    table
+        .flush_stream_disk_slice(xact_id, &mut disk_slice)
+        .await
+        .unwrap();
+
+    // Wait to apply the flush to simulate an async flush that hasn't returned
+    // Abort the transaction while the flush is pending
+    // This will move the state from the stream state to the snapshot task
+    table.abort_in_stream_batch(xact_id);
+
+    // Apply the flush
+    table.apply_stream_flush_result(xact_id, disk_slice);
+
+    // Make sure we can't read the row after flush
+    create_mooncake_snapshot_for_test(&mut table, &mut event_completion_rx).await;
+    {
+        let mut snapshot = table.snapshot.write().await;
+        let SnapshotReadOutput {
+            data_file_paths, ..
+        } = snapshot.request_read().await.unwrap();
+        assert_eq!(data_file_paths.len(), 0);
+    }
+}
+
+#[tokio::test]
+async fn test_streaming_begin_flush_abort_end_flush_multiple() {
+    let context = TestContext::new("streaming_begin_flush_abort_end_flush_multiple");
+    let mut table = test_table(
+        &context,
+        "streaming_begin_flush_abort_end_flush_multiple",
+        IdentityProp::Keys(vec![0]),
+    )
+    .await;
+    let (event_completion_tx, mut event_completion_rx) = mpsc::channel(100);
+    table.register_table_notify(event_completion_tx).await;
+
+    let xact_id = 1;
+
+    // Append a row to streaming mem slice
+    let row1 = test_row(1, "A", 20);
+    table.append_in_stream_batch(row1, xact_id).unwrap();
+    let row2 = test_row(2, "B", 21);
+    table.append_in_stream_batch(row2, xact_id).unwrap();
+
+    // Begin the flush
+    // This will drain the mem slice and add its relevant state to the stream state
+    let mut disk_slice1 = table.prepare_stream_disk_slice(xact_id);
+    table
+        .flush_stream_disk_slice(xact_id, &mut disk_slice1)
+        .await
+        .unwrap();
+
+    let mut disk_slice2 = table.prepare_stream_disk_slice(xact_id);
+    table
+        .flush_stream_disk_slice(xact_id, &mut disk_slice2)
+        .await
+        .unwrap();
+
+    // Wait to apply the flush to simulate an async flush that hasn't returned
+    // Abort the transaction while the flush is pending
+    // This will move the state from the stream state to the snapshot task
+    table.abort_in_stream_batch(xact_id);
+
+    // Apply the first flush
+    table.apply_stream_flush_result(xact_id, disk_slice1);
+
+    // Make sure the stream state is still present since we have outstanding flush
+    assert!(table.transaction_stream_states.contains_key(&xact_id));
+
+    // Apply the second flush
+    table.apply_stream_flush_result(xact_id, disk_slice2);
+
+    // Assert the stream state is removed
+    assert!(!table.transaction_stream_states.contains_key(&xact_id));
+
+    // Make sure we can't read the row after flush
+    create_mooncake_snapshot_for_test(&mut table, &mut event_completion_rx).await;
+    {
+        let mut snapshot = table.snapshot.write().await;
+        let SnapshotReadOutput {
+            data_file_paths, ..
+        } = snapshot.request_read().await.unwrap();
+        assert_eq!(data_file_paths.len(), 0);
+    }
+}

--- a/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
+++ b/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
@@ -229,6 +229,8 @@ impl MooncakeTable {
         // Record abortion in snapshot task so we can remove any uncomitted deletions
         let stream_state = self.transaction_stream_states.get_mut(&xact_id).unwrap();
 
+        stream_state.status = TransactionStreamStatus::Aborted;
+
         // If there are no pending flushes, we can remove the stream state immediately
         // Otherwise, let `apply_stream_flush_result` handle the abortion
         if stream_state.pending_flush_count == 0 {

--- a/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
+++ b/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
@@ -18,8 +18,26 @@ pub(super) struct TransactionStreamState {
     local_deletions: Vec<ProcessedDeletionRecord>,
     pending_deletions_in_main_mem_slice: Vec<RawDeletionRecord>,
     index_bloom_filter: BloomFilter,
-    flushed_file_index: MooncakeIndex,
+    /// Both in memory and on disk indices for this transaction.
+    stream_indices: MooncakeIndex,
     flushed_files: hashbrown::HashMap<MooncakeDataFileRef, DiskFileEntry>,
+    new_record_batches: Vec<(u64, Arc<RecordBatch>)>,
+    status: TransactionStreamStatus,
+    /// LSN of the commit for this transaction.
+    /// Required during `apply_stream_flush_result` to update the writer lsn of the disk slice.
+    commit_lsn: Option<u64>,
+    /// Number of pending flushes for this transaction.
+    /// Only safe to remove transaction stream state when there are no pending flushes.
+    pending_flush_count: u32,
+}
+
+/// Determines the state of a transaction stream.
+/// Transaction can be safely removed when it is no longer `Pending` and has no pending flushes.
+#[derive(PartialEq)]
+pub enum TransactionStreamStatus {
+    Pending,
+    Committed,
+    Aborted,
 }
 
 pub enum TransactionStreamOutput {
@@ -74,8 +92,12 @@ impl TransactionStreamState {
             local_deletions: Vec::new(),
             pending_deletions_in_main_mem_slice: Vec::new(),
             index_bloom_filter: BloomFilter::with_num_bits(1 << 24).expected_items(1_000_000),
-            flushed_file_index: MooncakeIndex::new(),
+            stream_indices: MooncakeIndex::new(),
             flushed_files: hashbrown::HashMap::new(),
+            new_record_batches: Vec::new(),
+            status: TransactionStreamStatus::Pending,
+            commit_lsn: None,
+            pending_flush_count: 0,
         }
     }
 }
@@ -154,7 +176,7 @@ impl MooncakeTable {
                 return;
             }
             // Delete from stream flushed files
-            let matches = stream_state.flushed_file_index.find_record(&record).await;
+            let matches = stream_state.stream_indices.find_record(&record).await;
             if !matches.is_empty() {
                 for loc in matches {
                     let RecordLocation::DiskFile(file_id, row_id) = loc else {
@@ -205,94 +227,225 @@ impl MooncakeTable {
 
     pub fn abort_in_stream_batch(&mut self, xact_id: u32) {
         // Record abortion in snapshot task so we can remove any uncomitted deletions
-        self.transaction_stream_states.remove(&xact_id);
+        let stream_state = self.transaction_stream_states.get_mut(&xact_id).unwrap();
+
+        // If there are no pending flushes, we can remove the stream state immediately
+        // Otherwise, let `apply_stream_flush_result` handle the abortion
+        if stream_state.pending_flush_count == 0 {
+            self.transaction_stream_states.remove(&xact_id);
+        }
+
         self.next_snapshot_task
             .new_streaming_xact
             .push(TransactionStreamOutput::Abort(xact_id));
     }
 
-    pub async fn flush_transaction_stream(&mut self, xact_id: u32) -> Result<()> {
-        if let Some(stream_state) = self.transaction_stream_states.get_mut(&xact_id) {
-            let next_file_id = self.next_file_id;
-            self.next_file_id += 1;
-            let mut disk_slice = Self::flush_mem_slice(
-                &mut stream_state.mem_slice,
-                &self.metadata,
-                next_file_id,
-                None,
-                None,
-            )
-            .await?;
+    /// Drains the current mem slice and prepares a disk slice for flushing.
+    /// Adds current mem slice batches and indices to the stream state.
+    pub fn prepare_stream_disk_slice(&mut self, xact_id: u32) -> DiskSliceWriter {
+        assert!(
+            self.transaction_stream_states.contains_key(&xact_id),
+            "Stream state not found for xact_id: {xact_id}"
+        );
 
-            for (file, file_attrs) in disk_slice.output_files().iter() {
-                ma::assert_gt!(file_attrs.file_size, 0);
-                let disk_file_entry = DiskFileEntry {
-                    file_size: file_attrs.file_size,
-                    cache_handle: None,
-                    batch_deletion_vector: BatchDeletionVector::new(file_attrs.row_num),
-                    puffin_deletion_blob: None,
-                };
-                stream_state
-                    .flushed_files
-                    .insert(file.clone(), disk_file_entry);
-            }
-            let index = disk_slice.take_index();
-            if let Some(index) = index {
-                stream_state.flushed_file_index.insert_file_index(index);
-            }
-            return Ok(());
-        }
+        let stream_state = self.transaction_stream_states.get_mut(&xact_id).unwrap();
+        let next_file_id = self.next_file_id;
+        self.next_file_id += 1;
+
+        // Add filtered record batches to stream state
+        // We filter here since in the stream case we delete from the current mem slice directly instead of adding to `new_deletions`
+        let (_, batches, index) = stream_state.mem_slice.drain().unwrap();
+        stream_state
+            .new_record_batches
+            .extend(batches.iter().filter_map(|b| {
+                b.batch
+                    .get_filtered_batch()
+                    .ok()
+                    .flatten()
+                    .map(|filtered_batch| (b.id, Arc::new(filtered_batch)))
+            }));
+
+        // Add mem index to stream state
+        let index = Arc::new(index);
+        stream_state
+            .stream_indices
+            .insert_memory_index(index.clone());
+
+        let path = self.metadata.path.clone();
+        let parquet_flush_threshold_size = self.metadata.config.disk_slice_parquet_file_size;
+
+        let disk_slice = DiskSliceWriter::new(
+            self.metadata.schema.clone(),
+            path,
+            batches,
+            None,
+            next_file_id,
+            index,
+            parquet_flush_threshold_size,
+        );
+
+        disk_slice
+    }
+
+    /// Flushes a disk slice for streaming transaction.
+    /// Increments the pending flush count for this transaction.
+    pub async fn flush_stream_disk_slice(
+        &mut self,
+        xact_id: u32,
+        disk_slice: &mut DiskSliceWriter,
+    ) -> Result<()> {
+        assert!(
+            self.transaction_stream_states.contains_key(&xact_id),
+            "Stream state not found for xact_id: {xact_id}"
+        );
+        let stream_state = self.transaction_stream_states.get_mut(&xact_id).unwrap();
+        stream_state.pending_flush_count += 1;
+        disk_slice.write().await?;
         Ok(())
     }
 
-    /// Commit a transaction stream commit.
-    /// This is used to commit a transaction stream commit that was buffered during initial copy.
-    /// It will be applied to the table at the end of initial copy.
-    pub async fn commit_transaction_stream(&mut self, xact_id: u32, lsn: u64) -> Result<()> {
-        self.flush_transaction_stream(xact_id).await?;
-        if let Some(mut stream_state) = self.transaction_stream_states.remove(&xact_id) {
-            // Sanith check flush LSN doesn't regress.
-            assert!(
-                self.next_snapshot_task.new_flush_lsn.is_none()
-                    || self.next_snapshot_task.new_flush_lsn.unwrap() <= lsn,
-                "Current flush LSN is {:?}, new flush LSN is {}",
-                self.next_snapshot_task.new_flush_lsn,
-                lsn,
-            );
+    /// Applies the result of a streaming flush to the stream state.
+    /// Decrements the pending flush count for this transaction.
+    /// Handles commit and abort cleanup.
+    /// Removes in memory indices and record batches from the stream state.
+    pub fn apply_stream_flush_result(&mut self, xact_id: u32, mut disk_slice: DiskSliceWriter) {
+        assert!(
+            self.transaction_stream_states.contains_key(&xact_id),
+            "Stream state not found for xact_id: {xact_id}"
+        );
 
-            let snapshot_task = &mut self.next_snapshot_task;
-            snapshot_task.new_commit_lsn = lsn;
+        let stream_state = self.transaction_stream_states.get_mut(&xact_id).unwrap();
+        stream_state.pending_flush_count -= 1;
 
-            // We update our delete records with the last lsn of the transaction
-            // Note that in the stream case we dont have this until commit time
-            for deletion in stream_state.pending_deletions_in_main_mem_slice.iter_mut() {
-                let pos = deletion.pos.unwrap();
-                // If the row is no longer in memslice, it must be flushed, let snapshot task find it.
-                if !self.mem_slice.try_delete_at_pos(pos) {
-                    deletion.pos = None;
-                }
+        // Transaction committed while stream was flushing. Add disk slice to snapshot task and let snapshot handle it.
+        // Drop the stream state since the transaction is over.
+        if stream_state.status == TransactionStreamStatus::Committed {
+            disk_slice.writer_lsn = stream_state.commit_lsn;
+            self.next_snapshot_task.new_disk_slices.push(disk_slice);
+            if stream_state.pending_flush_count == 0 {
+                self.transaction_stream_states.remove(&xact_id);
             }
-
-            for deletion in stream_state.local_deletions.iter_mut() {
-                deletion.lsn = lsn - 1;
-            }
-
-            let commit = TransactionStreamCommit {
-                xact_id,
-                commit_lsn: lsn,
-                flushed_file_index: stream_state.flushed_file_index,
-                flushed_files: stream_state.flushed_files,
-                local_deletions: stream_state.local_deletions,
-                pending_deletions: stream_state.pending_deletions_in_main_mem_slice,
-            };
-            snapshot_task
-                .new_streaming_xact
-                .push(TransactionStreamOutput::Commit(commit));
-            snapshot_task.new_flush_lsn = Some(lsn);
-            Ok(())
-        } else {
-            panic!("Transaction stream state not found for xact_id: {xact_id}");
+            return;
         }
+
+        // Transaction aborted while stream was flushing. Remove stream state and do nothing.
+        // Drop the stream state since the transaction is over.
+        if stream_state.status == TransactionStreamStatus::Aborted {
+            if stream_state.pending_flush_count == 0 {
+                self.transaction_stream_states.remove(&xact_id);
+            }
+            return;
+        }
+
+        // Append state so we can find deletes during tx
+        for (file, file_attrs) in disk_slice.output_files().iter() {
+            ma::assert_gt!(file_attrs.file_size, 0);
+            let disk_file_entry = DiskFileEntry {
+                file_size: file_attrs.file_size,
+                cache_handle: None,
+                batch_deletion_vector: BatchDeletionVector::new(file_attrs.row_num),
+                puffin_deletion_blob: None,
+            };
+            // Add now flushed files to stream state
+            stream_state
+                .flushed_files
+                .insert(file.clone(), disk_file_entry);
+        }
+
+        // Add flushed file index to stream state
+        let index = disk_slice.take_index();
+        if let Some(index) = index {
+            stream_state.stream_indices.insert_file_index(index);
+        }
+        // Remove now flushed in mem batches
+        for batch in disk_slice.input_batches().iter() {
+            stream_state.new_record_batches.retain(|b| b.0 != batch.id);
+        }
+        // Remove now flushed in mem indices
+        let old_index = disk_slice.old_index();
+        stream_state.stream_indices.delete_memory_index(old_index);
+    }
+
+    /// Commit a transaction stream.
+    /// Flushes any remaining rows from stream mem slice
+    /// Adds all in mem batches and indices to next snapshot task
+    /// Updates deletion records
+    /// Enqueues `TransactionStreamOutput::Commit` for snapshot task
+    pub async fn commit_transaction_stream(&mut self, xact_id: u32, lsn: u64) -> Result<()> {
+        let mut disk_slice = self.prepare_stream_disk_slice(xact_id);
+        self.flush_stream_disk_slice(xact_id, &mut disk_slice)
+            .await?;
+        self.next_snapshot_task.new_flush_lsn = Some(lsn);
+        self.apply_stream_flush_result(xact_id, disk_slice);
+
+        // Now remove and process the state
+        let stream_state = self
+            .transaction_stream_states
+            .get_mut(&xact_id)
+            .expect("stream state not found");
+
+        stream_state.commit_lsn = Some(lsn);
+
+        // Add state from current mem slice to stream first
+        let (_, batches, index) = stream_state.mem_slice.drain()?;
+        stream_state
+            .new_record_batches
+            .extend(batches.iter().filter_map(|b| {
+                b.batch
+                    .get_filtered_batch()
+                    .ok()
+                    .flatten()
+                    .map(|filtered_batch| (b.id, Arc::new(filtered_batch)))
+            }));
+        stream_state
+            .stream_indices
+            .insert_memory_index(Arc::new(index));
+
+        // Add stream record batches to next snapshot task
+        self.next_snapshot_task
+            .new_record_batches
+            .extend(stream_state.new_record_batches.clone());
+        // Add stream in mem indices to next snapshot task
+        self.next_snapshot_task.new_mem_indices.extend(
+            stream_state
+                .stream_indices
+                .in_memory_index
+                .iter()
+                .map(|ptr| ptr.arc_ptr()),
+        );
+        self.next_snapshot_task.new_commit_lsn = lsn;
+
+        // We update our delete records with the last lsn of the transaction
+        // Note that in the stream case we dont have this until commit time
+        for deletion in stream_state.pending_deletions_in_main_mem_slice.iter_mut() {
+            let pos = deletion.pos.unwrap();
+            // If the row is no longer in memslice, it must be flushed, let snapshot task find it.
+            if !self.mem_slice.try_delete_at_pos(pos) {
+                deletion.pos = None;
+            }
+        }
+
+        for deletion in stream_state.local_deletions.iter_mut() {
+            deletion.lsn = lsn - 1;
+        }
+
+        let commit = TransactionStreamCommit {
+            xact_id,
+            commit_lsn: lsn,
+            flushed_file_index: stream_state.stream_indices.clone(),
+            flushed_files: stream_state.flushed_files.clone(),
+            local_deletions: std::mem::take(&mut stream_state.local_deletions),
+            pending_deletions: std::mem::take(
+                &mut stream_state.pending_deletions_in_main_mem_slice,
+            ),
+        };
+        self.next_snapshot_task
+            .new_streaming_xact
+            .push(TransactionStreamOutput::Commit(commit));
+
+        stream_state.status = TransactionStreamStatus::Committed;
+
+        Ok(())
     }
 }
 

--- a/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
+++ b/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
@@ -320,7 +320,8 @@ impl MooncakeTable {
         // Transaction committed while stream was flushing. Add disk slice to snapshot task and let snapshot handle it.
         // Drop the stream state since the transaction is over.
         if stream_state.status == TransactionStreamStatus::Committed {
-            disk_slice.writer_lsn = stream_state.commit_lsn;
+            assert!(stream_state.commit_lsn.is_some());
+            disk_slice.set_lsn(stream_state.commit_lsn.unwrap());
             self.next_snapshot_task.new_disk_slices.push(disk_slice);
             if stream_state.pending_flush_count == 0 {
                 self.transaction_stream_states.remove(&xact_id);

--- a/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
+++ b/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
@@ -274,7 +274,7 @@ impl MooncakeTable {
         let path = self.metadata.path.clone();
         let parquet_flush_threshold_size = self.metadata.config.disk_slice_parquet_file_size;
 
-        let disk_slice = DiskSliceWriter::new(
+        DiskSliceWriter::new(
             self.metadata.schema.clone(),
             path,
             batches,
@@ -282,9 +282,7 @@ impl MooncakeTable {
             next_file_id,
             index,
             parquet_flush_threshold_size,
-        );
-
-        disk_slice
+        )
     }
 
     /// Flushes a disk slice for streaming transaction.

--- a/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
+++ b/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
@@ -223,11 +223,10 @@ impl MooncakeTable {
 
     pub fn abort_in_stream_batch(&mut self, xact_id: u32) {
         // Record abortion in snapshot task so we can remove any uncomitted deletions
-        assert!(
-            self.transaction_stream_states.contains_key(&xact_id),
-            "Stream state not found for xact_id: {xact_id}"
-        );
-        let stream_state = self.transaction_stream_states.get_mut(&xact_id).unwrap();
+        let stream_state = self
+            .transaction_stream_states
+            .get_mut(&xact_id)
+            .expect("Stream state not found for xact_id: {xact_id}");
 
         stream_state.status = TransactionStreamStatus::Aborted;
 
@@ -249,12 +248,10 @@ impl MooncakeTable {
         xact_id: u32,
         lsn: Option<u64>,
     ) -> Result<DiskSliceWriter> {
-        assert!(
-            self.transaction_stream_states.contains_key(&xact_id),
-            "Stream state not found for xact_id: {xact_id}"
-        );
-
-        let stream_state = self.transaction_stream_states.get_mut(&xact_id).unwrap();
+        let stream_state = self
+            .transaction_stream_states
+            .get_mut(&xact_id)
+            .expect("Stream state not found for xact_id: {xact_id}");
         let next_file_id = self.next_file_id;
         self.next_file_id += 1;
 
@@ -300,11 +297,10 @@ impl MooncakeTable {
         xact_id: u32,
         disk_slice: &mut DiskSliceWriter,
     ) -> Result<()> {
-        assert!(
-            self.transaction_stream_states.contains_key(&xact_id),
-            "Stream state not found for xact_id: {xact_id}"
-        );
-        let stream_state = self.transaction_stream_states.get_mut(&xact_id).unwrap();
+        let stream_state = self
+            .transaction_stream_states
+            .get_mut(&xact_id)
+            .expect("Stream state not found for xact_id: {xact_id}");
         stream_state.pending_flush_count += 1;
         disk_slice.write().await?;
         Ok(())
@@ -315,12 +311,10 @@ impl MooncakeTable {
     /// Handles commit and abort cleanup.
     /// Removes in memory indices and record batches from the stream state.
     pub fn apply_stream_flush_result(&mut self, xact_id: u32, mut disk_slice: DiskSliceWriter) {
-        assert!(
-            self.transaction_stream_states.contains_key(&xact_id),
-            "Stream state not found for xact_id: {xact_id}"
-        );
-
-        let stream_state = self.transaction_stream_states.get_mut(&xact_id).unwrap();
+        let stream_state = self
+            .transaction_stream_states
+            .get_mut(&xact_id)
+            .expect("Stream state not found for xact_id: {xact_id}");
         stream_state.pending_flush_count -= 1;
 
         // Transaction committed while stream was flushing. Add disk slice to snapshot task and let snapshot handle it.
@@ -392,11 +386,10 @@ impl MooncakeTable {
         self.flush_stream(xact_id, Some(lsn)).await?;
 
         // Now remove and process the state
-        assert!(
-            self.transaction_stream_states.contains_key(&xact_id),
-            "Stream state not found for xact_id: {xact_id}"
-        );
-        let stream_state = self.transaction_stream_states.get_mut(&xact_id).unwrap();
+        let stream_state = self
+            .transaction_stream_states
+            .get_mut(&xact_id)
+            .expect("Stream state not found for xact_id: {xact_id}");
 
         // Add state from current mem slice to stream first
         let (_, batches, index) = stream_state.mem_slice.drain()?;

--- a/src/moonlink/src/table_handler.rs
+++ b/src/moonlink/src/table_handler.rs
@@ -557,16 +557,8 @@ impl TableHandler {
                     Some(xact_id) => {
                         let res = table.append_in_stream_batch(row, xact_id);
                         if table.should_transaction_flush(xact_id) {
-                            if let Ok(mut disk_slice) = table.prepare_stream_disk_slice(xact_id) {
-                                if let Err(e) = table
-                                    .flush_stream_disk_slice(xact_id, &mut disk_slice)
-                                    .await
-                                {
-                                    error!(error = %e, "flush failed in append");
-                                }
-                                table.apply_stream_flush_result(xact_id, disk_slice);
-                            } else {
-                                error!(error = "prepare stream disk slice failed");
+                            if let Err(e) = table.flush_stream(xact_id, None).await {
+                                error!(error = %e, "flush failed in append");
                             }
                         }
                         res
@@ -608,16 +600,8 @@ impl TableHandler {
                 .await;
             }
             TableEvent::StreamFlush { xact_id } => {
-                if let Ok(mut disk_slice) = table.prepare_stream_disk_slice(xact_id) {
-                    if let Err(e) = table
-                        .flush_stream_disk_slice(xact_id, &mut disk_slice)
-                        .await
-                    {
-                        error!(error = %e, "stream flush failed");
-                    }
-                    table.apply_stream_flush_result(xact_id, disk_slice);
-                } else {
-                    error!(error = "prepare stream disk slice failed");
+                if let Err(e) = table.flush_stream(xact_id, None).await {
+                    error!(error = %e, "stream flush failed");
                 }
             }
             _ => {

--- a/src/moonlink/src/table_handler.rs
+++ b/src/moonlink/src/table_handler.rs
@@ -557,9 +557,14 @@ impl TableHandler {
                     Some(xact_id) => {
                         let res = table.append_in_stream_batch(row, xact_id);
                         if table.should_transaction_flush(xact_id) {
-                            if let Err(e) = table.flush_transaction_stream(xact_id).await {
+                            let mut disk_slice = table.prepare_stream_disk_slice(xact_id);
+                            if let Err(e) = table
+                                .flush_stream_disk_slice(xact_id, &mut disk_slice)
+                                .await
+                            {
                                 error!(error = %e, "flush failed in append");
                             }
+                            table.apply_stream_flush_result(xact_id, disk_slice);
                         }
                         res
                     }
@@ -600,9 +605,14 @@ impl TableHandler {
                 .await;
             }
             TableEvent::StreamFlush { xact_id } => {
-                if let Err(e) = table.flush_transaction_stream(xact_id).await {
+                let mut disk_slice = table.prepare_stream_disk_slice(xact_id);
+                if let Err(e) = table
+                    .flush_stream_disk_slice(xact_id, &mut disk_slice)
+                    .await
+                {
                     error!(error = %e, "stream flush failed");
                 }
+                table.apply_stream_flush_result(xact_id, disk_slice);
             }
             _ => {
                 unreachable!("unexpected event: {:?}", event)


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

Removes the assumption that flush happens in the foreground. Adds state to `TransactionStreamState` or `next_snapshot_task` to ensure transaction visibility during flush. Note that flush is still done in the foreground here, this will be changed in a future PR.

In general, each time we flush we need to add the current batches and indices to the stream state. When a flush finishes, we remove this state. On commit we move any remaining batches and indices from the `TransactionStreamState` into the snapshot task to ensure it is visible. When the flush finishes, we add its disk slice to the snapshot task. 

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1032

## Changes

- 
- 
- 

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
