### PR TITLE
[storage] Provide option for atomic write on local filesystem

### DIFF
--- a/src/moonlink/benches/bench_write.rs
+++ b/src/moonlink/benches/bench_write.rs
@@ -58,6 +58,7 @@ fn bench_write(c: &mut Criterion) {
                     accessor_config: AccessorConfig::new_with_storage_config(
                         StorageConfig::FileSystem {
                             root_directory: temp_warehouse_uri.clone(),
+                            atomic_write_dir: None,
                         },
                     ),
                     ..Default::default()
@@ -79,6 +80,7 @@ fn bench_write(c: &mut Criterion) {
                     Arc::new(FileSystemAccessor::new(
                         AccessorConfig::new_with_storage_config(StorageConfig::FileSystem {
                             root_directory: temp_warehouse_uri.clone(),
+                            atomic_write_dir: None,
                         }),
                     )),
                 )
@@ -105,6 +107,7 @@ fn bench_write(c: &mut Criterion) {
                     accessor_config: AccessorConfig::new_with_storage_config(
                         StorageConfig::FileSystem {
                             root_directory: temp_warehouse_uri.clone(),
+                            atomic_write_dir: None,
                         },
                     ),
                     ..Default::default()
@@ -126,6 +129,7 @@ fn bench_write(c: &mut Criterion) {
                     Arc::new(FileSystemAccessor::new(
                         AccessorConfig::new_with_storage_config(StorageConfig::FileSystem {
                             root_directory: temp_warehouse_uri.clone(),
+                            atomic_write_dir: None,
                         }),
                     )),
                 )
@@ -155,6 +159,7 @@ fn bench_write(c: &mut Criterion) {
                     accessor_config: AccessorConfig::new_with_storage_config(
                         StorageConfig::FileSystem {
                             root_directory: temp_warehouse_uri.clone(),
+                            atomic_write_dir: None,
                         },
                     ),
                     ..Default::default()
@@ -177,6 +182,7 @@ fn bench_write(c: &mut Criterion) {
                         Arc::new(FileSystemAccessor::new(
                             AccessorConfig::new_with_storage_config(StorageConfig::FileSystem {
                                 root_directory: temp_warehouse_uri.clone(),
+                                atomic_write_dir: None,
                             }),
                         )),
                     ))

--- a/src/moonlink/benches/microbench_write_mooncake_table.rs
+++ b/src/moonlink/benches/microbench_write_mooncake_table.rs
@@ -57,6 +57,7 @@ fn bench_write_mooncake_table(c: &mut Criterion) {
         accessor_config: AccessorConfig::new_with_storage_config(
             moonlink::StorageConfig::FileSystem {
                 root_directory: warehouse_location.clone(),
+                atomic_write_dir: None,
             },
         ),
     };
@@ -78,6 +79,7 @@ fn bench_write_mooncake_table(c: &mut Criterion) {
             Arc::new(FileSystemAccessor::new(
                 AccessorConfig::new_with_storage_config(StorageConfig::FileSystem {
                     root_directory: warehouse_location.clone(),
+                    atomic_write_dir: None,
                 }),
             )),
         ))

--- a/src/moonlink/src/storage/filesystem/accessor/filesystem_accessor.rs
+++ b/src/moonlink/src/storage/filesystem/accessor/filesystem_accessor.rs
@@ -63,6 +63,7 @@ impl FileSystemAccessor {
 
         let storage_config = crate::StorageConfig::FileSystem {
             root_directory: temp_dir.path().to_str().unwrap().to_string(),
+            atomic_write_dir: None,
         };
         let accessor_config = AccessorConfig::new_with_storage_config(storage_config);
         create_filesystem_accessor(accessor_config)
@@ -448,6 +449,7 @@ mod tests {
         let root_directory = temp_dir.path().to_str().unwrap().to_string();
         let storage_config = StorageConfig::FileSystem {
             root_directory: root_directory.clone(),
+            atomic_write_dir: None,
         };
         let filesystem_accessor = create_filesystem_accessor(
             AccessorConfig::new_with_storage_config(storage_config.clone()),
@@ -478,6 +480,7 @@ mod tests {
         let root_directory = temp_dir.path().to_str().unwrap().to_string();
         let storage_config = StorageConfig::FileSystem {
             root_directory: root_directory.clone(),
+            atomic_write_dir: None,
         };
         let filesystem_accessor = create_filesystem_accessor(
             AccessorConfig::new_with_storage_config(storage_config.clone()),
@@ -525,6 +528,7 @@ mod tests {
         let root_directory = temp_dir.path().to_str().unwrap().to_string();
         let storage_config = StorageConfig::FileSystem {
             root_directory: root_directory.clone(),
+            atomic_write_dir: None,
         };
         let accessor_config = AccessorConfig::new_with_storage_config(storage_config.clone());
         let filesystem_accessor = create_filesystem_accessor(accessor_config.clone());
@@ -560,6 +564,7 @@ mod tests {
         let root_directory = temp_dir.path().to_str().unwrap().to_string();
         let storage_config = StorageConfig::FileSystem {
             root_directory: root_directory.clone(),
+            atomic_write_dir: None,
         };
         let accessor_config = AccessorConfig::new_with_storage_config(storage_config.clone());
         let filesystem_accessor = create_filesystem_accessor(accessor_config.clone());
@@ -593,6 +598,7 @@ mod tests {
         let root_directory = temp_dir.path().to_str().unwrap().to_string();
         let storage_config = StorageConfig::FileSystem {
             root_directory: root_directory.clone(),
+            atomic_write_dir: None,
         };
         let accessor_config = AccessorConfig::new_with_storage_config(storage_config.clone());
         let filesystem_accessor = create_filesystem_accessor(accessor_config.clone());
@@ -622,6 +628,7 @@ mod tests {
         let root_directory = temp_dir.path().to_str().unwrap().to_string();
         let storage_config = StorageConfig::FileSystem {
             root_directory: root_directory.clone(),
+            atomic_write_dir: None,
         };
         let accessor_config = AccessorConfig::new_with_storage_config(storage_config.clone());
         let filesystem_accessor = create_filesystem_accessor(accessor_config.clone());

--- a/src/moonlink/src/storage/filesystem/accessor/filesystem_accessor_chaos_wrapper.rs
+++ b/src/moonlink/src/storage/filesystem/accessor/filesystem_accessor_chaos_wrapper.rs
@@ -163,6 +163,7 @@ mod tests {
     ) -> FileSystemAccessor {
         let storage_config = StorageConfig::FileSystem {
             root_directory: temp_dir.path().to_str().unwrap().to_string(),
+            atomic_write_dir: None,
         };
         let accessor_config = AccessorConfig {
             storage_config,

--- a/src/moonlink/src/storage/filesystem/accessor/operator_utils.rs
+++ b/src/moonlink/src/storage/filesystem/accessor/operator_utils.rs
@@ -13,8 +13,14 @@ use opendal::Operator;
 fn create_opendal_operator_impl(storage_config: &StorageConfig) -> Result<Operator> {
     match storage_config {
         #[cfg(feature = "storage-fs")]
-        StorageConfig::FileSystem { root_directory } => {
-            let builder = services::Fs::default().root(root_directory);
+        StorageConfig::FileSystem {
+            root_directory,
+            atomic_write_dir,
+        } => {
+            let mut builder = services::Fs::default().root(root_directory);
+            if let Some(atomic_write_dir) = atomic_write_dir {
+                builder = builder.atomic_write_dir(atomic_write_dir);
+            }
             Ok(Operator::new(builder)?.finish())
         }
         #[cfg(feature = "storage-gcs")]

--- a/src/moonlink/src/storage/filesystem/accessor/unbuffered_stream_writer.rs
+++ b/src/moonlink/src/storage/filesystem/accessor/unbuffered_stream_writer.rs
@@ -70,7 +70,10 @@ mod tests {
         let dst_filename = "dst".to_string();
 
         // Create an operator.
-        let storage_config = StorageConfig::FileSystem { root_directory };
+        let storage_config = StorageConfig::FileSystem {
+            root_directory,
+            atomic_write_dir: None,
+        };
         let accessor_config = AccessorConfig::new_with_storage_config(storage_config.clone());
         let operator = operator_utils::create_opendal_operator(&accessor_config)
             .await

--- a/src/moonlink/src/storage/filesystem/accessor_config.rs
+++ b/src/moonlink/src/storage/filesystem/accessor_config.rs
@@ -168,7 +168,8 @@ mod tests {
             config,
             AccessorConfig {
                 storage_config: StorageConfig::FileSystem {
-                    root_directory: "/tmp".to_string()
+                    root_directory: "/tmp".to_string(),
+                    atomic_write_dir: None,
                 },
                 retry_config: RetryConfig::default(),
                 timeout_config: TimeoutConfig::default(),
@@ -196,7 +197,8 @@ mod tests {
             config,
             AccessorConfig {
                 storage_config: StorageConfig::FileSystem {
-                    root_directory: "/tmp".to_string()
+                    root_directory: "/tmp".to_string(),
+                    atomic_write_dir: None,
                 },
                 retry_config: RetryConfig {
                     delay_factor: 2.0,

--- a/src/moonlink/src/storage/iceberg/file_catalog_test.rs
+++ b/src/moonlink/src/storage/iceberg/file_catalog_test.rs
@@ -62,6 +62,7 @@ async fn test_local_iceberg_table_creation() {
     let warehouse_path = temp_dir.path().to_str().unwrap();
     let storage_config = StorageConfig::FileSystem {
         root_directory: warehouse_path.to_string(),
+        atomic_write_dir: None,
     };
     let catalog = FileCatalog::new(
         AccessorConfig::new_with_storage_config(storage_config),

--- a/src/moonlink/src/storage/iceberg/file_catalog_test_utils.rs
+++ b/src/moonlink/src/storage/iceberg/file_catalog_test_utils.rs
@@ -13,6 +13,7 @@ pub(crate) fn create_test_file_catalog(tmp_dir: &TempDir, iceberg_schema: Schema
     let warehouse_path = tmp_dir.path().to_str().unwrap();
     let storage_config = StorageConfig::FileSystem {
         root_directory: warehouse_path.to_string(),
+        atomic_write_dir: None,
     };
     FileCatalog::new(
         AccessorConfig::new_with_storage_config(storage_config),

--- a/src/moonlink/src/storage/iceberg/iceberg_table_config.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_config.rs
@@ -20,6 +20,8 @@ impl Default for IcebergTableConfig {
     fn default() -> Self {
         let storage_config = StorageConfig::FileSystem {
             root_directory: Self::DEFAULT_WAREHOUSE_URI.to_string(),
+            // There's only one iceberg writer per-table, no need for atomic write feature.
+            atomic_write_dir: None,
         };
         Self {
             namespace: vec![Self::DEFAULT_NAMESPACE.to_string()],

--- a/src/moonlink/src/storage/mooncake_table/file_index_state_tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/file_index_state_tests.rs
@@ -188,6 +188,7 @@ pub(super) async fn create_mooncake_table_and_notify_for_index_merge(
 
     let storage_config = StorageConfig::FileSystem {
         root_directory: warehouse_uri.clone(),
+        atomic_write_dir: None,
     };
     let iceberg_table_config = IcebergTableConfig {
         accessor_config: AccessorConfig::new_with_storage_config(storage_config),

--- a/src/moonlink/src/storage/mooncake_table/table_creation_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_creation_test_utils.rs
@@ -33,7 +33,10 @@ use tokio::sync::mpsc::Receiver;
 /// Test util function to get iceberg table config for local filesystem.
 pub(crate) fn get_iceberg_table_config(temp_dir: &TempDir) -> IcebergTableConfig {
     let root_directory = temp_dir.path().to_str().unwrap().to_string();
-    let storage_config = StorageConfig::FileSystem { root_directory };
+    let storage_config = StorageConfig::FileSystem {
+        root_directory,
+        atomic_write_dir: None,
+    };
     let accessor_config = AccessorConfig::new_with_storage_config(storage_config);
     IcebergTableConfig {
         namespace: vec![ICEBERG_TEST_NAMESPACE.to_string()],
@@ -103,6 +106,7 @@ pub(crate) fn create_iceberg_table_config(warehouse_uri: String) -> IcebergTable
     } else {
         let storage_config = StorageConfig::FileSystem {
             root_directory: warehouse_uri.clone(),
+            atomic_write_dir: None,
         };
         AccessorConfig::new_with_storage_config(storage_config)
     };

--- a/src/moonlink/src/storage/mooncake_table/test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/test_utils.rs
@@ -48,7 +48,10 @@ pub fn test_row(id: i32, name: &str, age: i32) -> MoonlinkRow {
 /// Test util function to get iceberg table config for testing purpose.
 pub fn test_iceberg_table_config(context: &TestContext, table_name: &str) -> IcebergTableConfig {
     let root_directory = context.path().to_str().unwrap().to_string();
-    let storage_config = StorageConfig::FileSystem { root_directory };
+    let storage_config = StorageConfig::FileSystem {
+        root_directory,
+        atomic_write_dir: None,
+    };
     IcebergTableConfig {
         namespace: vec!["default".to_string()],
         table_name: table_name.to_string(),

--- a/src/moonlink/src/storage/wal.rs
+++ b/src/moonlink/src/storage/wal.rs
@@ -37,6 +37,8 @@ impl WalConfig {
                 .to_str()
                 .unwrap()
                 .to_string(),
+            // TODO(paul): evaluate atomic write option.
+            atomic_write_dir: None,
         };
         Self {
             accessor_config: AccessorConfig::new_with_storage_config(wal_storage_config),

--- a/src/moonlink/src/table_handler/chaos_test.rs
+++ b/src/moonlink/src/table_handler/chaos_test.rs
@@ -743,7 +743,10 @@ async fn test_chaos_on_local_fs_with_no_background_maintenance() {
         maintenance_option: TableMaintenanceOption::NoTableMaintenance,
         error_injection_enabled: false,
         event_count: 2500,
-        storage_config: StorageConfig::FileSystem { root_directory },
+        storage_config: StorageConfig::FileSystem {
+            root_directory,
+            atomic_write_dir: None,
+        },
     };
     let env = TestEnvironment::new(test_env_config).await;
     chaos_test_impl(env).await;
@@ -761,7 +764,10 @@ async fn test_chaos_on_local_fs_with_index_merge() {
         maintenance_option: TableMaintenanceOption::IndexMerge,
         error_injection_enabled: false,
         event_count: 3000,
-        storage_config: StorageConfig::FileSystem { root_directory },
+        storage_config: StorageConfig::FileSystem {
+            root_directory,
+            atomic_write_dir: None,
+        },
     };
     let env = TestEnvironment::new(test_env_config).await;
     chaos_test_impl(env).await;
@@ -779,7 +785,10 @@ async fn test_chaos_on_local_fs_with_data_compaction() {
         maintenance_option: TableMaintenanceOption::DataCompaction,
         error_injection_enabled: false,
         event_count: 3000,
-        storage_config: StorageConfig::FileSystem { root_directory },
+        storage_config: StorageConfig::FileSystem {
+            root_directory,
+            atomic_write_dir: None,
+        },
     };
     let env = TestEnvironment::new(test_env_config).await;
     chaos_test_impl(env).await;
@@ -801,7 +810,10 @@ async fn test_local_system_optimization_chaos_with_no_background_maintenance() {
         maintenance_option: TableMaintenanceOption::NoTableMaintenance,
         error_injection_enabled: false,
         event_count: 2500,
-        storage_config: StorageConfig::FileSystem { root_directory },
+        storage_config: StorageConfig::FileSystem {
+            root_directory,
+            atomic_write_dir: None,
+        },
     };
     let env = TestEnvironment::new(test_env_config).await;
     chaos_test_impl(env).await;
@@ -819,7 +831,10 @@ async fn test_local_system_optimization_chaos_with_index_merge() {
         maintenance_option: TableMaintenanceOption::IndexMerge,
         error_injection_enabled: false,
         event_count: 3000,
-        storage_config: StorageConfig::FileSystem { root_directory },
+        storage_config: StorageConfig::FileSystem {
+            root_directory,
+            atomic_write_dir: None,
+        },
     };
     let env = TestEnvironment::new(test_env_config).await;
     chaos_test_impl(env).await;
@@ -837,7 +852,10 @@ async fn test_local_system_optimization_chaos_with_data_compaction() {
         maintenance_option: TableMaintenanceOption::DataCompaction,
         error_injection_enabled: false,
         event_count: 3000,
-        storage_config: StorageConfig::FileSystem { root_directory },
+        storage_config: StorageConfig::FileSystem {
+            root_directory,
+            atomic_write_dir: None,
+        },
     };
     let env = TestEnvironment::new(test_env_config).await;
     chaos_test_impl(env).await;
@@ -987,7 +1005,10 @@ async fn test_chaos_injection_with_no_background_maintenance() {
         maintenance_option: TableMaintenanceOption::NoTableMaintenance,
         error_injection_enabled: true,
         event_count: 100,
-        storage_config: StorageConfig::FileSystem { root_directory },
+        storage_config: StorageConfig::FileSystem {
+            root_directory,
+            atomic_write_dir: None,
+        },
     };
     let env = TestEnvironment::new(test_env_config).await;
     chaos_test_impl(env).await;
@@ -1005,7 +1026,10 @@ async fn test_chaos_injection_with_index_merge() {
         maintenance_option: TableMaintenanceOption::IndexMerge,
         error_injection_enabled: true,
         event_count: 100,
-        storage_config: StorageConfig::FileSystem { root_directory },
+        storage_config: StorageConfig::FileSystem {
+            root_directory,
+            atomic_write_dir: None,
+        },
     };
     let env = TestEnvironment::new(test_env_config).await;
     chaos_test_impl(env).await;
@@ -1023,7 +1047,10 @@ async fn test_chaos_injection_with_data_compaction() {
         maintenance_option: TableMaintenanceOption::DataCompaction,
         error_injection_enabled: true,
         event_count: 100,
-        storage_config: StorageConfig::FileSystem { root_directory },
+        storage_config: StorageConfig::FileSystem {
+            root_directory,
+            atomic_write_dir: None,
+        },
     };
     let env = TestEnvironment::new(test_env_config).await;
     chaos_test_impl(env).await;

--- a/src/moonlink/src/table_handler/test_utils.rs
+++ b/src/moonlink/src/table_handler/test_utils.rs
@@ -44,6 +44,7 @@ pub fn create_row(id: i32, name: &str, age: i32) -> MoonlinkRow {
 pub fn get_iceberg_manager_config(table_name: String, warehouse_uri: String) -> IcebergTableConfig {
     let storage_config = StorageConfig::FileSystem {
         root_directory: warehouse_uri,
+        atomic_write_dir: None,
     };
     IcebergTableConfig {
         namespace: vec!["default".to_string()],

--- a/src/moonlink_backend/src/table_config.rs
+++ b/src/moonlink_backend/src/table_config.rs
@@ -64,6 +64,8 @@ impl TableConfig {
         if config.iceberg_config.is_none() {
             let storage_config = StorageConfig::FileSystem {
                 root_directory: default_table_directory.to_string(),
+                // By default disable atomic write option.
+                atomic_write_dir: None,
             };
             config.iceberg_config = Some(IcebergConfig::new_with_storage_config(storage_config));
         }
@@ -106,6 +108,7 @@ mod tests {
             iceberg_config: Some(IcebergConfig::new_with_storage_config(
                 moonlink::StorageConfig::FileSystem {
                     root_directory: "/tmp/path".to_string(),
+                    atomic_write_dir: None,
                 },
             )),
         };
@@ -143,6 +146,7 @@ mod tests {
             iceberg_config: Some(IcebergConfig::new_with_storage_config(
                 moonlink::StorageConfig::FileSystem {
                     root_directory: "/tmp".to_string(),
+                    atomic_write_dir: None,
                 },
             )),
         };

--- a/src/moonlink_backend/tests/common.rs
+++ b/src/moonlink_backend/tests/common.rs
@@ -64,7 +64,10 @@ impl TestGuard {
                 skip_data_compaction: true,
             },
             iceberg_config: Some(AccessorConfig::new_with_storage_config(
-                StorageConfig::FileSystem { root_directory },
+                StorageConfig::FileSystem {
+                    root_directory,
+                    atomic_write_dir: None,
+                },
             )),
         };
         serde_json::to_string(&table_config).unwrap()
@@ -267,7 +270,10 @@ fn get_serialized_table_config(tmp_dir: &TempDir) -> String {
             skip_data_compaction: true,
         },
         iceberg_config: Some(AccessorConfig::new_with_storage_config(
-            StorageConfig::FileSystem { root_directory },
+            StorageConfig::FileSystem {
+                root_directory,
+                atomic_write_dir: None,
+            },
         )),
     };
     serde_json::to_string(&table_config).unwrap()

--- a/src/moonlink_metadata_store/src/config_utils.rs
+++ b/src/moonlink_metadata_store/src/config_utils.rs
@@ -128,6 +128,8 @@ pub(crate) fn parse_moonlink_table_config(
 }
 
 /// Recover filesystem config from persisted config and secret.
+///
+/// For local filesystem, atomic write option is by default disabled, and it's caller's responsibility to enable if necessary.
 fn recover_storage_config(
     persisted_config: &MoonlinkTableConfigForPersistence,
     secret_entry: Option<MoonlinkTableSecret>,
@@ -166,12 +168,14 @@ fn recover_storage_config(
             MoonlinkSecretType::FileSystem => {
                 return StorageConfig::FileSystem {
                     root_directory: persisted_config.iceberg_table_config.warehouse_uri.clone(),
+                    atomic_write_dir: None,
                 };
             }
         }
     }
     StorageConfig::FileSystem {
         root_directory: persisted_config.iceberg_table_config.warehouse_uri.clone(),
+        atomic_write_dir: None,
     }
 }
 

--- a/src/moonlink_metadata_store/src/sqlite/tests.rs
+++ b/src/moonlink_metadata_store/src/sqlite/tests.rs
@@ -46,6 +46,7 @@ fn get_storage_config() -> StorageConfig {
     {
         return StorageConfig::FileSystem {
             root_directory: "/tmp/test_warehouse_uri".to_string(),
+            atomic_write_dir: None,
         };
     }
 

--- a/src/moonlink_metadata_store/tests/common/test_utils.rs
+++ b/src/moonlink_metadata_store/tests/common/test_utils.rs
@@ -10,6 +10,7 @@ pub(crate) fn get_moonlink_table_config() -> MoonlinkTableConfig {
             table_name: "table".to_string(),
             accessor_config: AccessorConfig::new_with_storage_config(StorageConfig::FileSystem {
                 root_directory: "/tmp/test_warehouse_uri".to_string(),
+                atomic_write_dir: None,
             }),
         },
         ..Default::default()


### PR DESCRIPTION
## Summary

This PR exposes atomic write option for local filesystem, which WAL might need.
Exposed interface resembles the one by opendal: provide an optional field and by default off.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1235
Closes https://github.com/Mooncake-Labs/moonlink/issues/1234

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [x] Documentation updated if necessary
- [x] I have reviewed my own changes
