### PR TITLE
hold deletion vectors for streaming batches in snapshot task

### DIFF
--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -206,8 +206,8 @@ pub struct SnapshotTask {
     new_disk_slices: Vec<DiskSliceWriter>,
     disk_file_lsn_map: HashMap<FileId, u64>,
     new_deletions: Vec<RawDeletionRecord>,
-    /// Pair of <batch id, record batch>.
-    new_record_batches: Vec<(u64, Arc<RecordBatch>)>,
+    /// Pair of <batch id, record batch, optional deletion vector for streaming batches>.
+    new_record_batches: Vec<(u64, Arc<RecordBatch>, Option<BatchDeletionVector>)>,
     new_rows: Option<SharedRowBufferSnapshot>,
     new_mem_indices: Vec<Arc<MemIndex>>,
     /// Assigned (non-zero) after a commit event.
@@ -727,7 +727,9 @@ impl MooncakeTable {
         let lookup_key = self.metadata.identity.get_lookup_key(&row);
         let identity_for_key = self.metadata.identity.extract_identity_for_key(&row);
         if let Some(batch) = self.mem_slice.append(lookup_key, row, identity_for_key)? {
-            self.next_snapshot_task.new_record_batches.push(batch);
+            self.next_snapshot_task
+                .new_record_batches
+                .push((batch.0, batch.1, None));
         }
         Ok(())
     }
@@ -799,7 +801,7 @@ impl MooncakeTable {
         let index = Arc::new(index);
         if let Some(task) = snapshot_task {
             if let Some(batch) = new_batch {
-                task.new_record_batches.push(batch);
+                task.new_record_batches.push((batch.0, batch.1, None));
             }
             task.new_mem_indices.push(index.clone());
         }

--- a/src/moonlink/src/storage/mooncake_table/delete_vector.rs
+++ b/src/moonlink/src/storage/mooncake_table/delete_vector.rs
@@ -52,6 +52,15 @@ impl BatchDeletionVector {
     #[must_use]
     pub(crate) fn delete_row(&mut self, row_idx: usize) -> bool {
         ma::assert_gt!(self.max_rows, 0);
+        println!("max rows is: {}", self.max_rows);
+
+        // CRITICAL ASSERTION: Catch the actual bug - deletion records with row_ids beyond deletion vector capacity
+        assert!(
+            row_idx < self.max_rows,
+            "Deletion vector capacity exceeded: trying to delete row_idx {} but deletion vector only has capacity for {} rows. \
+            This indicates a misalignment where deletion records reference rows beyond the deletion vector's range.",
+            row_idx, self.max_rows
+        );
 
         // Set the bit at row_idx to 1 (deleted)
         self.initialize_vector_for_once();

--- a/src/moonlink/src/storage/mooncake_table/delete_vector.rs
+++ b/src/moonlink/src/storage/mooncake_table/delete_vector.rs
@@ -52,9 +52,7 @@ impl BatchDeletionVector {
     #[must_use]
     pub(crate) fn delete_row(&mut self, row_idx: usize) -> bool {
         ma::assert_gt!(self.max_rows, 0);
-        println!("max rows is: {}", self.max_rows);
 
-        // CRITICAL ASSERTION: Catch the actual bug - deletion records with row_ids beyond deletion vector capacity
         assert!(
             row_idx < self.max_rows,
             "Deletion vector capacity exceeded: trying to delete row_idx {} but deletion vector only has capacity for {} rows. \

--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -619,13 +619,10 @@ impl SnapshotTableState {
     }
 
     fn finalize_batches(&mut self, task: &mut SnapshotTask) {
-        if task.new_record_batches.is_empty() {
-            return;
-        }
-
         let incoming = take(&mut task.new_record_batches);
-        let (streaming_batches, mut non_streaming_batches): (Vec<_>, Vec<_>) =
-            incoming.into_iter().partition(|(id, _)| *id < (1u64 << 63));
+        let (streaming_batches, mut non_streaming_batches): (Vec<_>, Vec<_>) = incoming
+            .into_iter()
+            .partition(|(id, _, _)| *id < (1u64 << 63));
 
         if !non_streaming_batches.is_empty() {
             // close previously‐open batch
@@ -647,17 +644,22 @@ impl SnapshotTableState {
 
         // Add completed batches
         // Assert that no incoming batch ID is already present in the map.
-        for (id, rb) in streaming_batches
+        for (id, rb, deletion_vector) in streaming_batches
             .into_iter()
             .chain(non_streaming_batches.into_iter())
         {
+            let deletions = match deletion_vector {
+                Some(dv) => dv, // Use the deletion vector from streaming transaction
+                None => BatchDeletionVector::new(rb.num_rows()), // Create fresh deletion vector for non-streaming
+            };
+
             assert!(
                 self.batches
                     .insert(
                         id,
                         InMemoryBatch {
                             data: Some(rb.clone()),
-                            deletions: BatchDeletionVector::new(rb.num_rows()),
+                            deletions,
                         }
                     )
                     .is_none(),

--- a/src/moonlink/src/table_handler/tests.rs
+++ b/src/moonlink/src/table_handler/tests.rs
@@ -2150,3 +2150,16 @@ async fn test_commit_flush_streaming_transaction_with_deletes() {
 
     env.shutdown().await;
 }
+
+/// Minimal test to ensure we panic when deletion records have row_ids exceeding deletion vector capacity
+#[test]
+#[should_panic(expected = "Deletion vector capacity exceeded")]
+fn test_deletion_vector_capacity_exceeded_minimal() {
+    use crate::storage::mooncake_table::delete_vector::BatchDeletionVector;
+
+    // Create a deletion vector with capacity for only 3 rows (0, 1, 2)
+    let mut deletion_vector = BatchDeletionVector::new(3);
+
+    // This should panic - trying to delete row_id=5 when capacity is only 3
+    let _ = deletion_vector.delete_row(5);
+}


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

In the case that a streaming transaction deletes from its own mem slice, we apply the deletion [inline](https://github.com/Mooncake-Labs/moonlink/blob/1f5f369c20e0d587d535eedca379a2385f4fb47b/src/moonlink/src/storage/mooncake_table/transaction_stream.rs#L178) and then filter the batch when preparing the disk slice/commit the transaction.

This is incorrect. We are not able to filter the batches at this point since its possible we have created deletion vectors that depend on the row_ids of these batches. However, we also currently don't persist deletion vector information when adding batches to snapshot task, so if we don't filter the batches we will lose deletion information.

The correct approach is to maintain deletion vector information when adding to snapshot task in the streaming case, and leave as none for non-streaming. Then we can avoid filtering batches and causing out-of-bound errors for deletes. 

## Related Issues

Closes #<issue-number> or links to related issues.

## Changes

- 
- 
- 

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
