### PR TITLE
[deploy] Initial deployment for standalone moonlink

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,37 @@
+# Ignore build artifacts and dependencies
+target
+.cargo
+node_modules
+__pycache__
+
+# Ignore documentation dependencies.
+asserts
+
+# Ignore devcontainer setup.
+.devcontainer
+
+# Ignore CI setup.
+.config
+
+# Ignore mac filesystem file.
+.DS_Store
+
+# Ignore VCS
+.git
+.gitignore
+
+# Ignore IDE/editor config
+.vscode
+.idea
+
+# Ignore local data or temp files
+*.log
+*.tmp
+*.parquet
+*.db
+*.sqlite
+*.ipynb_checkpoints
+
+# Ignore Docker itself
+Dockerfile
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# TODO(hjiang): Use release build for docker images, update after official release.
+
+# Build base image for compilation and linking.
+FROM mcr.microsoft.com/devcontainers/rust:latest AS builder
+
+WORKDIR /workspace
+
+COPY . .
+
+RUN apt-get update && apt-get install -y gcc-x86-64-linux-gnu
+ENV CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=x86_64-linux-gnu-gcc
+RUN rustup target add x86_64-unknown-linux-gnu
+RUN cargo build --target x86_64-unknown-linux-gnu --verbose
+
+# Use a slim image for docker image used for cloud deployment.
+FROM ubuntu:22.04
+
+RUN apt-get update && \
+    apt-get install -y ca-certificates libssl3 libpq5 && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY --from=builder /workspace/target/x86_64-unknown-linux-gnu/debug/moonlink_service .
+
+ENTRYPOINT ["/app/moonlink_service", "/tmp/moonlink"]

--- a/cloud/gcp/moonlink_service.yaml
+++ b/cloud/gcp/moonlink_service.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-rust-cli
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: my-rust-cli
+  template:
+    metadata:
+      labels:
+        app: my-rust-cli
+    spec:
+      containers:
+      # TODO(hjiang): Rename container name.
+      # TODO(hjiang): Add resource limit/request.
+      - name: my-rust-cli
+        image: us-west1-docker.pkg.dev/coral-ring-465417-r0/moonlink-standalone-experiment/my-rust-cli:deefde16-0ab8-4c03-90b6-b1a2ae201df0
+        env:
+        - name: PGHOST
+          value: localhost
+        - name: PGUSER
+          value: user
+        - name: PGPASSWORD
+          value: password
+        - name: PGDATABASE
+          value: mydb
+        - name: PGPORT
+          value: "5432"
+      # TODO(hjiang): Postgres container to test moonlink.
+      - name: postgres
+        image: postgres:17
+        env:
+        - name: POSTGRES_USER
+          value: user
+        - name: POSTGRES_PASSWORD
+          value: password
+        - name: POSTGRES_DB
+          value: mydb
+        - name: POSTGRES_INITDB_ARGS
+          value: "-c wal_level=logical"
+        ports:
+        - containerPort: 5432
+        volumeMounts:
+        - name: pgdata
+          mountPath: /var/lib/postgresql/data
+      volumes:
+      - name: pgdata
+        emptyDir: {}


### PR DESCRIPTION
## Summary

This PR adds initial dockerfile and kubernetes deployment on GKE.

I have checked: with local postgres, moonlink deployed in the same pod performs normally: able to send events to mooncake table, able to persist to iceberg table.

Commands to create docker image and upload to GAR:
```sh
(myenv) hjiang@hjiangs-MacBook-Pro Downloads % docker build --platform linux/amd64 -t my-rust-cli:latest .
(myenv) hjiang@hjiangs-MacBook-Pro Downloads % docker tag my-rust-cli:latest us-west-1-docker.pkg.dev/coral-ring-465417-r0/moonlink-standalone-experiment/my-rust-cli:latest
(myenv) hjiang@hjiangs-MacBook-Pro Downloads % docker push us-west1-docker.pkg.dev/coral-ring-465417-r0/moonlink-standalone-experiment/my-rust-cli:latest 
```

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
