### PR TITLE
[storage] Remove puffin blob from iceberg table manager

### DIFF
--- a/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
@@ -1,7 +1,6 @@
 use crate::storage::filesystem::accessor::base_filesystem_accessor::BaseFileSystemAccess;
 use crate::storage::iceberg::catalog_utils;
 use crate::storage::iceberg::moonlink_catalog::MoonlinkCatalog;
-use crate::storage::iceberg::puffin_utils::PuffinBlobRef;
 use crate::storage::iceberg::table_manager::{
     PersistenceFileParams, PersistenceResult, TableManager,
 };
@@ -41,8 +40,6 @@ pub(crate) struct DataFileEntry {
     pub(crate) data_file: DataFile,
     /// In-memory deletion vector.
     pub(crate) deletion_vector: BatchDeletionVector,
-    /// Puffin blob for its deletion vector.
-    pub(crate) persisted_deletion_vector: Option<PuffinBlobRef>,
 }
 
 #[derive(Debug)]

--- a/src/moonlink/src/storage/iceberg/iceberg_table_syncer.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_syncer.rs
@@ -194,7 +194,6 @@ impl IcebergTableManager {
                     deletion_vector: BatchDeletionVector::new(
                         max_rows.unwrap_or(UNINITIALIZED_BATCH_DELETION_VECTOR_MAX_ROW),
                     ),
-                    persisted_deletion_vector: None,
                 },
             );
             assert!(old_entry.is_none());


### PR DESCRIPTION
## Summary

`persisted_puffin_blob` field is not used in iceberg table manager, the only deletion records required is batch deletion vector, which for merge operation on each persistence.

It's also bad to hold at iceberg layer, since inside puffin blob ref, there's cached file handle which holds reference counts.

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
