### PR TITLE
[chaos] Disable some sanity iceberg check

### DIFF
--- a/src/moonlink/src/storage/iceberg/manifest_utils.rs
+++ b/src/moonlink/src/storage/iceberg/manifest_utils.rs
@@ -67,7 +67,7 @@ pub(crate) fn create_manifest_writer_builder(
 }
 
 /// Get manifest entry number for all types.
-#[cfg(any(test, debug_assertions))]
+#[cfg(all(not(feature = "chaos-test"), any(test, debug_assertions)))]
 pub(crate) async fn get_manifest_entries_number(
     table_metadata: &TableMetadata,
     file_io: FileIO,


### PR DESCRIPTION
## Summary

I notices chaos test timed out too frequently these days, disable some expensive sanity check which I added recently.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1207

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
