### PR TITLE
[storage] Fix unset unflushed commit LSN

### DIFF
--- a/src/moonlink/src/table_handler/table_handler_state.rs
+++ b/src/moonlink/src/table_handler/table_handler_state.rs
@@ -166,13 +166,13 @@ impl TableHandlerState {
                     self.latest_commit_lsn = Some(*lsn);
                     self.table_consistent_view_lsn = Some(*lsn);
                     if xact_id.is_none() {
+                        // Unset at flush operation.
                         self.last_unflushed_commit_lsn = Some(*lsn);
                     }
                 }
                 TableEvent::CommitFlush { lsn, .. } => {
                     self.latest_commit_lsn = Some(*lsn);
                     self.table_consistent_view_lsn = Some(*lsn);
-                    self.last_unflushed_commit_lsn = None;
                 }
                 // Unset for table write operations.
                 TableEvent::Append { .. }


### PR DESCRIPTION
## Summary

Only unset after flush operations, the only affected interface is the one used in chaos test `TableEvent::CommitFlush`.
I tested with failed random tests and their random seed.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1213

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
