### PR TITLE
[storage] Avoid unnecessary manifest file rewrite

### DIFF
--- a/src/moonlink/src/storage/iceberg/file_catalog.rs
+++ b/src/moonlink/src/storage/iceberg/file_catalog.rs
@@ -320,7 +320,7 @@ impl PuffinWrite for FileCatalog {
         self.data_files_to_remove = data_files;
     }
 
-    fn set_puffin_files_to_remove(&mut self, puffin_filepaths: HashSet<String>) {
+    fn set_index_puffin_files_to_remove(&mut self, puffin_filepaths: HashSet<String>) {
         assert!(self.puffin_blobs_to_remove.is_empty());
         self.puffin_blobs_to_remove = puffin_filepaths;
     }
@@ -687,9 +687,9 @@ impl Catalog for FileCatalog {
         append_puffin_metadata_and_rewrite(
             &metadata,
             &self.file_io,
-            &self.data_files_to_remove,
             &self.deletion_vector_blobs_to_add,
             &self.file_index_blobs_to_add,
+            &self.data_files_to_remove,
             &self.puffin_blobs_to_remove,
         )
         .await?;

--- a/src/moonlink/src/storage/iceberg/file_index_manifest_manager.rs
+++ b/src/moonlink/src/storage/iceberg/file_index_manifest_manager.rs
@@ -17,7 +17,7 @@ use iceberg::Result as IcebergResult;
 pub(crate) struct FileIndexManifestManager<'a> {
     table_metadata: &'a TableMetadata,
     file_io: &'a FileIO,
-    puffin_blobs_to_remove: &'a HashSet<String>,
+    index_puffin_blobs_to_remove: &'a HashSet<String>,
     writer: Option<ManifestWriter>,
 }
 
@@ -25,12 +25,12 @@ impl<'a> FileIndexManifestManager<'a> {
     pub(crate) fn new(
         table_metadata: &'a TableMetadata,
         file_io: &'a FileIO,
-        puffin_blobs_to_remove: &'a HashSet<String>,
+        index_puffin_blobs_to_remove: &'a HashSet<String>,
     ) -> FileIndexManifestManager<'a> {
         Self {
             table_metadata,
             file_io,
-            puffin_blobs_to_remove,
+            index_puffin_blobs_to_remove,
             writer: None,
         }
     }
@@ -58,7 +58,7 @@ impl<'a> FileIndexManifestManager<'a> {
         for cur_manifest_entry in manifest_entries.into_iter() {
             // Skip file indices which are requested to remove (due to index merge and data file compaction).
             if self
-                .puffin_blobs_to_remove
+                .index_puffin_blobs_to_remove
                 .contains(cur_manifest_entry.data_file().file_path())
             {
                 continue;

--- a/src/moonlink/src/storage/iceberg/iceberg_table_syncer.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_syncer.rs
@@ -432,7 +432,7 @@ impl IcebergTableManager {
             .collect::<Vec<_>>();
 
         // Process file indices to remove.
-        self.catalog.set_puffin_files_to_remove(
+        self.catalog.set_index_puffin_files_to_remove(
             file_indices_to_remove
                 .iter()
                 .map(|cur_index| self.persisted_file_indices.remove(cur_index).unwrap())

--- a/src/moonlink/src/storage/iceberg/moonlink_catalog.rs
+++ b/src/moonlink/src/storage/iceberg/moonlink_catalog.rs
@@ -28,7 +28,7 @@ pub trait PuffinWrite {
     fn set_data_files_to_remove(&mut self, data_files: HashSet<String>);
 
     /// Set puffin file to remove.
-    fn set_puffin_files_to_remove(&mut self, puffin_filepaths: HashSet<String>);
+    fn set_index_puffin_files_to_remove(&mut self, puffin_filepaths: HashSet<String>);
 
     /// After transaction commits, puffin metadata should be cleared for next puffin write.
     fn clear_puffin_metadata(&mut self);


### PR DESCRIPTION
## Summary

Since iceberg-rust doesn't support customized puffin blob and deletion vector for now, the hack I did is manually operate on manifest files before transaction commit.

Current implementation is not ideal, it rewrites deletion vector and file index manifest files, whether or not there're updates.
This PR avoid so if possible, no behavior change.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1158

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
