### PR TITLE
[chaos] Add object storage to chaos test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,6 @@ on:
   pull_request:
     branches: [main]
 
-# Cancel superseded runs for the same branch / PR
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
@@ -19,158 +18,170 @@ defaults:
   run:
     shell: bash
 
-# ---------------------------------------------------------------------------
-# Jobs
-# ---------------------------------------------------------------------------
 jobs:
-  # ────────────────────────────── 1 · FORMAT + CLIPPY ─────────────────────────
   lint:
     name: Format & Clippy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
       - uses: dtolnay/rust-toolchain@stable
         id: toolchain
         with:
           components: rustfmt,clippy
-
       - uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-deny
-
+        with: { tool: cargo-deny }
       - uses: swatinem/rust-cache@v2
         with:
           shared-key: ${{ steps.toolchain.outputs.cachekey }}
+      - run: cargo fmt --check
+      - run: cargo clippy --all-targets --all-features -- -D warnings
+      - run: cargo deny check
 
-      - name: rustfmt check
-        run: cargo fmt --check
-
-      - name: clippy lint
-        run: cargo clippy --all-targets --all-features -- -D warnings
-
-      - name: cargo deny check
-        run: cargo deny check
-
-  # ──────────────────────── 2 · GCS feature test ────────────────────────────
-  gcs_test:
-    name: Unit tests with GCS feature enabled
+  # ───────────── Matrix for GCS and S3 Feature Tests ─────────────
+  feature_tests:
+    name: Feature Test (${{ matrix.storage }})
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        include:
+          - storage: gcs
+            port: 4443
+            hostname: gcs.local
+            container: fake-gcs
+            image: fsouza/fake-gcs-server:latest
+            healthcheck: curl -sf http://gcs.local:4443/storage/v1/b
+            features: storage-gcs
+            args: -scheme http -port 4443
+          - storage: s3
+            port: 9000
+            hostname: s3.local
+            container: minio
+            image: minio/minio:latest
+            healthcheck: curl -sf http://minio:9000/minio/health/ready
+            features: storage-s3
+            args: server /data
     steps:
       - uses: actions/checkout@v4
 
-      # ─────────────────────── Start Fake GCS Server ──────────────────────────
-      - name: Start Fake GCS Server
+      - name: Start Fake ${{ matrix.storage | upper }} Server
         run: |
           docker run -d \
-            --name fake-gcs \
-            -p 4443:4443 \
-            -e STORAGE_DIR=/data \
-            fsouza/fake-gcs-server:latest \
-            -scheme http -port 4443
-      
-      # ─────────────── Add hostnames to /etc/hosts ──────────────────────────
-      - name: Add gcs.local to /etc/hosts
-        run: |
-          echo "127.0.0.1 gcs.local" | sudo tee -a /etc/hosts
-
-      # ───────────────────── Wait for Fake GCS to be ready ───────────────────
-      - name: Wait for Fake GCS ready
-        timeout-minutes: 5
-        run: |
-          for i in {1..10}; do
-            if curl -sf http://gcs.local:4443/storage/v1/b; then
-              echo "Fake GCS is ready!"
-              break
-            fi
-            echo "Waiting for Fake GCS..."
-            sleep 2
-          done
-
-      # ────────────────────── Toolchain + Test Tools ─────────────────────────
-      - name: Run GCS feature tests
-        timeout-minutes: 5
-        run: |
-          cargo test -p moonlink --features=storage-gcs
-
-  # ──────────────────────── 3 · S3 feature test ────────────────────────────
-  s3_test:
-    name: Unit tests with S3 feature enabled
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      # ─────────────────────── Start Fake S3 Server ──────────────────────────
-      - name: Start Fake S3 Server
-        run: |
-          docker run -d \
-            --name minio \
-            -p 9000:9000 \
+            --name ${{ matrix.container }} \
+            -p ${{ matrix.port }}:${{ matrix.port }} \
             -e MINIO_ROOT_USER=minioadmin \
             -e MINIO_ROOT_PASSWORD=minioadmin \
-            minio/minio:latest server /data
-      
-      # ─────────────── Add hostnames to /etc/hosts ──────────────────────────
-      - name: Add s3.local to /etc/hosts
-        run: |
-          echo "127.0.0.1 s3.local" | sudo tee -a /etc/hosts
+            -e STORAGE_DIR=/data \
+            ${{ matrix.image }} ${{ matrix.args }}
 
-      # ───────────────────── Wait for Fake S3 to be ready ───────────────────
-      - name: Wait for Fake S3
+      - name: Add hostname
+        run: |
+          echo "127.0.0.1 ${{ matrix.hostname }}" | sudo tee -a /etc/hosts
+
+      - name: Wait for server
         timeout-minutes: 5
         run: |
           for i in {1..10}; do
-            if curl -sf http://minio:9000/minio/health/ready; then
-              echo "Fake S3 is ready!"
+            if ${{ matrix.healthcheck }}; then
+              echo "Server ready!"
               break
             fi
-            echo "Waiting for Fake GCS..."
+            echo "Waiting for server..."
             sleep 2
           done
 
-      # ────────────────────── Toolchain + Test Tools ─────────────────────────
-      - name: Run S3 feature tests
-        timeout-minutes: 5
-        run: |
-          cargo test -p moonlink --features=storage-s3
+      - name: Run tests with --features=${{ matrix.features }}
+        run: cargo test -p moonlink --features=${{ matrix.features }}
 
-  # ───────────────────────── 4 · TEST & COVERAGE ────────────────────────────
-  coverage:
-    name: Unit Tests + Coverage (llvm-cov + nextest)
+  # ───────────── Matrix for Chaos Tests ─────────────
+  chaos_tests:
+    name: Chaos Test (${{ matrix.storage || 'local' }})
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - name: local
+            test: table_handler::chaos_test
+            features: chaos-test
+          - name: s3
+            port: 9000
+            hostname: s3.local
+            container: minio
+            image: minio/minio:latest
+            args: server /data
+            test: table_handler::chaos_s3_test
+            features: chaos-test,storage-s3
+            healthcheck: curl -sf http://minio:9000/minio/health/ready
+          - name: gcs
+            port: 4443
+            hostname: gcs.local
+            container: fake-gcs
+            image: fsouza/fake-gcs-server:latest
+            args: -scheme http -port 4443
+            test: table_handler::chaos_gcs_test
+            features: chaos-test,storage-gcs
+            healthcheck: curl -sf http://gcs.local:4443/storage/v1/b
 
     steps:
       - uses: actions/checkout@v4
 
-      # ────────────────────── Toolchain + Test Tools ─────────────────────────
+      - name: Start storage server
+        if: ${{ matrix.storage != null }}
+        run: |
+          docker run -d \
+            --name ${{ matrix.container }} \
+            -p ${{ matrix.port }}:${{ matrix.port }} \
+            -e MINIO_ROOT_USER=minioadmin \
+            -e MINIO_ROOT_PASSWORD=minioadmin \
+            -e STORAGE_DIR=/data \
+            ${{ matrix.image }} ${{ matrix.args }}
+
+      - name: Add hostname
+        if: ${{ matrix.storage != null }}
+        run: |
+          echo "127.0.0.1 ${{ matrix.hostname }}" | sudo tee -a /etc/hosts
+
+      - name: Wait for server
+        if: ${{ matrix.storage != null }}
+        timeout-minutes: 5
+        run: |
+          for i in {1..10}; do
+            if ${{ matrix.healthcheck }}; then
+              echo "Server ready!"
+              break
+            fi
+            echo "Waiting for server..."
+            sleep 2
+          done
+
+      - name: Run chaos test
+        timeout-minutes: 10
+        run: cargo test ${{ matrix.test }} --features=${{ matrix.features }} -p moonlink -- --nocapture
+
+  # ───────────── Coverage Job ─────────────
+  coverage:
+    name: Coverage (llvm-cov + nextest)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         id: toolchain
         with:
           components: llvm-tools-preview
-
       - uses: swatinem/rust-cache@v2
         with:
           shared-key: ${{ steps.toolchain.outputs.cachekey }}
-
       - uses: taiki-e/install-action@v2
         with: { tool: cargo-llvm-cov }
       - uses: taiki-e/install-action@v2
         with: { tool: nextest }
 
-      - name: Run tests via llvm-cov/nextest
-        timeout-minutes: 5
-        run: |
+      - run: |
           cargo llvm-cov \
             --locked \
             --lib \
             --lcov --output-path lcov.info \
-            nextest \
-              --profile ci \
-              --no-fail-fast
+            nextest --profile ci --no-fail-fast
 
-      # ---------- Upload JUnit test results to Codecov ----------
       - name: Upload test results (JUnit)
         if: ${{ !cancelled() }}
         uses: codecov/test-results-action@v1
@@ -180,7 +191,6 @@ jobs:
           files: target/nextest/ci/junit.xml
           fail_ci_if_error: true
 
-      # ---------- Upload coverage report to Codecov ----------
       - name: Upload coverage (lcov)
         if: ${{ !cancelled() }}
         uses: codecov/codecov-action@v5
@@ -189,16 +199,3 @@ jobs:
         with:
           files: lcov.info
           fail_ci_if_error: true
-
-  # ──────────────────────── 4 · Chaos test ────────────────────────────
-  chaos_test:
-    name: Chaos test
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Start chaos test
-        timeout-minutes: 10
-        run: |
-          cargo test table_handler::chaos_test --features=chaos-test -p moonlink -- --nocapture

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches: [main]
 
+# Cancel superseded runs for the same branch / PR
 concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
@@ -18,170 +19,158 @@ defaults:
   run:
     shell: bash
 
+# ---------------------------------------------------------------------------
+# Jobs
+# ---------------------------------------------------------------------------
 jobs:
+  # ────────────────────────────── 1 · FORMAT + CLIPPY ─────────────────────────
   lint:
     name: Format & Clippy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - uses: dtolnay/rust-toolchain@stable
         id: toolchain
         with:
           components: rustfmt,clippy
+
       - uses: taiki-e/install-action@v2
-        with: { tool: cargo-deny }
+        with:
+          tool: cargo-deny
+
       - uses: swatinem/rust-cache@v2
         with:
           shared-key: ${{ steps.toolchain.outputs.cachekey }}
-      - run: cargo fmt --check
-      - run: cargo clippy --all-targets --all-features -- -D warnings
-      - run: cargo deny check
 
-  # ───────────── Matrix for GCS and S3 Feature Tests ─────────────
-  feature_tests:
-    name: Feature Test (${{ matrix.storage }})
+      - name: rustfmt check
+        run: cargo fmt --check
+
+      - name: clippy lint
+        run: cargo clippy --all-targets --all-features -- -D warnings
+
+      - name: cargo deny check
+        run: cargo deny check
+
+  # ──────────────────────── 2 · GCS feature test ────────────────────────────
+  gcs_test:
+    name: Unit tests with GCS feature enabled
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - storage: gcs
-            port: 4443
-            hostname: gcs.local
-            container: fake-gcs
-            image: fsouza/fake-gcs-server:latest
-            healthcheck: curl -sf http://gcs.local:4443/storage/v1/b
-            features: storage-gcs
-            args: -scheme http -port 4443
-          - storage: s3
-            port: 9000
-            hostname: s3.local
-            container: minio
-            image: minio/minio:latest
-            healthcheck: curl -sf http://minio:9000/minio/health/ready
-            features: storage-s3
-            args: server /data
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Start Fake ${{ matrix.storage | upper }} Server
-        run: |
-          docker run -d \
-            --name ${{ matrix.container }} \
-            -p ${{ matrix.port }}:${{ matrix.port }} \
-            -e MINIO_ROOT_USER=minioadmin \
-            -e MINIO_ROOT_PASSWORD=minioadmin \
-            -e STORAGE_DIR=/data \
-            ${{ matrix.image }} ${{ matrix.args }}
-
-      - name: Add hostname
-        run: |
-          echo "127.0.0.1 ${{ matrix.hostname }}" | sudo tee -a /etc/hosts
-
-      - name: Wait for server
-        timeout-minutes: 5
-        run: |
-          for i in {1..10}; do
-            if ${{ matrix.healthcheck }}; then
-              echo "Server ready!"
-              break
-            fi
-            echo "Waiting for server..."
-            sleep 2
-          done
-
-      - name: Run tests with --features=${{ matrix.features }}
-        run: cargo test -p moonlink --features=${{ matrix.features }}
-
-  # ───────────── Matrix for Chaos Tests ─────────────
-  chaos_tests:
-    name: Chaos Test (${{ matrix.storage || 'local' }})
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        include:
-          - name: local
-            test: table_handler::chaos_test
-            features: chaos-test
-          - name: s3
-            port: 9000
-            hostname: s3.local
-            container: minio
-            image: minio/minio:latest
-            args: server /data
-            test: table_handler::chaos_s3_test
-            features: chaos-test,storage-s3
-            healthcheck: curl -sf http://minio:9000/minio/health/ready
-          - name: gcs
-            port: 4443
-            hostname: gcs.local
-            container: fake-gcs
-            image: fsouza/fake-gcs-server:latest
-            args: -scheme http -port 4443
-            test: table_handler::chaos_gcs_test
-            features: chaos-test,storage-gcs
-            healthcheck: curl -sf http://gcs.local:4443/storage/v1/b
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Start storage server
-        if: ${{ matrix.storage != null }}
+      # ─────────────────────── Start Fake GCS Server ──────────────────────────
+      - name: Start Fake GCS Server
         run: |
           docker run -d \
-            --name ${{ matrix.container }} \
-            -p ${{ matrix.port }}:${{ matrix.port }} \
-            -e MINIO_ROOT_USER=minioadmin \
-            -e MINIO_ROOT_PASSWORD=minioadmin \
+            --name fake-gcs \
+            -p 4443:4443 \
             -e STORAGE_DIR=/data \
-            ${{ matrix.image }} ${{ matrix.args }}
-
-      - name: Add hostname
-        if: ${{ matrix.storage != null }}
+            fsouza/fake-gcs-server:latest \
+            -scheme http -port 4443
+      
+      # ─────────────── Add hostnames to /etc/hosts ──────────────────────────
+      - name: Add gcs.local to /etc/hosts
         run: |
-          echo "127.0.0.1 ${{ matrix.hostname }}" | sudo tee -a /etc/hosts
+          echo "127.0.0.1 gcs.local" | sudo tee -a /etc/hosts
 
-      - name: Wait for server
-        if: ${{ matrix.storage != null }}
+      # ───────────────────── Wait for Fake GCS to be ready ───────────────────
+      - name: Wait for Fake GCS ready
         timeout-minutes: 5
         run: |
           for i in {1..10}; do
-            if ${{ matrix.healthcheck }}; then
-              echo "Server ready!"
+            if curl -sf http://gcs.local:4443/storage/v1/b; then
+              echo "Fake GCS is ready!"
               break
             fi
-            echo "Waiting for server..."
+            echo "Waiting for Fake GCS..."
             sleep 2
           done
 
-      - name: Run chaos test
-        timeout-minutes: 10
-        run: cargo test ${{ matrix.test }} --features=${{ matrix.features }} -p moonlink -- --nocapture
+      # ────────────────────── Toolchain + Test Tools ─────────────────────────
+      - name: Run GCS feature tests
+        timeout-minutes: 5
+        run: |
+          cargo test -p moonlink --features=storage-gcs
 
-  # ───────────── Coverage Job ─────────────
+  # ──────────────────────── 3 · S3 feature test ────────────────────────────
+  s3_test:
+    name: Unit tests with S3 feature enabled
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # ─────────────────────── Start Fake S3 Server ──────────────────────────
+      - name: Start Fake S3 Server
+        run: |
+          docker run -d \
+            --name minio \
+            -p 9000:9000 \
+            -e MINIO_ROOT_USER=minioadmin \
+            -e MINIO_ROOT_PASSWORD=minioadmin \
+            minio/minio:latest server /data
+      
+      # ─────────────── Add hostnames to /etc/hosts ──────────────────────────
+      - name: Add s3.local to /etc/hosts
+        run: |
+          echo "127.0.0.1 s3.local" | sudo tee -a /etc/hosts
+
+      # ───────────────────── Wait for Fake S3 to be ready ───────────────────
+      - name: Wait for Fake S3
+        timeout-minutes: 5
+        run: |
+          for i in {1..10}; do
+            if curl -sf http://minio:9000/minio/health/ready; then
+              echo "Fake S3 is ready!"
+              break
+            fi
+            echo "Waiting for Fake GCS..."
+            sleep 2
+          done
+
+      # ────────────────────── Toolchain + Test Tools ─────────────────────────
+      - name: Run S3 feature tests
+        timeout-minutes: 5
+        run: |
+          cargo test -p moonlink --features=storage-s3
+
+  # ───────────────────────── 4 · TEST & COVERAGE ────────────────────────────
   coverage:
-    name: Coverage (llvm-cov + nextest)
+    name: Unit Tests + Coverage (llvm-cov + nextest)
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v4
+
+      # ────────────────────── Toolchain + Test Tools ─────────────────────────
       - uses: dtolnay/rust-toolchain@stable
         id: toolchain
         with:
           components: llvm-tools-preview
+
       - uses: swatinem/rust-cache@v2
         with:
           shared-key: ${{ steps.toolchain.outputs.cachekey }}
+
       - uses: taiki-e/install-action@v2
         with: { tool: cargo-llvm-cov }
       - uses: taiki-e/install-action@v2
         with: { tool: nextest }
 
-      - run: |
+      - name: Run tests via llvm-cov/nextest
+        timeout-minutes: 5
+        run: |
           cargo llvm-cov \
             --locked \
             --lib \
             --lcov --output-path lcov.info \
-            nextest --profile ci --no-fail-fast
+            nextest \
+              --profile ci \
+              --no-fail-fast
 
+      # ---------- Upload JUnit test results to Codecov ----------
       - name: Upload test results (JUnit)
         if: ${{ !cancelled() }}
         uses: codecov/test-results-action@v1
@@ -191,6 +180,7 @@ jobs:
           files: target/nextest/ci/junit.xml
           fail_ci_if_error: true
 
+      # ---------- Upload coverage report to Codecov ----------
       - name: Upload coverage (lcov)
         if: ${{ !cancelled() }}
         uses: codecov/codecov-action@v5
@@ -199,3 +189,98 @@ jobs:
         with:
           files: lcov.info
           fail_ci_if_error: true
+
+  # ──────────────────────── 4 · Chaos test ────────────────────────────
+  chaos_test:
+    name: Chaos test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Start chaos test
+        timeout-minutes: 10
+        run: |
+          cargo test table_handler::chaos_test --features=chaos-test -p moonlink -- --nocapture
+
+  # ──────────────────────── 5 · S3 Chaos test ────────────────────────────
+  s3_chaos_test:
+    name: S3 chaos test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # ─────────────────────── Start Fake S3 Server ──────────────────────────
+      - name: Start Fake S3 Server
+        run: |
+          docker run -d \
+            --name minio \
+            -p 9000:9000 \
+            -e MINIO_ROOT_USER=minioadmin \
+            -e MINIO_ROOT_PASSWORD=minioadmin \
+            minio/minio:latest server /data
+      
+      # ─────────────── Add hostnames to /etc/hosts ──────────────────────────
+      - name: Add s3.local to /etc/hosts
+        run: |
+          echo "127.0.0.1 s3.local" | sudo tee -a /etc/hosts
+
+      # ───────────────────── Wait for Fake S3 to be ready ───────────────────
+      - name: Wait for Fake S3
+        timeout-minutes: 5
+        run: |
+          for i in {1..10}; do
+            if curl -sf http://minio:9000/minio/health/ready; then
+              echo "Fake S3 is ready!"
+              break
+            fi
+            echo "Waiting for Fake GCS..."
+            sleep 2
+          done
+
+      - name: Start chaos test
+        timeout-minutes: 10
+        run: |
+          cargo test table_handler::chaos_s3_test --features=chaos-test,storage-s3 -p moonlink -- --nocapture
+
+  # ──────────────────────── 6 · GCS Chaos test ────────────────────────────
+  gcs_chaos_test:
+    name: GCS chaos test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      # ─────────────────────── Start Fake GCS Server ──────────────────────────
+      - name: Start Fake GCS Server
+        run: |
+          docker run -d \
+            --name fake-gcs \
+            -p 4443:4443 \
+            -e STORAGE_DIR=/data \
+            fsouza/fake-gcs-server:latest \
+            -scheme http -port 4443
+      
+      # ─────────────── Add hostnames to /etc/hosts ──────────────────────────
+      - name: Add gcs.local to /etc/hosts
+        run: |
+          echo "127.0.0.1 gcs.local" | sudo tee -a /etc/hosts
+
+      # ───────────────────── Wait for Fake GCS to be ready ───────────────────
+      - name: Wait for Fake GCS ready
+        timeout-minutes: 5
+        run: |
+          for i in {1..10}; do
+            if curl -sf http://gcs.local:4443/storage/v1/b; then
+              echo "Fake GCS is ready!"
+              break
+            fi
+            echo "Waiting for Fake GCS..."
+            sleep 2
+          done
+
+      - name: Start chaos test
+        timeout-minutes: 10
+        run: |
+          cargo test table_handler::chaos_gcs_test --features=chaos-test,storage-gcs -p moonlink -- --nocapture

--- a/src/moonlink/src/storage/mooncake_table/table_creation_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_creation_test_utils.rs
@@ -39,6 +39,7 @@ pub(crate) fn get_iceberg_table_config(temp_dir: &TempDir) -> IcebergTableConfig
 }
 
 /// Test util function to get iceberg table cofig from filesystem config.
+#[cfg(feature = "chaos-test")]
 pub(crate) fn get_iceberg_table_config_with_filesystem_config(
     filesystem_config: FileSystemConfig,
 ) -> IcebergTableConfig {

--- a/src/moonlink/src/storage/mooncake_table/table_creation_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_creation_test_utils.rs
@@ -38,15 +38,25 @@ pub(crate) fn get_iceberg_table_config(temp_dir: &TempDir) -> IcebergTableConfig
     }
 }
 
+/// Test util function to get iceberg table cofig from filesystem config.
+pub(crate) fn get_iceberg_table_config_with_filesystem_config(
+    filesystem_config: FileSystemConfig,
+) -> IcebergTableConfig {
+    IcebergTableConfig {
+        namespace: vec![ICEBERG_TEST_NAMESPACE.to_string()],
+        table_name: ICEBERG_TEST_TABLE.to_string(),
+        filesystem_config,
+    }
+}
+
 /// Test util function with error injection at filesystem layer.
 #[cfg(feature = "chaos-test")]
 pub(crate) fn get_iceberg_table_config_with_chaos_injection(
-    temp_dir: &TempDir,
+    filesystem_config: FileSystemConfig,
 ) -> IcebergTableConfig {
     use crate::storage::filesystem::accessor::filesystem_accessor_chaos_wrapper::FileSystemChaosOption;
 
-    let root_directory = temp_dir.path().to_str().unwrap().to_string();
-    let inner_config = Box::new(FileSystemConfig::FileSystem { root_directory });
+    let inner_config = Box::new(filesystem_config);
     let chaos_option = FileSystemChaosOption {
         min_latency: std::time::Duration::from_secs(0),
         max_latency: std::time::Duration::from_secs(1),

--- a/src/moonlink/src/table_handler/chaos_test.rs
+++ b/src/moonlink/src/table_handler/chaos_test.rs
@@ -771,7 +771,7 @@ async fn test_s3_chaos_with_no_background_maintenance() {
     let test_env_config = TestEnvConfig {
         maintenance_option: TableMainenanceOption::NoTableMaintenance,
         error_injection_enabled: false,
-        event_count: 2500,
+        event_count: 3000,
         filesystem_config: s3_filesystem_config,
     };
     let env = TestEnvironment::new(test_env_config).await;
@@ -788,7 +788,7 @@ async fn test_s3_chaos_with_index_merge() {
     let test_env_config = TestEnvConfig {
         maintenance_option: TableMainenanceOption::IndexMerge,
         error_injection_enabled: false,
-        event_count: 2500,
+        event_count: 3000,
         filesystem_config: s3_filesystem_config,
     };
     let env = TestEnvironment::new(test_env_config).await;
@@ -805,7 +805,7 @@ async fn test_s3_chaos_with_data_compaction() {
     let test_env_config = TestEnvConfig {
         maintenance_option: TableMainenanceOption::DataCompaction,
         error_injection_enabled: false,
-        event_count: 2500,
+        event_count: 3000,
         filesystem_config: s3_filesystem_config,
     };
     let env = TestEnvironment::new(test_env_config).await;
@@ -826,7 +826,7 @@ async fn test_gcs_chaos_with_no_background_maintenance() {
     let test_env_config = TestEnvConfig {
         maintenance_option: TableMainenanceOption::NoTableMaintenance,
         error_injection_enabled: false,
-        event_count: 2500,
+        event_count: 3000,
         filesystem_config: gcs_filesystem_config,
     };
     let env = TestEnvironment::new(test_env_config).await;
@@ -843,7 +843,7 @@ async fn test_gcs_chaos_with_index_merge() {
     let test_env_config = TestEnvConfig {
         maintenance_option: TableMainenanceOption::IndexMerge,
         error_injection_enabled: false,
-        event_count: 2500,
+        event_count: 3000,
         filesystem_config: gcs_filesystem_config,
     };
     let env = TestEnvironment::new(test_env_config).await;
@@ -860,7 +860,7 @@ async fn test_gcs_chaos_with_data_compaction() {
     let test_env_config = TestEnvConfig {
         maintenance_option: TableMainenanceOption::DataCompaction,
         error_injection_enabled: false,
-        event_count: 2500,
+        event_count: 3000,
         filesystem_config: gcs_filesystem_config,
     };
     let env = TestEnvironment::new(test_env_config).await;

--- a/src/moonlink/src/table_handler/chaos_test.rs
+++ b/src/moonlink/src/table_handler/chaos_test.rs
@@ -7,12 +7,20 @@
 /// - LSN always increases
 use crate::event_sync::create_table_event_syncer;
 use crate::row::{MoonlinkRow, RowValue};
+#[cfg(feature = "storage-gcs")]
+use crate::storage::filesystem::gcs::gcs_test_utils::*;
+#[cfg(feature = "storage-gcs")]
+use crate::storage::filesystem::gcs::test_guard::TestGuard as GcsTestGuard;
+#[cfg(feature = "storage-s3")]
+use crate::storage::filesystem::s3::s3_test_utils::*;
+#[cfg(feature = "storage-s3")]
+use crate::storage::filesystem::s3::test_guard::TestGuard as S3TestGuard;
 use crate::storage::mooncake_table::table_operation_test_utils::sync_read_request_for_test;
 use crate::storage::mooncake_table::{table_creation_test_utils::*, TableMetadata};
 use crate::table_handler::test_utils::*;
 use crate::table_handler::{TableEvent, TableHandler};
 use crate::union_read::ReadStateManager;
-use crate::TableEventManager;
+use crate::{FileSystemConfig, TableEventManager};
 use crate::{IcebergTableConfig, ObjectStorageCache};
 
 use more_asserts as ma;
@@ -472,12 +480,13 @@ struct TestEnvConfig {
     event_count: usize,
     /// Whether error injection is enabled.
     error_injection_enabled: bool,
+    /// Filesystem config for persistence.
+    filesystem_config: FileSystemConfig,
 }
 
 #[allow(dead_code)]
 struct TestEnvironment {
     test_env_config: TestEnvConfig,
-    iceberg_temp_dir: TempDir,
     cache_temp_dir: TempDir,
     table_temp_dir: TempDir,
     object_storage_cache: ObjectStorageCache,
@@ -516,11 +525,10 @@ impl TestEnvironment {
         let object_storage_cache = ObjectStorageCache::default_for_test(&cache_temp_dir);
 
         // Create mooncake table and table event notification receiver.
-        let iceberg_temp_dir = tempdir().unwrap();
         let iceberg_table_config = if config.error_injection_enabled {
-            get_iceberg_table_config_with_chaos_injection(&iceberg_temp_dir)
+            get_iceberg_table_config_with_chaos_injection(config.filesystem_config.clone())
         } else {
-            get_iceberg_table_config(&iceberg_temp_dir)
+            get_iceberg_table_config_with_filesystem_config(config.filesystem_config.clone())
         };
         let table = create_mooncake_table(
             mooncake_table_metadata.clone(),
@@ -547,7 +555,6 @@ impl TestEnvironment {
 
         Self {
             test_env_config: config,
-            iceberg_temp_dir,
             cache_temp_dir,
             table_temp_dir,
             object_storage_cache,
@@ -701,13 +708,20 @@ async fn chaos_test_impl(mut env: TestEnvironment) {
     }
 }
 
+/// ============================
+/// Local filesystem persistence
+/// ============================
+///
 /// Chaos test with no background table maintenance enabled.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_chaos_with_no_background_maintenance() {
+    let iceberg_temp_dir = tempdir().unwrap();
+    let root_directory = iceberg_temp_dir.path().to_str().unwrap().to_string();
     let test_env_config = TestEnvConfig {
         maintenance_option: TableMainenanceOption::NoTableMaintenance,
         error_injection_enabled: false,
         event_count: 3000,
+        filesystem_config: FileSystemConfig::FileSystem { root_directory },
     };
     let env = TestEnvironment::new(test_env_config).await;
     chaos_test_impl(env).await;
@@ -716,10 +730,13 @@ async fn test_chaos_with_no_background_maintenance() {
 /// Chaos test with index merge enabled by default.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_chaos_with_index_merge() {
+    let iceberg_temp_dir = tempdir().unwrap();
+    let root_directory = iceberg_temp_dir.path().to_str().unwrap().to_string();
     let test_env_config = TestEnvConfig {
         maintenance_option: TableMainenanceOption::IndexMerge,
         error_injection_enabled: false,
         event_count: 3000,
+        filesystem_config: FileSystemConfig::FileSystem { root_directory },
     };
     let env = TestEnvironment::new(test_env_config).await;
     chaos_test_impl(env).await;
@@ -728,22 +745,142 @@ async fn test_chaos_with_index_merge() {
 /// Chaos test with data compaction enabled by default.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_chaos_with_data_compaction() {
+    let iceberg_temp_dir = tempdir().unwrap();
+    let root_directory = iceberg_temp_dir.path().to_str().unwrap().to_string();
     let test_env_config = TestEnvConfig {
         maintenance_option: TableMainenanceOption::DataCompaction,
         error_injection_enabled: false,
         event_count: 3000,
+        filesystem_config: FileSystemConfig::FileSystem { root_directory },
     };
     let env = TestEnvironment::new(test_env_config).await;
     chaos_test_impl(env).await;
 }
 
+/// ============================
+/// S3 persistence
+/// ============================
+///
+/// Chaos test with no background table maintenance enabled.
+#[cfg(feature = "storage-s3")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_s3_chaos_with_no_background_maintenance() {
+    let (bucket, warehouse_uri) = get_test_s3_bucket_and_warehouse();
+    let _test_guard = S3TestGuard::new(bucket.clone()).await;
+    let s3_filesystem_config = create_s3_filesystem_config(&warehouse_uri);
+    let test_env_config = TestEnvConfig {
+        maintenance_option: TableMainenanceOption::NoTableMaintenance,
+        error_injection_enabled: false,
+        event_count: 2500,
+        filesystem_config: s3_filesystem_config,
+    };
+    let env = TestEnvironment::new(test_env_config).await;
+    chaos_test_impl(env).await;
+}
+
+/// Chaos test with index merge enabled by default.
+#[cfg(feature = "storage-s3")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_s3_chaos_with_index_merge() {
+    let (bucket, warehouse_uri) = get_test_s3_bucket_and_warehouse();
+    let _test_guard = S3TestGuard::new(bucket.clone()).await;
+    let s3_filesystem_config = create_s3_filesystem_config(&warehouse_uri);
+    let test_env_config = TestEnvConfig {
+        maintenance_option: TableMainenanceOption::IndexMerge,
+        error_injection_enabled: false,
+        event_count: 2500,
+        filesystem_config: s3_filesystem_config,
+    };
+    let env = TestEnvironment::new(test_env_config).await;
+    chaos_test_impl(env).await;
+}
+
+/// Chaos test with data compaction enabled by default.
+#[cfg(feature = "storage-s3")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_s3_chaos_with_data_compaction() {
+    let (bucket, warehouse_uri) = get_test_s3_bucket_and_warehouse();
+    let _test_guard = S3TestGuard::new(bucket.clone()).await;
+    let s3_filesystem_config = create_s3_filesystem_config(&warehouse_uri);
+    let test_env_config = TestEnvConfig {
+        maintenance_option: TableMainenanceOption::DataCompaction,
+        error_injection_enabled: false,
+        event_count: 2500,
+        filesystem_config: s3_filesystem_config,
+    };
+    let env = TestEnvironment::new(test_env_config).await;
+    chaos_test_impl(env).await;
+}
+
+/// ============================
+/// GCS persistence
+/// ============================
+///
+/// Chaos test with no background table maintenance enabled.
+#[cfg(feature = "storage-gcs")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_gcs_chaos_with_no_background_maintenance() {
+    let (bucket, warehouse_uri) = get_test_gcs_bucket_and_warehouse();
+    let _test_guard = GcsTestGuard::new(bucket.clone()).await;
+    let gcs_filesystem_config = create_gcs_filesystem_config(&warehouse_uri);
+    let test_env_config = TestEnvConfig {
+        maintenance_option: TableMainenanceOption::NoTableMaintenance,
+        error_injection_enabled: false,
+        event_count: 2500,
+        filesystem_config: gcs_filesystem_config,
+    };
+    let env = TestEnvironment::new(test_env_config).await;
+    chaos_test_impl(env).await;
+}
+
+/// Chaos test with index merge enabled by default.
+#[cfg(feature = "storage-gcs")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_gcs_chaos_with_index_merge() {
+    let (bucket, warehouse_uri) = get_test_gcs_bucket_and_warehouse();
+    let _test_guard = GcsTestGuard::new(bucket.clone()).await;
+    let gcs_filesystem_config = create_gcs_filesystem_config(&warehouse_uri);
+    let test_env_config = TestEnvConfig {
+        maintenance_option: TableMainenanceOption::IndexMerge,
+        error_injection_enabled: false,
+        event_count: 2500,
+        filesystem_config: gcs_filesystem_config,
+    };
+    let env = TestEnvironment::new(test_env_config).await;
+    chaos_test_impl(env).await;
+}
+
+/// Chaos test with data compaction enabled by default.
+#[cfg(feature = "storage-gcs")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_gcs_chaos_with_data_compaction() {
+    let (bucket, warehouse_uri) = get_test_gcs_bucket_and_warehouse();
+    let _test_guard = GcsTestGuard::new(bucket.clone()).await;
+    let gcs_filesystem_config = create_gcs_filesystem_config(&warehouse_uri);
+    let test_env_config = TestEnvConfig {
+        maintenance_option: TableMainenanceOption::DataCompaction,
+        error_injection_enabled: false,
+        event_count: 2500,
+        filesystem_config: gcs_filesystem_config,
+    };
+    let env = TestEnvironment::new(test_env_config).await;
+    chaos_test_impl(env).await;
+}
+
+/// ============================
+/// Delay and error injection
+/// ============================
+///
 /// Chaos test with no background table maintenance enabled.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_chaos_with_no_background_maintenance_with_chaos_injection() {
+    let iceberg_temp_dir = tempdir().unwrap();
+    let root_directory = iceberg_temp_dir.path().to_str().unwrap().to_string();
     let test_env_config = TestEnvConfig {
         maintenance_option: TableMainenanceOption::NoTableMaintenance,
         error_injection_enabled: true,
         event_count: 100,
+        filesystem_config: FileSystemConfig::FileSystem { root_directory },
     };
     let env = TestEnvironment::new(test_env_config).await;
     chaos_test_impl(env).await;
@@ -752,10 +889,13 @@ async fn test_chaos_with_no_background_maintenance_with_chaos_injection() {
 /// Chaos test with index merge enabled by default.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_chaos_with_index_merge_with_chaos_injection() {
+    let iceberg_temp_dir = tempdir().unwrap();
+    let root_directory = iceberg_temp_dir.path().to_str().unwrap().to_string();
     let test_env_config = TestEnvConfig {
         maintenance_option: TableMainenanceOption::IndexMerge,
         error_injection_enabled: true,
         event_count: 100,
+        filesystem_config: FileSystemConfig::FileSystem { root_directory },
     };
     let env = TestEnvironment::new(test_env_config).await;
     chaos_test_impl(env).await;
@@ -764,10 +904,13 @@ async fn test_chaos_with_index_merge_with_chaos_injection() {
 /// Chaos test with data compaction enabled by default.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_chaos_with_data_compaction_with_chaos_injection() {
+    let iceberg_temp_dir = tempdir().unwrap();
+    let root_directory = iceberg_temp_dir.path().to_str().unwrap().to_string();
     let test_env_config = TestEnvConfig {
         maintenance_option: TableMainenanceOption::DataCompaction,
         error_injection_enabled: true,
         event_count: 100,
+        filesystem_config: FileSystemConfig::FileSystem { root_directory },
     };
     let env = TestEnvironment::new(test_env_config).await;
     chaos_test_impl(env).await;


### PR DESCRIPTION
## Summary

This PR adds object storage to chaos test, we need a way to check whether local/remote files are properly handled.
For example, we use `mmap` for index blocks, need to make sure it's on local filesystem.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1102

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [x] Documentation updated if necessary
- [x] I have reviewed my own changes
