### PR TITLE
[storage] Compaction by deleted rows

### DIFF
--- a/src/moonlink/src/storage/iceberg/compaction_tests.rs
+++ b/src/moonlink/src/storage/iceberg/compaction_tests.rs
@@ -94,6 +94,7 @@ fn get_data_compaction_config() -> DataCompactionConfig {
         min_data_file_to_compact: 2,
         max_data_file_to_compact: u32::MAX,
         data_file_final_size: 1000000,
+        data_file_deletion_percentage: 0,
     }
 }
 

--- a/src/moonlink/src/storage/iceberg/iceberg_table_loader.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_loader.rs
@@ -201,6 +201,7 @@ impl IcebergTableManager {
             mooncake_snapshot.disk_files.insert(
                 data_file,
                 DiskFileEntry {
+                    num_rows: data_file_entry.data_file.record_count() as usize,
                     file_size: data_file_entry.data_file.file_size_in_bytes() as usize,
                     cache_handle: None,
                     puffin_deletion_blob,

--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -126,6 +126,8 @@ impl TableMetadata {
 pub(crate) struct DiskFileEntry {
     /// Cache handle. If assigned, it's pinned in object storage cache.
     pub(crate) cache_handle: Option<NonEvictableHandle>,
+    /// Number of rows.
+    pub(crate) num_rows: usize,
     /// File size.
     pub(crate) file_size: usize,
     /// In-memory deletion vector, used for new deletion records in-memory processing.

--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -348,6 +348,7 @@ impl SnapshotTableState {
             self.current_snapshot.disk_files.insert(
                 cur_new_data_file.clone(),
                 DiskFileEntry {
+                    num_rows: cur_entry.num_rows,
                     file_size: cur_entry.file_size,
                     cache_handle: Some(cache_handle),
                     batch_deletion_vector: BatchDeletionVector::new(
@@ -695,6 +696,7 @@ impl SnapshotTableState {
                 self.current_snapshot.disk_files.insert(
                     file.clone(),
                     DiskFileEntry {
+                        num_rows: file_attrs.row_num,
                         file_size: file_attrs.file_size,
                         cache_handle: Some(cache_handle),
                         batch_deletion_vector: BatchDeletionVector::new(file_attrs.row_num),

--- a/src/moonlink/src/storage/mooncake_table/table_creation_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_creation_test_utils.rs
@@ -210,6 +210,7 @@ pub(crate) fn create_test_table_metadata_with_data_compaction_disable_flush(
         min_data_file_to_compact: 2,
         max_data_file_to_compact: u32::MAX,
         data_file_final_size: u64::MAX,
+        data_file_deletion_percentage: 0,
     };
     let mut config = MooncakeTableConfig::new(local_table_directory.clone());
     config.data_compaction_config = data_compaction_config;
@@ -307,6 +308,7 @@ pub(crate) async fn create_mooncake_table_and_notify_for_compaction(
             data_file_final_size: u64::MAX,
             min_data_file_to_compact: 2,
             max_data_file_to_compact: u32::MAX,
+            data_file_deletion_percentage: 0,
         },
         ..Default::default()
     };

--- a/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
+++ b/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
@@ -396,6 +396,7 @@ impl MooncakeTable {
         for (file, file_attrs) in disk_slice.output_files().iter() {
             ma::assert_gt!(file_attrs.file_size, 0);
             let disk_file_entry = DiskFileEntry {
+                num_rows: file_attrs.row_num,
                 file_size: file_attrs.file_size,
                 cache_handle: None,
                 batch_deletion_vector: BatchDeletionVector::new(file_attrs.row_num),

--- a/src/moonlink/src/table_handler/tests.rs
+++ b/src/moonlink/src/table_handler/tests.rs
@@ -1496,6 +1496,7 @@ async fn test_full_maintenance_with_sufficient_data_files() {
             min_data_file_to_compact: 2,
             max_data_file_to_compact: u32::MAX,
             data_file_final_size: u64::MAX,
+            data_file_deletion_percentage: 0,
         },
         file_index_config: FileIndexMergeConfig {
             min_file_indices_to_merge: u32::MAX,

--- a/src/moonlink_metadata_store/src/config_utils.rs
+++ b/src/moonlink_metadata_store/src/config_utils.rs
@@ -266,6 +266,8 @@ mod tests {
                 min_data_file_to_compact: 10,
                 max_data_file_to_compact: DataCompactionConfig::default_max_data_file_to_compact(),
                 data_file_final_size: 123456,
+                data_file_deletion_percentage:
+                    DataCompactionConfig::default_data_file_deletion_percentage(),
             },
             // Index merge config.
             file_index_config: FileIndexMergeConfig {


### PR DESCRIPTION
## Summary

Current compaction strategy is bad: for large files (which are over configured size), it still takes part in compaction as long as there're deleted rows.
This PR adds a percentage-based threshold to guard against unnecessary compaction.

Several policies considered:
- File size based: it's hard to calculate the size of deleted or undeleted rows
- Row number based (by absolute value): it treats differently for large objects and small objects
  + For example, for data files with large objects, it could never reach the row number threshold even though half of the storage space could be optimized
- Deletion percentage based: the ideal situation is deletion percentage indicates file size percentage
  + For example, 50% rows deleted indicates >50% of the storage space could be freed after compaction

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/878

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
