### PR TITLE
[REST] Enable graceful shutdown for REST API server

### DIFF
--- a/src/moonlink_service/src/error.rs
+++ b/src/moonlink_service/src/error.rs
@@ -8,6 +8,8 @@ pub enum Error {
     Io(#[from] std::io::Error),
     #[error("RPC error: {0}")]
     Rpc(#[from] moonlink_rpc::Error),
+    #[error("Join error: {0}.")]
+    TokioTaskJoin(#[from] tokio::task::JoinError),
 }
 
 pub type Result<T> = std::result::Result<T, Error>;


### PR DESCRIPTION
## Summary

Certain things I would like to followup later inside of termination handler, a few examples:
- create iceberg snapshot if possible
- flush stats (after I add observability metrics)

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
