### PR TITLE
[deployment] Service for moonlink and data server

### DIFF
--- a/cloud/gcp/deployment/moonlink_deployment.yaml
+++ b/cloud/gcp/deployment/moonlink_deployment.yaml
@@ -1,22 +1,20 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: my-rust-cli
+  name: moonlink-deployment
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: my-rust-cli
+      app: moonlink-deployment
   template:
     metadata:
       labels:
-        app: my-rust-cli
+        app: moonlink-deployment
     spec:
       containers:
-      # TODO(hjiang): Rename container name.
-      # TODO(hjiang): Add resource limit/request.
-      - name: my-rust-cli
-        image: us-west1-docker.pkg.dev/coral-ring-465417-r0/moonlink-standalone-experiment/my-rust-cli:deefde16-0ab8-4c03-90b6-b1a2ae201df0
+      - name: moonlink-deployment
+        image: us-west1-docker.pkg.dev/coral-ring-465417-r0/moonlink-standalone-experiment/moonlink-deployment:bc30497c-e2e2-48c1-8dea-ce565ac1b4d4
         env:
         - name: PGHOST
           value: localhost
@@ -28,7 +26,19 @@ spec:
           value: mydb
         - name: PGPORT
           value: "5432"
-      # TODO(hjiang): Postgres container to test moonlink.
+        volumeMounts:
+        - name: shared-cache-directory
+          mountPath: /tmp/moonlink
+
+      - name: nginx
+        image: nginx:latest
+        ports:
+        - containerPort: 80
+        volumeMounts:
+        # nginx serves local files under certain directory.
+        - name: shared-cache-directory
+          mountPath: /usr/share/nginx/html
+
       - name: postgres
         image: postgres:17
         env:
@@ -45,6 +55,10 @@ spec:
         volumeMounts:
         - name: pgdata
           mountPath: /var/lib/postgresql/data
+
       volumes:
       - name: pgdata
+        emptyDir: {}
+      # Shared cache directory between data server and moonlink.
+      - name: shared-cache-directory
         emptyDir: {}

--- a/cloud/gcp/service/moonlink_service.yaml
+++ b/cloud/gcp/service/moonlink_service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: moonlink-service
+spec:
+  type: LoadBalancer
+  # IP assigned by kubernetes automatically.
+  selector:
+    app: moonlink-deployment
+  ports:
+  - protocol: TCP
+    port: 8080
+    targetPort: 80


### PR DESCRIPTION
## Summary

This PR deploys moonlink service, which exposes data server endpoint.
I checked with curl and confirm it works to access cache files.
```sh
root@moonlink-deployment-75746db7d7-nlnqs:/# ls -lR ls /usr/share/nginx/html
ls: cannot access 'ls': No such file or directory
/usr/share/nginx/html:
total 4
drwxr-xr-x 2 root root 4096 Aug  6 22:57 read_cache

/usr/share/nginx/html/read_cache:
total 4
-rw-r--r-- 1 root root 11 Aug  6 22:57 helloworld
```
curl request and response:
```sh
(myenv) hjiang@hjiangs-MacBook-Pro moonlink % curl http://<IP>:8080/read_cache/helloworld
helloworld
```

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1230
Closes https://github.com/Mooncake-Labs/moonlink/issues/1222

## Checklist

- [ ] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
