### PR TITLE
[storage] Mark more fields as must_use

### DIFF
--- a/src/moonlink/src/storage/mooncake_table/data_batches.rs
+++ b/src/moonlink/src/storage/mooncake_table/data_batches.rs
@@ -271,6 +271,7 @@ impl ColumnStoreBuffer {
         self.current_rows.get_snapshot()
     }
 
+    #[must_use]
     pub(super) fn try_delete_at_pos(&mut self, pos: (u64, usize)) -> bool {
         let idx = self
             .in_memory_batches

--- a/src/moonlink/src/storage/mooncake_table/mem_slice.rs
+++ b/src/moonlink/src/storage/mooncake_table/mem_slice.rs
@@ -92,6 +92,7 @@ impl MemSlice {
         None
     }
 
+    #[must_use]
     pub fn try_delete_at_pos(&mut self, pos: (u64, usize)) -> bool {
         self.column_store.try_delete_at_pos(pos)
     }


### PR DESCRIPTION
## Summary

Verb + noun functions should all declare `must_use` otherwise it's easy to forget checking succeed or not.

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
