### PR TITLE
[storage] Avoid sync completed read on eventloop

### DIFF
--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -453,9 +453,6 @@ pub struct SnapshotTask {
     /// --- States related to WAL operation ---
     new_wal_persistence_metadata: Option<WalPersistenceMetadata>,
 
-    /// --- States related to read operation ---
-    read_cache_handles: Vec<NonEvictableHandle>,
-
     /// --- States related to file indices merge operation ---
     /// These persisted items will be reflected to mooncake snapshot in the next invocation of periodic mooncake snapshot operation.
     index_merge_result: FileIndiceMergeResult,
@@ -488,8 +485,6 @@ impl SnapshotTask {
             committed_deletion_logs: HashSet::new(),
             // WAL related fields.
             new_wal_persistence_metadata: None,
-            // Read request related fields.
-            read_cache_handles: Vec::new(),
             // Index merge related fields.
             index_merge_result: FileIndiceMergeResult::default(),
             // Data compaction related fields.
@@ -513,9 +508,6 @@ impl SnapshotTask {
             return false;
         }
         if !self.new_streaming_xact.is_empty() {
-            return false;
-        }
-        if !self.read_cache_handles.is_empty() {
             return false;
         }
         if !self.index_merge_result.is_empty() {
@@ -924,13 +916,6 @@ impl MooncakeTable {
         wal_persistence_meatdata: WalPersistenceMetadata,
     ) {
         self.next_snapshot_task.new_wal_persistence_metadata = Some(wal_persistence_meatdata);
-    }
-
-    /// Set read request completion result, which will be sync-ed to mooncake table snapshot in the next periodic snapshot iteration.
-    pub(crate) fn set_read_request_res(&mut self, cache_handles: Vec<NonEvictableHandle>) {
-        self.next_snapshot_task
-            .read_cache_handles
-            .extend(cache_handles);
     }
 
     /// Set file indices merge result, which will be sync-ed to mooncake and iceberg snapshot in the next periodic snapshot iteration.

--- a/src/moonlink/src/storage/mooncake_table/deletion_vector_puffin_state_tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/deletion_vector_puffin_state_tests.rs
@@ -329,13 +329,8 @@ async fn test_2_read_without_local_optimization(#[case] use_batch_write: bool) {
     );
 
     // Drop all read states and check reference count.
-    let files_to_delete = drop_read_states_and_create_mooncake_snapshot(
-        vec![read_state],
-        &mut table,
-        &mut table_notify,
-    )
-    .await;
-    assert!(files_to_delete.is_empty());
+    drop_read_states_and_create_mooncake_snapshot(vec![read_state], &mut table, &mut table_notify)
+        .await;
     assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 0).await;
     assert_evictable_cache_size(&mut cache, /*expected_count=*/ 1).await; // data file
     assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 2).await; // puffin file and index block.
@@ -388,13 +383,8 @@ async fn test_2_read_with_local_optimization(#[case] use_batch_write: bool) {
     );
 
     // Drop all read states and check reference count.
-    let files_to_delete = drop_read_states_and_create_mooncake_snapshot(
-        vec![read_state],
-        &mut table,
-        &mut table_notify,
-    )
-    .await;
-    assert!(files_to_delete.is_empty());
+    drop_read_states_and_create_mooncake_snapshot(vec![read_state], &mut table, &mut table_notify)
+        .await;
     assert_pending_eviction_entries_size(&mut cache, /*expected_count=*/ 0).await;
     assert_evictable_cache_size(&mut cache, /*expected_count=*/ 1).await; // data file
     assert_non_evictable_cache_size(&mut cache, /*expected_count=*/ 2).await; // puffin file and index block.

--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -442,12 +442,6 @@ impl SnapshotTableState {
         // All evicted data files by the object storage cache.
         let mut evicted_data_files_to_delete = vec![];
 
-        // Reflect read request result to mooncake snapshot.
-        let completed_read_evicted_files = self
-            .update_snapshot_by_read_request_results(&mut task)
-            .await;
-        evicted_data_files_to_delete.extend(completed_read_evicted_files);
-
         // Reflect iceberg snapshot to mooncake snapshot.
         let persistence_evicted_files = self.update_snapshot_by_iceberg_snapshot(&task).await;
         evicted_data_files_to_delete.extend(persistence_evicted_files);

--- a/src/moonlink/src/storage/mooncake_table/snapshot_cache_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot_cache_utils.rs
@@ -6,23 +6,6 @@ use crate::storage::mooncake_table::SnapshotTask;
 use crate::storage::storage_utils::TableId;
 
 impl SnapshotTableState {
-    /// Unreference pinned cache handles used in read operations.
-    /// Return evicted data files to delete.
-    pub(super) async fn unreference_read_cache_handles(
-        &mut self,
-        task: &mut SnapshotTask,
-    ) -> Vec<String> {
-        // Aggregate evicted data files to delete.
-        let mut evicted_files_to_delete = vec![];
-
-        for cur_cache_handle in task.read_cache_handles.iter_mut() {
-            let cur_evicted_files = cur_cache_handle.unreference().await;
-            evicted_files_to_delete.extend(cur_evicted_files);
-        }
-
-        evicted_files_to_delete
-    }
-
     /// Unreference all pinned data files.
     /// Return all evicted files to evict
     pub(crate) async fn unreference_and_delete_all_cache_handles(&mut self) -> Vec<String> {

--- a/src/moonlink/src/storage/mooncake_table/snapshot_read.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot_read.rs
@@ -6,7 +6,6 @@ use crate::storage::mooncake_table::snapshot_read_output::{
     DataFileForRead, ReadOutput as SnapshotReadOutput,
 };
 use crate::storage::mooncake_table::table_status::TableSnapshotStatus;
-use crate::storage::mooncake_table::SnapshotTask;
 use crate::storage::storage_utils::RecordLocation;
 use crate::storage::PuffinDeletionBlobAtRead;
 use crate::NonEvictableHandle;
@@ -203,15 +202,5 @@ impl SnapshotTableState {
             filesystem_accessor: Some(self.filesystem_accessor.clone()),
             table_notifier: Some(self.table_notify.as_ref().unwrap().clone()),
         })
-    }
-
-    /// Take read request result and update mooncake snapshot.
-    /// Return evicted data files to delete.
-    pub(super) async fn update_snapshot_by_read_request_results(
-        &mut self,
-        task: &mut SnapshotTask,
-    ) -> Vec<String> {
-        // Unpin cached files used in the read request.
-        self.unreference_read_cache_handles(task).await
     }
 }

--- a/src/moonlink/src/storage/mooncake_table/snapshot_read_output.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot_read_output.rs
@@ -112,7 +112,6 @@ impl ReadOutput {
             // Fields used for read state cleanup after query completion.
             self.associated_files,
             cache_handles,
-            self.table_notifier,
         ))
     }
 }

--- a/src/moonlink/src/table_handler.rs
+++ b/src/moonlink/src/table_handler.rs
@@ -483,9 +483,6 @@ impl TableHandler {
                                 return;
                             }
                         }
-                        TableEvent::ReadRequestCompletion { read_complete_handles } => {
-                            table.set_read_request_res(read_complete_handles.handles);
-                        }
                         TableEvent::EvictedFilesToDelete { evicted_files } => {
                             start_task_to_delete_evicted(evicted_files.files);
                         }

--- a/src/moonlink/src/table_notify.rs
+++ b/src/moonlink/src/table_notify.rs
@@ -5,8 +5,6 @@ use crate::storage::mooncake_table::FileIndiceMergePayload;
 use crate::storage::mooncake_table::FileIndiceMergeResult;
 use crate::storage::mooncake_table::IcebergSnapshotPayload;
 use crate::storage::mooncake_table::IcebergSnapshotResult;
-
-use crate::NonEvictableHandle;
 use crate::Result;
 
 /// Table maintenance status.
@@ -48,20 +46,6 @@ impl std::fmt::Debug for EvictedFiles {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("EvictedFiles")
             .field("evicted files count", &self.files.len())
-            .finish()
-    }
-}
-
-#[derive(Clone)]
-pub struct ReadCompleteCacheHandle {
-    /// Cache handles which get pinned before query.
-    pub handles: Vec<NonEvictableHandle>,
-}
-
-impl std::fmt::Debug for ReadCompleteCacheHandle {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ReadCompleteCacheHandle")
-            .field("cache handle count", &self.handles.len())
             .finish()
     }
 }
@@ -167,11 +151,6 @@ pub enum TableEvent {
     DataCompactionResult {
         /// Result for data compaction.
         data_compaction_result: Result<DataCompactionResult>,
-    },
-    /// Read request completion.
-    ReadRequestCompletion {
-        /// Cache handles, which are pinned before query.
-        read_complete_handles: ReadCompleteCacheHandle,
     },
     /// Evicted files to delete.
     EvictedFilesToDelete {

--- a/src/moonlink/src/union_read/read_state_manager.rs
+++ b/src/moonlink/src/union_read/read_state_manager.rs
@@ -32,7 +32,6 @@ impl ReadStateManager {
                 /*position_deletes=*/ Vec::new(),
                 /*associated_files=*/ Vec::new(),
                 /*cache_handles=*/ Vec::new(),
-                /*table_notify=*/ None,
             ))),
             table_snapshot,
             table_snapshot_watch_receiver,


### PR DESCRIPTION
## Summary

Error message 
```sh
thread 'tokio-runtime-worker' panicked at src/moonlink/src/union_read/read_state.rs:45:22:
called `Result::unwrap()` on an `Err` value: SendError { .. }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
test table_handler::chaos_test::test_chaos_with_data_compaction ... ok
```

Currently the completed read request is sent back to table handler eventloop to unreference cache handles, but it's not synchronized with events like drop table, which leads to sent failure.

A few proposals to resolve:
(1) Read state takes a Arc<Receiver>, so event sending is always valid
The downside is when reading from receiver it requires mutability, so have to play with some rust tricks here.
(2) Put unreference logic in read state destruction, so there's no interaction with table handler
The downside is we don't have any way to validate whether files get read over are unreferenced and deleted (in tests).
(3) Tolerate send error, and issue a warning message on failure.
The downside is it could hide real synchronization problems.

I choose (2) in the PR, mainly because:
- The logic for unreference and deletion is relatively simple
- Table handler and snapshot logic is already complicated enough, it's good to remove a few states and simplify the workload

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1149

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
