### PR TITLE
[minor] Rename flush LSN

### DIFF
--- a/src/moonlink/src/storage/iceberg/compaction_tests.rs
+++ b/src/moonlink/src/storage/iceberg/compaction_tests.rs
@@ -341,7 +341,7 @@ async fn test_compaction_1_1_1() {
         .unwrap();
 
     assert_eq!(next_file_id, 2); // one compacted data file, one compacted index block file
-    assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 1);
+    assert_eq!(snapshot.flush_lsn.unwrap(), 1);
     check_loaded_snapshot(&snapshot, /*row_indices=*/ vec![0, 1, 2, 3]).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
@@ -407,7 +407,7 @@ async fn test_compaction_1_1_2() {
         .unwrap();
 
     assert_eq!(next_file_id, 2); // one compacted data file, one compacted index block file
-    assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 1);
+    assert_eq!(snapshot.flush_lsn.unwrap(), 1);
     check_loaded_snapshot(&snapshot, /*row_indices=*/ vec![0, 1, 2, 3]).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
@@ -496,7 +496,7 @@ async fn test_compaction_1_2_1() {
         .unwrap();
 
     assert_eq!(next_file_id, 2); // one compacted data file, one compacted index block file
-    assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 1);
+    assert_eq!(snapshot.flush_lsn.unwrap(), 1);
     check_loaded_snapshot(&snapshot, /*row_indices=*/ vec![0, 1, 2, 3]).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
@@ -585,7 +585,7 @@ async fn test_compaction_1_2_2() {
         .unwrap();
 
     assert_eq!(next_file_id, 2); // one compacted data file, one compacted index block file
-    assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 1);
+    assert_eq!(snapshot.flush_lsn.unwrap(), 1);
     check_loaded_snapshot(&snapshot, /*row_indices=*/ vec![0, 1, 2, 3]).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
@@ -688,7 +688,7 @@ async fn test_compaction_2_2_1() {
         .unwrap();
 
     assert_eq!(next_file_id, 2); // one compacted data file, one compacted index block file
-    assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 3);
+    assert_eq!(snapshot.flush_lsn.unwrap(), 3);
     check_loaded_snapshot(&snapshot, /*row_indices=*/ vec![1, 2, 3]).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
@@ -780,7 +780,7 @@ async fn test_compaction_2_2_2() {
         .unwrap();
 
     assert_eq!(next_file_id, 2); // one compacted data file, one compacted index block file
-    assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 3);
+    assert_eq!(snapshot.flush_lsn.unwrap(), 3);
     check_loaded_snapshot(&snapshot, /*row_indices=*/ vec![1, 2, 3]).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
@@ -887,7 +887,7 @@ async fn test_compaction_2_3_1() {
         .unwrap();
 
     assert_eq!(next_file_id, 2); // one compacted data file, one compacted index block file
-    assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 5);
+    assert_eq!(snapshot.flush_lsn.unwrap(), 5);
     check_loaded_snapshot(&snapshot, /*row_indices=*/ vec![1, 3]).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
@@ -966,7 +966,7 @@ async fn test_compaction_2_3_2() {
         .unwrap();
 
     assert_eq!(next_file_id, 2); // one compacted data file, one compacted index block file
-    assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 5);
+    assert_eq!(snapshot.flush_lsn.unwrap(), 5);
     check_loaded_snapshot(&snapshot, /*row_indices=*/ vec![1, 3]).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
@@ -1073,7 +1073,7 @@ async fn test_compaction_3_2_1() {
         .unwrap();
 
     assert_eq!(next_file_id, 2); // one compacted data file, one compacted index block file
-    assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 1);
+    assert_eq!(snapshot.flush_lsn.unwrap(), 1);
     check_loaded_snapshot(&snapshot, /*row_indices=*/ vec![0, 1, 2, 3]).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
@@ -1171,7 +1171,7 @@ async fn test_compaction_3_3_1() {
         .unwrap();
 
     assert_eq!(next_file_id, 0);
-    assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 7);
+    assert_eq!(snapshot.flush_lsn.unwrap(), 7);
     assert!(snapshot.disk_files.is_empty());
     assert!(snapshot.indices.file_indices.is_empty());
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;

--- a/src/moonlink/src/storage/iceberg/iceberg_table_loader.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_loader.rs
@@ -217,7 +217,7 @@ impl IcebergTableManager {
         };
 
         // Fill in flush LSN.
-        mooncake_snapshot.data_file_flush_lsn = flush_lsn;
+        mooncake_snapshot.flush_lsn = flush_lsn;
         // Fill in wal persistence metadata.
         mooncake_snapshot.wal_persistence_metadata = wal_metadata;
 
@@ -252,7 +252,7 @@ impl IcebergTableManager {
         if table_metadata.current_snapshot().is_none() {
             let mut empty_mooncake_snapshot =
                 MooncakeSnapshot::new(self.mooncake_table_metadata.clone());
-            empty_mooncake_snapshot.data_file_flush_lsn = snapshot_property.flush_lsn;
+            empty_mooncake_snapshot.flush_lsn = snapshot_property.flush_lsn;
             return Ok((next_file_id as u32, empty_mooncake_snapshot));
         }
 

--- a/src/moonlink/src/storage/iceberg/state_tests.rs
+++ b/src/moonlink/src/storage/iceberg/state_tests.rs
@@ -293,7 +293,7 @@ async fn validate_no_snapshot(
     assert_eq!(next_file_id, 0);
     assert!(snapshot.disk_files.is_empty());
     assert!(snapshot.indices.file_indices.is_empty());
-    assert!(snapshot.data_file_flush_lsn.is_none());
+    assert!(snapshot.flush_lsn.is_none());
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
     validate_recovered_snapshot(
         &snapshot,
@@ -315,7 +315,7 @@ async fn validate_only_initial_snapshot(
     assert_eq!(next_file_id, 2); // one data file, one index block file
     check_prev_data_files(&snapshot, iceberg_table_manager, /*deleted=*/ false).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
-    assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 100);
+    assert_eq!(snapshot.flush_lsn.unwrap(), 100);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
     validate_recovered_snapshot(
         &snapshot,
@@ -337,7 +337,7 @@ async fn validate_only_new_data_files_in_snapshot(
     assert_eq!(next_file_id, 2); // one data file, one index block file
     check_new_data_files(&snapshot, iceberg_table_manager, /*deleted=*/ false).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
-    assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 200);
+    assert_eq!(snapshot.flush_lsn.unwrap(), 200);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
     validate_recovered_snapshot(
         &snapshot,
@@ -359,7 +359,7 @@ async fn validate_only_new_deletion_vectors_in_snapshot(
     assert_eq!(next_file_id, 3); // one data file, one index block file, one deletion vector puffin
     check_prev_data_files(&snapshot, iceberg_table_manager, /*deleted=*/ true).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
-    assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 300);
+    assert_eq!(snapshot.flush_lsn.unwrap(), 300);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
     validate_recovered_snapshot(
         &snapshot,
@@ -389,7 +389,7 @@ async fn validate_new_data_files_and_deletion_vectors_in_snapshot(
     )
     .await;
     assert_eq!(snapshot.indices.file_indices.len(), 2);
-    assert_eq!(snapshot.data_file_flush_lsn.unwrap(), expected_flush_lsn);
+    assert_eq!(snapshot.flush_lsn.unwrap(), expected_flush_lsn);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
     validate_recovered_snapshot(
         &snapshot,

--- a/src/moonlink/src/storage/iceberg/tests.rs
+++ b/src/moonlink/src/storage/iceberg/tests.rs
@@ -517,7 +517,7 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
         .load_snapshot_from_table()
         .await
         .unwrap();
-    assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 2);
+    assert_eq!(snapshot.flush_lsn.unwrap(), 2);
     assert_eq!(
         snapshot
             .wal_persistence_metadata
@@ -606,7 +606,7 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
         .load_snapshot_from_table()
         .await
         .unwrap();
-    assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 3);
+    assert_eq!(snapshot.flush_lsn.unwrap(), 3);
     assert_eq!(snapshot.disk_files.len(), 1);
     let (data_file, batch_deletion_vector) = snapshot.disk_files.iter().next().unwrap();
     // No deletion vector is expected.
@@ -677,7 +677,7 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
         .load_snapshot_from_table()
         .await
         .unwrap();
-    assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 4);
+    assert_eq!(snapshot.flush_lsn.unwrap(), 4);
     assert!(snapshot.disk_files.is_empty());
     assert!(snapshot.indices.in_memory_index.is_empty());
     assert!(snapshot.indices.file_indices.is_empty());
@@ -839,7 +839,7 @@ async fn test_empty_snapshot_load_impl(iceberg_table_config: IcebergTableConfig)
     assert!(snapshot.disk_files.is_empty());
     assert!(snapshot.indices.in_memory_index.is_empty());
     assert!(snapshot.indices.file_indices.is_empty());
-    assert!(snapshot.data_file_flush_lsn.is_none());
+    assert!(snapshot.flush_lsn.is_none());
     validate_recovered_snapshot(
         &snapshot,
         &iceberg_table_config.accessor_config.get_root_path(),
@@ -955,7 +955,7 @@ async fn test_index_merge_and_create_snapshot_impl(iceberg_table_config: Iceberg
     assert_eq!(next_file_id, 5); // three data files, two index block file
     assert_eq!(snapshot.disk_files.len(), 3);
     assert_eq!(snapshot.indices.file_indices.len(), 2);
-    assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 3);
+    assert_eq!(snapshot.flush_lsn.unwrap(), 3);
     validate_recovered_snapshot(
         &snapshot,
         &iceberg_table_config.accessor_config.get_root_path(),
@@ -990,7 +990,7 @@ async fn test_index_merge_and_create_snapshot_impl(iceberg_table_config: Iceberg
     assert_eq!(next_file_id, 6); // three data files, one index block file, two deletion vectors
     assert_eq!(snapshot.disk_files.len(), 3);
     assert_eq!(snapshot.indices.file_indices.len(), 1);
-    assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 5);
+    assert_eq!(snapshot.flush_lsn.unwrap(), 5);
     validate_recovered_snapshot(
         &snapshot,
         &iceberg_table_config.accessor_config.get_root_path(),
@@ -1115,7 +1115,7 @@ async fn test_data_compaction_and_create_snapshot_impl(iceberg_table_config: Ice
     assert_eq!(next_file_id, 4); // two data files, two index block file
     assert_eq!(snapshot.disk_files.len(), 2);
     assert_eq!(snapshot.indices.file_indices.len(), 2);
-    assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 3);
+    assert_eq!(snapshot.flush_lsn.unwrap(), 3);
     validate_recovered_snapshot(
         &snapshot,
         &iceberg_table_config.accessor_config.get_root_path(),
@@ -1156,7 +1156,7 @@ async fn test_data_compaction_and_create_snapshot_impl(iceberg_table_config: Ice
     assert_eq!(next_file_id, 2); // one data file, one index block file
     assert_eq!(snapshot.disk_files.len(), 1);
     assert_eq!(snapshot.indices.file_indices.len(), 1);
-    assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 5);
+    assert_eq!(snapshot.flush_lsn.unwrap(), 5);
     validate_recovered_snapshot(
         &snapshot,
         &iceberg_table_config.accessor_config.get_root_path(),
@@ -1291,7 +1291,7 @@ async fn test_data_compaction_by_deletion_and_create_snapshot_impl(
     assert_eq!(next_file_id, 3); // two data files, and one file index
     assert_eq!(snapshot.disk_files.len(), 2);
     assert_eq!(snapshot.indices.file_indices.len(), 1);
-    assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 8);
+    assert_eq!(snapshot.flush_lsn.unwrap(), 8);
     validate_recovered_snapshot(
         &snapshot,
         &iceberg_table_config.accessor_config.get_root_path(),
@@ -1393,7 +1393,7 @@ async fn test_empty_content_snapshot_creation_impl(iceberg_table_config: Iceberg
     assert!(snapshot.disk_files.is_empty());
     assert!(snapshot.indices.in_memory_index.is_empty());
     assert!(snapshot.indices.file_indices.is_empty());
-    assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 0);
+    assert_eq!(snapshot.flush_lsn.unwrap(), 0);
 }
 
 #[tokio::test]
@@ -1700,7 +1700,7 @@ async fn test_async_iceberg_snapshot_impl(iceberg_table_config: IcebergTableConf
     assert_eq!(next_file_id, 2); // one data file, one index block file
     assert_eq!(snapshot.disk_files.len(), 1);
     assert_eq!(snapshot.indices.file_indices.len(), 1);
-    assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 10);
+    assert_eq!(snapshot.flush_lsn.unwrap(), 10);
 
     // Get file io after load snapshot.
     let file_io = iceberg_table_manager_for_recovery
@@ -1757,7 +1757,7 @@ async fn test_async_iceberg_snapshot_impl(iceberg_table_config: IcebergTableConf
     assert_eq!(next_file_id, 7); // three data files, three index block files, one deletion vector puffin
     assert_eq!(snapshot.disk_files.len(), 3);
     assert_eq!(snapshot.indices.file_indices.len(), 3);
-    assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 40);
+    assert_eq!(snapshot.flush_lsn.unwrap(), 40);
 
     validate_recovered_snapshot(
         &snapshot,
@@ -1924,7 +1924,7 @@ async fn mooncake_table_snapshot_persist_impl(iceberg_table_config: IcebergTable
     check_row_index_nonexistent(&snapshot, &row1).await;
     check_row_index_on_disk(&snapshot, &row2, filesystem_accessor.as_ref()).await;
     check_row_index_on_disk(&snapshot, &row3, filesystem_accessor.as_ref()).await;
-    assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 200);
+    assert_eq!(snapshot.flush_lsn.unwrap(), 200);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
     validate_recovered_snapshot(
         &snapshot,
@@ -1998,7 +1998,7 @@ async fn mooncake_table_snapshot_persist_impl(iceberg_table_config: IcebergTable
     // row2 is deleted, but still exist in data file
     check_row_index_on_disk(&snapshot, &row2, filesystem_accessor.as_ref()).await;
     check_row_index_on_disk(&snapshot, &row3, filesystem_accessor.as_ref()).await;
-    assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 300);
+    assert_eq!(snapshot.flush_lsn.unwrap(), 300);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
     validate_recovered_snapshot(
         &snapshot,
@@ -2060,7 +2060,7 @@ async fn mooncake_table_snapshot_persist_impl(iceberg_table_config: IcebergTable
     // row2 and row3 are deleted, but still exist in data file
     check_row_index_on_disk(&snapshot, &row2, filesystem_accessor.as_ref()).await;
     check_row_index_on_disk(&snapshot, &row3, filesystem_accessor.as_ref()).await;
-    assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 400);
+    assert_eq!(snapshot.flush_lsn.unwrap(), 400);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
     validate_recovered_snapshot(
         &snapshot,
@@ -2127,7 +2127,7 @@ async fn mooncake_table_snapshot_persist_impl(iceberg_table_config: IcebergTable
     check_row_index_on_disk(&snapshot, &row2, filesystem_accessor.as_ref()).await;
     check_row_index_on_disk(&snapshot, &row3, filesystem_accessor.as_ref()).await;
     check_row_index_on_disk(&snapshot, &row4, filesystem_accessor.as_ref()).await;
-    assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 500);
+    assert_eq!(snapshot.flush_lsn.unwrap(), 500);
 
     let (file_in_new_snapshot, _) = snapshot
         .disk_files
@@ -2323,7 +2323,7 @@ async fn test_schema_update_with_no_table_write_impl(iceberg_table_config: Icebe
         .await
         .unwrap();
     assert_eq!(next_file_id, 0);
-    assert_eq!(snapshot.data_file_flush_lsn, Some(0));
+    assert_eq!(snapshot.flush_lsn, Some(0));
     assert!(snapshot.disk_files.is_empty());
     assert!(snapshot.indices.file_indices.is_empty());
 
@@ -2365,7 +2365,7 @@ async fn test_schema_update_with_no_table_write_impl(iceberg_table_config: Icebe
         .await
         .unwrap();
     assert_eq!(next_file_id, 2); // one data file, one file index
-    assert_eq!(snapshot.data_file_flush_lsn, Some(20));
+    assert_eq!(snapshot.flush_lsn, Some(20));
     assert_eq!(snapshot.disk_files.len(), 1);
     assert_eq!(snapshot.indices.file_indices.len(), 1);
 
@@ -2460,7 +2460,7 @@ async fn test_schema_update_impl(iceberg_table_config: IcebergTableConfig) {
         .await
         .unwrap();
     assert_eq!(next_file_id, 2);
-    assert_eq!(snapshot.data_file_flush_lsn, Some(10));
+    assert_eq!(snapshot.flush_lsn, Some(10));
     assert_eq!(snapshot.disk_files.len(), 1);
     assert_eq!(snapshot.indices.file_indices.len(), 1);
 
@@ -2498,7 +2498,7 @@ async fn test_schema_update_impl(iceberg_table_config: IcebergTableConfig) {
         .await
         .unwrap();
     assert_eq!(next_file_id, 4); // two data files, two file indices
-    assert_eq!(snapshot.data_file_flush_lsn, Some(20));
+    assert_eq!(snapshot.flush_lsn, Some(20));
     assert_eq!(snapshot.disk_files.len(), 2);
     assert_eq!(snapshot.indices.file_indices.len(), 2);
 }

--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -160,7 +160,7 @@ pub struct Snapshot {
     ///
     /// At iceberg snapshot creation, we should only dump consistent data files and deletion logs.
     /// Data file flush LSN is recorded here, to get corresponding deletion logs from "committed deletion logs".
-    pub(crate) data_file_flush_lsn: Option<u64>,
+    pub(crate) flush_lsn: Option<u64>,
     /// WAL persistence metadata.
     pub(crate) wal_persistence_metadata: Option<WalPersistenceMetadata>,
     /// indices
@@ -173,7 +173,7 @@ impl Snapshot {
             metadata,
             disk_files: HashMap::new(),
             snapshot_version: 0,
-            data_file_flush_lsn: None,
+            flush_lsn: None,
             wal_persistence_metadata: None,
             indices: MooncakeIndex::new(),
         }
@@ -513,7 +513,7 @@ impl MooncakeTable {
         table_metadata.config.validate();
         let (table_snapshot_watch_sender, table_snapshot_watch_receiver) = watch::channel(u64::MAX);
         let (next_file_id, current_snapshot) = table_manager.load_snapshot_from_table().await?;
-        let last_iceberg_snapshot_lsn = current_snapshot.data_file_flush_lsn;
+        let last_iceberg_snapshot_lsn = current_snapshot.flush_lsn;
         let last_wal_persisted_metadata = current_snapshot.wal_persistence_metadata.clone();
         if let Some(persistence_lsn) = last_iceberg_snapshot_lsn {
             table_snapshot_watch_sender.send(persistence_lsn).unwrap();

--- a/src/moonlink/src/storage/mooncake_table/snapshot_read.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot_read.rs
@@ -31,7 +31,7 @@ impl SnapshotTableState {
     pub(crate) fn get_table_snapshot_states(&self) -> Result<TableSnapshotStatus> {
         Ok(TableSnapshotStatus {
             commit_lsn: self.current_snapshot.snapshot_version,
-            flush_lsn: self.current_snapshot.data_file_flush_lsn,
+            flush_lsn: self.current_snapshot.flush_lsn,
         })
     }
 

--- a/src/moonlink/src/storage/mooncake_table/snapshot_validation.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot_validation.rs
@@ -12,22 +12,16 @@ impl SnapshotTableState {
         opt: &SnapshotOption,
     ) {
         if let Some(new_flush_lsn) = task.new_flush_lsn {
-            if self.current_snapshot.data_file_flush_lsn.is_some() {
+            if self.current_snapshot.flush_lsn.is_some() {
                 // Invariant-1: flush LSN doesn't regress.
                 //
                 // Force snapshot not change table states, it's possible to use the latest flush LSN.
                 if opt.force_create {
-                    ma::assert_le!(
-                        self.current_snapshot.data_file_flush_lsn.unwrap(),
-                        new_flush_lsn
-                    );
+                    ma::assert_le!(self.current_snapshot.flush_lsn.unwrap(), new_flush_lsn);
                 }
                 // Otherwise, flush LSN always progresses.
                 else {
-                    ma::assert_lt!(
-                        self.current_snapshot.data_file_flush_lsn.unwrap(),
-                        new_flush_lsn
-                    );
+                    ma::assert_lt!(self.current_snapshot.flush_lsn.unwrap(), new_flush_lsn);
                 }
 
                 // Invariant-2: flush must follow a commit, but commit doesn't need to be followed by a flush.

--- a/src/moonlink/src/table_handler/tests.rs
+++ b/src/moonlink/src/table_handler/tests.rs
@@ -1257,7 +1257,7 @@ async fn test_flush_lsn_consistency_across_snapshots() {
             .load_snapshot_from_table()
             .await
             .unwrap();
-        assert_eq!(snapshot.data_file_flush_lsn, Some(lsn));
+        assert_eq!(snapshot.flush_lsn, Some(lsn));
     }
 
     env.shutdown().await;
@@ -1371,7 +1371,7 @@ async fn test_periodical_force_snapshot() {
         .load_snapshot_from_table()
         .await
         .unwrap();
-    assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 10);
+    assert_eq!(snapshot.flush_lsn.unwrap(), 10);
 }
 
 #[tokio::test]
@@ -1413,7 +1413,7 @@ async fn test_index_merge_with_sufficient_file_indices() {
         .await
         .unwrap();
     assert_eq!(next_file_id, 3);
-    assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 20);
+    assert_eq!(snapshot.flush_lsn.unwrap(), 20);
     assert_eq!(snapshot.disk_files.len(), 2); // two data files created by two flushes
     assert_eq!(snapshot.indices.file_indices.len(), 1); // one merged file index
 
@@ -1441,7 +1441,7 @@ async fn test_index_merge_with_sufficient_file_indices() {
         .await
         .unwrap();
     assert_eq!(next_file_id, 4);
-    assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 30);
+    assert_eq!(snapshot.flush_lsn.unwrap(), 30);
     assert_eq!(snapshot.disk_files.len(), 3); // three data files created by three flushes
     assert_eq!(snapshot.indices.file_indices.len(), 1); // one merged file index
 }
@@ -1485,7 +1485,7 @@ async fn test_data_compaction_with_sufficient_data_files() {
         .await
         .unwrap();
     assert_eq!(next_file_id, 2);
-    assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 20);
+    assert_eq!(snapshot.flush_lsn.unwrap(), 20);
     assert_eq!(snapshot.disk_files.len(), 1); // one compacted data file
     assert_eq!(snapshot.indices.file_indices.len(), 1); // one compacted file index
 
@@ -1513,7 +1513,7 @@ async fn test_data_compaction_with_sufficient_data_files() {
         .await
         .unwrap();
     assert_eq!(next_file_id, 2);
-    assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 30);
+    assert_eq!(snapshot.flush_lsn.unwrap(), 30);
     assert_eq!(snapshot.disk_files.len(), 1); // one compacted data file
     assert_eq!(snapshot.indices.file_indices.len(), 1); // one compacted file index
 }
@@ -1573,7 +1573,7 @@ async fn test_full_maintenance_with_sufficient_data_files() {
         .await
         .unwrap();
     assert_eq!(next_file_id, 2);
-    assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 20);
+    assert_eq!(snapshot.flush_lsn.unwrap(), 20);
     assert_eq!(snapshot.disk_files.len(), 1); // one compacted data file
     assert_eq!(snapshot.indices.file_indices.len(), 1); // one compacted file index
 
@@ -1601,7 +1601,7 @@ async fn test_full_maintenance_with_sufficient_data_files() {
         .await
         .unwrap();
     assert_eq!(next_file_id, 2);
-    assert_eq!(snapshot.data_file_flush_lsn.unwrap(), 30);
+    assert_eq!(snapshot.flush_lsn.unwrap(), 30);
     assert_eq!(snapshot.disk_files.len(), 1); // one compacted data file
     assert_eq!(snapshot.indices.file_indices.len(), 1); // one compacted file index
 }
@@ -1622,7 +1622,7 @@ async fn test_discard_duplicate_writes() {
     });
 
     let mut mock_mooncake_snapshot = MooncakeSnapshot::new(mooncake_table_metadata.clone());
-    mock_mooncake_snapshot.data_file_flush_lsn = Some(10);
+    mock_mooncake_snapshot.flush_lsn = Some(10);
     let mut mock_table_manager = MockTableManager::new();
     mock_table_manager
         .expect_get_warehouse_location()


### PR DESCRIPTION
## Summary

Rename from `data_file_flush_lsn` to `flush_lsn`; the former is not a correct naming, we also flush with no data file involved when force snapshot.

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
