### PR TITLE
[storage] Send iceberg snapshot in channel

### DIFF
--- a/src/moonlink/src/table_notify.rs
+++ b/src/moonlink/src/table_notify.rs
@@ -134,6 +134,11 @@ pub enum TableEvent {
         /// Evicted object storage cache to delete.
         evicted_data_files_to_delete: Vec<String>,
     },
+    /// Regular iceberg persistence.
+    RegularIcebergSnapshot {
+        /// Payload used to create a new iceberg snapshot.
+        iceberg_snapshot_payload: IcebergSnapshotPayload,
+    },
     /// Iceberg snapshot completes.
     IcebergSnapshotResult {
         /// Result for iceberg snapshot.


### PR DESCRIPTION
## Summary

This PR is a no-op change to split mooncake snapshot result handling, which send iceberg persistence request back to event channel for better visibility (i.e., we could view the start of persistence event in replay).

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1110

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
