### PR TITLE
[storage] Avoid operator creation blocking

### DIFF
--- a/src/moonlink/src/storage/filesystem/accessor/filesystem_accessor.rs
+++ b/src/moonlink/src/storage/filesystem/accessor/filesystem_accessor.rs
@@ -77,7 +77,9 @@ impl FileSystemAccessor {
     /// Get IO operator from the catalog.
     async fn get_operator(&self) -> Result<&Operator> {
         self.operator
-            .get_or_try_init(|| async { operator_utils::create_opendal_operator(&self.config) })
+            .get_or_try_init(|| async {
+                operator_utils::create_opendal_operator(&self.config).await
+            })
             .await
     }
 

--- a/src/moonlink/src/storage/filesystem/accessor/unbuffered_stream_writer.rs
+++ b/src/moonlink/src/storage/filesystem/accessor/unbuffered_stream_writer.rs
@@ -72,7 +72,9 @@ mod tests {
         // Create an operator.
         let storage_config = StorageConfig::FileSystem { root_directory };
         let accessor_config = AccessorConfig::new_with_storage_config(storage_config.clone());
-        let operator = operator_utils::create_opendal_operator(&accessor_config).unwrap();
+        let operator = operator_utils::create_opendal_operator(&accessor_config)
+            .await
+            .unwrap();
 
         // Create writer and append in blocks.
         let writer =

--- a/src/moonlink/src/storage/filesystem/gcs/tests.rs
+++ b/src/moonlink/src/storage/filesystem/gcs/tests.rs
@@ -134,7 +134,9 @@ async fn test_unbuffered_stream_writer() {
     let (bucket, warehouse_uri) = get_test_gcs_bucket_and_warehouse();
     let _test_guard = TestGuard::new(bucket.clone()).await;
     let gcs_storage_config = create_gcs_storage_config(&warehouse_uri);
-    let operator = operator_utils::create_opendal_operator(&gcs_storage_config).unwrap();
+    let operator = operator_utils::create_opendal_operator(&gcs_storage_config)
+        .await
+        .unwrap();
 
     // Create writer and append in blocks.
     let writer =

--- a/src/moonlink/src/storage/filesystem/s3/tests.rs
+++ b/src/moonlink/src/storage/filesystem/s3/tests.rs
@@ -191,7 +191,9 @@ async fn test_unbuffered_stream_writer() {
     let (bucket, warehouse_uri) = get_test_s3_bucket_and_warehouse();
     let _test_guard = TestGuard::new(bucket.clone()).await;
     let s3_storage_config = create_s3_storage_config(&warehouse_uri);
-    let operator = operator_utils::create_opendal_operator(&s3_storage_config).unwrap();
+    let operator = operator_utils::create_opendal_operator(&s3_storage_config)
+        .await
+        .unwrap();
 
     // Create writer and append in blocks.
     let writer =


### PR DESCRIPTION
## Summary

opendal operator creation involves blocking IO operations: https://github.com/apache/opendal/blob/b53d802718adf6909c03a336dbb8a6ca1d09113b/core/src/services/fs/backend.rs#L90-L100
so we cannot use it in async tokio runtime.

- I've put an issue to opendal repo, let's wait for their response
- On moonlink side we have to schedule it to dedicated threadpool executor

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1169

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
