### PR TITLE
[storage] Clean up default metadata storage crate

### DIFF
--- a/logs/xvba_debug.log
+++ b/logs/xvba_debug.log
@@ -1,0 +1,1 @@
+2025-08-07 15:23:06 info: XVBA Ribbon Starts

--- a/src/moonlink_metadata_store/Cargo.toml
+++ b/src/moonlink_metadata_store/Cargo.toml
@@ -5,7 +5,9 @@ edition = { workspace = true }
 license = { workspace = true }
 
 [features]
-default = ["storage-fs", "metadata-postgres", "metadata-sqlite"]
+default = ["storage-fs", "metadata-sqlite"]
+storage-all = ["storage-fs", "metadata-postgres", "metadata-sqlite"]
+test-utils = []
 
 storage-s3 = ["moonlink/storage-s3"]
 storage-gcs = ["moonlink/storage-gcs"]
@@ -31,3 +33,13 @@ url = { workspace = true }
 
 [dev-dependencies]
 serial_test = { workspace = true }
+
+[[test]]
+name = "test_pg_metadata_store_utils"
+path = "tests/test_pg_metadata_store_utils.rs"
+required-features = ["metadata-postgres"]
+
+[[test]]
+name = "test_pg_metadata_store"
+path = "tests/test_pg_metadata_store.rs"
+required-features = ["metadata-postgres"]

--- a/src/moonlink_metadata_store/src/error.rs
+++ b/src/moonlink_metadata_store/src/error.rs
@@ -1,10 +1,13 @@
 use serde_json::Error as SerdeJsonError;
 use std::sync::Arc;
 use thiserror::Error;
+
+#[cfg(feature = "metadata-postgres")]
 use tokio_postgres::Error as TokioPostgresError;
 
 #[derive(Clone, Debug, Error)]
 pub enum Error {
+    #[cfg(feature = "metadata-postgres")]
     #[error("tokio postgres error: {source}")]
     TokioPostgres { source: Arc<TokioPostgresError> },
 
@@ -35,6 +38,7 @@ pub enum Error {
 
 pub type Result<T> = std::result::Result<T, Error>;
 
+#[cfg(feature = "metadata-postgres")]
 impl From<TokioPostgresError> for Error {
     fn from(source: TokioPostgresError) -> Self {
         Error::TokioPostgres {

--- a/src/moonlink_metadata_store/src/lib.rs
+++ b/src/moonlink_metadata_store/src/lib.rs
@@ -2,10 +2,13 @@ pub mod base_metadata_store;
 mod config_utils;
 pub mod error;
 pub mod metadata_store_utils;
+
+#[cfg(feature = "metadata-postgres")]
 mod postgres;
 mod sqlite;
 
-pub use postgres::pg_metadata_store::PgMetadataStore;
-pub use postgres::utils as PgUtils;
+#[cfg(feature = "metadata-postgres")]
+pub use {postgres::pg_metadata_store::PgMetadataStore, postgres::utils as PgUtils};
+
 pub use sqlite::sqlite_metadata_store::SqliteMetadataStore;
 pub use sqlite::utils as SqliteUtils;


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

Make metadata-sqlite optional for compilation

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1246

## Changes

Cargo.toml:
	•	remove metadata-sqlite from default setting
	•	Silence postgres tests for other features
Others (lib.rs, error.rs):
	•	Add #[cfg(feature = "metadata-postgres")] for choosing package

## Checklist

- [✓] Code builds correctly
- [✓] Tests have been added or updated
- [✓] Documentation updated if necessary
- [✓] I have reviewed my own changes
