### PR TITLE
[storage] Make configurable iceberg persistence threshold

### DIFF
--- a/src/moonlink/src/storage/mooncake_table_config.rs
+++ b/src/moonlink/src/storage/mooncake_table_config.rs
@@ -12,25 +12,57 @@ pub struct IcebergPersistenceConfig {
     /// Number of unpersisted committed delete logs to trigger an iceberg snapshot.
     #[serde(default = "IcebergPersistenceConfig::default_new_committed_deletion_log")]
     pub new_committed_deletion_log: usize,
+
+    /// Number of new compacted data files to trigger an iceberg snapshot.
+    #[serde(default = "IcebergPersistenceConfig::default_new_compacted_data_file_count")]
+    pub new_compacted_data_file_count: usize,
+
+    /// Number of old compacted data files to trigger an iceberg snapshot.
+    #[serde(default = "IcebergPersistenceConfig::default_old_compacted_data_file_count")]
+    pub old_compacted_data_file_count: usize,
+
+    /// Number of old merged file indices to trigger an iceberg snapshot.
+    #[serde(default = "IcebergPersistenceConfig::default_old_compacted_data_file_count")]
+    pub old_merged_file_indices_count: usize,
 }
 
-// TODO(hjiang): Add another threshold for merged file indices to trigger iceberg snapshot.
 impl IcebergPersistenceConfig {
     #[cfg(debug_assertions)]
     pub(crate) const DEFAULT_ICEBERG_NEW_DATA_FILE_COUNT: usize = 1;
     #[cfg(debug_assertions)]
     pub(crate) const DEFAULT_ICEBERG_SNAPSHOT_NEW_COMMITTED_DELETION_LOG: usize = 1000;
+    #[cfg(debug_assertions)]
+    pub(crate) const DEFAULT_ICEBERG_NEW_COMPACTED_DATA_FILE_COUNT: usize = 1;
+    #[cfg(debug_assertions)]
+    pub(crate) const DEFAULT_ICEBERG_OLD_COMPACTED_DATA_FILE_COUNT: usize = 1;
+    #[cfg(debug_assertions)]
+    pub(crate) const DEFAULT_ICEBERG_OLD_MERGED_FILE_INDICES_COUNT: usize = 1;
 
     #[cfg(not(debug_assertions))]
     pub(crate) const DEFAULT_ICEBERG_NEW_DATA_FILE_COUNT: usize = 1;
     #[cfg(not(debug_assertions))]
     pub(crate) const DEFAULT_ICEBERG_SNAPSHOT_NEW_COMMITTED_DELETION_LOG: usize = 1000;
+    #[cfg(not(debug_assertions))]
+    pub(crate) const DEFAULT_ICEBERG_NEW_COMPACTED_DATA_FILE_COUNT: usize = 1;
+    #[cfg(not(debug_assertions))]
+    pub(crate) const DEFAULT_ICEBERG_OLD_COMPACTED_DATA_FILE_COUNT: usize = 1;
+    #[cfg(not(debug_assertions))]
+    pub(crate) const DEFAULT_ICEBERG_OLD_MERGED_FILE_INDICES_COUNT: usize = 1;
 
     pub fn default_new_data_file_count() -> usize {
         Self::DEFAULT_ICEBERG_NEW_DATA_FILE_COUNT
     }
     pub fn default_new_committed_deletion_log() -> usize {
         Self::DEFAULT_ICEBERG_SNAPSHOT_NEW_COMMITTED_DELETION_LOG
+    }
+    pub fn default_new_compacted_data_file_count() -> usize {
+        Self::DEFAULT_ICEBERG_NEW_COMPACTED_DATA_FILE_COUNT
+    }
+    pub fn default_old_compacted_data_file_count() -> usize {
+        Self::DEFAULT_ICEBERG_OLD_COMPACTED_DATA_FILE_COUNT
+    }
+    pub fn default_old_merged_file_indices_count() -> usize {
+        Self::DEFAULT_ICEBERG_OLD_MERGED_FILE_INDICES_COUNT
     }
 }
 
@@ -39,6 +71,9 @@ impl Default for IcebergPersistenceConfig {
         Self {
             new_data_file_count: Self::DEFAULT_ICEBERG_NEW_DATA_FILE_COUNT,
             new_committed_deletion_log: Self::DEFAULT_ICEBERG_SNAPSHOT_NEW_COMMITTED_DELETION_LOG,
+            new_compacted_data_file_count: Self::DEFAULT_ICEBERG_NEW_COMPACTED_DATA_FILE_COUNT,
+            old_compacted_data_file_count: Self::DEFAULT_ICEBERG_OLD_COMPACTED_DATA_FILE_COUNT,
+            old_merged_file_indices_count: Self::DEFAULT_ICEBERG_OLD_MERGED_FILE_INDICES_COUNT,
         }
     }
 }
@@ -136,5 +171,14 @@ impl MooncakeTableConfig {
     }
     pub fn iceberg_snapshot_new_committed_deletion_log(&self) -> usize {
         self.persistence_config.new_committed_deletion_log
+    }
+    pub fn iceberg_snapshot_new_compacted_data_file_count(&self) -> usize {
+        self.persistence_config.new_compacted_data_file_count
+    }
+    pub fn iceberg_snapshot_old_compacted_data_file_count(&self) -> usize {
+        self.persistence_config.old_compacted_data_file_count
+    }
+    pub fn iceberg_snapshot_old_merged_file_indices_count(&self) -> usize {
+        self.persistence_config.old_merged_file_indices_count
     }
 }

--- a/src/moonlink/src/table_handler/tests.rs
+++ b/src/moonlink/src/table_handler/tests.rs
@@ -77,6 +77,9 @@ async fn test_append_with_small_disk_slice() {
         persistence_config: IcebergPersistenceConfig {
             new_data_file_count: 1000,
             new_committed_deletion_log: 1000,
+            new_compacted_data_file_count: 1,
+            old_compacted_data_file_count: 1,
+            old_merged_file_indices_count: 1,
         },
     };
     let env = TestEnvironment::new(temp_dir, mooncake_table_config.clone()).await;
@@ -570,6 +573,9 @@ async fn test_iceberg_snapshot_creation_for_batch_write() {
         persistence_config: IcebergPersistenceConfig {
             new_data_file_count: 1000,
             new_committed_deletion_log: 1000,
+            new_compacted_data_file_count: 1,
+            old_compacted_data_file_count: 1,
+            old_merged_file_indices_count: 1,
         },
     };
     let mut env = TestEnvironment::new(temp_dir, mooncake_table_config.clone()).await;
@@ -769,6 +775,9 @@ async fn test_iceberg_snapshot_creation_for_streaming_write() {
         persistence_config: IcebergPersistenceConfig {
             new_data_file_count: 1000,
             new_committed_deletion_log: 1000,
+            new_compacted_data_file_count: 1,
+            old_compacted_data_file_count: 1,
+            old_merged_file_indices_count: 1,
         },
     };
     let mut env = TestEnvironment::new(temp_dir, mooncake_table_config.clone()).await;
@@ -999,6 +1008,9 @@ async fn test_multiple_snapshot_requests() {
         persistence_config: IcebergPersistenceConfig {
             new_data_file_count: 1000,
             new_committed_deletion_log: 1000,
+            new_compacted_data_file_count: 1,
+            old_compacted_data_file_count: 1,
+            old_merged_file_indices_count: 1,
         },
     };
     let mut env = TestEnvironment::new(temp_dir, mooncake_table_config.clone()).await;


### PR DESCRIPTION
## Summary

This is a no-op change PR.
Currently iceberg persistence threshold is hard-coded to be 1, I made it a config param so we could tune for perf before release.

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
