### PR TITLE
[storage] Validate snapshot disk file count

### DIFF
--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -2,6 +2,7 @@ mod batch_id_counter;
 mod data_batches;
 pub(crate) mod delete_vector;
 mod disk_slice;
+mod iceberg_persisted_records;
 mod mem_slice;
 mod persistence_buffer;
 mod shared_array;
@@ -35,6 +36,7 @@ use crate::storage::iceberg::iceberg_table_manager::IcebergTableManager;
 use crate::storage::iceberg::table_manager::{PersistenceFileParams, TableManager};
 use crate::storage::index::persisted_bucket_hash_map::GlobalIndexBuilder;
 use crate::storage::mooncake_table::batch_id_counter::BatchIdCounter;
+use crate::storage::mooncake_table::iceberg_persisted_records::IcebergPersistedRecords;
 use crate::storage::mooncake_table::shared_array::SharedRowBufferSnapshot;
 pub use crate::storage::mooncake_table::snapshot_read_output::ReadOutput as SnapshotReadOutput;
 #[cfg(test)]
@@ -182,133 +184,6 @@ impl Snapshot {
             self.metadata.name, self.metadata.table_id, self.snapshot_version
         ));
         directory
-    }
-}
-
-/// Record iceberg persisted records, used to sync to mooncake snapshot.
-#[derive(Debug, Default)]
-pub(crate) struct IcebergPersistedRecords {
-    /// Flush LSN for iceberg snapshot.
-    flush_lsn: Option<u64>,
-    /// New data file, puffin file and file indices result.
-    import_result: IcebergSnapshotImportResult,
-    /// Index merge persistence result.
-    index_merge_result: IcebergSnapshotIndexMergeResult,
-    /// Data compaction persistence result.
-    data_compaction_result: IcebergSnapshotDataCompactionResult,
-}
-
-impl IcebergPersistedRecords {
-    /// Return whether persistence result is empty.
-    #[allow(dead_code)]
-    pub fn is_empty(&self) -> bool {
-        if self.flush_lsn.is_none() {
-            assert!(self.import_result.is_empty());
-            assert!(self.index_merge_result.is_empty());
-            assert!(self.data_compaction_result.is_empty());
-            return true;
-        }
-
-        false
-    }
-
-    /// Get persisted data files.
-    pub fn get_data_files_to_reflect_persistence(&self) -> Vec<MooncakeDataFileRef> {
-        let mut persisted_data_files = vec![];
-        persisted_data_files.extend(self.import_result.new_data_files.iter().cloned());
-        persisted_data_files.extend(
-            self.data_compaction_result
-                .new_data_files_imported
-                .iter()
-                .cloned(),
-        );
-        persisted_data_files
-    }
-
-    /// Get persisted file indices, and files id for data files referenced by index blocks to delete.
-    ///
-    /// Notice, we don't need to reflect file indices persistence for index merge and data compaction, since file indices are always cached on-disk, thus mooncake snapshot only access local cache files.
-    ///
-    /// TODO(hjiang): It's actually better not to assume certain cache implementation, and only apply what iceberg table manager returns.
-    pub fn get_file_indices_to_reflect_persistence(&self) -> (HashSet<FileId>, Vec<FileIndex>) {
-        let mut persisted_file_indices = vec![];
-        persisted_file_indices.extend(self.import_result.new_file_indices.iter().cloned());
-        persisted_file_indices.extend(
-            self.index_merge_result
-                .new_file_indices_imported
-                .iter()
-                .cloned(),
-        );
-        persisted_file_indices.extend(
-            self.data_compaction_result
-                .new_file_indices_imported
-                .iter()
-                .cloned(),
-        );
-
-        let mut index_blocks_to_delete = HashSet::new();
-        for cur_file_index in self.import_result.new_file_indices.iter() {
-            index_blocks_to_delete.extend(cur_file_index.files.iter().map(|f| f.file_id()));
-        }
-        for cur_file_index in self.index_merge_result.new_file_indices_imported.iter() {
-            index_blocks_to_delete.extend(cur_file_index.files.iter().map(|f| f.file_id()));
-        }
-        for cur_file_index in self.data_compaction_result.new_file_indices_imported.iter() {
-            index_blocks_to_delete.extend(cur_file_index.files.iter().map(|f| f.file_id()));
-        }
-
-        (index_blocks_to_delete, persisted_file_indices)
-    }
-
-    /// Util function to validate all data files referenced by file indices are remote files.
-    fn validate_file_indices_remote(&self, file_index: &FileIndex, warehouse_uri: &str) {
-        for cur_index_block in file_index.index_blocks.iter() {
-            assert!(cur_index_block
-                .index_file
-                .file_path()
-                .starts_with(warehouse_uri));
-        }
-    }
-
-    /// Validate all imported data files, file indices and index blocks point to remote files.
-    pub fn validate_imported_files_remote(&self, warehouse_uri: &str) {
-        #[cfg(any(test, debug_assertions))]
-        {
-            let import_result = &self.import_result;
-
-            // Validate persisted data files point to remote.
-            for cur_data_file in import_result.new_data_files.iter() {
-                assert!(cur_data_file.file_path().starts_with(warehouse_uri));
-            }
-
-            // Validate persisted file indices and index blocks point to remote.
-            for cur_file_index in import_result.new_file_indices.iter() {
-                self.validate_file_indices_remote(cur_file_index, warehouse_uri);
-            }
-        }
-
-        #[cfg(any(test, debug_assertions))]
-        {
-            let index_merge_results = &self.index_merge_result;
-            for cur_file_index in index_merge_results.new_file_indices_imported.iter() {
-                self.validate_file_indices_remote(cur_file_index, warehouse_uri);
-            }
-        }
-
-        #[cfg(any(test, debug_assertions))]
-        {
-            let data_compaction_results = &self.data_compaction_result;
-
-            // Validate persisted data files point to remote.
-            for cur_data_file in data_compaction_results.new_data_files_imported.iter() {
-                assert!(cur_data_file.file_path().starts_with(warehouse_uri));
-            }
-
-            // Validate persisted file indices and index blocks point to remote.
-            for cur_file_index in data_compaction_results.new_file_indices_imported.iter() {
-                self.validate_file_indices_remote(cur_file_index, warehouse_uri);
-            }
-        }
     }
 }
 

--- a/src/moonlink/src/storage/mooncake_table/iceberg_persisted_records.rs
+++ b/src/moonlink/src/storage/mooncake_table/iceberg_persisted_records.rs
@@ -1,0 +1,136 @@
+use crate::storage::index::FileIndex;
+use crate::storage::mooncake_table::table_snapshot::IcebergSnapshotDataCompactionResult;
+use crate::storage::mooncake_table::table_snapshot::{
+    IcebergSnapshotImportResult, IcebergSnapshotIndexMergeResult,
+};
+use crate::storage::storage_utils::FileId;
+use crate::storage::storage_utils::MooncakeDataFileRef;
+
+use std::collections::HashSet;
+
+/// Record iceberg persisted records, used to sync to mooncake snapshot.
+#[derive(Debug, Default)]
+pub(crate) struct IcebergPersistedRecords {
+    /// Flush LSN for iceberg snapshot.
+    pub(crate) flush_lsn: Option<u64>,
+    /// New data file, puffin file and file indices result.
+    pub(crate) import_result: IcebergSnapshotImportResult,
+    /// Index merge persistence result.
+    pub(crate) index_merge_result: IcebergSnapshotIndexMergeResult,
+    /// Data compaction persistence result.
+    pub(crate) data_compaction_result: IcebergSnapshotDataCompactionResult,
+}
+
+impl IcebergPersistedRecords {
+    /// Return whether persistence result is empty.
+    #[allow(dead_code)]
+    pub fn is_empty(&self) -> bool {
+        if self.flush_lsn.is_none() {
+            assert!(self.import_result.is_empty());
+            assert!(self.index_merge_result.is_empty());
+            assert!(self.data_compaction_result.is_empty());
+            return true;
+        }
+
+        false
+    }
+
+    /// Get persisted data files.
+    pub fn get_data_files_to_reflect_persistence(&self) -> Vec<MooncakeDataFileRef> {
+        let mut persisted_data_files = vec![];
+        persisted_data_files.extend(self.import_result.new_data_files.iter().cloned());
+        persisted_data_files.extend(
+            self.data_compaction_result
+                .new_data_files_imported
+                .iter()
+                .cloned(),
+        );
+        persisted_data_files
+    }
+
+    /// Get persisted file indices, and files id for data files referenced by index blocks to delete.
+    ///
+    /// Notice, we don't need to reflect file indices persistence for index merge and data compaction, since file indices are always cached on-disk, thus mooncake snapshot only access local cache files.
+    ///
+    /// TODO(hjiang): It's actually better not to assume certain cache implementation, and only apply what iceberg table manager returns.
+    pub fn get_file_indices_to_reflect_persistence(&self) -> (HashSet<FileId>, Vec<FileIndex>) {
+        let mut persisted_file_indices = vec![];
+        persisted_file_indices.extend(self.import_result.new_file_indices.iter().cloned());
+        persisted_file_indices.extend(
+            self.index_merge_result
+                .new_file_indices_imported
+                .iter()
+                .cloned(),
+        );
+        persisted_file_indices.extend(
+            self.data_compaction_result
+                .new_file_indices_imported
+                .iter()
+                .cloned(),
+        );
+
+        let mut index_blocks_to_delete = HashSet::new();
+        for cur_file_index in self.import_result.new_file_indices.iter() {
+            index_blocks_to_delete.extend(cur_file_index.files.iter().map(|f| f.file_id()));
+        }
+        for cur_file_index in self.index_merge_result.new_file_indices_imported.iter() {
+            index_blocks_to_delete.extend(cur_file_index.files.iter().map(|f| f.file_id()));
+        }
+        for cur_file_index in self.data_compaction_result.new_file_indices_imported.iter() {
+            index_blocks_to_delete.extend(cur_file_index.files.iter().map(|f| f.file_id()));
+        }
+
+        (index_blocks_to_delete, persisted_file_indices)
+    }
+
+    /// Util function to validate all data files referenced by file indices are remote files.
+    fn validate_file_indices_remote(&self, file_index: &FileIndex, warehouse_uri: &str) {
+        for cur_index_block in file_index.index_blocks.iter() {
+            assert!(cur_index_block
+                .index_file
+                .file_path()
+                .starts_with(warehouse_uri));
+        }
+    }
+
+    /// Validate all imported data files, file indices and index blocks point to remote files.
+    pub fn validate_imported_files_remote(&self, warehouse_uri: &str) {
+        #[cfg(any(test, debug_assertions))]
+        {
+            let import_result = &self.import_result;
+
+            // Validate persisted data files point to remote.
+            for cur_data_file in import_result.new_data_files.iter() {
+                assert!(cur_data_file.file_path().starts_with(warehouse_uri));
+            }
+
+            // Validate persisted file indices and index blocks point to remote.
+            for cur_file_index in import_result.new_file_indices.iter() {
+                self.validate_file_indices_remote(cur_file_index, warehouse_uri);
+            }
+        }
+
+        #[cfg(any(test, debug_assertions))]
+        {
+            let index_merge_results = &self.index_merge_result;
+            for cur_file_index in index_merge_results.new_file_indices_imported.iter() {
+                self.validate_file_indices_remote(cur_file_index, warehouse_uri);
+            }
+        }
+
+        #[cfg(any(test, debug_assertions))]
+        {
+            let data_compaction_results = &self.data_compaction_result;
+
+            // Validate persisted data files point to remote.
+            for cur_data_file in data_compaction_results.new_data_files_imported.iter() {
+                assert!(cur_data_file.file_path().starts_with(warehouse_uri));
+            }
+
+            // Validate persisted file indices and index blocks point to remote.
+            for cur_file_index in data_compaction_results.new_file_indices_imported.iter() {
+                self.validate_file_indices_remote(cur_file_index, warehouse_uri);
+            }
+        }
+    }
+}

--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -440,6 +440,12 @@ impl SnapshotTableState {
             .validate_imported_files_remote(&self.iceberg_warehouse_location);
 
         // Calculate the expected disk files number after current snapshot update.
+        let expected_disk_files_count = self.current_snapshot.disk_files.len()
+            + task.new_disk_slices.iter().map(|cur_disk_slice| cur_disk_slice.output_files().len()).sum::<usize>() // new persisted files by non-streaming committed transactions
+            + task.new_streaming_xact.iter().map(|cur_txn| cur_txn.get_committed_persisted_disk_count()).sum::<usize>() // new persisted files files by streaming committed transactions
+            - task.data_compaction_result.old_data_files.len() // old data files before compaction
+            + task.data_compaction_result.new_data_files.len() // new data files after compaction
+            ;
 
         // All evicted data files by the object storage cache.
         let mut evicted_data_files_to_delete = vec![];
@@ -569,6 +575,10 @@ impl SnapshotTableState {
                 ));
             }
         }
+
+        // Validate disk files count is as expected.
+        let actual_disk_files_count = self.current_snapshot.disk_files.len();
+        assert_eq!(expected_disk_files_count, actual_disk_files_count);
 
         // Expensive assertion, which is only enabled in unit tests.
         #[cfg(any(test, debug_assertions))]

--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -439,6 +439,8 @@ impl SnapshotTableState {
         task.iceberg_persisted_records
             .validate_imported_files_remote(&self.iceberg_warehouse_location);
 
+        // Calculate the expected disk files number after current snapshot update.
+
         // All evicted data files by the object storage cache.
         let mut evicted_data_files_to_delete = vec![];
 

--- a/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
+++ b/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
@@ -43,6 +43,16 @@ pub enum TransactionStreamOutput {
     Abort(u32),
 }
 
+impl TransactionStreamOutput {
+    /// Get committed persisted disk files count.
+    pub fn get_committed_persisted_disk_count(&self) -> usize {
+        match &self {
+            TransactionStreamOutput::Abort(_) => 0,
+            TransactionStreamOutput::Commit(commit) => commit.flushed_files.len(),
+        }
+    }
+}
+
 pub struct TransactionStreamCommit {
     xact_id: u32,
     commit_lsn: u64,


### PR DESCRIPTION
## Summary

I met not-easy-to-repro error, which shows less committed records at snapshot read.
This PR adds assertion for mooncake snapshot on expected disk file count.

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
