### PR TITLE
[storage] Integrate conditional write with iceberg commit

### DIFF
--- a/src/moonlink/src/storage/filesystem/accessor/base_filesystem_accessor.rs
+++ b/src/moonlink/src/storage/filesystem/accessor/base_filesystem_accessor.rs
@@ -51,7 +51,11 @@ pub trait BaseFileSystemAccess: std::fmt::Debug + Send + Sync {
     ) -> Result<Pin<Box<dyn Stream<Item = Result<Vec<u8>>> + Send>>>;
 
     /// Write the whole content to the given object.
-    async fn write_object(&self, object_filepath: &str, content: Vec<u8>) -> Result<()>;
+    async fn write_object(
+        &self,
+        object_filepath: &str,
+        content: Vec<u8>,
+    ) -> Result<opendal::Metadata>;
     /// Write the whole content with conditional write and put-if-absent semantics support.
     ///
     /// # Arguments

--- a/src/moonlink/src/storage/filesystem/accessor/filesystem_accessor_chaos_wrapper.rs
+++ b/src/moonlink/src/storage/filesystem/accessor/filesystem_accessor_chaos_wrapper.rs
@@ -150,7 +150,7 @@ impl BaseFileSystemAccess for FileSystemChaosWrapper {
         self.inner.stream_read(object).await
     }
 
-    async fn write_object(&self, object: &str, content: Vec<u8>) -> Result<()> {
+    async fn write_object(&self, object: &str, content: Vec<u8>) -> Result<opendal::Metadata> {
         self.perform_wrapper_function().await?;
         self.inner.write_object(object, content).await
     }

--- a/src/moonlink/src/storage/filesystem/accessor/filesystem_accessor_retry_wrapper.rs
+++ b/src/moonlink/src/storage/filesystem/accessor/filesystem_accessor_retry_wrapper.rs
@@ -89,7 +89,7 @@ impl BaseFileSystemAccess for FileSystemRetryWrapper {
             .await
     }
 
-    async fn write_object(&self, object: &str, content: Vec<u8>) -> Result<()> {
+    async fn write_object(&self, object: &str, content: Vec<u8>) -> Result<opendal::Metadata> {
         self.retry_async(|| {
             let content = content.clone();
             async move { self.inner.write_object(object, content).await }
@@ -169,7 +169,9 @@ mod tests {
         mock_filesystem_access
             .expect_write_object()
             .times(1)
-            .returning(|_, _| Box::pin(async move { Ok(()) }));
+            .returning(|_, _| {
+                Box::pin(async move { Ok(opendal::Metadata::new(opendal::EntryMode::FILE)) })
+            });
 
         let retry_wrapper = FileSystemRetryWrapper::new(Arc::new(mock_filesystem_access));
         retry_wrapper


### PR DESCRIPTION
## Summary

This PR integrates conditional write with iceberg transaction commit; also make conditional write robust by checking the support of if-match feature.
Existing S3 tests already covered transaction commit; fake GCS server doesn't seem to support conditional write.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1097

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
