### PR TITLE
[storage] Update chaos wrapper option

### DIFF
--- a/src/moonlink/src/storage/filesystem/filesystem_config.rs
+++ b/src/moonlink/src/storage/filesystem/filesystem_config.rs
@@ -3,9 +3,10 @@ use crate::storage::filesystem::accessor::filesystem_accessor_chaos_wrapper::Fil
 #[cfg(any(feature = "storage-gcs", feature = "storage-s3"))]
 use crate::MoonlinkSecretType;
 use crate::MoonlinkTableSecret;
+use serde::{Deserialize, Serialize};
 
 /// FileSystemConfig contains configuration for multiple storage backends.
-#[derive(Clone, PartialEq)]
+#[derive(Clone, Deserialize, PartialEq, Serialize)]
 pub enum FileSystemConfig {
     #[cfg(feature = "storage-fs")]
     FileSystem { root_directory: String },

--- a/src/moonlink/src/storage/mooncake_table/table_creation_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_creation_test_utils.rs
@@ -15,8 +15,6 @@ use crate::storage::mooncake_table::IcebergPersistenceConfig;
 use crate::storage::mooncake_table::{MooncakeTableConfig, TableMetadata as MooncakeTableMetadata};
 use crate::storage::MooncakeTable;
 use crate::table_notify::TableEvent;
-#[cfg(feature = "chaos-test")]
-use crate::Error;
 use crate::FileSystemConfig;
 use crate::ObjectStorageCache;
 
@@ -61,10 +59,7 @@ pub(crate) fn get_iceberg_table_config_with_chaos_injection(
     let chaos_option = FileSystemChaosOption {
         min_latency: std::time::Duration::from_secs(0),
         max_latency: std::time::Duration::from_secs(1),
-        injected_error: Some(Error::from(
-            opendal::Error::new(opendal::ErrorKind::Unexpected, "Injected error").set_temporary(),
-        )),
-        prob: 5, // 5% error probability, a few retry attempts should work
+        err_prob: 5, // 5% error probability, a few retry attempts should work
     };
     IcebergTableConfig {
         namespace: vec![ICEBERG_TEST_NAMESPACE.to_string()],


### PR DESCRIPTION
## Summary

When working on backend config (https://github.com/Mooncake-Labs/moonlink/pull/965), if filesystem config is serializable it would make table creation config much easier.

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
