### PR TITLE
[Build] upgrade roaring to 0.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2067,7 +2067,7 @@ dependencies = [
  "rand 0.8.5",
  "reqsign",
  "reqwest",
- "roaring",
+ "roaring 0.10.12",
  "rust_decimal",
  "serde",
  "serde_bytes",
@@ -2724,7 +2724,7 @@ dependencies = [
  "pprof",
  "rand 0.9.1",
  "reqwest",
- "roaring",
+ "roaring 0.11.2",
  "rstest",
  "rstest_reuse",
  "serde",
@@ -2754,7 +2754,7 @@ dependencies = [
  "more-asserts",
  "nix 0.27.1",
  "parquet",
- "roaring",
+ "roaring 0.11.2",
  "serde",
  "serde_json",
  "serial_test",
@@ -4033,6 +4033,16 @@ name = "roaring"
 version = "0.10.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19e8d2cfa184d94d0726d650a9f4a1be7f9b76ac9fdb954219878dc00c1c1e7b"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+]
+
+[[package]]
+name = "roaring"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f08d6a905edb32d74a5d5737a0c9d7e950c312f3c46cb0ca0a2ca09ea11878a0"
 dependencies = [
  "bytemuck",
  "byteorder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ paste = "1"
 postgres-replication = { git = "https://github.com/Mooncake-labs/rust-postgres.git", rev = "e6bd7d5cacc4eb7a03930b5ca3db1ef9caf0a3d5" }
 postgres-types = { git = "https://github.com/Mooncake-Labs/rust-postgres.git", rev = "e6bd7d5cacc4eb7a03930b5ca3db1ef9caf0a3d5", features = ["with-serde_json-1"] }
 rand = "0.9"
-roaring = "0.10"
+roaring = "0.11"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = "1"
 serial_test = "3.0"


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

Upgrade the `roaring` version from `0.10` to `0.11` while `0.11.2` is released (see [here](https://github.com/RoaringBitmap/roaring-rs/releases/tag/v0.11.2))

## Related Issues

Closes #371

## Changes

- `roaring` version from `0.10` to `0.11`

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
