### PR TITLE
[AsyncFlush 3/3] Use asynchronous flush

### DIFF
--- a/src/moonlink/benches/bench_write.rs
+++ b/src/moonlink/benches/bench_write.rs
@@ -91,8 +91,7 @@ fn bench_write(c: &mut Criterion) {
                         values: row.values.clone(),
                     });
                 }
-                let handle = table.flush(100000);
-                handle.await.unwrap();
+                let _ = table.flush(100000);
             });
         });
     });
@@ -143,8 +142,7 @@ fn bench_write(c: &mut Criterion) {
                         1,
                     );
                 }
-                let handle = table.flush(100000);
-                handle.await.unwrap();
+                let _ = table.flush(100000);
             });
         });
     });
@@ -196,7 +194,7 @@ fn bench_write(c: &mut Criterion) {
                             1,
                         );
                     }
-                    table.flush_stream(1, None).await.unwrap();
+                    table.flush_stream(1, None).unwrap();
                 });
                 table
             },
@@ -212,9 +210,7 @@ fn bench_write(c: &mut Criterion) {
                             )
                             .await;
                     }
-                    table.flush_stream(1, None).await.unwrap();
-                    //let handle = table.create_snapshot();
-                    //let _ = handle.unwrap().await.unwrap();
+                    table.flush_stream(1, None).unwrap();
                 });
             },
             BatchSize::PerIteration,

--- a/src/moonlink/src/storage/index.rs
+++ b/src/moonlink/src/storage/index.rs
@@ -20,16 +20,19 @@ pub struct MooncakeIndex {
 /// Type for primary keys
 pub type PrimaryKey = u64;
 
+#[derive(Clone, Debug)]
 pub struct SinglePrimitiveKey {
     hash: PrimaryKey,
     location: RecordLocation,
 }
+#[derive(Clone, Debug)]
 pub struct KeyWithIdentity {
     hash: PrimaryKey,
     identity: MoonlinkRow,
     location: RecordLocation,
 }
 /// Index containing records in memory
+#[derive(Clone, Debug)]
 pub enum MemIndex {
     SinglePrimitive(hashbrown::HashTable<SinglePrimitiveKey>),
     Key(hashbrown::HashTable<KeyWithIdentity>),

--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -698,11 +698,6 @@ impl MooncakeTable {
         self.last_iceberg_snapshot_lsn
     }
 
-    #[cfg(test)]
-    pub(crate) fn set_iceberg_snapshot_lsn(&mut self, lsn: u64) {
-        self.last_iceberg_snapshot_lsn = Some(lsn);
-    }
-
     pub(crate) fn get_state_for_reader(
         &self,
     ) -> (Arc<RwLock<SnapshotTableState>>, watch::Receiver<u64>) {

--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -898,6 +898,7 @@ impl MooncakeTable {
         Ok(())
     }
 
+    // Sets the flush LSN for the next iceberg snapshot. Note that we can only set the flush LSN if it's greater than the current min pending flush LSN. Otherwise, LSNs will be persisted to iceberg in the wrong order.
     fn set_next_flush_lsn(&mut self, lsn: u64) {
         let min_pending_lsn = self.get_min_pending_flush_lsn();
         if lsn < min_pending_lsn {

--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -907,6 +907,7 @@ impl MooncakeTable {
         }
     }
 
+    // We fallback to u64::MAX if there are no pending flush LSNs so that the LSN is always greater than the flush LSN and the iceberg snapshot can proceed.
     pub fn get_min_pending_flush_lsn(&self) -> u64 {
         self.ongoing_flush_lsns
             .iter()

--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -928,6 +928,10 @@ impl MooncakeTable {
         );
     }
 
+    pub fn has_ongoing_flush(&self) -> bool {
+        !self.ongoing_flush_lsns.is_empty()
+    }
+
     // Create a snapshot of the last committed version, return current snapshot's version and payload to perform iceberg snapshot.
     fn create_snapshot_impl(&mut self, opt: SnapshotOption) {
         // Check invariant: there should be at most one ongoing mooncake snapshot.

--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -857,7 +857,7 @@ impl MooncakeTable {
         let lsn = disk_slice
             .lsn()
             .expect("LSN should never be none for non streaming flush");
-        self.pending_flush_lsns.remove(&lsn);
+        self.remove_pending_flush_lsn(lsn);
         self.set_next_flush_lsn(lsn);
         self.next_snapshot_task.new_disk_slices.push(disk_slice);
     }

--- a/src/moonlink/src/storage/mooncake_table/data_batches.rs
+++ b/src/moonlink/src/storage/mooncake_table/data_batches.rs
@@ -11,7 +11,7 @@ use arrow::array::{ArrayRef, RecordBatch};
 use arrow_schema::Schema;
 use std::sync::Arc;
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub(super) struct InMemoryBatch {
     pub(super) data: Option<Arc<RecordBatch>>,
     pub(super) deletions: BatchDeletionVector,
@@ -45,7 +45,7 @@ impl InMemoryBatch {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(super) struct BatchEntry {
     pub(super) id: u64,
     pub(super) batch: InMemoryBatch,

--- a/src/moonlink/src/storage/mooncake_table/data_file_state_tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/data_file_state_tests.rs
@@ -134,10 +134,13 @@ async fn prepare_test_disk_file_for_read(
         table
             .append_in_stream_batch(row.clone(), /*xact_id=*/ 0)
             .unwrap();
-        table
-            .commit_transaction_stream(/*xact_id=*/ 0, /*lsn=*/ 1)
-            .await
-            .unwrap();
+        commit_transaction_stream_and_sync(
+            &mut table,
+            &mut table_notify,
+            /*xact_id=*/ 0,
+            /*lsn=*/ 1,
+        )
+        .await
     }
 
     (table, table_notify)

--- a/src/moonlink/src/storage/mooncake_table/deletion_vector_puffin_state_tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/deletion_vector_puffin_state_tests.rs
@@ -88,19 +88,25 @@ async fn prepare_test_deletion_vector_for_read(
         table
             .append_in_stream_batch(row.clone(), /*xact_id=*/ 0)
             .unwrap();
-        table
-            .commit_transaction_stream(/*xact_id=*/ 0, /*lsn=*/ 1)
-            .await
-            .unwrap();
+        commit_transaction_stream_and_sync(
+            &mut table,
+            &mut table_notify,
+            /*xact_id=*/ 0,
+            /*lsn=*/ 1,
+        )
+        .await;
 
         // Delete the row.
         table
             .delete_in_stream_batch(row.clone(), /*xact_id=*/ 1)
             .await;
-        table
-            .commit_transaction_stream(/*xact_id=*/ 1, /*lsn=*/ 3)
-            .await
-            .unwrap();
+        commit_transaction_stream_and_sync(
+            &mut table,
+            &mut table_notify,
+            /*xact_id=*/ 1,
+            /*lsn=*/ 3,
+        )
+        .await
     }
 
     (table, table_notify)

--- a/src/moonlink/src/storage/mooncake_table/disk_slice.rs
+++ b/src/moonlink/src/storage/mooncake_table/disk_slice.rs
@@ -56,9 +56,17 @@ pub struct DiskSliceWriter {
 impl std::fmt::Debug for DiskSliceWriter {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let batch_ids: Vec<u64> = self.batches.iter().map(|batch| batch.id).collect();
+        let num_data_files = self.files.len();
+        let num_index_blocks = self
+            .new_index
+            .as_ref()
+            .map(|idx| idx.index_blocks.len())
+            .unwrap_or(0);
         f.debug_struct("DiskSliceWriter")
             .field("batch_ids", &batch_ids)
             .field("lsn", &self.writer_lsn)
+            .field("num_data_files", &num_data_files)
+            .field("num_index_blocks", &num_index_blocks)
             .finish()
     }
 }

--- a/src/moonlink/src/storage/mooncake_table/disk_slice.rs
+++ b/src/moonlink/src/storage/mooncake_table/disk_slice.rs
@@ -122,10 +122,6 @@ impl DiskSliceWriter {
         &self.batches
     }
 
-    pub(super) fn take_input_batches(&mut self) -> Vec<BatchEntry> {
-        std::mem::take(&mut self.batches)
-    }
-
     /// Get the list of files in the DiskSlice
     pub(super) fn output_files(&self) -> &[(MooncakeDataFileRef, DiskFileAttrs)] {
         self.files.as_slice()

--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -526,8 +526,8 @@ impl SnapshotTableState {
             self.current_snapshot.flush_lsn = Some(new_flush_lsn);
         }
 
-        if task.new_commit_lsn != 0 {
-            self.current_snapshot.snapshot_version = task.new_commit_lsn;
+        if task.commit_lsn_baseline != 0 {
+            self.current_snapshot.snapshot_version = task.commit_lsn_baseline;
         }
         if let Some(cp) = task.new_commit_point {
             self.last_commit = cp;
@@ -914,7 +914,7 @@ impl SnapshotTableState {
 
         for mut entry in take(&mut self.uncommitted_deletion_log) {
             let deletion = entry.take().unwrap();
-            if deletion.lsn < task.new_commit_lsn {
+            if deletion.lsn < task.commit_lsn_baseline {
                 self.commit_deletion(deletion);
             } else {
                 still_uncommitted.push(Some(deletion));
@@ -951,7 +951,7 @@ impl SnapshotTableState {
                 true
             }
         });
-        self.add_processed_deletion(already_processed, task.new_commit_lsn);
+        self.add_processed_deletion(already_processed, task.commit_lsn_baseline);
         new_deletions.sort_by_key(|deletion| deletion.lookup_key);
         if new_deletions.is_empty() {
             return;
@@ -991,7 +991,7 @@ impl SnapshotTableState {
                     &task.disk_file_lsn_map,
                 )
                 .await;
-            self.add_processed_deletion(processed_deletions, task.new_commit_lsn);
+            self.add_processed_deletion(processed_deletions, task.commit_lsn_baseline);
         }
     }
 }

--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -719,6 +719,7 @@ impl SnapshotTableState {
                     slice.remap_deletion_if_needed(deletion)
                 {
                     // Find the disk file entry and apply the deletion
+                    // Precondition: all new data files have been reflected to disk file map
                     for (file_ref, disk_entry) in self.current_snapshot.disk_files.iter_mut() {
                         if file_ref.file_id() == file_id {
                             assert!(disk_entry.batch_deletion_vector.delete_row(row_idx));

--- a/src/moonlink/src/storage/mooncake_table/snapshot_validation.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot_validation.rs
@@ -29,13 +29,13 @@ impl SnapshotTableState {
                 // Force snapshot could flush as long as the table at a clean state (aka, no uncommitted states), possible to go without commit at current snapshot iteration.
                 if opt.force_create {
                     assert!(
-                        task.new_commit_lsn == 0 || task.new_commit_lsn >= new_flush_lsn,
+                        task.commit_lsn_baseline == 0 || task.commit_lsn_baseline >= new_flush_lsn,
                         "New commit LSN is {}, new flush LSN is {}",
-                        task.new_commit_lsn,
+                        task.commit_lsn_baseline,
                         new_flush_lsn
                     );
                 } else {
-                    ma::assert_ge!(task.new_commit_lsn, new_flush_lsn);
+                    ma::assert_ge!(task.commit_lsn_baseline, new_flush_lsn);
                 }
             }
         }

--- a/src/moonlink/src/storage/mooncake_table/snapshot_validation.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot_validation.rs
@@ -29,7 +29,9 @@ impl SnapshotTableState {
                 // Force snapshot could flush as long as the table at a clean state (aka, no uncommitted states), possible to go without commit at current snapshot iteration.
                 if opt.force_create {
                     assert!(
-                        task.commit_lsn_baseline == 0 || task.commit_lsn_baseline >= new_flush_lsn,
+                        task.commit_lsn_baseline == 0
+                            || task.commit_lsn_baseline >= new_flush_lsn
+                            || task.commit_lsn_baseline == task.prev_commit_lsn_baseline,
                         "New commit LSN is {}, new flush LSN is {}",
                         task.commit_lsn_baseline,
                         new_flush_lsn

--- a/src/moonlink/src/storage/mooncake_table/table_creation_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_creation_test_utils.rs
@@ -30,6 +30,13 @@ use tempfile::TempDir;
 use tokio::sync::mpsc;
 use tokio::sync::mpsc::Receiver;
 
+impl MooncakeTable {
+    #[cfg(test)]
+    pub(crate) fn set_iceberg_snapshot_lsn(&mut self, lsn: u64) {
+        self.last_iceberg_snapshot_lsn = Some(lsn);
+    }
+}
+
 /// Test util function to get iceberg table config for local filesystem.
 pub(crate) fn get_iceberg_table_config(temp_dir: &TempDir) -> IcebergTableConfig {
     let root_directory = temp_dir.path().to_str().unwrap().to_string();

--- a/src/moonlink/src/storage/mooncake_table/table_operation_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_operation_test_utils.rs
@@ -54,7 +54,7 @@ pub(crate) async fn flush_table_and_sync(
 }
 
 /// Flush mooncake, block wait its completion but do NOT apply the result.
-/// This leaves the LSN in pending_flush_lsns until apply_flush_result is called.
+/// This leaves the LSN in ongoing_flush_lsns until apply_flush_result is called.
 #[cfg(test)]
 pub(crate) async fn flush_table_and_sync_no_apply(
     table: &mut MooncakeTable,
@@ -84,7 +84,7 @@ pub(crate) async fn flush_table_and_sync_no_apply(
     }
 }
 
-/// Flush mooncake, block wait its completion and reflect result to mooncake table.
+/// Flush mooncake, block wait its completion.
 #[cfg(test)]
 pub(crate) async fn flush_stream_and_sync_no_apply(
     table: &mut MooncakeTable,

--- a/src/moonlink/src/storage/mooncake_table/table_operation_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_operation_test_utils.rs
@@ -5,6 +5,7 @@ use tokio::sync::mpsc::Receiver;
 #[cfg(test)]
 use crate::row::MoonlinkRow;
 use crate::storage::io_utils;
+use crate::storage::mooncake_table::disk_slice::DiskSliceWriter;
 use crate::storage::mooncake_table::{
     AlterTableRequest, DataCompactionPayload, DataCompactionResult, FileIndiceMergePayload,
     FileIndiceMergeResult, IcebergSnapshotPayload, IcebergSnapshotResult, MaintenanceOption,
@@ -15,6 +16,7 @@ use crate::table_notify::{
 };
 use crate::{MooncakeTable, SnapshotReadOutput};
 use crate::{ReadState, Result};
+use tracing::{debug, error};
 
 /// ===============================
 /// Flush
@@ -24,11 +26,124 @@ use crate::{ReadState, Result};
 #[cfg(test)]
 pub(crate) async fn flush_table_and_sync(
     table: &mut MooncakeTable,
-    _receiver: &mut Receiver<TableEvent>,
+    receiver: &mut Receiver<TableEvent>,
     lsn: u64,
 ) -> Result<()> {
-    // TODO(Nolan): Use receiver to block wait until table flush finishes.
-    table.flush(lsn).await
+    table.flush(lsn).unwrap();
+    let flush_result = receiver.recv().await.unwrap();
+    match flush_result {
+        TableEvent::FlushResult {
+            xact_id: _,
+            flush_result,
+        } => match flush_result {
+            Some(Ok(disk_slice)) => {
+                table.apply_flush_result(disk_slice);
+            }
+            Some(Err(e)) => {
+                error!(error = ?e, "failed to flush disk slice");
+            }
+            None => {
+                debug!("Flush result is none, disk slice was empty");
+            }
+        },
+        _ => {
+            panic!("Expected FlushResult as first event, but got others.");
+        }
+    }
+    Ok(())
+}
+
+/// Flush mooncake, block wait its completion but do NOT apply the result.
+/// This leaves the LSN in pending_flush_lsns until apply_flush_result is called.
+#[cfg(test)]
+pub(crate) async fn flush_table_and_sync_no_apply(
+    table: &mut MooncakeTable,
+    receiver: &mut Receiver<TableEvent>,
+    lsn: u64,
+) -> Option<DiskSliceWriter> {
+    table.flush(lsn).unwrap();
+    let flush_result = receiver.recv().await.unwrap();
+    match flush_result {
+        TableEvent::FlushResult {
+            xact_id: _,
+            flush_result,
+        } => match flush_result {
+            Some(Ok(disk_slice)) => Some(disk_slice),
+            Some(Err(e)) => {
+                error!(error = ?e, "failed to flush disk slice");
+                None
+            }
+            None => {
+                debug!("Flush result is none, disk slice was empty");
+                None
+            }
+        },
+        _ => {
+            panic!("Expected FlushResult as first event, but got others.");
+        }
+    }
+}
+
+/// Flush mooncake, block wait its completion and reflect result to mooncake table.
+#[cfg(test)]
+pub(crate) async fn flush_stream_and_sync_no_apply(
+    table: &mut MooncakeTable,
+    receiver: &mut Receiver<TableEvent>,
+    xact_id: u32,
+    lsn: Option<u64>,
+) -> Option<DiskSliceWriter> {
+    table.flush_stream(xact_id, lsn).unwrap();
+    let flush_result = receiver.recv().await.unwrap();
+    match flush_result {
+        TableEvent::FlushResult {
+            xact_id: _,
+            flush_result,
+        } => match flush_result {
+            Some(Ok(disk_slice)) => Some(disk_slice),
+            Some(Err(e)) => {
+                error!(error = ?e, "failed to flush disk slice");
+                None
+            }
+            None => {
+                debug!("Flush result is none, disk slice was empty");
+                None
+            }
+        },
+        _ => {
+            panic!("Expected FlushResult as first event, but got others.");
+        }
+    }
+}
+
+/// Commit transaction stream, block wait its completion and reflect result to mooncake table.
+#[cfg(test)]
+pub(crate) async fn commit_transaction_stream_and_sync(
+    table: &mut MooncakeTable,
+    receiver: &mut Receiver<TableEvent>,
+    xact_id: u32,
+    lsn: u64,
+) {
+    table.commit_transaction_stream(xact_id, lsn).unwrap();
+    let flush_result = receiver.recv().await.unwrap();
+    match flush_result {
+        TableEvent::FlushResult {
+            xact_id: Some(xact_id),
+            flush_result,
+        } => match flush_result {
+            Some(Ok(disk_slice)) => {
+                table.apply_stream_flush_result(xact_id, disk_slice);
+            }
+            Some(Err(e)) => {
+                error!(error = ?e, "failed to flush disk slice");
+            }
+            None => {
+                debug!("Flush result is none, disk slice was empty");
+            }
+        },
+        _ => {
+            panic!("Expected FlushResult as first event, but got others.");
+        }
+    }
 }
 
 /// ===============================
@@ -153,7 +268,9 @@ pub(crate) async fn sync_mooncake_snapshot(
         panic!("Expected mooncake snapshot completion notification, but get others.");
     }
 }
-async fn sync_iceberg_snapshot(receiver: &mut Receiver<TableEvent>) -> IcebergSnapshotResult {
+pub(crate) async fn sync_iceberg_snapshot(
+    receiver: &mut Receiver<TableEvent>,
+) -> IcebergSnapshotResult {
     let notification = receiver.recv().await.unwrap();
     if let TableEvent::IcebergSnapshotResult {
         iceberg_snapshot_result,

--- a/src/moonlink/src/storage/mooncake_table/tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/tests.rs
@@ -3,8 +3,11 @@ use super::*;
 use crate::storage::iceberg::table_manager::MockTableManager;
 use crate::storage::mooncake_table::table_creation_test_utils::*;
 use crate::storage::mooncake_table::table_operation_test_utils::*;
+use crate::storage::mooncake_table::test_utils::{append_rows, test_row, test_table, TestContext};
 use crate::storage::mooncake_table::Snapshot as MooncakeSnapshot;
 use crate::storage::wal::test_utils::WAL_TEST_TABLE_ID;
+use crate::table_handler::table_handler_state::MaintenanceProcessStatus;
+use crate::table_handler::table_handler_state::TableHandlerState;
 use crate::FileSystemAccessor;
 use iceberg::{Error as IcebergError, ErrorKind};
 use rstest::*;
@@ -728,18 +731,16 @@ async fn test_streaming_begin_flush_commit_end_flush() {
 
     // Begin the flush
     // This will drain the mem slice and add its relevant state to the stream state
-    let mut disk_slice = table.prepare_stream_disk_slice(xact_id, Some(lsn)).unwrap();
-    table
-        .flush_stream_disk_slice(xact_id, &mut disk_slice)
-        .await
-        .unwrap();
+    let disk_slice =
+        flush_stream_and_sync_no_apply(&mut table, &mut event_completion_rx, xact_id, Some(lsn))
+            .await
+            .expect("Disk slice should be present");
 
     // Wait to apply the flush to simulate an async flush that hasn't returned
     // Commit the transaction while the flush is pending
     // This will move the state from the stream state to the snapshot task
     table
-        .commit_transaction_stream(xact_id, lsn + 1)
-        .await
+        .commit_transaction_stream_impl(xact_id, lsn + 1)
         .unwrap();
 
     // Make sure the row is visible in snapshot before flush finishes
@@ -778,10 +779,10 @@ async fn test_streaming_begin_flush_commit_end_flush() {
 
 #[tokio::test]
 async fn test_streaming_begin_flush_commit_end_flush_multiple() {
-    let context = TestContext::new("streaming_begin_flush_commit_end_flush");
+    let context = TestContext::new("streaming_begin_flush_commit_end_flush_multiple");
     let mut table = test_table(
         &context,
-        "streaming_begin_flush_commit_end_flush",
+        "streaming_begin_flush_commit_end_flush_multiple",
         IdentityProp::Keys(vec![0]),
     )
     .await;
@@ -797,30 +798,29 @@ async fn test_streaming_begin_flush_commit_end_flush_multiple() {
 
     // Begin the flush
     // This will drain the mem slice and add its relevant state to the stream state
-    let mut disk_slice1 = table.prepare_stream_disk_slice(xact_id, Some(lsn)).unwrap();
-    table
-        .flush_stream_disk_slice(xact_id, &mut disk_slice1)
-        .await
-        .unwrap();
+    let disk_slice1 =
+        flush_stream_and_sync_no_apply(&mut table, &mut event_completion_rx, xact_id, Some(lsn))
+            .await
+            .unwrap();
 
     let row2 = test_row(2, "B", 21);
     table.append_in_stream_batch(row2, xact_id).unwrap();
 
     // Begin the flush
     // This will drain the mem slice and add its relevant state to the stream state
-    let mut disk_slice2 = table.prepare_stream_disk_slice(xact_id, Some(lsn)).unwrap();
-    table
-        .flush_stream_disk_slice(xact_id, &mut disk_slice2)
-        .await
-        .unwrap();
+    let disk_slice2 = flush_stream_and_sync_no_apply(
+        &mut table,
+        &mut event_completion_rx,
+        xact_id,
+        Some(lsn + 1),
+    )
+    .await
+    .unwrap();
 
     // Wait to apply the flush to simulate an async flush that hasn't returned
     // Commit the transaction while the flush is pending
     // This will move the state from the stream state to the snapshot task
-    table
-        .commit_transaction_stream(xact_id, lsn + 1)
-        .await
-        .unwrap();
+    table.commit_transaction_stream_impl(xact_id, lsn).unwrap();
 
     // Make sure the rows are visible in snapshot before flush finishes
     create_mooncake_snapshot_for_test(&mut table, &mut event_completion_rx).await;
@@ -872,7 +872,7 @@ async fn test_streaming_begin_flush_commit_end_flush_multiple() {
 }
 
 #[tokio::test]
-async fn test_streaming_begin_flush_delete_commit_end_flush() {
+async fn test_streaming_begin_flush_commit_delete_end_flush() {
     let context = TestContext::new("streaming_begin_flush_commit_delete_end_flush");
     let mut table = test_table(
         &context,
@@ -894,23 +894,29 @@ async fn test_streaming_begin_flush_delete_commit_end_flush() {
 
     // Begin the flush
     // This will drain the mem slice and add its relevant state to the stream state
-    let mut disk_slice = table.prepare_stream_disk_slice(xact_id, Some(lsn)).unwrap();
-    table
-        .flush_stream_disk_slice(xact_id, &mut disk_slice)
-        .await
-        .unwrap();
+    let disk_slice =
+        flush_stream_and_sync_no_apply(&mut table, &mut event_completion_rx, xact_id, Some(lsn))
+            .await
+            .expect("Disk slice should be present");
 
     // Delete the row that is still flushing
     table.delete_in_stream_batch(row2, xact_id).await;
+
+    // Make sure the data is not visible before commit
+    create_mooncake_snapshot_for_test(&mut table, &mut event_completion_rx).await;
+    {
+        let mut snapshot = table.snapshot.write().await;
+        let SnapshotReadOutput {
+            data_file_paths, ..
+        } = snapshot.request_read().await.unwrap();
+        assert_eq!(data_file_paths.len(), 0);
+    }
 
     // Finish the flush
     table.apply_stream_flush_result(xact_id, disk_slice);
 
     // Commit the transaction
-    table
-        .commit_transaction_stream(xact_id, lsn + 1)
-        .await
-        .unwrap();
+    table.commit_transaction_stream_impl(xact_id, lsn).unwrap();
 
     // Make sure we only have one row in the snapshot
     create_mooncake_snapshot_for_test(&mut table, &mut event_completion_rx).await;
@@ -937,11 +943,11 @@ async fn test_streaming_begin_flush_delete_commit_end_flush() {
 }
 
 #[tokio::test]
-async fn test_streaming_begin_flush_commit_delete_end_flush() {
-    let context = TestContext::new("streaming_begin_flush_commit_delete_end_flush");
+async fn test_streaming_begin_flush_delete_commit_end_flush() {
+    let context = TestContext::new("streaming_begin_flush_delete_commit_end_flush");
     let mut table = test_table(
         &context,
-        "streaming_begin_flush_commit_delete_end_flush",
+        "streaming_begin_flush_delete_commit_end_flush",
         IdentityProp::Keys(vec![0]),
     )
     .await;
@@ -959,18 +965,16 @@ async fn test_streaming_begin_flush_commit_delete_end_flush() {
 
     // Begin the flush
     // This will drain the mem slice and add its relevant state to the stream state
-    let mut disk_slice = table.prepare_stream_disk_slice(xact_id, Some(lsn)).unwrap();
-    table
-        .flush_stream_disk_slice(xact_id, &mut disk_slice)
-        .await
-        .unwrap();
+    let disk_slice =
+        flush_stream_and_sync_no_apply(&mut table, &mut event_completion_rx, xact_id, Some(lsn))
+            .await
+            .unwrap();
 
     // Wait to apply the flush to simulate an async flush that hasn't returned
     // Commit the transaction while the flush is pending
     // This will move the state from the stream state to the snapshot task
     table
-        .commit_transaction_stream(xact_id, lsn + 1)
-        .await
+        .commit_transaction_stream_impl(xact_id, lsn + 1)
         .unwrap();
 
     // Make sure the rows are visible in snapshot before flush finishes
@@ -993,21 +997,99 @@ async fn test_streaming_begin_flush_commit_delete_end_flush() {
 
     // Commit the new transaction
     table
-        .commit_transaction_stream(xact_id2, lsn2 + 1)
-        .await
+        .commit_transaction_stream_impl(xact_id2, lsn2 + 1)
         .unwrap();
 
-    let mut disk_slice2 = table
-        .prepare_stream_disk_slice(xact_id2, Some(lsn2))
-        .unwrap();
-    table
-        .flush_stream_disk_slice(xact_id2, &mut disk_slice2)
-        .await
-        .unwrap();
+    let disk_slice2 =
+        flush_stream_and_sync_no_apply(&mut table, &mut event_completion_rx, xact_id2, Some(lsn2))
+            .await
+            .unwrap();
 
-    // Apply the flush for both transactions
     table.apply_stream_flush_result(xact_id, disk_slice);
     table.apply_stream_flush_result(xact_id2, disk_slice2);
+
+    // Make sure we only have one row in the snapshot
+    create_mooncake_snapshot_for_test(&mut table, &mut event_completion_rx).await;
+
+    // Read the snapshot
+    {
+        let mut snapshot = table.snapshot.write().await;
+        let SnapshotReadOutput {
+            data_file_paths,
+            puffin_cache_handles,
+            position_deletes,
+            deletion_vectors,
+            ..
+        } = snapshot.request_read().await.unwrap();
+        verify_files_and_deletions(
+            get_data_files_for_read(&data_file_paths).as_slice(),
+            get_deletion_puffin_files_for_read(&puffin_cache_handles).as_slice(),
+            position_deletes,
+            deletion_vectors,
+            &[1],
+        )
+        .await;
+    }
+}
+
+#[tokio::test]
+async fn test_streaming_begin_flush_commit_end_flush_delete() {
+    let context = TestContext::new("streaming_begin_flush_commit_end_flush_delete");
+    let mut table = test_table(
+        &context,
+        "streaming_begin_flush_commit_end_flush_delete",
+        IdentityProp::Keys(vec![0]),
+    )
+    .await;
+    let (event_completion_tx, mut event_completion_rx) = mpsc::channel(100);
+    table.register_table_notify(event_completion_tx).await;
+
+    let xact_id = 1;
+    let lsn = 1;
+
+    // Append a row to streaming mem slice
+    let row1 = test_row(1, "A", 20);
+    table.append_in_stream_batch(row1, xact_id).unwrap();
+    let row2 = test_row(2, "B", 21);
+    table.append_in_stream_batch(row2.clone(), xact_id).unwrap();
+
+    // Begin the flush
+    // This will drain the mem slice and add its relevant state to the stream state
+    // Wait to apply the flush to simulate an async flush that hasn't returned
+    // Commit the transaction while the flush is pending
+    // This will move the state from the stream state to the snapshot task
+    let disk_slice =
+        flush_stream_and_sync_no_apply(&mut table, &mut event_completion_rx, xact_id, Some(lsn))
+            .await
+            .unwrap();
+
+    // Commit the transaction
+    table.commit_transaction_stream_impl(xact_id, lsn).unwrap();
+
+    // Apply the flush
+    table.apply_stream_flush_result(xact_id, disk_slice);
+
+    // Make sure the rows are visible in snapshot before commit finishes
+    create_mooncake_snapshot_for_test(&mut table, &mut event_completion_rx).await;
+    // Read the snapshot
+    {
+        let mut snapshot = table.snapshot.write().await;
+        let SnapshotReadOutput {
+            data_file_paths, ..
+        } = snapshot.request_read().await.unwrap();
+        verify_file_contents(&data_file_paths[0].get_file_path(), &[1, 2], Some(2));
+    }
+
+    // Start a new transaction
+    let xact_id2 = 2;
+    let lsn2 = 2;
+
+    // Delete the row from the previous transaction (has not been flushed yet)
+    table.delete_in_stream_batch(row2, xact_id2).await;
+
+    // Flush and Commit the new transaction
+    commit_transaction_stream_and_sync(&mut table, &mut event_completion_rx, xact_id2, lsn2 + 1)
+        .await;
 
     // Make sure we only have one row in the snapshot
     create_mooncake_snapshot_for_test(&mut table, &mut event_completion_rx).await;
@@ -1046,7 +1128,6 @@ async fn test_streaming_begin_flush_abort_end_flush() {
     table.register_table_notify(event_completion_tx).await;
 
     let xact_id = 1;
-    let lsn = 1;
 
     // Append a row to streaming mem slice
     let row = test_row(1, "A", 20);
@@ -1054,11 +1135,10 @@ async fn test_streaming_begin_flush_abort_end_flush() {
 
     // Begin the flush
     // This will drain the mem slice and add its relevant state to the stream state
-    let mut disk_slice = table.prepare_stream_disk_slice(xact_id, Some(lsn)).unwrap();
-    table
-        .flush_stream_disk_slice(xact_id, &mut disk_slice)
-        .await
-        .unwrap();
+    let disk_slice =
+        flush_stream_and_sync_no_apply(&mut table, &mut event_completion_rx, xact_id, None)
+            .await
+            .expect("Disk slice should be present");
 
     // Wait to apply the flush to simulate an async flush that hasn't returned
     // Abort the transaction while the flush is pending
@@ -1092,7 +1172,6 @@ async fn test_streaming_begin_flush_abort_end_flush_multiple() {
     table.register_table_notify(event_completion_tx).await;
 
     let xact_id = 1;
-    let lsn = 1;
 
     // Append a row to streaming mem slice
     let row1 = test_row(1, "A", 20);
@@ -1102,17 +1181,15 @@ async fn test_streaming_begin_flush_abort_end_flush_multiple() {
 
     // Begin the flush
     // This will drain the mem slice and add its relevant state to the stream state
-    let mut disk_slice1 = table.prepare_stream_disk_slice(xact_id, Some(lsn)).unwrap();
-    table
-        .flush_stream_disk_slice(xact_id, &mut disk_slice1)
-        .await
-        .unwrap();
+    let disk_slice1 =
+        flush_stream_and_sync_no_apply(&mut table, &mut event_completion_rx, xact_id, None)
+            .await
+            .expect("Disk slice should be present");
 
-    let mut disk_slice2 = table.prepare_stream_disk_slice(xact_id, Some(lsn)).unwrap();
-    table
-        .flush_stream_disk_slice(xact_id, &mut disk_slice2)
-        .await
-        .unwrap();
+    let disk_slice2 =
+        flush_stream_and_sync_no_apply(&mut table, &mut event_completion_rx, xact_id, None)
+            .await
+            .expect("Disk slice should be present");
 
     // Wait to apply the flush to simulate an async flush that hasn't returned
     // Abort the transaction while the flush is pending
@@ -1142,12 +1219,917 @@ async fn test_streaming_begin_flush_abort_end_flush_multiple() {
     }
 }
 
+/// ===================================
+/// LSN Ordering Tests for Iceberg Snapshots
+/// ===================================
+
 #[tokio::test]
-async fn test_streaming_commit_with_unflushed_data() {
-    let context = TestContext::new("streaming_commit_with_unflushed_data");
+async fn test_pending_flush_lsns_tracking() -> Result<()> {
+    let context = TestContext::new("pending_flush_tracking");
+    let mut table = test_table(&context, "lsn_table", IdentityProp::FullRow).await;
+    let (event_completion_tx, mut event_completion_rx) = mpsc::channel(100);
+    table.register_table_notify(event_completion_tx).await;
+
+    // Verify initially no pending flushes
+    assert!(table.pending_flush_lsns.is_empty());
+    assert_eq!(table.get_min_pending_flush_lsn(), u64::MAX);
+
+    // Add data and start multiple flushes with monotonically increasing LSNs
+    append_rows(&mut table, vec![test_row(1, "A", 20)])?;
+    table.commit(1);
+    let disk_slice_1 = flush_table_and_sync_no_apply(&mut table, &mut event_completion_rx, 5)
+        .await
+        .expect("Disk slice 1 should be present");
+
+    append_rows(&mut table, vec![test_row(2, "B", 21)])?;
+    table.commit(2);
+    let disk_slice_2 = flush_table_and_sync_no_apply(&mut table, &mut event_completion_rx, 10)
+        .await
+        .expect("Disk slice 2 should be present");
+
+    append_rows(&mut table, vec![test_row(3, "C", 22)])?;
+    table.commit(3);
+    let disk_slice_3 = flush_table_and_sync_no_apply(&mut table, &mut event_completion_rx, 15)
+        .await
+        .expect("Disk slice 3 should be present");
+
+    // Verify all LSNs are tracked
+    assert!(table.pending_flush_lsns.contains(&5));
+    assert!(table.pending_flush_lsns.contains(&10));
+    assert!(table.pending_flush_lsns.contains(&15));
+    assert_eq!(table.pending_flush_lsns.len(), 3);
+
+    // Verify min is correctly calculated (should be 5)
+    assert_eq!(table.get_min_pending_flush_lsn(), 5);
+
+    // Complete flush with LSN 10 (out of order completion)
+    table.apply_flush_result(disk_slice_2);
+    assert!(table.pending_flush_lsns.contains(&5));
+    assert!(!table.pending_flush_lsns.contains(&10));
+    assert!(table.pending_flush_lsns.contains(&15));
+    assert_eq!(table.get_min_pending_flush_lsn(), 5); // Still 5
+
+    // Complete flush with LSN 5
+    table.apply_flush_result(disk_slice_1);
+    assert!(!table.pending_flush_lsns.contains(&5));
+    assert!(table.pending_flush_lsns.contains(&15));
+    assert_eq!(table.get_min_pending_flush_lsn(), 15); // Now 15
+
+    // Complete last flush
+    table.apply_flush_result(disk_slice_3);
+    assert!(table.pending_flush_lsns.is_empty());
+    assert_eq!(table.get_min_pending_flush_lsn(), u64::MAX);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_streaming_flush_lsns_tracking() -> Result<()> {
+    let context = TestContext::new("streaming_flush_tracking");
+    let mut table = test_table(&context, "lsn_table", IdentityProp::FullRow).await;
+    let (event_completion_tx, mut event_completion_rx) = mpsc::channel(100);
+    table.register_table_notify(event_completion_tx).await;
+
+    let xact_id_1 = 1;
+    let xact_id_2 = 2;
+
+    // Start streaming transactions
+    table.append_in_stream_batch(test_row(1, "A", 20), xact_id_1)?;
+    table.append_in_stream_batch(test_row(2, "B", 21), xact_id_2)?;
+
+    // Flush streaming transactions with different LSNs (can be out of order)
+    let disk_slice_1 =
+        flush_stream_and_sync_no_apply(&mut table, &mut event_completion_rx, xact_id_1, Some(100))
+            .await
+            .expect("Disk slice 1 should be present");
+
+    let disk_slice_2 =
+        flush_stream_and_sync_no_apply(&mut table, &mut event_completion_rx, xact_id_2, Some(50))
+            .await
+            .expect("Disk slice 2 should be present");
+
+    // Verify both streaming LSNs are tracked
+    assert!(table.pending_flush_lsns.contains(&100));
+    assert!(table.pending_flush_lsns.contains(&50));
+    assert_eq!(table.get_min_pending_flush_lsn(), 50);
+
+    // Mix with regular flush (must be higher than previous regular flush)
+    append_rows(&mut table, vec![test_row(3, "C", 22)])?;
+    table.commit(3);
+    let disk_slice_3 = flush_table_and_sync_no_apply(&mut table, &mut event_completion_rx, 75)
+        .await
+        .expect("Disk slice 3 should be present");
+
+    // Verify all three LSNs are tracked
+    assert!(table.pending_flush_lsns.contains(&100));
+    assert!(table.pending_flush_lsns.contains(&50));
+    assert!(table.pending_flush_lsns.contains(&75));
+    assert_eq!(table.get_min_pending_flush_lsn(), 50);
+
+    // Complete streaming flushes
+    table.apply_stream_flush_result(xact_id_1, disk_slice_1);
+    table.apply_stream_flush_result(xact_id_2, disk_slice_2);
+    table.apply_flush_result(disk_slice_3);
+
+    // Verify all pending flushes are cleared
+    assert!(table.pending_flush_lsns.is_empty());
+    assert_eq!(table.get_min_pending_flush_lsn(), u64::MAX);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_lsn_ordering_constraint_with_real_table_handler_state() -> Result<()> {
+    let context = TestContext::new("lsn_ordering_constraint");
+    let mut table = test_table(&context, "lsn_table", IdentityProp::FullRow).await;
+    let (event_completion_tx, mut event_completion_rx) = mpsc::channel(100);
+    table.register_table_notify(event_completion_tx).await;
+
+    // Test case 1: No pending flushes - should allow any flush LSN
+    assert!(table.pending_flush_lsns.is_empty());
+    let min_pending = table.get_min_pending_flush_lsn();
+    assert_eq!(min_pending, u64::MAX);
+
+    // With no pending flushes, should allow iceberg snapshots
+    assert!(TableHandlerState::can_initiate_iceberg_snapshot(
+        100,
+        min_pending,
+        true,
+        false
+    ));
+    assert!(TableHandlerState::can_initiate_iceberg_snapshot(
+        1000,
+        min_pending,
+        true,
+        false
+    ));
+
+    // Test case 2: Start some flushes
+    append_rows(&mut table, vec![test_row(1, "A", 20)])?;
+    table.commit(1);
+    let disk_slice_1 = flush_table_and_sync_no_apply(&mut table, &mut event_completion_rx, 30)
+        .await
+        .expect("Disk slice should be present");
+
+    append_rows(&mut table, vec![test_row(2, "B", 21)])?;
+    table.commit(2);
+    let disk_slice_2 = flush_table_and_sync_no_apply(&mut table, &mut event_completion_rx, 50)
+        .await
+        .expect("Disk slice should be present");
+
+    let min_pending = table.get_min_pending_flush_lsn();
+    assert_eq!(min_pending, 30);
+
+    // Should allow iceberg snapshots with flush_lsn < 30
+    assert!(TableHandlerState::can_initiate_iceberg_snapshot(
+        10,
+        min_pending,
+        true,
+        false
+    ));
+    assert!(TableHandlerState::can_initiate_iceberg_snapshot(
+        29,
+        min_pending,
+        true,
+        false
+    ));
+
+    // Should NOT allow iceberg snapshots with flush_lsn >= 30
+    assert!(!TableHandlerState::can_initiate_iceberg_snapshot(
+        30,
+        min_pending,
+        true,
+        false
+    ));
+    assert!(!TableHandlerState::can_initiate_iceberg_snapshot(
+        40,
+        min_pending,
+        true,
+        false
+    ));
+    assert!(!TableHandlerState::can_initiate_iceberg_snapshot(
+        100,
+        min_pending,
+        true,
+        false
+    ));
+
+    // Test case 3: Test iceberg snapshot ongoing constraint
+    // Even with valid flush_lsn < min_pending, should not allow due to ongoing snapshot
+    assert!(!TableHandlerState::can_initiate_iceberg_snapshot(
+        10,
+        min_pending,
+        true,
+        true
+    ));
+    assert!(!TableHandlerState::can_initiate_iceberg_snapshot(
+        29,
+        min_pending,
+        true,
+        true
+    ));
+
+    // Test case 4: Test iceberg snapshot result not consumed constraint
+    // Even with valid conditions, should not allow due to unconsumed result
+    assert!(!TableHandlerState::can_initiate_iceberg_snapshot(
+        10,
+        min_pending,
+        false,
+        false
+    ));
+    assert!(!TableHandlerState::can_initiate_iceberg_snapshot(
+        29,
+        min_pending,
+        false,
+        false
+    ));
+
+    // Complete the flush with LSN 30
+    table.apply_flush_result(disk_slice_1);
+    let min_pending = table.get_min_pending_flush_lsn();
+    assert_eq!(min_pending, 50);
+
+    // Now should allow iceberg snapshots with flush_lsn < 50
+    assert!(TableHandlerState::can_initiate_iceberg_snapshot(
+        30,
+        min_pending,
+        true,
+        false
+    ));
+    assert!(TableHandlerState::can_initiate_iceberg_snapshot(
+        49,
+        min_pending,
+        true,
+        false
+    ));
+
+    // Should NOT allow iceberg snapshots with flush_lsn >= 50
+    assert!(!TableHandlerState::can_initiate_iceberg_snapshot(
+        50,
+        min_pending,
+        true,
+        false
+    ));
+    assert!(!TableHandlerState::can_initiate_iceberg_snapshot(
+        60,
+        min_pending,
+        true,
+        false
+    ));
+
+    // Complete the remaining flush
+    table.apply_flush_result(disk_slice_2);
+    let min_pending = table.get_min_pending_flush_lsn();
+    assert_eq!(min_pending, u64::MAX);
+
+    // Now should allow any iceberg snapshot again
+    assert!(TableHandlerState::can_initiate_iceberg_snapshot(
+        100,
+        min_pending,
+        true,
+        false
+    ));
+    assert!(TableHandlerState::can_initiate_iceberg_snapshot(
+        1000,
+        min_pending,
+        true,
+        false
+    ));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_out_of_order_flush_completion() -> Result<()> {
+    let context = TestContext::new("out_of_order_flush");
+    let mut table = test_table(&context, "lsn_table", IdentityProp::FullRow).await;
+    let (event_completion_tx, mut event_completion_rx) = mpsc::channel(100);
+    table.register_table_notify(event_completion_tx).await;
+
+    // Start flushes in order: 10, 20, 30
+    append_rows(&mut table, vec![test_row(1, "A", 20)])?;
+    table.commit(1);
+    let disk_slice_10 = flush_table_and_sync_no_apply(&mut table, &mut event_completion_rx, 10)
+        .await
+        .expect("Disk slice should be present");
+
+    append_rows(&mut table, vec![test_row(2, "B", 21)])?;
+    table.commit(2);
+    let disk_slice_20 = flush_table_and_sync_no_apply(&mut table, &mut event_completion_rx, 20)
+        .await
+        .expect("Disk slice should be present");
+
+    append_rows(&mut table, vec![test_row(3, "C", 22)])?;
+    table.commit(3);
+    let disk_slice_30 = flush_table_and_sync_no_apply(&mut table, &mut event_completion_rx, 30)
+        .await
+        .expect("Disk slice should be present");
+
+    // Verify all are pending and min is 10
+    assert!(table.pending_flush_lsns.contains(&10));
+    assert!(table.pending_flush_lsns.contains(&20));
+    assert!(table.pending_flush_lsns.contains(&30));
+    assert_eq!(table.get_min_pending_flush_lsn(), 10);
+
+    // Complete flush 30 first (out of order)
+    table.apply_flush_result(disk_slice_30);
+    assert!(!table.pending_flush_lsns.contains(&30));
+    assert!(table.pending_flush_lsns.contains(&10));
+    assert!(table.pending_flush_lsns.contains(&20));
+    assert_eq!(table.get_min_pending_flush_lsn(), 10); // Still 10
+
+    // Complete flush 10 (should update min to 20)
+    table.apply_flush_result(disk_slice_10);
+    assert!(!table.pending_flush_lsns.contains(&10));
+    assert!(table.pending_flush_lsns.contains(&20));
+    assert_eq!(table.get_min_pending_flush_lsn(), 20);
+
+    // Complete flush 20 (should clear all)
+    table.apply_flush_result(disk_slice_20);
+    assert!(table.pending_flush_lsns.is_empty());
+    assert_eq!(table.get_min_pending_flush_lsn(), u64::MAX);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_mixed_regular_and_streaming_lsn_ordering() -> Result<()> {
+    let context = TestContext::new("mixed_lsn_ordering");
+    let mut table = test_table(&context, "lsn_table", IdentityProp::FullRow).await;
+    let (event_completion_tx, mut event_completion_rx) = mpsc::channel(100);
+    table.register_table_notify(event_completion_tx).await;
+
+    let xact_id = 1;
+
+    // Start regular flush with LSN 100
+    append_rows(&mut table, vec![test_row(1, "A", 20)])?;
+    table.commit(1);
+    let regular_disk_slice =
+        flush_table_and_sync_no_apply(&mut table, &mut event_completion_rx, 100)
+            .await
+            .expect("Regular disk slice should be present");
+
+    // Start streaming flush with LSN 50 (lower than regular, but allowed for streaming)
+    table.append_in_stream_batch(test_row(2, "B", 21), xact_id)?;
+    let streaming_disk_slice =
+        flush_stream_and_sync_no_apply(&mut table, &mut event_completion_rx, xact_id, Some(50))
+            .await
+            .expect("Streaming disk slice should be present");
+
+    // Verify both are tracked and min is 50
+    assert!(table.pending_flush_lsns.contains(&100));
+    assert!(table.pending_flush_lsns.contains(&50));
+    assert_eq!(table.get_min_pending_flush_lsn(), 50);
+
+    // According to table handler logic, iceberg snapshots with flush_lsn >= 50 should be blocked
+    let min_pending = table.get_min_pending_flush_lsn();
+    assert!(!TableHandlerState::can_initiate_iceberg_snapshot(
+        50,
+        min_pending,
+        true,
+        false
+    )); // Blocked
+    assert!(!TableHandlerState::can_initiate_iceberg_snapshot(
+        75,
+        min_pending,
+        true,
+        false
+    )); // Blocked
+    assert!(TableHandlerState::can_initiate_iceberg_snapshot(
+        40,
+        min_pending,
+        true,
+        false
+    )); // Allowed
+
+    // Complete streaming flush first
+    table.apply_stream_flush_result(xact_id, streaming_disk_slice);
+    assert!(!table.pending_flush_lsns.contains(&50));
+    assert!(table.pending_flush_lsns.contains(&100));
+    assert_eq!(table.get_min_pending_flush_lsn(), 100);
+
+    // Now iceberg snapshots with flush_lsn < 100 should be allowed
+    let min_pending = table.get_min_pending_flush_lsn();
+    assert!(TableHandlerState::can_initiate_iceberg_snapshot(
+        75,
+        min_pending,
+        true,
+        false
+    )); // Now allowed
+    assert!(!TableHandlerState::can_initiate_iceberg_snapshot(
+        100,
+        min_pending,
+        true,
+        false
+    )); // Still blocked
+
+    // Complete regular flush
+    table.apply_flush_result(regular_disk_slice);
+    assert!(table.pending_flush_lsns.is_empty());
+    assert_eq!(table.get_min_pending_flush_lsn(), u64::MAX);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_lsn_ordering_both_functions_in_tandem() -> Result<()> {
+    let context = TestContext::new("lsn_ordering_tandem");
+    let mut table = test_table(&context, "lsn_table", IdentityProp::FullRow).await;
+    let (event_completion_tx, mut event_completion_rx) = mpsc::channel(100);
+    table.register_table_notify(event_completion_tx).await;
+
+    // Test case 1: No pending flushes - both functions should allow operations
+    assert!(table.pending_flush_lsns.is_empty());
+    let min_pending = table.get_min_pending_flush_lsn();
+    assert_eq!(min_pending, u64::MAX);
+
+    // With no pending flushes, should allow iceberg snapshots for any flush_lsn
+    assert!(TableHandlerState::can_initiate_iceberg_snapshot(
+        100,
+        min_pending,
+        true,
+        false
+    ));
+    assert!(TableHandlerState::can_initiate_iceberg_snapshot(
+        1000,
+        min_pending,
+        true,
+        false
+    ));
+
+    // With no pending flushes, should not force snapshots for any commit_lsn (no maintenance needed)
+    assert!(!TableHandlerState::should_force_snapshot_by_commit_lsn(
+        100,
+        min_pending,
+        &MaintenanceProcessStatus::Unrequested,
+        None,
+        false
+    ));
+    assert!(!TableHandlerState::should_force_snapshot_by_commit_lsn(
+        1000,
+        min_pending,
+        &MaintenanceProcessStatus::Unrequested,
+        None,
+        false
+    ));
+
+    // Test case 2: Start flushes and test both functions
+    append_rows(&mut table, vec![test_row(1, "A", 20)])?;
+    table.commit(1);
+    let disk_slice_1 = flush_table_and_sync_no_apply(&mut table, &mut event_completion_rx, 30)
+        .await
+        .expect("Disk slice should be present");
+
+    append_rows(&mut table, vec![test_row(2, "B", 21)])?;
+    table.commit(2);
+    let disk_slice_2 = flush_table_and_sync_no_apply(&mut table, &mut event_completion_rx, 50)
+        .await
+        .expect("Disk slice should be present");
+
+    let min_pending = table.get_min_pending_flush_lsn();
+    assert_eq!(min_pending, 30);
+
+    // Test complementary LSN ordering logic:
+    // can_initiate_iceberg_snapshot requires: flush_lsn < min_pending_flush_lsn
+    // should_force_snapshot_by_commit_lsn requires: min_pending_flush_lsn >= commit_lsn (returns false if min_pending_flush_lsn < commit_lsn)
+
+    // For LSNs < 30 (min pending):
+    // - can_initiate_iceberg_snapshot should return true (flush_lsn < min_pending)
+    // - should_force_snapshot_by_commit_lsn should return false (no force needed, min_pending >= commit_lsn)
+    assert!(TableHandlerState::can_initiate_iceberg_snapshot(
+        10,
+        min_pending,
+        true,
+        false
+    ));
+    assert!(TableHandlerState::can_initiate_iceberg_snapshot(
+        29,
+        min_pending,
+        true,
+        false
+    ));
+    assert!(!TableHandlerState::should_force_snapshot_by_commit_lsn(
+        10,
+        min_pending,
+        &MaintenanceProcessStatus::Unrequested,
+        None,
+        false
+    ));
+    assert!(!TableHandlerState::should_force_snapshot_by_commit_lsn(
+        29,
+        min_pending,
+        &MaintenanceProcessStatus::Unrequested,
+        None,
+        false
+    ));
+
+    // For LSNs >= 30 (min pending):
+    // - can_initiate_iceberg_snapshot should return false (flush_lsn >= min_pending)
+    // - should_force_snapshot_by_commit_lsn should return false (constraint violated: min_pending < commit_lsn)
+    assert!(!TableHandlerState::can_initiate_iceberg_snapshot(
+        30,
+        min_pending,
+        true,
+        false
+    ));
+    assert!(!TableHandlerState::can_initiate_iceberg_snapshot(
+        40,
+        min_pending,
+        true,
+        false
+    ));
+    assert!(!TableHandlerState::should_force_snapshot_by_commit_lsn(
+        40,
+        min_pending,
+        &MaintenanceProcessStatus::Unrequested,
+        None,
+        false
+    )); // Blocked by LSN ordering
+    assert!(!TableHandlerState::should_force_snapshot_by_commit_lsn(
+        100,
+        min_pending,
+        &MaintenanceProcessStatus::Unrequested,
+        None,
+        false
+    )); // Blocked by LSN ordering
+
+    // Test case 3: Complete first flush and test again
+    table.apply_flush_result(disk_slice_1);
+    let min_pending = table.get_min_pending_flush_lsn();
+    assert_eq!(min_pending, 50);
+
+    // Now with min_pending = 50:
+    // LSNs < 50 should allow iceberg snapshots
+    assert!(TableHandlerState::can_initiate_iceberg_snapshot(
+        30,
+        min_pending,
+        true,
+        false
+    ));
+    assert!(TableHandlerState::can_initiate_iceberg_snapshot(
+        49,
+        min_pending,
+        true,
+        false
+    ));
+    assert!(!TableHandlerState::should_force_snapshot_by_commit_lsn(
+        30,
+        min_pending,
+        &MaintenanceProcessStatus::Unrequested,
+        None,
+        false
+    ));
+    assert!(!TableHandlerState::should_force_snapshot_by_commit_lsn(
+        49,
+        min_pending,
+        &MaintenanceProcessStatus::Unrequested,
+        None,
+        false
+    ));
+
+    // LSNs >= 50 should block both
+    assert!(!TableHandlerState::can_initiate_iceberg_snapshot(
+        50,
+        min_pending,
+        true,
+        false
+    ));
+    assert!(!TableHandlerState::can_initiate_iceberg_snapshot(
+        60,
+        min_pending,
+        true,
+        false
+    ));
+    assert!(!TableHandlerState::should_force_snapshot_by_commit_lsn(
+        50,
+        min_pending,
+        &MaintenanceProcessStatus::Unrequested,
+        None,
+        false
+    ));
+    assert!(!TableHandlerState::should_force_snapshot_by_commit_lsn(
+        60,
+        min_pending,
+        &MaintenanceProcessStatus::Unrequested,
+        None,
+        false
+    ));
+
+    // Test case 4: Test state-based constraints for should_force_snapshot_by_commit_lsn
+    // Test ReadyToPersist maintenance status - should force snapshot regardless of LSN (if LSN constraints allow)
+    assert!(TableHandlerState::should_force_snapshot_by_commit_lsn(
+        25,
+        min_pending,
+        &MaintenanceProcessStatus::ReadyToPersist,
+        None,
+        false
+    )); // LSN 25 < min_pending (50), should be allowed and forced due to ReadyToPersist
+    assert!(TableHandlerState::should_force_snapshot_by_commit_lsn(
+        30,
+        min_pending,
+        &MaintenanceProcessStatus::ReadyToPersist,
+        None,
+        false
+    )); // LSN 30 < min_pending (50), should be allowed and forced due to ReadyToPersist
+
+    // But higher commit LSNs should still be blocked by the pending flush constraint
+    assert!(!TableHandlerState::should_force_snapshot_by_commit_lsn(
+        60,
+        min_pending,
+        &MaintenanceProcessStatus::ReadyToPersist,
+        None,
+        false
+    )); // Blocked by LSN ordering even with ReadyToPersist
+
+    // Test force snapshot request with largest_force_snapshot_lsn
+    assert!(TableHandlerState::should_force_snapshot_by_commit_lsn(
+        25,
+        min_pending,
+        &MaintenanceProcessStatus::Unrequested,
+        Some(25), // Request force snapshot for LSN 25
+        false
+    )); // LSN 25 >= requested (25) and < min_pending (50), should be allowed
+    assert!(TableHandlerState::should_force_snapshot_by_commit_lsn(
+        30,
+        min_pending,
+        &MaintenanceProcessStatus::Unrequested,
+        Some(25), // Request force snapshot for LSN 25
+        false
+    )); // LSN 30 >= requested (25) and < min_pending (50), should be allowed
+
+    // Complete the remaining flush
+    table.apply_flush_result(disk_slice_2);
+    let min_pending = table.get_min_pending_flush_lsn();
+    assert_eq!(min_pending, u64::MAX);
+
+    // Now with no pending flushes, both functions should work without LSN constraints
+    assert!(TableHandlerState::can_initiate_iceberg_snapshot(
+        100,
+        min_pending,
+        true,
+        false
+    ));
+    assert!(TableHandlerState::can_initiate_iceberg_snapshot(
+        1000,
+        min_pending,
+        true,
+        false
+    ));
+
+    // Force snapshot should now work for requested LSN (if other conditions are met)
+    assert!(TableHandlerState::should_force_snapshot_by_commit_lsn(
+        25,
+        min_pending,
+        &MaintenanceProcessStatus::Unrequested,
+        Some(25),
+        false
+    )); // Now force snapshot can proceed
+    assert!(TableHandlerState::should_force_snapshot_by_commit_lsn(
+        100,
+        min_pending,
+        &MaintenanceProcessStatus::Unrequested,
+        Some(25),
+        false
+    )); // Higher LSNs also work
+
+    // Test mooncake_snapshot_ongoing constraint
+    assert!(!TableHandlerState::should_force_snapshot_by_commit_lsn(
+        25,
+        min_pending,
+        &MaintenanceProcessStatus::ReadyToPersist,
+        Some(25),
+        true // mooncake_snapshot_ongoing = true
+    )); // Should be blocked even with ReadyToPersist and force request
+
+    Ok(())
+}
+
+/// ===================================
+/// Tests for Iceberg Snapshot Pipeline
+/// ===================================
+
+#[tokio::test]
+async fn test_iceberg_snapshot_blocked_by_pending_flushes() -> Result<()> {
+    let context = TestContext::new("iceberg_snapshot_blocked");
+    let mut table = test_table(&context, "blocked_table", IdentityProp::FullRow).await;
+    let (event_completion_tx, mut event_completion_rx) = mpsc::channel(100);
+    table.register_table_notify(event_completion_tx).await;
+
+    // Add data and start a flush but don't complete it
+    append_rows(&mut table, vec![test_row(1, "A", 20)])?;
+    table.commit(1);
+    let disk_slice_1 = flush_table_and_sync_no_apply(&mut table, &mut event_completion_rx, 30)
+        .await
+        .expect("Disk slice should be present");
+
+    // Add more data and commit it (this will be part of the snapshot)
+    append_rows(&mut table, vec![test_row(2, "B", 21)])?;
+    table.commit(2);
+
+    // Verify we have pending flushes
+    assert!(table.pending_flush_lsns.contains(&30));
+    assert_eq!(table.get_min_pending_flush_lsn(), 30);
+
+    // Create a mooncake snapshot - this will create an iceberg payload
+    let created = table.create_snapshot(SnapshotOption {
+        uuid: uuid::Uuid::new_v4(),
+        force_create: true,
+        skip_iceberg_snapshot: false,
+        index_merge_option: MaintenanceOption::Skip,
+        data_compaction_option: MaintenanceOption::Skip,
+    });
+    assert!(created, "Mooncake snapshot should be created");
+
+    // Wait for mooncake snapshot completion
+    let (commit_lsn, iceberg_snapshot_payload, _, _, _) =
+        sync_mooncake_snapshot(&mut table, &mut event_completion_rx).await;
+
+    assert_eq!(commit_lsn, 2, "Should have committed data up to LSN 2");
+
+    // Test the table handler constraint logic
+    if let Some(payload) = iceberg_snapshot_payload {
+        let min_pending = table.get_min_pending_flush_lsn();
+
+        // The table handler should block this iceberg snapshot due to pending flushes
+        let can_initiate = TableHandlerState::can_initiate_iceberg_snapshot(
+            payload.flush_lsn,
+            min_pending,
+            true,  // iceberg_snapshot_result_consumed
+            false, // iceberg_snapshot_ongoing
+        );
+
+        assert!(!can_initiate,
+            "Table handler should block iceberg snapshot due to pending flush at LSN {} vs payload flush LSN {}", 
+            min_pending, payload.flush_lsn);
+    }
+
+    // Complete the pending flush
+    table.apply_flush_result(disk_slice_1);
+    assert!(table.pending_flush_lsns.is_empty());
+
+    // Now test that iceberg snapshots can proceed
+    let created = table.create_snapshot(SnapshotOption {
+        uuid: uuid::Uuid::new_v4(),
+        force_create: true,
+        skip_iceberg_snapshot: false,
+        index_merge_option: MaintenanceOption::Skip,
+        data_compaction_option: MaintenanceOption::Skip,
+    });
+    assert!(created, "Second mooncake snapshot should be created");
+
+    let (_, iceberg_snapshot_payload, _, _, _) =
+        sync_mooncake_snapshot(&mut table, &mut event_completion_rx).await;
+
+    // Now table handler should allow iceberg snapshot
+    if let Some(payload) = iceberg_snapshot_payload {
+        let min_pending = table.get_min_pending_flush_lsn();
+        let can_initiate = TableHandlerState::can_initiate_iceberg_snapshot(
+            payload.flush_lsn,
+            min_pending,
+            true,
+            false,
+        );
+
+        assert!(
+            can_initiate,
+            "Table handler should allow iceberg snapshot when no pending flushes"
+        );
+    }
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_out_of_order_flush_completion_with_iceberg_snapshots() -> Result<()> {
+    let context = TestContext::new("out_of_order_iceberg");
+    let mut table = test_table(&context, "ooo_table", IdentityProp::FullRow).await;
+    let (event_completion_tx, mut event_completion_rx) = mpsc::channel(100);
+    table.register_table_notify(event_completion_tx).await;
+
+    // Start multiple flushes
+    append_rows(&mut table, vec![test_row(1, "A", 20)])?;
+    table.commit(1);
+    let disk_slice_1 = flush_table_and_sync_no_apply(&mut table, &mut event_completion_rx, 10)
+        .await
+        .expect("Disk slice 1 should be present");
+
+    append_rows(&mut table, vec![test_row(2, "B", 21)])?;
+    table.commit(2);
+    let disk_slice_2 = flush_table_and_sync_no_apply(&mut table, &mut event_completion_rx, 20)
+        .await
+        .expect("Disk slice 2 should be present");
+
+    append_rows(&mut table, vec![test_row(3, "C", 22)])?;
+    table.commit(3);
+    let disk_slice_3 = flush_table_and_sync_no_apply(&mut table, &mut event_completion_rx, 30)
+        .await
+        .expect("Disk slice 3 should be present");
+
+    // Verify all pending flushes and min pending LSN
+    assert_eq!(table.get_min_pending_flush_lsn(), 10);
+    assert!(table.pending_flush_lsns.contains(&10));
+    assert!(table.pending_flush_lsns.contains(&20));
+    assert!(table.pending_flush_lsns.contains(&30));
+
+    // Create snapshot and test constraint with min_pending_flush_lsn = 10
+    let created = table.create_snapshot(SnapshotOption {
+        uuid: uuid::Uuid::new_v4(),
+        force_create: true,
+        skip_iceberg_snapshot: false,
+        index_merge_option: MaintenanceOption::Skip,
+        data_compaction_option: MaintenanceOption::Skip,
+    });
+    assert!(created);
+
+    let (_, iceberg_snapshot_payload, _, _, _) =
+        sync_mooncake_snapshot(&mut table, &mut event_completion_rx).await;
+
+    // Test constraint with min pending flush LSN = 10
+    if let Some(payload) = iceberg_snapshot_payload {
+        let can_initiate = TableHandlerState::can_initiate_iceberg_snapshot(
+            payload.flush_lsn,
+            10, // min_pending_flush_lsn
+            true,
+            false,
+        );
+
+        // Should be blocked if flush_lsn >= 10
+        if payload.flush_lsn >= 10 {
+            assert!(
+                !can_initiate,
+                "Should block iceberg snapshot when flush_lsn {} >= min_pending_flush_lsn 10",
+                payload.flush_lsn
+            );
+        } else {
+            assert!(
+                can_initiate,
+                "Should allow iceberg snapshot when flush_lsn {} < min_pending_flush_lsn 10",
+                payload.flush_lsn
+            );
+        }
+    }
+
+    // Complete flushes OUT OF ORDER - complete middle one first (LSN 20)
+    table.apply_flush_result(disk_slice_2);
+    assert_eq!(table.get_min_pending_flush_lsn(), 10); // Should still be 10
+    assert!(table.pending_flush_lsns.contains(&10));
+    assert!(!table.pending_flush_lsns.contains(&20));
+    assert!(table.pending_flush_lsns.contains(&30));
+
+    // Complete the first flush (LSN 10) - now min should be 30
+    table.apply_flush_result(disk_slice_1);
+    assert_eq!(table.get_min_pending_flush_lsn(), 30); // Now should be 30
+    assert!(!table.pending_flush_lsns.contains(&10));
+    assert!(!table.pending_flush_lsns.contains(&20));
+    assert!(table.pending_flush_lsns.contains(&30));
+
+    // Test constraint logic with new min pending flush LSN = 30
+    let can_initiate_low = TableHandlerState::can_initiate_iceberg_snapshot(
+        25, // flush_lsn < min_pending_flush_lsn
+        30, // min_pending_flush_lsn
+        true, false,
+    );
+    assert!(
+        can_initiate_low,
+        "Should allow iceberg snapshot when flush_lsn < min_pending_flush_lsn"
+    );
+
+    let can_initiate_high = TableHandlerState::can_initiate_iceberg_snapshot(
+        35, // flush_lsn > min_pending_flush_lsn
+        30, // min_pending_flush_lsn
+        true, false,
+    );
+    assert!(
+        !can_initiate_high,
+        "Should block iceberg snapshot when flush_lsn >= min_pending_flush_lsn"
+    );
+
+    // Complete the last flush
+    table.apply_flush_result(disk_slice_3);
+    assert!(table.pending_flush_lsns.is_empty());
+    assert_eq!(table.get_min_pending_flush_lsn(), u64::MAX);
+
+    // Now any flush LSN should be allowed
+    let can_initiate_any = TableHandlerState::can_initiate_iceberg_snapshot(
+        100,      // Any flush_lsn
+        u64::MAX, // No pending flushes
+        true,
+        false,
+    );
+    assert!(
+        can_initiate_any,
+        "Should allow any iceberg snapshot when no pending flushes"
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_streaming_batch_id_mismatch_with_data_compaction() -> Result<()> {
+    let context = TestContext::new("streaming_batch_id_mismatch");
     let mut table = test_table(
         &context,
-        "streaming_commit_with_unflushed_data",
+        "streaming_batch_id_mismatch",
         IdentityProp::Keys(vec![0]),
     )
     .await;
@@ -1155,25 +2137,372 @@ async fn test_streaming_commit_with_unflushed_data() {
     table.register_table_notify(event_completion_tx).await;
 
     let xact_id = 1;
-    let lsn = 1;
 
-    // Append rows to streaming mem slice but don't flush them
-    let row1 = test_row(1, "A", 20);
-    table.append_in_stream_batch(row1, xact_id).unwrap();
-    let row2 = test_row(2, "B", 21);
-    table.append_in_stream_batch(row2, xact_id).unwrap();
+    // Step 1: Create initial data in main table and flush it to create data files
+    // This is needed for data compaction to trigger
+    append_rows(&mut table, vec![test_row(1, "Initial", 20)])?;
+    table.commit(1);
+    flush_table_and_sync(&mut table, &mut event_completion_rx, 10).await?;
+    create_mooncake_and_persist_for_test(&mut table, &mut event_completion_rx).await;
 
-    // Commit the transaction directly without flushing first
-    table.commit_transaction_stream(xact_id, lsn).await.unwrap();
+    // Step 2: Start a streaming transaction with multiple operations
+    // Add rows to streaming transaction
+    table.append_in_stream_batch(test_row(2, "Stream1", 21), xact_id)?;
+    table.append_in_stream_batch(test_row(3, "Stream2", 22), xact_id)?;
 
-    // Verify the data is still accessible after commit
+    // Step 3: Flush the streaming transaction
+    // This creates a disk slice with the original batch IDs
+    let disk_slice =
+        flush_stream_and_sync_no_apply(&mut table, &mut event_completion_rx, xact_id, Some(20))
+            .await
+            .expect("Disk slice should be present");
+
+    // Step 4: Delete one of the rows in the streaming transaction
+    // This can cause some batches to become empty after filtering
+    table
+        .delete_in_stream_batch(test_row(3, "Stream2", 22), xact_id)
+        .await;
+
+    // Step 5: Commit the streaming transaction
+    // This processes the batches and adds filtered ones to new_record_batches
+    // But some original batch IDs might be missing from the filtered results
+    table.commit_transaction_stream_impl(xact_id, 21)?;
+
+    // Step 6: Apply the flush result
+    // The disk slice still contains the original batch IDs
+    table.apply_stream_flush_result(xact_id, disk_slice);
+
+    // Step 7: Create a mooncake snapshot
     create_mooncake_snapshot_for_test(&mut table, &mut event_completion_rx).await;
 
-    let mut snapshot = table.snapshot.write().await;
-    let SnapshotReadOutput {
-        data_file_paths, ..
-    } = snapshot.request_read().await.unwrap();
+    // Step 8: Add more data to trigger data compaction
+    append_rows(&mut table, vec![test_row(4, "PostStream", 23)])?;
+    table.commit(35); // Use LSN >= flush LSN (30) to satisfy validation
+    flush_table_and_sync(&mut table, &mut event_completion_rx, 30).await?;
 
-    // Should have the data from the unflushed mem slice
-    verify_file_contents(&data_file_paths[0].get_file_path(), &[1, 2], Some(2));
+    // Step 9: Force data compaction
+    let created = table.create_snapshot(SnapshotOption {
+        uuid: uuid::Uuid::new_v4(),
+        force_create: true,
+        skip_iceberg_snapshot: true, // Skip iceberg to focus on the mooncake issue
+        index_merge_option: MaintenanceOption::Skip,
+        data_compaction_option: MaintenanceOption::ForceRegular, // Trigger data compaction
+    });
+
+    assert!(created, "Mooncake snapshot should be created");
+
+    // This should trigger the assertion failure:
+    // "assertion failed: self.batches.remove(&b.id).is_some()"
+    // in integrate_disk_slices at line 741
+    sync_mooncake_snapshot(&mut table, &mut event_completion_rx).await;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_streaming_empty_batch_filtering_bug() -> Result<()> {
+    let context = TestContext::new("streaming_empty_batch_filtering");
+    let mut table = test_table(
+        &context,
+        "streaming_empty_batch_filtering",
+        IdentityProp::Keys(vec![0]),
+    )
+    .await;
+    let (event_completion_tx, mut event_completion_rx) = mpsc::channel(100);
+    table.register_table_notify(event_completion_tx).await;
+
+    let xact_id1 = 1;
+    let xact_id2 = 2;
+
+    // Create some initial data for compaction
+    append_rows(&mut table, vec![test_row(1, "Base", 20)])?;
+    table.commit(1);
+    flush_table_and_sync(&mut table, &mut event_completion_rx, 5).await?;
+
+    // Stream 1: Add and immediately delete rows (creates empty batches)
+    table.append_in_stream_batch(test_row(2, "ToDelete", 21), xact_id1)?;
+    table.append_in_stream_batch(test_row(3, "AlsoDelete", 22), xact_id1)?;
+
+    // Flush stream 1
+    let disk_slice1 =
+        flush_stream_and_sync_no_apply(&mut table, &mut event_completion_rx, xact_id1, Some(10))
+            .await
+            .expect("Stream 1 disk slice should be present");
+
+    // Delete all rows in stream 1 (making batches empty after filtering)
+    table
+        .delete_in_stream_batch(test_row(2, "ToDelete", 21), xact_id1)
+        .await;
+    table
+        .delete_in_stream_batch(test_row(3, "AlsoDelete", 22), xact_id1)
+        .await;
+
+    // Commit stream 1
+    table.commit_transaction_stream_impl(xact_id1, 11)?;
+    table.apply_stream_flush_result(xact_id1, disk_slice1);
+
+    // Stream 2: Normal operations
+    table.append_in_stream_batch(test_row(4, "Keep", 23), xact_id2)?;
+    commit_transaction_stream_and_sync(&mut table, &mut event_completion_rx, xact_id2, 15).await;
+
+    // Add more data to trigger compaction threshold
+    append_rows(&mut table, vec![test_row(5, "More", 24)])?;
+    table.commit(3);
+    flush_table_and_sync(&mut table, &mut event_completion_rx, 20).await?;
+
+    // Create snapshot with data compaction
+    let created = table.create_snapshot(SnapshotOption {
+        uuid: uuid::Uuid::new_v4(),
+        force_create: true,
+        skip_iceberg_snapshot: true,
+        index_merge_option: MaintenanceOption::Skip,
+        data_compaction_option: MaintenanceOption::ForceRegular,
+    });
+
+    assert!(created);
+
+    sync_mooncake_snapshot(&mut table, &mut event_completion_rx).await;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_batch_id_removal_assertion_direct() -> Result<()> {
+    let context = TestContext::new("batch_id_removal_assertion");
+    let mut table = test_table(
+        &context,
+        "batch_id_removal_assertion",
+        IdentityProp::Keys(vec![0]),
+    )
+    .await;
+    let (event_completion_tx, mut event_completion_rx) = mpsc::channel(100);
+    table.register_table_notify(event_completion_tx).await;
+
+    let xact_id = 1;
+
+    // Step 1: Create a streaming transaction with rows that will be filtered out
+    // Add a row to the streaming transaction
+    table.append_in_stream_batch(test_row(1, "ToFilter", 20), xact_id)?;
+
+    // Step 2: Immediately delete the row, making the batch empty after filtering
+    // This simulates the scenario where batches become empty and get filtered out
+    table
+        .delete_in_stream_batch(test_row(1, "ToFilter", 20), xact_id)
+        .await;
+
+    // Step 3: Flush the streaming transaction while it has the deletion
+    // This creates a disk slice that contains the original batch ID
+    // but the batch will be filtered out during processing (empty after deletion)
+    let disk_slice =
+        flush_stream_and_sync_no_apply(&mut table, &mut event_completion_rx, xact_id, Some(10))
+            .await
+            .expect("Disk slice should be present");
+
+    // Step 4: Commit the streaming transaction
+    table.commit_transaction_stream_impl(xact_id, 11)?;
+
+    // Step 5: Apply the stream flush result
+    table.apply_stream_flush_result(xact_id, disk_slice);
+
+    // Step 6: Create a simple snapshot
+    let created = table.create_snapshot(SnapshotOption {
+        uuid: uuid::Uuid::new_v4(),
+        force_create: true,
+        skip_iceberg_snapshot: true,
+        index_merge_option: MaintenanceOption::Skip,
+        data_compaction_option: MaintenanceOption::Skip, // No compaction to avoid other issues
+    });
+
+    assert!(created, "Mooncake snapshot should be created");
+
+    sync_mooncake_snapshot(&mut table, &mut event_completion_rx).await;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_puffin_deletion_blob_inconsistency_assertion() -> Result<()> {
+    let context = TestContext::new("puffin_deletion_blob_inconsistency");
+    let mut table = test_table(
+        &context,
+        "puffin_deletion_blob_inconsistency",
+        IdentityProp::Keys(vec![0]),
+    )
+    .await;
+    let (event_completion_tx, mut event_completion_rx) = mpsc::channel(100);
+    table.register_table_notify(event_completion_tx).await;
+
+    // Step 1: Create initial data and flush it to create persistent data files
+    append_rows(
+        &mut table,
+        vec![
+            test_row(1, "Data1", 20),
+            test_row(2, "Data2", 21),
+            test_row(3, "Data3", 22),
+            test_row(4, "Data4", 23),
+        ],
+    )?;
+    table.commit(1);
+    flush_table_and_sync(&mut table, &mut event_completion_rx, 10).await?;
+
+    // Step 2: Delete some rows to create deletion vectors
+    table.delete(test_row(2, "Data2", 21), 11).await;
+    table.delete(test_row(3, "Data3", 22), 11).await;
+    table.commit(12);
+
+    // Step 3: Create and persist snapshot to create puffin deletion blobs
+    // This should persist the deletion vectors as puffin blobs
+    create_mooncake_and_persist_for_test(&mut table, &mut event_completion_rx).await;
+
+    // Step 4: Add more data to trigger compaction threshold
+    append_rows(
+        &mut table,
+        vec![
+            test_row(5, "Data5", 24),
+            test_row(6, "Data6", 25),
+            test_row(7, "Data7", 26),
+            test_row(8, "Data8", 27),
+        ],
+    )?;
+    table.commit(15);
+    flush_table_and_sync(&mut table, &mut event_completion_rx, 20).await?;
+
+    // Step 5: Create more deletions and persist again
+    table.delete(test_row(5, "Data5", 24), 21).await;
+    table.delete(test_row(6, "Data6", 25), 21).await;
+    table.commit(22);
+    create_mooncake_and_persist_for_test(&mut table, &mut event_completion_rx).await;
+
+    // Step 6: Add even more data to ensure we have enough files for compaction
+    append_rows(
+        &mut table,
+        vec![test_row(9, "Data9", 28), test_row(10, "Data10", 29)],
+    )?;
+    table.commit(27);
+    flush_table_and_sync(&mut table, &mut event_completion_rx, 26).await?;
+
+    // Step 7: Force data compaction
+    let created = table.create_snapshot(SnapshotOption {
+        uuid: uuid::Uuid::new_v4(),
+        force_create: true,
+        skip_iceberg_snapshot: true,
+        index_merge_option: MaintenanceOption::Skip,
+        data_compaction_option: MaintenanceOption::ForceRegular, // Force data compaction
+    });
+
+    assert!(created, "Mooncake snapshot should be created");
+
+    sync_mooncake_snapshot(&mut table, &mut event_completion_rx).await;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_stream_commit_with_pending_flush_deletion_remapping_bug() -> Result<()> {
+    let context = TestContext::new("stream_commit_pending_flush_deletion_bug");
+    let mut table = test_table(
+        &context,
+        "stream_commit_pending_flush_deletion_bug",
+        IdentityProp::Keys(vec![0]),
+    )
+    .await;
+    let (event_completion_tx, mut event_completion_rx) = mpsc::channel(100);
+    table.register_table_notify(event_completion_tx).await;
+
+    // Step 1: Add some initial data and flush it to create a data file
+    append_rows(&mut table, vec![test_row(1, "Initial", 20)])?;
+    table.commit(1);
+    flush_table_and_sync(&mut table, &mut event_completion_rx, 2).await?;
+
+    // Step 2: Start a streaming transaction
+    let xact_id = 1;
+    table.append_in_stream_batch(test_row(2, "Stream", 21), xact_id)?;
+
+    // Step 3: Delete a row from the committed data within the streaming transaction
+    // This adds the deletion to committed_deletion_log
+    table
+        .delete_in_stream_batch(test_row(1, "Initial", 20), xact_id)
+        .await;
+
+    // Step 4: Flush the streaming transaction (creates disk slice)
+    // The disk slice now contains the deletion remapping info
+    let disk_slice =
+        flush_stream_and_sync_no_apply(&mut table, &mut event_completion_rx, xact_id, Some(4))
+            .await
+            .expect("Disk slice should be present");
+
+    // Step 5: Commit the streaming transaction
+    // This processes deletions and adds them to committed_deletion_log
+    // but the disk slice is still pending to be integrated
+    table.commit_transaction_stream_impl(xact_id, 3)?;
+
+    // Step 6: Apply the stream flush result
+    // This adds the disk slice to snapshot_task for later processing
+    table.apply_stream_flush_result(xact_id, disk_slice);
+
+    // Step 7: Create a snapshot to trigger integrate_disk_slices
+    // Without the fix, this would fail because deletions in committed_deletion_log
+    // get remapped but not applied to batch_deletion_vector
+    let created = table.create_snapshot(SnapshotOption {
+        uuid: uuid::Uuid::new_v4(),
+        force_create: true,
+        skip_iceberg_snapshot: true,
+        index_merge_option: MaintenanceOption::Skip,
+        data_compaction_option: MaintenanceOption::Skip,
+    });
+    assert!(created, "Mooncake snapshot should be created");
+
+    // This should succeed with the fix, but would fail without it
+    sync_mooncake_snapshot(&mut table, &mut event_completion_rx).await;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_chaos_sequence_exact_repro_with_async_flush() -> Result<()> {
+    let context = TestContext::new("chaos_sequence_exact_repro_async_flush");
+    let mut table = test_table(
+        &context,
+        "chaos_sequence_exact_repro_async_flush",
+        IdentityProp::Keys(vec![0]),
+    )
+    .await;
+    let (event_completion_tx, mut event_completion_rx) = mpsc::channel(100);
+    table.register_table_notify(event_completion_tx).await;
+
+    // LSN 0-3: First streaming transaction
+    let xact_id_0 = 0;
+    table.append_in_stream_batch(test_row(0, "user", 0), xact_id_0)?; // LSN 0
+    table.append_in_stream_batch(test_row(1, "user", 1), xact_id_0)?; // LSN 1
+    table
+        .delete_in_stream_batch(test_row(0, "user", 0), xact_id_0)
+        .await; // LSN 2
+    table.commit_transaction_stream_impl(xact_id_0, 3)?; // LSN 3
+
+    // LSN 4-7: Non-streaming operations
+    table.append(test_row(2, "user", 2))?; // LSN 4
+    table.delete(test_row(1, "user", 1), 5).await; // LSN 5
+    table.append(test_row(3, "user", 3))?; // LSN 6
+    table.commit(7); // LSN 7 - CommitFlush
+
+    // LSN 8-10: Second streaming transaction with flush
+    let xact_id_1 = 1;
+    table.append_in_stream_batch(test_row(4, "user", 4), xact_id_1)?; // LSN 8
+    table.append_in_stream_batch(test_row(5, "user", 0), xact_id_1)?; // LSN 9
+    commit_transaction_stream_and_sync(&mut table, &mut event_completion_rx, xact_id_1, 10).await; // LSN 10 - CommitFlush
+
+    let created = table.create_snapshot(SnapshotOption {
+        uuid: uuid::Uuid::new_v4(),
+        force_create: true,
+        skip_iceberg_snapshot: true,
+        index_merge_option: MaintenanceOption::Skip,
+        data_compaction_option: MaintenanceOption::Skip,
+    });
+    assert!(created, "Mooncake snapshot should be created");
+
+    // This should fail with the same assertion as the chaos test:
+    // "assertion failed: res" at snapshot.rs:893:21
+    sync_mooncake_snapshot(&mut table, &mut event_completion_rx).await;
+
+    Ok(())
 }

--- a/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
+++ b/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
@@ -348,7 +348,7 @@ impl MooncakeTable {
     /// Removes in memory indices and record batches from the stream state.
     pub fn apply_stream_flush_result(&mut self, xact_id: u32, mut disk_slice: DiskSliceWriter) {
         if let Some(lsn) = disk_slice.lsn() {
-            self.pending_flush_lsns.remove(&lsn);
+            self.remove_pending_flush_lsn(lsn);
             self.set_next_flush_lsn(lsn);
         }
 

--- a/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
+++ b/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
@@ -483,7 +483,7 @@ impl MooncakeTable {
                 .iter()
                 .map(|ptr| ptr.arc_ptr()),
         );
-        self.next_snapshot_task.new_commit_lsn = lsn;
+        self.next_snapshot_task.commit_lsn_baseline = lsn;
 
         // We update our delete records with the last lsn of the transaction
         // Note that in the stream case we dont have this until commit time

--- a/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
+++ b/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
@@ -27,6 +27,8 @@ pub(super) struct TransactionStreamState {
     /// Number of pending flushes for this transaction.
     /// Only safe to remove transaction stream state when there are no pending flushes.
     pending_flush_count: u32,
+    /// Commit LSN for this transaction, set when transaction is committed.
+    commit_lsn: Option<u64>,
 }
 
 /// Determines the state of a transaction stream.
@@ -105,6 +107,7 @@ impl TransactionStreamState {
             new_record_batches: hashbrown::HashMap::new(),
             status: TransactionStreamStatus::Pending,
             pending_flush_count: 0,
+            commit_lsn: None,
         }
     }
 }
@@ -296,15 +299,11 @@ impl MooncakeTable {
 
     /// Drains the current mem slice and prepares a disk slice for flushing.
     /// Adds current mem slice batches and indices to the stream state.
-    pub fn prepare_stream_disk_slice(
+    pub(super) fn prepare_stream_disk_slice(
         &mut self,
-        xact_id: u32,
+        stream_state: &mut TransactionStreamState,
         lsn: Option<u64>,
     ) -> Result<DiskSliceWriter> {
-        let stream_state = self
-            .transaction_stream_states
-            .get_mut(&xact_id)
-            .expect("Stream state not found for xact_id: {xact_id}");
         let next_file_id = self.next_file_id;
         self.next_file_id += 1;
 
@@ -343,36 +342,36 @@ impl MooncakeTable {
         Ok(disk_slice)
     }
 
-    /// Flushes a disk slice for streaming transaction.
-    /// Increments the pending flush count for this transaction.
-    pub async fn flush_stream_disk_slice(
-        &mut self,
-        xact_id: u32,
-        disk_slice: &mut DiskSliceWriter,
-    ) -> Result<()> {
-        let stream_state = self
-            .transaction_stream_states
-            .get_mut(&xact_id)
-            .expect("Stream state not found for xact_id: {xact_id}");
-        stream_state.pending_flush_count += 1;
-        disk_slice.write().await?;
-        Ok(())
-    }
-
     /// Applies the result of a streaming flush to the stream state.
     /// Decrements the pending flush count for this transaction.
     /// Handles commit and abort cleanup.
     /// Removes in memory indices and record batches from the stream state.
     pub fn apply_stream_flush_result(&mut self, xact_id: u32, mut disk_slice: DiskSliceWriter) {
+        if let Some(lsn) = disk_slice.lsn() {
+            self.pending_flush_lsns.remove(&lsn);
+            self.set_next_flush_lsn(lsn);
+        }
+
         let stream_state = self
             .transaction_stream_states
             .get_mut(&xact_id)
             .expect("Stream state not found for xact_id: {xact_id}");
+
         stream_state.pending_flush_count -= 1;
 
         // Transaction committed while stream was flushing. Add disk slice to snapshot task and let snapshot handle it.
         // Drop the stream state since the transaction is over.
         if stream_state.status == TransactionStreamStatus::Committed {
+            let commit_lsn = stream_state
+                .commit_lsn
+                .expect("Committed transaction must have commit_lsn");
+
+            // If there's no writer_lsn, it means this is a periodic flush before commit.
+            // In this case we assign the commit_lsn as writer_lsn.
+            if disk_slice.writer_lsn.is_none() {
+                disk_slice.writer_lsn = Some(commit_lsn);
+            }
+
             self.next_snapshot_task.new_disk_slices.push(disk_slice);
             if stream_state.pending_flush_count == 0 {
                 self.transaction_stream_states.remove(&xact_id);
@@ -424,27 +423,28 @@ impl MooncakeTable {
         }
     }
 
-    pub async fn flush_stream(&mut self, xact_id: u32, lsn: Option<u64>) -> Result<()> {
-        let mut disk_slice = self.prepare_stream_disk_slice(xact_id, lsn)?;
-        self.flush_stream_disk_slice(xact_id, &mut disk_slice)
-            .await?;
-        if let Some(lsn) = lsn {
-            self.next_snapshot_task.new_flush_lsn = Some(lsn);
-        }
-        self.apply_stream_flush_result(xact_id, disk_slice);
+    pub fn flush_stream(&mut self, xact_id: u32, lsn: Option<u64>) -> Result<()> {
+        // Temporarily remove to drop reference to self
+        let mut stream_state = self
+            .transaction_stream_states
+            .remove(&xact_id)
+            .expect("Stream state not found for xact_id: {xact_id}");
+
+        let mut disk_slice = self.prepare_stream_disk_slice(&mut stream_state, lsn)?;
+
+        let table_notify_tx = self.table_notify.as_ref().unwrap().clone();
+
+        stream_state.pending_flush_count += 1;
+
+        self.flush_disk_slice(&mut disk_slice, table_notify_tx, Some(xact_id));
+
+        // Add back stream state
+        self.transaction_stream_states.insert(xact_id, stream_state);
 
         Ok(())
     }
 
-    /// Commit a transaction stream.
-    /// Flushes any remaining rows from stream mem slice
-    /// Adds all in mem batches and indices to next snapshot task
-    /// Updates deletion records
-    /// Enqueues `TransactionStreamOutput::Commit` for snapshot task
-    pub async fn commit_transaction_stream(&mut self, xact_id: u32, lsn: u64) -> Result<()> {
-        self.flush_stream(xact_id, Some(lsn)).await?;
-
-        // Now remove and process the state
+    pub fn commit_transaction_stream_impl(&mut self, xact_id: u32, lsn: u64) -> Result<()> {
         let stream_state = self
             .transaction_stream_states
             .get_mut(&xact_id)
@@ -512,8 +512,20 @@ impl MooncakeTable {
             .push(TransactionStreamOutput::Commit(commit));
 
         stream_state.status = TransactionStreamStatus::Committed;
+        // We may have pending flushes that we need to stamp with this commit LSN so we store it in stream_state.
+        stream_state.commit_lsn = Some(lsn);
 
         Ok(())
+    }
+
+    /// Commit a transaction stream.
+    /// Flushes any remaining rows from stream mem slice
+    /// Adds all in mem batches and indices to next snapshot task
+    /// Updates deletion records
+    /// Enqueues `TransactionStreamOutput::Commit` for snapshot task
+    pub fn commit_transaction_stream(&mut self, xact_id: u32, lsn: u64) -> Result<()> {
+        self.flush_stream(xact_id, Some(lsn))?;
+        self.commit_transaction_stream_impl(xact_id, lsn)
     }
 }
 

--- a/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
+++ b/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
@@ -467,11 +467,13 @@ impl MooncakeTable {
 
         // Add stream record batches to next snapshot task
         for (id, batch) in stream_state.new_record_batches.iter() {
-            self.next_snapshot_task.new_record_batches.push((
-                *id,
-                batch.data.as_ref().unwrap().clone(),
-                Some(batch.deletions.clone()),
-            ));
+            self.next_snapshot_task
+                .new_record_batches
+                .push(RecordBatchWithDeletionVector {
+                    batch_id: *id,
+                    record_batch: batch.data.as_ref().unwrap().clone(),
+                    deletion_vector: Some(batch.deletions.clone()),
+                });
         }
         // Add stream in mem indices to next snapshot task
         self.next_snapshot_task.new_mem_indices.extend(

--- a/src/moonlink/src/table_handler.rs
+++ b/src/moonlink/src/table_handler.rs
@@ -269,7 +269,7 @@ impl TableHandler {
                         // So we block wait for asynchronous request completion.
                         TableEvent::DropTable => {
                             // Fast-path: no other concurrent events, directly clean up states and ack back.
-                            if table_handler_state.can_drop_table_now() {
+                            if table_handler_state.can_drop_table_now(table.has_ongoing_flush()) {
                                 drop_table(&mut table, event_sync_sender).await;
                                 return;
                             }
@@ -367,7 +367,7 @@ impl TableHandler {
                             table_handler_state.mooncake_snapshot_ongoing = false;
 
                             // Drop table if requested, and table at a clean state.
-                            if table_handler_state.special_table_state == SpecialTableState::DropTable && table_handler_state.can_drop_table_now() {
+                            if table_handler_state.special_table_state == SpecialTableState::DropTable && table_handler_state.can_drop_table_now(table.has_ongoing_flush()) {
                                 drop_table(&mut table, event_sync_sender).await;
                                 return;
                             }
@@ -468,7 +468,7 @@ impl TableHandler {
                             }
 
                             // Drop table if requested, and table at a clean state.
-                            if table_handler_state.special_table_state == SpecialTableState::DropTable && table_handler_state.can_drop_table_now() {
+                            if table_handler_state.special_table_state == SpecialTableState::DropTable && table_handler_state.can_drop_table_now(table.has_ongoing_flush()) {
                                 drop_table(&mut table, event_sync_sender).await;
                                 return;
                             }
@@ -477,7 +477,7 @@ impl TableHandler {
                             table.set_file_indices_merge_res(index_merge_result);
                             table_handler_state.mark_index_merge_completed().await;
                             // Check whether need to drop table.
-                            if table_handler_state.special_table_state == SpecialTableState::DropTable && table_handler_state.can_drop_table_now() {
+                            if table_handler_state.special_table_state == SpecialTableState::DropTable && table_handler_state.can_drop_table_now(table.has_ongoing_flush()) {
                                 drop_table(&mut table, event_sync_sender).await;
                                 return;
                             }
@@ -493,7 +493,7 @@ impl TableHandler {
                                 }
                             }
                             // Check whether need to drop table.
-                            if table_handler_state.special_table_state == SpecialTableState::DropTable && table_handler_state.can_drop_table_now() {
+                            if table_handler_state.special_table_state == SpecialTableState::DropTable && table_handler_state.can_drop_table_now(table.has_ongoing_flush()) {
                                 drop_table(&mut table, event_sync_sender).await;
                                 return;
                             }
@@ -517,7 +517,7 @@ impl TableHandler {
                                     table_handler_state.wal_persist_ongoing = false;
 
                                     // Check whether need to drop table.
-                                    if table_handler_state.special_table_state == SpecialTableState::DropTable && table_handler_state.can_drop_table_now() {
+                                    if table_handler_state.special_table_state == SpecialTableState::DropTable && table_handler_state.can_drop_table_now(table.has_ongoing_flush()) {
                                         drop_table(&mut table, event_sync_sender).await;
                                         return;
                                     }

--- a/src/moonlink/src/table_handler.rs
+++ b/src/moonlink/src/table_handler.rs
@@ -22,7 +22,7 @@ use tokio::task::JoinHandle;
 use tokio::time::Duration;
 use tracing::Instrument;
 use tracing::{debug, error, info_span};
-mod table_handler_state;
+pub(crate) mod table_handler_state;
 use table_handler_state::{
     MaintenanceProcessStatus, MaintenanceRequestStatus, SpecialTableState, TableHandlerState,
 };
@@ -291,7 +291,7 @@ impl TableHandler {
                         }
                         TableEvent::FinishInitialCopy { start_lsn } => {
                             debug!("finishing initial copy");
-                            if let Err(e) = table.commit_transaction_stream(INITIAL_COPY_XACT_ID, 0).await {
+                            if let Err(e) = table.commit_transaction_stream(INITIAL_COPY_XACT_ID, 0) {
                                 error!(error = %e, "failed to finish initial copy");
                             }
                             // Force create the snapshot with LSN 0
@@ -323,7 +323,7 @@ impl TableHandler {
                             // Check whether a flush and force snapshot is needed.
                             if table_handler_state.has_pending_force_snapshot_request() && !table_handler_state.iceberg_snapshot_ongoing {
                                 if let Some(commit_lsn) = table_handler_state.table_consistent_view_lsn {
-                                    table.flush(commit_lsn).await.unwrap();
+                                    table.flush(commit_lsn).unwrap();
                                     table_handler_state.last_unflushed_commit_lsn = None;
                                     table_handler_state.reset_iceberg_state_at_mooncake_snapshot();
                                     if let SpecialTableState::AlterTable { .. } = table_handler_state.special_table_state {
@@ -376,7 +376,8 @@ impl TableHandler {
                             table.notify_snapshot_reader(lsn);
 
                             // Process iceberg snapshot and trigger iceberg snapshot if necessary.
-                            if table_handler_state.can_initiate_iceberg_snapshot() {
+                            let min_pending_flush_lsn = table.get_min_pending_flush_lsn();
+                            if TableHandlerState::can_initiate_iceberg_snapshot(lsn, min_pending_flush_lsn, table_handler_state.iceberg_snapshot_result_consumed, table_handler_state.iceberg_snapshot_ongoing) {
                                 if let Some(iceberg_snapshot_payload) = iceberg_snapshot_payload {
                                     table_handler_event_sender.send(TableEvent::RegularIcebergSnapshot {
                                         iceberg_snapshot_payload,
@@ -526,6 +527,26 @@ impl TableHandler {
                                 }
                             }
                         }
+                        TableEvent::FlushResult { xact_id, flush_result } => {
+                            match flush_result {
+                                Some(Ok(disk_slice)) => {
+                                    if let Some(lsn) = disk_slice.lsn() {
+                                        table.remove_pending_flush_lsn(lsn);
+                                    }
+                                    if let Some(xact_id) = xact_id {
+                                        table.apply_stream_flush_result(xact_id, disk_slice);
+                                    } else {
+                                        table.apply_flush_result(disk_slice);
+                                    }
+                                }
+                                Some(Err(e)) => {
+                                    error!(error = ?e, "failed to flush disk slice");
+                                }
+                                None => {
+                                    error!("flush result is none");
+                                }
+                            }
+                        }
                         // ==============================
                         // Replication events
                         // ==============================
@@ -600,8 +621,8 @@ impl TableHandler {
                     Some(xact_id) => {
                         let res = table.append_in_stream_batch(row, xact_id);
                         if table.should_transaction_flush(xact_id) {
-                            if let Err(e) = table.flush_stream(xact_id, None).await {
-                                error!(error = %e, "flush failed in append");
+                            if let Err(e) = table.flush_stream(xact_id, None) {
+                                error!(error = %e, "failed to flush stream");
                             }
                         }
                         res
@@ -645,8 +666,8 @@ impl TableHandler {
                 .await;
             }
             TableEvent::StreamFlush { xact_id, .. } => {
-                if let Err(e) = table.flush_stream(xact_id, None).await {
-                    error!(error = %e, "stream flush failed");
+                if let Err(e) = table.flush_stream(xact_id, None) {
+                    error!(error = %e, "failed to flush stream");
                 }
             }
             _ => {
@@ -679,8 +700,16 @@ impl TableHandler {
         // 1. force snapshot is requested
         // and 2. LSN which meets force snapshot requirement has appeared, before that we still allow buffering
         // and 3. there's no snapshot creation operation ongoing
+        // and 4. there's no pending flush LSNs < lsn
 
-        let should_force_snapshot = table_handler_state.should_force_snapshot_by_commit_lsn(lsn);
+        let min_pending_flush_lsn = table.get_min_pending_flush_lsn();
+        let should_force_snapshot = TableHandlerState::should_force_snapshot_by_commit_lsn(
+            lsn,
+            min_pending_flush_lsn,
+            &table_handler_state.table_maintenance_process_status,
+            table_handler_state.largest_force_snapshot_lsn,
+            table_handler_state.mooncake_snapshot_ongoing,
+        );
 
         match xact_id {
             Some(xact_id) => {
@@ -688,7 +717,7 @@ impl TableHandler {
                 if let Some(last_unflushed_commit_lsn) =
                     table_handler_state.last_unflushed_commit_lsn
                 {
-                    if let Err(e) = table.flush(last_unflushed_commit_lsn).await {
+                    if let Err(e) = table.flush(last_unflushed_commit_lsn) {
                         error!(error = %e, "flush non-streaming writes failed in LSN {lsn}");
                     }
                     table_handler_state.last_unflushed_commit_lsn = None;
@@ -702,7 +731,7 @@ impl TableHandler {
                         return;
                     }
                 }
-                if let Err(e) = table.commit_transaction_stream(xact_id, lsn).await {
+                if let Err(e) = table.commit_transaction_stream(xact_id, lsn) {
                     error!(error = %e, "stream commit flush failed");
                 }
             }
@@ -710,7 +739,7 @@ impl TableHandler {
                 table.commit(lsn);
                 if table.should_flush() || should_force_snapshot || force_flush_requested {
                     table_handler_state.last_unflushed_commit_lsn = None;
-                    if let Err(e) = table.flush(lsn).await {
+                    if let Err(e) = table.flush(lsn) {
                         error!(error = %e, "flush failed in commit");
                     }
                 }

--- a/src/moonlink/src/table_handler.rs
+++ b/src/moonlink/src/table_handler.rs
@@ -376,7 +376,7 @@ impl TableHandler {
                             table.notify_snapshot_reader(lsn);
 
                             // Process iceberg snapshot and trigger iceberg snapshot if necessary.
-                            let min_pending_flush_lsn = table.get_min_pending_flush_lsn();
+                            let min_pending_flush_lsn = table.get_min_ongoing_flush_lsn();
                             if TableHandlerState::can_initiate_iceberg_snapshot(lsn, min_pending_flush_lsn, table_handler_state.iceberg_snapshot_result_consumed, table_handler_state.iceberg_snapshot_ongoing) {
                                 if let Some(iceberg_snapshot_payload) = iceberg_snapshot_payload {
                                     table_handler_event_sender.send(TableEvent::RegularIcebergSnapshot {
@@ -538,6 +538,7 @@ impl TableHandler {
                                 }
                                 Some(Err(e)) => {
                                     error!(error = ?e, "failed to flush disk slice");
+                                    panic!("Fatal flush error: {e:?}");
                                 }
                                 None => {
                                     error!("flush result is none");
@@ -699,7 +700,7 @@ impl TableHandler {
         // and 3. there's no snapshot creation operation ongoing
         // and 4. there's no pending flush LSNs < lsn
 
-        let min_pending_flush_lsn = table.get_min_pending_flush_lsn();
+        let min_pending_flush_lsn = table.get_min_ongoing_flush_lsn();
         let should_force_snapshot = TableHandlerState::should_force_snapshot_by_commit_lsn(
             lsn,
             min_pending_flush_lsn,

--- a/src/moonlink/src/table_handler.rs
+++ b/src/moonlink/src/table_handler.rs
@@ -530,9 +530,6 @@ impl TableHandler {
                         TableEvent::FlushResult { xact_id, flush_result } => {
                             match flush_result {
                                 Some(Ok(disk_slice)) => {
-                                    if let Some(lsn) = disk_slice.lsn() {
-                                        table.remove_pending_flush_lsn(lsn);
-                                    }
                                     if let Some(xact_id) = xact_id {
                                         table.apply_stream_flush_result(xact_id, disk_slice);
                                     } else {

--- a/src/moonlink/src/table_handler/failure_tests.rs
+++ b/src/moonlink/src/table_handler/failure_tests.rs
@@ -204,6 +204,19 @@ async fn test_force_index_merge_with_failed_iceberg_persistence() {
     mock_table_manager
         .expect_sync_snapshot()
         .times(1)
+        .returning(|snapshot_payload: IcebergSnapshotPayload, _| {
+            Box::pin(async move {
+                let mock_persistence_result = PersistenceResult {
+                    remote_data_files: snapshot_payload.import_payload.data_files.clone(),
+                    remote_file_indices: snapshot_payload.import_payload.file_indices.clone(),
+                    puffin_blob_ref: HashMap::new(),
+                };
+                Ok(mock_persistence_result)
+            })
+        });
+    mock_table_manager
+        .expect_sync_snapshot()
+        .times(1)
         .returning(|_, _| {
             Box::pin(async move {
                 Err(IcebergError::new(
@@ -234,7 +247,7 @@ async fn test_force_index_merge_with_failed_iceberg_persistence() {
     )
     .await;
     env.commit(/*lsn=*/ 20).await;
-    env.flush_table(/*lsn=*/ 30).await;
+    env.flush_table_and_sync(/*lsn=*/ 30, None).await;
 
     // Append another row, commit, and flush.
     env.append_row(
@@ -243,7 +256,7 @@ async fn test_force_index_merge_with_failed_iceberg_persistence() {
     )
     .await;
     env.commit(/*lsn=*/ 50).await;
-    env.flush_table(/*lsn=*/ 50).await;
+    env.flush_table_and_sync(/*lsn=*/ 50, None).await;
 
     // Request a force index merge.
     let res = env.force_index_merge_and_sync().await;
@@ -299,6 +312,19 @@ async fn test_force_data_compaction_with_failed_iceberg_persistence() {
     mock_table_manager
         .expect_sync_snapshot()
         .times(1)
+        .returning(|snapshot_payload: IcebergSnapshotPayload, _| {
+            Box::pin(async move {
+                let mock_persistence_result = PersistenceResult {
+                    remote_data_files: snapshot_payload.import_payload.data_files.clone(),
+                    remote_file_indices: snapshot_payload.import_payload.file_indices.clone(),
+                    puffin_blob_ref: HashMap::new(),
+                };
+                Ok(mock_persistence_result)
+            })
+        });
+    mock_table_manager
+        .expect_sync_snapshot()
+        .times(1)
         .returning(|_, _| {
             Box::pin(async move {
                 Err(IcebergError::new(
@@ -329,7 +355,8 @@ async fn test_force_data_compaction_with_failed_iceberg_persistence() {
     )
     .await;
     env.commit(/*lsn=*/ 20).await;
-    env.flush_table(/*lsn=*/ 30).await;
+    // env.flush_table(/*lsn=*/ 30).await;
+    env.flush_table_and_sync(/*lsn=*/ 30, None).await;
 
     // Append another row, commit, and flush.
     env.append_row(
@@ -338,7 +365,8 @@ async fn test_force_data_compaction_with_failed_iceberg_persistence() {
     )
     .await;
     env.commit(/*lsn=*/ 50).await;
-    env.flush_table(/*lsn=*/ 50).await;
+    // env.flush_table(/*lsn=*/ 50).await;
+    env.flush_table_and_sync(/*lsn=*/ 50, None).await;
 
     // Request a force index merge.
     let res = env.force_data_compaction_and_sync().await;
@@ -394,6 +422,19 @@ async fn test_force_full_compaction_with_failed_iceberg_persistence() {
     mock_table_manager
         .expect_sync_snapshot()
         .times(1)
+        .returning(|snapshot_payload: IcebergSnapshotPayload, _| {
+            Box::pin(async move {
+                let mock_persistence_result = PersistenceResult {
+                    remote_data_files: snapshot_payload.import_payload.data_files.clone(),
+                    remote_file_indices: snapshot_payload.import_payload.file_indices.clone(),
+                    puffin_blob_ref: HashMap::new(),
+                };
+                Ok(mock_persistence_result)
+            })
+        });
+    mock_table_manager
+        .expect_sync_snapshot()
+        .times(1)
         .returning(|_, _| {
             Box::pin(async move {
                 Err(IcebergError::new(
@@ -424,7 +465,7 @@ async fn test_force_full_compaction_with_failed_iceberg_persistence() {
     )
     .await;
     env.commit(/*lsn=*/ 20).await;
-    env.flush_table(/*lsn=*/ 30).await;
+    env.flush_table_and_sync(/*lsn=*/ 30, None).await;
 
     // Append another row, commit, and flush.
     env.append_row(
@@ -433,7 +474,7 @@ async fn test_force_full_compaction_with_failed_iceberg_persistence() {
     )
     .await;
     env.commit(/*lsn=*/ 50).await;
-    env.flush_table(/*lsn=*/ 50).await;
+    env.flush_table_and_sync(/*lsn=*/ 50, None).await;
 
     // Request a force index merge.
     let res = env.force_full_maintenance_and_sync().await;

--- a/src/moonlink/src/table_handler/failure_tests.rs
+++ b/src/moonlink/src/table_handler/failure_tests.rs
@@ -355,7 +355,6 @@ async fn test_force_data_compaction_with_failed_iceberg_persistence() {
     )
     .await;
     env.commit(/*lsn=*/ 20).await;
-    // env.flush_table(/*lsn=*/ 30).await;
     env.flush_table_and_sync(/*lsn=*/ 30, None).await;
 
     // Append another row, commit, and flush.

--- a/src/moonlink/src/table_handler/table_handler_state.rs
+++ b/src/moonlink/src/table_handler/table_handler_state.rs
@@ -299,20 +299,31 @@ impl TableHandlerState {
     }
 
     /// Return whether should force to create a mooncake and iceberg snapshot, based on the new coming commit LSN.
-    pub(crate) fn should_force_snapshot_by_commit_lsn(&self, commit_lsn: u64) -> bool {
+    pub(crate) fn should_force_snapshot_by_commit_lsn(
+        commit_lsn: u64,
+        min_pending_flush_lsn: u64,
+        table_maintenance_process_status: &MaintenanceProcessStatus,
+        largest_force_snapshot_lsn: Option<u64>,
+        mooncake_snapshot_ongoing: bool,
+    ) -> bool {
         // No force snasphot if already mooncake snapshot ongoing.
-        if self.mooncake_snapshot_ongoing {
+        if mooncake_snapshot_ongoing {
+            return false;
+        }
+
+        // No force snapshot if pending flush LSNs < commit LSN.
+        if min_pending_flush_lsn < commit_lsn {
             return false;
         }
 
         // Case-1: there're completed but not persisted table maintenance changes.
-        if self.table_maintenance_process_status == MaintenanceProcessStatus::ReadyToPersist {
+        if *table_maintenance_process_status == MaintenanceProcessStatus::ReadyToPersist {
             return true;
         }
 
         // Case-2: there're pending force snapshot requests.
-        if let Some(largest_requested_lsn) = self.largest_force_snapshot_lsn {
-            return largest_requested_lsn <= commit_lsn && !self.mooncake_snapshot_ongoing;
+        if let Some(largest_requested_lsn) = largest_force_snapshot_lsn {
+            return largest_requested_lsn <= commit_lsn && !mooncake_snapshot_ongoing;
         }
 
         false
@@ -422,10 +433,17 @@ impl TableHandlerState {
     ///
     /// Used to decide whether we could create an iceberg snapshot.
     /// The completion of an iceberg snapshot is **NOT** marked as the finish of snapshot thread, but the handling of its results.
-    /// We can only create a new iceberg snapshot when (1) there's no ongoing iceberg snapshot, (2) previous snapshot results have been acknowledged.
+    /// We can only create a new iceberg snapshot when (1) there's no ongoing iceberg snapshot, (2) previous snapshot results have been acknowledged, (3) there's no pending flush LSNs < flush_lsn
     ///
-    pub(crate) fn can_initiate_iceberg_snapshot(&self) -> bool {
-        self.iceberg_snapshot_result_consumed && !self.iceberg_snapshot_ongoing
+    pub(crate) fn can_initiate_iceberg_snapshot(
+        flush_lsn: u64,
+        min_pending_flush_lsn: u64,
+        iceberg_snapshot_result_consumed: bool,
+        iceberg_snapshot_ongoing: bool,
+    ) -> bool {
+        iceberg_snapshot_result_consumed
+            && !iceberg_snapshot_ongoing
+            && flush_lsn < min_pending_flush_lsn
     }
 
     pub(crate) fn reset_iceberg_state_at_mooncake_snapshot(&mut self) {

--- a/src/moonlink/src/table_handler/table_handler_state.rs
+++ b/src/moonlink/src/table_handler/table_handler_state.rs
@@ -301,7 +301,7 @@ impl TableHandlerState {
     /// Return whether should force to create a mooncake and iceberg snapshot, based on the new coming commit LSN.
     pub(crate) fn should_force_snapshot_by_commit_lsn(
         commit_lsn: u64,
-        min_pending_flush_lsn: u64,
+        min_ongoing_flush_lsn: u64,
         table_maintenance_process_status: &MaintenanceProcessStatus,
         largest_force_snapshot_lsn: Option<u64>,
         mooncake_snapshot_ongoing: bool,
@@ -312,7 +312,7 @@ impl TableHandlerState {
         }
 
         // No force snapshot if pending flush LSNs < commit LSN.
-        if min_pending_flush_lsn < commit_lsn {
+        if min_ongoing_flush_lsn < commit_lsn {
             return false;
         }
 
@@ -440,13 +440,13 @@ impl TableHandlerState {
     ///
     pub(crate) fn can_initiate_iceberg_snapshot(
         flush_lsn: u64,
-        min_pending_flush_lsn: u64,
+        min_ongoing_flush_lsn: u64,
         iceberg_snapshot_result_consumed: bool,
         iceberg_snapshot_ongoing: bool,
     ) -> bool {
         iceberg_snapshot_result_consumed
             && !iceberg_snapshot_ongoing
-            && flush_lsn < min_pending_flush_lsn
+            && flush_lsn < min_ongoing_flush_lsn
     }
 
     pub(crate) fn reset_iceberg_state_at_mooncake_snapshot(&mut self) {

--- a/src/moonlink/src/table_handler/table_handler_state.rs
+++ b/src/moonlink/src/table_handler/table_handler_state.rs
@@ -335,7 +335,7 @@ impl TableHandlerState {
     }
 
     /// Return whether there's background tasks ongoing.
-    fn has_background_task_ongoing(&mut self) -> bool {
+    fn has_background_task_ongoing(&mut self, has_ongoing_flush: bool) -> bool {
         if self.mooncake_snapshot_ongoing {
             return false;
         }
@@ -346,6 +346,9 @@ impl TableHandlerState {
             return false;
         }
         if self.table_maintenance_process_status != MaintenanceProcessStatus::Unrequested {
+            return false;
+        }
+        if has_ongoing_flush {
             return false;
         }
         true
@@ -362,8 +365,8 @@ impl TableHandlerState {
 
     /// Return whether table handler could be dropped now.
     /// If there're any background activities ongoing, we cannot drop table immediately.
-    pub(crate) fn can_drop_table_now(&mut self) -> bool {
-        self.has_background_task_ongoing()
+    pub(crate) fn can_drop_table_now(&mut self, has_ongoing_flush: bool) -> bool {
+        self.has_background_task_ongoing(has_ongoing_flush)
     }
 
     /// ============================

--- a/src/moonlink/src/table_handler/tests.rs
+++ b/src/moonlink/src/table_handler/tests.rs
@@ -10,7 +10,6 @@ use crate::storage::filesystem::accessor::filesystem_accessor::FileSystemAccesso
 use crate::storage::index::index_merge_config::FileIndexMergeConfig;
 use crate::storage::mooncake_table::table_creation_test_utils::*;
 use crate::storage::mooncake_table::validation_test_utils::*;
-use crate::storage::mooncake_table::IcebergSnapshotPayload;
 use crate::storage::mooncake_table::Snapshot as MooncakeSnapshot;
 use crate::storage::mooncake_table::TableMetadata as MooncakeTableMetadata;
 use crate::storage::mooncake_table_config::IcebergPersistenceConfig;
@@ -19,14 +18,12 @@ use crate::storage::wal::test_utils::WAL_TEST_TABLE_ID;
 use crate::storage::wal::WalManager;
 use crate::storage::MockTableManager;
 use crate::storage::MooncakeTable;
-use crate::storage::PersistenceResult;
 use crate::storage::TableManager;
 use crate::table_handler::table_handler_state::TableHandlerState;
 use crate::ObjectStorageCache;
 use crate::TableEventManager;
 use crate::WalConfig;
 
-use std::collections::HashMap;
 use std::sync::Arc;
 
 #[tokio::test]
@@ -397,7 +394,8 @@ async fn test_stream_delete_previously_flushed_row_same_xact() {
     // Phase 1: Append Row A (ID:10) to stream, then periodic flush
     env.append_row(10, "UserA-StreamFlush", 25, /*lsn=*/ 0, Some(xact_id))
         .await;
-    env.stream_flush(xact_id).await; // Row A now in a xact-specific disk slice
+    // env.stream_flush(xact_id).await; // Row A now in a xact-specific disk slice
+    env.flush_table_and_sync(0, None).await;
 
     // Phase 2: In same stream, delete Row A (ID:10), append Row B (ID:11)
     env.delete_row(10, "UserA-StreamFlush", 25, 0, Some(xact_id))
@@ -604,7 +602,7 @@ async fn test_drop_table_with_data() {
     )
     .await;
     env.commit(/*lsn=*/ 1).await;
-    env.flush_table(/*lsn=*/ 1).await;
+    env.flush_table_and_sync(/*lsn=*/ 1, None).await;
     env.set_readable_lsn(/*lsn=*/ 1);
 
     // Force mooncake and iceberg snapshot, and block wait until mooncake snapshot completion via getting a read state.
@@ -1624,8 +1622,7 @@ async fn test_discard_duplicate_writes() {
         identity: crate::row::IdentityProp::Keys(vec![0]),
     });
 
-    let mut mock_mooncake_snapshot = MooncakeSnapshot::new(mooncake_table_metadata.clone());
-    mock_mooncake_snapshot.flush_lsn = Some(10);
+    let mock_mooncake_snapshot = MooncakeSnapshot::new(mooncake_table_metadata.clone());
     let mut mock_table_manager = MockTableManager::new();
     mock_table_manager
         .expect_get_warehouse_location()
@@ -1640,24 +1637,11 @@ async fn test_discard_duplicate_writes() {
                 Ok((/*next_file_id=*/ 0, mock_mooncake_snapshot_copy))
             })
         });
-    mock_table_manager
-        .expect_sync_snapshot()
-        .times(1)
-        .returning(|snapshot_payload: IcebergSnapshotPayload, _| {
-            Box::pin(async move {
-                let mock_persistence_result = PersistenceResult {
-                    remote_data_files: snapshot_payload.import_payload.data_files.clone(),
-                    remote_file_indices: snapshot_payload.import_payload.file_indices.clone(),
-                    puffin_blob_ref: HashMap::new(),
-                };
-                Ok(mock_persistence_result)
-            })
-        });
 
     let wal_config = WalConfig::default_wal_config_local(WAL_TEST_TABLE_ID, temp_dir.path());
     let wal_manager = WalManager::new(&wal_config);
 
-    let mooncake_table = MooncakeTable::new_with_table_manager(
+    let mut mooncake_table = MooncakeTable::new_with_table_manager(
         mooncake_table_metadata,
         Box::new(mock_table_manager),
         ObjectStorageCache::default_for_test(&temp_dir),
@@ -1666,6 +1650,7 @@ async fn test_discard_duplicate_writes() {
     )
     .await
     .unwrap();
+    mooncake_table.set_iceberg_snapshot_lsn(10);
     let env = TestEnvironment::new_with_mooncake_table(temp_dir, mooncake_table).await;
 
     // Perform non-streaming write operation which should be discarded.
@@ -2117,4 +2102,36 @@ fn test_deletion_vector_capacity_exceeded_minimal() {
 
     // This should panic - trying to delete row_id=5 when capacity is only 3
     let _ = deletion_vector.delete_row(5);
+}
+
+#[tokio::test]
+async fn test_stream_delete_from_stream_memslice_row_debug() {
+    let mut env = TestEnvironment::default().await;
+    let xact_id = 402;
+    let stream_commit_lsn = 41;
+
+    // Phase 1: Add row 20
+    env.append_row(20, "UserC-StreamMem", 35, /*lsn=*/ 0, Some(xact_id))
+        .await;
+
+    // Phase 2: Delete row 20 (but don't add row 21 yet)
+    env.delete_row(20, "UserC-StreamMem", 35, 0, Some(xact_id))
+        .await;
+
+    // Phase 3: Verify data is NOT visible before commit
+    env.set_table_commit_lsn(0);
+    env.set_replication_lsn(stream_commit_lsn + 5);
+    env.set_snapshot_lsn(0);
+    env.verify_snapshot(stream_commit_lsn, &[]).await;
+
+    // Phase 4: Commit the streaming transaction
+    env.stream_commit(stream_commit_lsn, xact_id).await;
+    println!("Debug: Verifying final state post-commit (should be empty)");
+
+    // Phase 5: Verify final state - should be empty
+    env.set_table_commit_lsn(stream_commit_lsn);
+    env.set_replication_lsn(stream_commit_lsn + 5);
+    env.verify_snapshot(stream_commit_lsn, &[]).await; // Should be empty
+
+    env.shutdown().await;
 }

--- a/src/moonlink/src/table_notify.rs
+++ b/src/moonlink/src/table_notify.rs
@@ -1,6 +1,7 @@
 use crate::row::MoonlinkRow;
 use crate::storage::mooncake_table::DataCompactionPayload;
 use crate::storage::mooncake_table::DataCompactionResult;
+use crate::storage::mooncake_table::DiskSliceWriter;
 use crate::storage::mooncake_table::FileIndiceMergePayload;
 use crate::storage::mooncake_table::FileIndiceMergeResult;
 use crate::storage::mooncake_table::IcebergSnapshotPayload;
@@ -179,6 +180,12 @@ pub enum TableEvent {
     /// Periodic persist and truncate wal completes.
     PeriodicalWalPersistenceUpdateResult {
         result: Result<WalPersistenceUpdateResult>,
+    },
+    FlushResult {
+        // Transaction ID
+        xact_id: Option<u32>,
+        /// Result for mem slice flush.
+        flush_result: Option<Result<DiskSliceWriter>>,
     },
 }
 


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

Final PR for implementing asynchronous flush events for both streaming and non-streaming transactions.

Previous PRs: 
Use globally unique batch ids: https://github.com/Mooncake-Labs/moonlink/pull/1031
Add streaming and non-streaming state to same snapshot: https://github.com/Mooncake-Labs/moonlink/pull/1100

In this PR, we change all table flush to be asynchronous. We spawn the flush as background task and send `TableEvent::FlushResult` on complete, at which point we apply the results of the flush. Given we may have multiple concurrent flushes at once we track a queue of pending flush LSNs. Before iceberg snapshot we ensure there is no pending LSN less than the LSN we want to persist at. 

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/234

## Changes

- 
- 
- 

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
