### PR TITLE
chore: use smallvec in LRU cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2731,6 +2731,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1",
+ "smallvec",
  "tempfile",
  "thiserror 2.0.12",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ roaring = "0.11"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = "1"
 serial_test = "3.0"
+smallvec = "1.15.1"
 tempfile = "3"
 thiserror = "2"
 tokio = { version = "1.47", default-features = false, features = [

--- a/src/moonlink/Cargo.toml
+++ b/src/moonlink/Cargo.toml
@@ -70,6 +70,7 @@ roaring = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha1 = { version = "0.10", optional = true }
+smallvec = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-bitstream-io = { workspace = true }

--- a/src/moonlink/src/storage/cache/object_storage/base_cache.rs
+++ b/src/moonlink/src/storage/cache/object_storage/base_cache.rs
@@ -9,6 +9,7 @@ use crate::storage::cache::object_storage::cache_handle::NonEvictableHandle;
 use crate::storage::filesystem::accessor::base_filesystem_accessor::BaseFileSystemAccess;
 use crate::storage::storage_utils::TableUniqueFileId;
 use crate::Result;
+use smallvec::SmallVec;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct FileMetadata {
@@ -34,12 +35,13 @@ pub trait CacheTrait {
         &mut self,
         file_id: TableUniqueFileId,
         cache_entry: CacheEntry,
-    ) -> (NonEvictableHandle, Vec<String>);
+    ) -> (NonEvictableHandle, SmallVec<[String; 1]>);
 
     /// Similar to [`delete_cache_entry`], but doesn't panic if requested entry doesn't exist.
     #[must_use]
     #[allow(async_fn_in_trait)]
-    async fn try_delete_cache_entry(&mut self, file_id: TableUniqueFileId) -> Vec<String>;
+    async fn try_delete_cache_entry(&mut self, file_id: TableUniqueFileId)
+        -> SmallVec<[String; 1]>;
 
     /// Attempt to get a pinned cache file entry.
     ///
@@ -55,6 +57,6 @@ pub trait CacheTrait {
         filesystem_accessor: &dyn BaseFileSystemAccess,
     ) -> Result<(
         Option<NonEvictableHandle>,
-        Vec<String>, /*files_to_delete*/
+        SmallVec<[String; 1]>, /*files_to_delete*/
     )>;
 }

--- a/src/moonlink/src/storage/cache/object_storage/cache_handle.rs
+++ b/src/moonlink/src/storage/cache/object_storage/cache_handle.rs
@@ -4,6 +4,7 @@ use crate::storage::cache::object_storage::base_cache::CacheEntry;
 use crate::storage::cache::object_storage::object_storage_cache::ObjectStorageCacheInternal;
 use crate::storage::storage_utils::TableUniqueFileId;
 
+use smallvec::SmallVec;
 use tokio::sync::RwLock;
 
 #[derive(Clone)]
@@ -52,7 +53,7 @@ impl NonEvictableHandle {
 
     /// Unreference and pinned cache file and mark it as deleted.
     #[must_use]
-    pub(crate) async fn unreference_and_delete(&mut self) -> Vec<String> {
+    pub(crate) async fn unreference_and_delete(&mut self) -> SmallVec<[String; 1]> {
         let mut guard = self.cache.write().await;
 
         // Total bytes within cache doesn't change, so current cache entry not evicted.

--- a/src/moonlink/src/storage/cache/object_storage/object_storage_cache.rs
+++ b/src/moonlink/src/storage/cache/object_storage/object_storage_cache.rs
@@ -12,6 +12,7 @@ use crate::Result;
 
 use lru::LruCache;
 use more_asserts as ma;
+use smallvec::SmallVec;
 #[cfg(test)]
 use tempfile::TempDir;
 use tokio::sync::RwLock;
@@ -118,7 +119,7 @@ impl ObjectStorageCacheInternal {
         &mut self,
         file_id: TableUniqueFileId,
         panic_if_non_existent: bool,
-    ) -> Vec<String> {
+    ) -> SmallVec<[String; 1]> {
         let mut evicted_files_to_delete = vec![];
 
         // If the requested entries are already evictable, remove it directly.
@@ -140,7 +141,7 @@ impl ObjectStorageCacheInternal {
             }
         }
 
-        evicted_files_to_delete
+        evicted_files_to_delete.into()
     }
 
     /// Unreference the given cache entry.
@@ -388,7 +389,7 @@ impl CacheTrait for ObjectStorageCache {
         &mut self,
         file_id: TableUniqueFileId,
         cache_entry: CacheEntry,
-    ) -> (NonEvictableHandle, Vec<String>) {
+    ) -> (NonEvictableHandle, SmallVec<[String; 1]>) {
         let cache_entry_wrapper = CacheEntryWrapper {
             cache_entry: cache_entry.clone(),
             reference_count: 1,
@@ -409,7 +410,7 @@ impl CacheTrait for ObjectStorageCache {
                 /*tolerate_insufficiency=*/ false,
             )
             .1;
-        (non_evictable_handle, cache_files_to_delete)
+        (non_evictable_handle, cache_files_to_delete.into())
     }
 
     async fn get_cache_entry(
@@ -419,7 +420,7 @@ impl CacheTrait for ObjectStorageCache {
         filesystem_accessor: &dyn BaseFileSystemAccess,
     ) -> Result<(
         Option<NonEvictableHandle>,
-        Vec<String>, /*files_to_delete*/
+        SmallVec<[String; 1]>, /*files_to_delete*/
     )> {
         {
             let mut guard = self.cache.write().await;
@@ -432,7 +433,10 @@ impl CacheTrait for ObjectStorageCache {
                 let cache_entry = value.cache_entry.clone();
                 let non_evictable_handle =
                     NonEvictableHandle::new(file_id, cache_entry, self.cache.clone());
-                return Ok((Some(non_evictable_handle), /*files_to_delete=*/ vec![]));
+                return Ok((
+                    Some(non_evictable_handle),
+                    /*files_to_delete=*/ vec![].into(),
+                ));
             }
 
             // Check evictable cache.
@@ -452,7 +456,10 @@ impl CacheTrait for ObjectStorageCache {
                 assert!(files_to_delete.is_empty());
                 let non_evictable_handle =
                     NonEvictableHandle::new(file_id, cache_entry, self.cache.clone());
-                return Ok((Some(non_evictable_handle), /*files_to_delete=*/ vec![]));
+                return Ok((
+                    Some(non_evictable_handle),
+                    /*files_to_delete=*/ vec![].into(),
+                ));
             }
         }
 
@@ -478,18 +485,21 @@ impl CacheTrait for ObjectStorageCache {
                 /*tolerate_insufficiency=*/ true,
             );
             if cache_succ {
-                return Ok((Some(non_evictable_handle), files_to_delete));
+                return Ok((Some(non_evictable_handle), files_to_delete.into()));
             }
 
             // Otherwise, it means cache entry failed to insert.
             ma::assert_ge!(guard.cur_bytes, file_size);
             guard.cur_bytes -= file_size;
 
-            Ok((None, files_to_delete))
+            Ok((None, files_to_delete.into()))
         }
     }
 
-    async fn try_delete_cache_entry(&mut self, file_id: TableUniqueFileId) -> Vec<String> {
+    async fn try_delete_cache_entry(
+        &mut self,
+        file_id: TableUniqueFileId,
+    ) -> SmallVec<[String; 1]> {
         let mut guard = self.cache.write().await;
         guard.delete_cache_entry(file_id, /*panic_if_non_existent=*/ false)
     }

--- a/src/moonlink/src/storage/cache/object_storage/state_tests.rs
+++ b/src/moonlink/src/storage/cache/object_storage/state_tests.rs
@@ -36,6 +36,7 @@ use crate::storage::cache::object_storage::object_storage_cache::ObjectStorageCa
 use crate::storage::cache::object_storage::test_utils::*;
 use crate::storage::filesystem::accessor::filesystem_accessor::FileSystemAccessor;
 
+use smallvec::SmallVec;
 use tempfile::tempdir;
 
 // (1) + create mooncake snapshot => (2)
@@ -321,7 +322,7 @@ async fn test_cache_2_new_entry_with_insufficient_space() {
     )
     .await;
     let cache_file_1 = cache_handle_1.cache_entry.cache_filepath.clone();
-    assert_eq!(files_to_evict, vec![cache_file_1]);
+    assert_eq!(files_to_evict, SmallVec::from([cache_file_1]));
 
     // Check cache status.
     assert_cache_bytes_size(&mut cache, /*expected_bytes=*/ CONTENT.len() as u64).await;
@@ -472,7 +473,10 @@ async fn test_cache_2_requested_to_delete_4() {
 
     // Unreference and delete cache handle, so requested cache handle is not referenced.
     let evicted_files = cache_handle.unreference_and_delete().await;
-    assert_eq!(evicted_files, vec![test_file.to_str().unwrap().to_string()]);
+    assert_eq!(
+        evicted_files,
+        SmallVec::from([test_file.to_str().unwrap().to_string()])
+    );
 
     // Check cache status.
     assert_cache_bytes_size(&mut cache, /*expected_bytes=*/ 0).await;

--- a/src/moonlink/src/storage/mooncake_table/snapshot_read_output.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot_read_output.rs
@@ -92,7 +92,7 @@ impl ReadOutput {
                             .unwrap()
                             .send(TableEvent::EvictedFilesToDelete {
                                 evicted_files: EvictedFiles {
-                                    files: files_to_delete,
+                                    files: files_to_delete.to_vec(),
                                 },
                             })
                             .await


### PR DESCRIPTION
## Summary

- Replace Vec with size 1 smallvec to avoid allocation problem

## Related Issues

Closes #https://github.com/Mooncake-Labs/moonlink/issues/563
## Changes

- Replace Vec with size 1 smallvec
- Fix relates test

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
