### PR TITLE
[storage] Fix mooncake table config store

### DIFF
--- a/src/moonlink/src/lib.rs
+++ b/src/moonlink/src/lib.rs
@@ -11,10 +11,11 @@ pub use event_sync::EventSyncSender;
 pub use storage::storage_utils::create_data_file;
 pub(crate) use storage::NonEvictableHandle;
 pub use storage::{
-    EventSyncReceiver, FileSystemAccessor, FileSystemConfig, IcebergTableConfig,
-    IcebergTableManager, MooncakeTable, MooncakeTableConfig, MoonlinkSecretType,
-    MoonlinkTableConfig, MoonlinkTableSecret, ObjectStorageCache, ObjectStorageCacheConfig,
-    SnapshotReadOutput, TableEventManager, TableManager, TableStatus, TableStatusReader,
+    DataCompactionConfig, EventSyncReceiver, FileIndexMergeConfig, FileSystemAccessor,
+    FileSystemConfig, IcebergPersistenceConfig, IcebergTableConfig, IcebergTableManager,
+    MooncakeTable, MooncakeTableConfig, MoonlinkSecretType, MoonlinkTableConfig,
+    MoonlinkTableSecret, ObjectStorageCache, ObjectStorageCacheConfig, SnapshotReadOutput,
+    TableEventManager, TableManager, TableStatus, TableStatusReader,
 };
 pub use table_handler::TableHandler;
 pub use table_notify::TableEvent;

--- a/src/moonlink/src/storage.rs
+++ b/src/moonlink/src/storage.rs
@@ -16,18 +16,21 @@ pub use crate::event_sync::EventSyncReceiver;
 pub use cache::object_storage::cache_config::ObjectStorageCacheConfig;
 pub(crate) use cache::object_storage::cache_handle::NonEvictableHandle;
 pub use cache::object_storage::object_storage_cache::ObjectStorageCache;
+pub use compaction::compaction_config::DataCompactionConfig;
 pub use filesystem::accessor::filesystem_accessor::FileSystemAccessor;
 pub use filesystem::filesystem_config::FileSystemConfig;
 pub use iceberg::iceberg_table_config::IcebergTableConfig;
 pub use iceberg::iceberg_table_manager::IcebergTableManager;
 pub use iceberg::table_event_manager::TableEventManager;
 pub use iceberg::table_manager::TableManager;
+pub use index::index_merge_config::FileIndexMergeConfig;
 pub use mooncake_table::table_config::TableConfig as MoonlinkTableConfig;
 pub use mooncake_table::table_secret::{
     SecretEntry as MoonlinkTableSecret, SecretType as MoonlinkSecretType,
 };
 pub use mooncake_table::table_status::TableStatus;
 pub use mooncake_table::table_status_reader::TableStatusReader;
+pub use mooncake_table::IcebergPersistenceConfig;
 pub use mooncake_table::SnapshotReadOutput;
 pub use mooncake_table::{MooncakeTable, MooncakeTableConfig};
 pub(crate) use mooncake_table::{PuffinDeletionBlobAtRead, SnapshotTableState};

--- a/src/moonlink/src/storage/compaction/compaction_config.rs
+++ b/src/moonlink/src/storage/compaction/compaction_config.rs
@@ -1,9 +1,10 @@
+use serde::{Deserialize, Serialize};
 use typed_builder::TypedBuilder;
 
 /// Configurations for data compaction.
 ///
 /// TODO(hjiang): To reduce code change before preview release, disable data compaction by default until we do further testing to make sure moonlink fine.
-#[derive(Clone, Debug, PartialEq, TypedBuilder)]
+#[derive(Clone, Debug, PartialEq, TypedBuilder, Deserialize, Serialize)]
 pub struct DataCompactionConfig {
     /// Number of existing data files with deletion vector and under final size to trigger a compaction operation.
     pub data_file_to_compact: u32,

--- a/src/moonlink/src/storage/index/index_merge_config.rs
+++ b/src/moonlink/src/storage/index/index_merge_config.rs
@@ -1,9 +1,10 @@
+use serde::{Deserialize, Serialize};
 use typed_builder::TypedBuilder;
 
 /// Configuration for index merge.
 ///
 /// TODO(hjiang): To reduce code change before preview release, disable data compaction by default until we do further testing to make sure moonlink fine.
-#[derive(Clone, Debug, PartialEq, TypedBuilder)]
+#[derive(Clone, Debug, PartialEq, TypedBuilder, Deserialize, Serialize)]
 pub struct FileIndexMergeConfig {
     /// Number of existing index blocks under final size to trigger a merge operation.
     pub file_indices_to_merge: u32,

--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -56,6 +56,7 @@ use arrow_schema::Schema;
 use delete_vector::BatchDeletionVector;
 pub(crate) use disk_slice::DiskSliceWriter;
 use mem_slice::MemSlice;
+use serde::{Deserialize, Serialize};
 pub(crate) use snapshot::{PuffinDeletionBlobAtRead, SnapshotTableState};
 use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
@@ -74,7 +75,7 @@ use transaction_stream::{TransactionStreamOutput, TransactionStreamState};
 /// [https://github.com/postgres/postgres/blob/d5b9b2d40262f57f58322ad49f8928fd4a492adb/src/include/access/transam.h#L31]
 pub(crate) const INITIAL_COPY_XACT_ID: u32 = 0;
 
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct IcebergPersistenceConfig {
     /// Number of new data files to trigger an iceberg snapshot.
     pub new_data_file_count: usize,
@@ -93,8 +94,10 @@ impl IcebergPersistenceConfig {
     pub(crate) const DEFAULT_ICEBERG_NEW_DATA_FILE_COUNT: usize = 1;
     #[cfg(not(debug_assertions))]
     pub(crate) const DEFAULT_ICEBERG_SNAPSHOT_NEW_COMMITTED_DELETION_LOG: usize = 1000;
+}
 
-    pub fn default() -> Self {
+impl Default for IcebergPersistenceConfig {
+    fn default() -> Self {
         Self {
             new_data_file_count: Self::DEFAULT_ICEBERG_NEW_DATA_FILE_COUNT,
             new_committed_deletion_log: Self::DEFAULT_ICEBERG_SNAPSHOT_NEW_COMMITTED_DELETION_LOG,
@@ -148,7 +151,7 @@ impl MooncakeTableConfig {
     pub(crate) const DEFAULT_DISK_SLICE_PARQUET_FILE_SIZE: usize = 1024 * 1024 * 128; // 128MiB
 
     /// Default local directory to hold temporary files for union read.
-    pub(crate) const DEFAULT_TEMP_FILE_DIRECTORY: &str = "/tmp/moonlink_temp_file";
+    pub const DEFAULT_TEMP_FILE_DIRECTORY: &str = "/tmp/moonlink_temp_file";
 
     pub fn new(temp_files_directory: String) -> Self {
         Self {

--- a/src/moonlink_backend/src/lib.rs
+++ b/src/moonlink_backend/src/lib.rs
@@ -15,6 +15,8 @@ use std::hash::Hash;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 
+use crate::recovery_utils::BackendAttributes;
+
 pub struct MoonlinkBackend<
     D: std::convert::From<u32> + Eq + Hash + Clone + std::fmt::Display,
     T: std::convert::From<u32> + Eq + Hash + Clone + std::fmt::Display,
@@ -52,8 +54,16 @@ where
             temp_files_dir.to_str().unwrap().to_string(),
             file_utils::create_default_object_storage_cache(read_cache_files_dir),
         );
-        recovery_utils::recover_all_tables(&*metadata_store_accessor, &mut replication_manager)
-            .await?;
+
+        let backend_attributes = BackendAttributes {
+            temp_files_dir: temp_files_dir.to_str().unwrap().to_string(),
+        };
+        recovery_utils::recover_all_tables(
+            backend_attributes,
+            &*metadata_store_accessor,
+            &mut replication_manager,
+        )
+        .await?;
 
         Ok(Self {
             replication_manager: RwLock::new(replication_manager),

--- a/src/moonlink_metadata_store/src/config_utils.rs
+++ b/src/moonlink_metadata_store/src/config_utils.rs
@@ -1,7 +1,8 @@
 use crate::error::Result;
 use moonlink::{
-    FileSystemConfig, IcebergTableConfig, MooncakeTableConfig, MoonlinkSecretType,
-    MoonlinkTableConfig, MoonlinkTableSecret,
+    DataCompactionConfig, FileIndexMergeConfig, FileSystemConfig, IcebergPersistenceConfig,
+    IcebergTableConfig, MooncakeTableConfig, MoonlinkSecretType, MoonlinkTableConfig,
+    MoonlinkTableSecret,
 };
 /// This module contains util functions related to moonlink config.
 use serde::{Deserialize, Serialize};
@@ -31,12 +32,54 @@ impl IcebergTableConfigForPersistence {
     }
 }
 
+/// Struct for mooncake table config.
+/// Notice it's a subset of [`MooncakeTableConfig`] since we want to keep things persisted minimum.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+struct MooncakeTableConfigForPersistence {
+    /// Number of batch records which decides when to flush records from MemSlice to disk.
+    mem_slice_size: usize,
+    /// Number of new deletion records which decides whether to create a new mooncake table snapshot.
+    snapshot_deletion_record_count: usize,
+    /// Max number of rows in each record batch within MemSlice.
+    batch_size: usize,
+    /// Disk slice parquet file flush threshold.
+    disk_slice_parquet_file_size: usize,
+    /// Config for data compaction.
+    data_compaction_config: DataCompactionConfig,
+    /// Config for index merge.
+    file_index_config: FileIndexMergeConfig,
+    /// Config for iceberg persistence config.
+    persistence_config: IcebergPersistenceConfig,
+    /// Filesystem directory to store temporary files, used for union read.
+    temp_files_directory: String,
+}
+
 /// Struct for moonlink table config.
 /// Notice it's a subset of [`MoonlinkTableConfig`] since we want to keep things persisted minimum.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 struct MoonlinkTableConfigForPersistence {
+    /// Mooncake table configuration.
+    mooncake_table_config: MooncakeTableConfigForPersistence,
     /// Iceberg table configuration.
     iceberg_table_config: IcebergTableConfigForPersistence,
+}
+
+impl MoonlinkTableConfigForPersistence {
+    /// Get mooncake table config from persisted moonlink config.
+    fn get_mooncake_table_config(&self) -> MooncakeTableConfig {
+        MooncakeTableConfig {
+            mem_slice_size: self.mooncake_table_config.mem_slice_size,
+            snapshot_deletion_record_count: self
+                .mooncake_table_config
+                .snapshot_deletion_record_count,
+            batch_size: self.mooncake_table_config.batch_size,
+            disk_slice_parquet_file_size: self.mooncake_table_config.disk_slice_parquet_file_size,
+            persistence_config: self.mooncake_table_config.persistence_config.clone(),
+            data_compaction_config: self.mooncake_table_config.data_compaction_config.clone(),
+            file_index_config: self.mooncake_table_config.file_index_config.clone(),
+            temp_files_directory: self.mooncake_table_config.temp_files_directory.clone(),
+        }
+    }
 }
 
 /// Parse moonlink table config into json value to persist into postgres, and return the secret entry.
@@ -46,11 +89,22 @@ pub(crate) fn parse_moonlink_table_config(
 ) -> Result<(serde_json::Value, Option<MoonlinkTableSecret>)> {
     // Serialize mooncake table config.
     let iceberg_config = moonlink_table_config.iceberg_table_config;
+    let mooncake_config = moonlink_table_config.mooncake_table_config;
     let persisted = MoonlinkTableConfigForPersistence {
         iceberg_table_config: IcebergTableConfigForPersistence {
             warehouse_uri: iceberg_config.filesystem_config.get_root_path(),
             namespace: iceberg_config.namespace[0].to_string(),
             table_name: iceberg_config.table_name,
+        },
+        mooncake_table_config: MooncakeTableConfigForPersistence {
+            mem_slice_size: mooncake_config.mem_slice_size,
+            snapshot_deletion_record_count: mooncake_config.snapshot_deletion_record_count,
+            batch_size: mooncake_config.batch_size,
+            disk_slice_parquet_file_size: mooncake_config.disk_slice_parquet_file_size,
+            data_compaction_config: mooncake_config.data_compaction_config.clone(),
+            file_index_config: mooncake_config.file_index_config.clone(),
+            persistence_config: mooncake_config.persistence_config.clone(),
+            temp_files_directory: mooncake_config.temp_files_directory.clone(),
         },
     };
     let config_json = serde_json::to_value(&persisted)?;
@@ -118,15 +172,15 @@ pub(crate) fn deserialze_moonlink_table_config(
 ) -> Result<MoonlinkTableConfig> {
     let parsed: MoonlinkTableConfigForPersistence = serde_json::from_value(serialized_config)?;
     let filesystem_config = recover_filesystem_config(&parsed, secret_entry);
+    let mooncake_table_config = parsed.get_mooncake_table_config();
 
-    // TODO(hjiang): Need to recover iceberg table config from metadata.
     let moonlink_table_config = MoonlinkTableConfig {
         iceberg_table_config: IcebergTableConfig {
             namespace: vec![parsed.iceberg_table_config.namespace],
             table_name: parsed.iceberg_table_config.table_name,
             filesystem_config,
         },
-        mooncake_table_config: MooncakeTableConfig::default(),
+        mooncake_table_config,
     };
 
     Ok(moonlink_table_config)

--- a/src/moonlink_metadata_store/src/config_utils.rs
+++ b/src/moonlink_metadata_store/src/config_utils.rs
@@ -50,8 +50,6 @@ struct MooncakeTableConfigForPersistence {
     file_index_config: FileIndexMergeConfig,
     /// Config for iceberg persistence config.
     persistence_config: IcebergPersistenceConfig,
-    /// Filesystem directory to store temporary files, used for union read.
-    temp_files_directory: String,
 }
 
 /// Struct for moonlink table config.
@@ -77,7 +75,7 @@ impl MoonlinkTableConfigForPersistence {
             persistence_config: self.mooncake_table_config.persistence_config.clone(),
             data_compaction_config: self.mooncake_table_config.data_compaction_config.clone(),
             file_index_config: self.mooncake_table_config.file_index_config.clone(),
-            temp_files_directory: self.mooncake_table_config.temp_files_directory.clone(),
+            temp_files_directory: MooncakeTableConfig::DEFAULT_TEMP_FILE_DIRECTORY.to_string(),
         }
     }
 }
@@ -104,7 +102,6 @@ pub(crate) fn parse_moonlink_table_config(
             data_compaction_config: mooncake_config.data_compaction_config.clone(),
             file_index_config: mooncake_config.file_index_config.clone(),
             persistence_config: mooncake_config.persistence_config.clone(),
-            temp_files_directory: mooncake_config.temp_files_directory.clone(),
         },
     };
     let config_json = serde_json::to_value(&persisted)?;


### PR DESCRIPTION
## Summary

This is sth I missed, essentially when store table metadata, we should not only persist iceberg related configs, but also mooncake table related configs.
For example, people won't expect before recovery index merge enabled, but disabled after recovery.

How I tested:
```sql
pg_mooncake (pid: 5983) =# DROP EXTENSION IF EXISTS pg_mooncake CASCADE;
DROP TABLE IF EXISTS r;
CREATE EXTENSION pg_mooncake;
CREATE TABLE r (a int primary key, b text);
CALL mooncake.create_table('c', 'r');
INSERT INTO r SELECT a, 'val_' || a FROM generate_series(1, 250000) AS a;
SELECT count(*) FROM c;
DELETE FROM r WHERE a % 2 = 0;
SELECT count(*) FROM c;
NOTICE:  extension "pg_mooncake" does not exist, skipping
DROP EXTENSION
NOTICE:  table "r" does not exist, skipping
DROP TABLE
CREATE EXTENSION
CREATE TABLE
CALL
INSERT 0 250000
 count  
--------
 250000
(1 row)

DELETE 125000
 count  
--------
 125000
(1 row)

pg_mooncake (pid: 5983) =# CALL mooncake.create_snapshot('c');
CALL
pg_mooncake (pid: 5983) =# SELECT COUNT(*) FROM c;
 count  
--------
 125000
(1 row)
```
shutdown the connection and reconnect
```sql
pg_mooncake (pid: 8265) =# SELECT COUNT(*) FROM c;
 count  
--------
 125000
(1 row)
```

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1113

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
