### PR TITLE
Refine moonlink errors with new Error struct

### DIFF
--- a/src/moonlink/src/error.rs
+++ b/src/moonlink/src/error.rs
@@ -1,109 +1,144 @@
 use arrow::error::ArrowError;
 use iceberg::Error as IcebergError;
 use parquet::errors::ParquetError;
+use std::fmt;
 use std::io;
 use std::result;
-use std::sync::Arc;
 use thiserror::Error;
 use tokio::sync::watch;
+
+/// Error status indicating whether an error is retryable
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ErrorStatus {
+    Permanent,
+    Temporary,
+    Persistent,
+}
+
+/// Custom error struct for moonlink
+#[derive(Clone, Debug)]
+pub struct ErrorStruct {
+    pub message: String,
+    pub status: ErrorStatus,
+    // TODO: take out source now to deal with other field first, should add it back
+}
+
+impl fmt::Display for ErrorStruct {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
 
 /// Custom error type for moonlink
 #[derive(Clone, Debug, Error)]
 pub enum Error {
-    #[error("Arrow error: {source}")]
-    Arrow { source: Arc<ArrowError> },
+    #[error("{0}")]
+    Arrow(ErrorStruct),
 
-    #[error("IO error: {source}")]
-    Io { source: Arc<io::Error> },
+    #[error("{0}")]
+    Io(ErrorStruct),
 
-    #[error("Parquet error: {source}")]
-    Parquet { source: Arc<ParquetError> },
+    #[error("{0}")]
+    Parquet(ErrorStruct),
 
     #[error("Transaction {0} not found")]
     TransactionNotFound(u32),
 
-    #[error("Watch channel receiver error: {source}")]
-    WatchChannelRecvError {
-        #[source]
-        source: watch::error::RecvError,
-    },
+    #[error("{0}")]
+    WatchChannelRecvError(ErrorStruct),
 
     #[error("Tokio join error: {0}. This typically occurs when a spawned task fails to complete successfully. Check the task's execution or panic status for more details.")]
     TokioJoinError(String),
 
-    #[error("Iceberg error: {source}")]
-    IcebergError { source: Arc<IcebergError> },
+    #[error("{0}")]
+    IcebergError(ErrorStruct),
 
     #[error("Iceberg error: {0}")]
     IcebergMessage(String),
 
-    #[error("OpenDAL error: {source}")]
-    OpenDal { source: Arc<opendal::Error> },
+    #[error("{0}")]
+    OpenDal(ErrorStruct),
 
     #[error("UTF-8 conversion error: {0}")]
     Utf8(#[from] std::string::FromUtf8Error),
 
-    #[error("Join error: {source}")]
-    JoinError { source: Arc<tokio::task::JoinError> },
+    #[error("{0}")]
+    JoinError(ErrorStruct),
 
-    #[error("JSON serialization/deserialization error: {source}")]
-    Json { source: Arc<serde_json::Error> },
+    #[error("{0}")]
+    Json(ErrorStruct),
 }
 
 pub type Result<T> = result::Result<T, Error>;
 
+impl From<watch::error::RecvError> for Error {
+    fn from(source: watch::error::RecvError) -> Self {
+        Error::WatchChannelRecvError(ErrorStruct {
+            message: format!("Watch channel receiver error: {source}"),
+            status: ErrorStatus::Permanent,
+        })
+    }
+}
+
 impl From<ArrowError> for Error {
     fn from(source: ArrowError) -> Self {
-        Error::Arrow {
-            source: Arc::new(source),
-        }
+        Error::Arrow(ErrorStruct {
+            message: format!("Arrow error: {source}"),
+            status: ErrorStatus::Permanent,
+        })
     }
 }
 
 impl From<IcebergError> for Error {
     fn from(source: IcebergError) -> Self {
-        Error::IcebergError {
-            source: Arc::new(source),
-        }
+        Error::IcebergError(ErrorStruct {
+            message: format!("Iceberg error: {source}"),
+            status: ErrorStatus::Permanent,
+        })
     }
 }
 
 impl From<io::Error> for Error {
     fn from(source: io::Error) -> Self {
-        Error::Io {
-            source: Arc::new(source),
-        }
+        Error::Io(ErrorStruct {
+            message: format!("IO error: {source}"),
+            status: ErrorStatus::Permanent,
+        })
     }
 }
 
 impl From<opendal::Error> for Error {
     fn from(source: opendal::Error) -> Self {
-        Error::OpenDal {
-            source: Arc::new(source),
-        }
+        Error::OpenDal(ErrorStruct {
+            message: format!("OpenDAL error: {source}"),
+            status: ErrorStatus::Permanent,
+        })
     }
 }
 
 impl From<tokio::task::JoinError> for Error {
     fn from(source: tokio::task::JoinError) -> Self {
-        Error::JoinError {
-            source: Arc::new(source),
-        }
+        Error::JoinError(ErrorStruct {
+            message: format!("Join error: {source}"),
+            status: ErrorStatus::Permanent,
+        })
     }
 }
 
 impl From<ParquetError> for Error {
     fn from(source: ParquetError) -> Self {
-        Error::Parquet {
-            source: Arc::new(source),
-        }
+        Error::Parquet(ErrorStruct {
+            message: format!("Parquet error: {source}"),
+            status: ErrorStatus::Permanent,
+        })
     }
 }
 
 impl From<serde_json::Error> for Error {
     fn from(source: serde_json::Error) -> Self {
-        Error::Json {
-            source: Arc::new(source),
-        }
+        Error::Parquet(ErrorStruct {
+            message: format!("JSON serialization/deserialization error: {source}"),
+            status: ErrorStatus::Permanent,
+        })
     }
 }

--- a/src/moonlink/src/union_read/read_state_manager.rs
+++ b/src/moonlink/src/union_read/read_state_manager.rs
@@ -183,15 +183,9 @@ impl ReadStateManager {
         table_snapshot_rx: &mut watch::Receiver<u64>,
     ) -> Result<()> {
         if requested_lsn_val > current_replication_lsn {
-            replication_lsn_rx
-                .changed()
-                .await
-                .map_err(|e| Error::WatchChannelRecvError { source: e })?;
+            replication_lsn_rx.changed().await.map_err(Error::from)?;
         } else {
-            table_snapshot_rx
-                .changed()
-                .await
-                .map_err(|e| Error::WatchChannelRecvError { source: e })?;
+            table_snapshot_rx.changed().await.map_err(Error::from)?;
         }
         Ok(())
     }


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

Error status should contain a few key attributes for better debuggability, including error status, message, and source

## Related Issues

Part of #852

## Changes

- Add a new `ErrorStruct` for setting fields needed for errors
- Apply `ErrorStruct` to other existing error types
- 

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
