### PR TITLE
[deployment] Implement moonlink TCP server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,5 +22,3 @@ RUN apt-get update && \
 WORKDIR /app
 
 COPY --from=builder /workspace/target/x86_64-unknown-linux-gnu/debug/moonlink_service .
-
-ENTRYPOINT ["/app/moonlink_service", "/tmp/moonlink"]

--- a/cloud/gcp/deployment/moonlink_deployment.yaml
+++ b/cloud/gcp/deployment/moonlink_deployment.yaml
@@ -15,24 +15,13 @@ spec:
       containers:
       # Moonlink deployment, which serves REST API and TCP rpc requests.
       - name: moonlink-deployment
-        image: us-west1-docker.pkg.dev/coral-ring-465417-r0/moonlink-standalone-experiment/moonlink-deployment:8aa98bda-70da-47ab-abcf-0eadda072665
+        image: us-west1-docker.pkg.dev/coral-ring-465417-r0/moonlink-standalone-experiment/moonlink-deployment:42f29a70-e2f2-4ac2-99f8-95f830464ecc
         command: ["/app/moonlink_service"]
         args:
         - "/tmp/moonlink"
         - "--no-rest-api"
         - "--tcp-port=3031"
         env:
-        # TODO(hjiang): Remove all pg test related envs before release. 
-        - name: PGHOST
-          value: localhost
-        - name: PGUSER
-          value: user
-        - name: PGPASSWORD
-          value: password
-        - name: PGDATABASE
-          value: mydb
-        - name: PGPORT
-          value: "5432"
         volumeMounts:
         - name: shared-cache-directory
           mountPath: /tmp/moonlink
@@ -54,16 +43,10 @@ spec:
 
       # TODO(hjiang): Currently serves merely as source database to sync from, need to remove before release.
       - name: postgres
-        image: postgres:17
+        image: mooncakelabs/pg_mooncake
         env:
-        - name: POSTGRES_USER
-          value: user
         - name: POSTGRES_PASSWORD
           value: password
-        - name: POSTGRES_DB
-          value: mydb
-        - name: POSTGRES_INITDB_ARGS
-          value: "-c wal_level=logical"
         ports:
         - containerPort: 5432
         volumeMounts:

--- a/cloud/gcp/deployment/moonlink_deployment.yaml
+++ b/cloud/gcp/deployment/moonlink_deployment.yaml
@@ -13,9 +13,16 @@ spec:
         app: moonlink-deployment
     spec:
       containers:
+      # Moonlink deployment, which serves REST API and TCP rpc requests.
       - name: moonlink-deployment
-        image: us-west1-docker.pkg.dev/coral-ring-465417-r0/moonlink-standalone-experiment/moonlink-deployment:bc30497c-e2e2-48c1-8dea-ce565ac1b4d4
+        image: us-west1-docker.pkg.dev/coral-ring-465417-r0/moonlink-standalone-experiment/moonlink-deployment:8aa98bda-70da-47ab-abcf-0eadda072665
+        command: ["/app/moonlink_service"]
+        args:
+        - "/tmp/moonlink"
+        - "--no-rest-api"
+        - "--tcp-port=3031"
         env:
+        # TODO(hjiang): Remove all pg test related envs before release. 
         - name: PGHOST
           value: localhost
         - name: PGUSER
@@ -29,7 +36,13 @@ spec:
         volumeMounts:
         - name: shared-cache-directory
           mountPath: /tmp/moonlink
+        ports:
+        # Port number for REST API server.
+        - containerPort: 3030
+        # Port number for TCP rpc server.
+        - containerPort: 3031
 
+      # Data server, which serves data plane requests.
       - name: nginx
         image: nginx:latest
         ports:
@@ -39,6 +52,7 @@ spec:
         - name: shared-cache-directory
           mountPath: /usr/share/nginx/html
 
+      # TODO(hjiang): Currently serves merely as source database to sync from, need to remove before release.
       - name: postgres
         image: postgres:17
         env:

--- a/cloud/gcp/service/moonlink_service.yaml
+++ b/cloud/gcp/service/moonlink_service.yaml
@@ -8,6 +8,18 @@ spec:
   selector:
     app: moonlink-deployment
   ports:
-  - protocol: TCP
+  # Exposed port for data server.
+  - name: data
+    protocol: TCP
     port: 8080
     targetPort: 80
+  # Exposed port for REST API server.
+  - name: rest
+    protocol: TCP
+    port: 3030
+    targetPort: 3030
+  # Exposed port for TCP rpc server.
+  - name: tcp
+    protocol: TCP
+    port: 3031
+    targetPort: 3031

--- a/cloud/gcp/service/postgres_service.yaml
+++ b/cloud/gcp/service/postgres_service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres-service
+spec:
+  type: LoadBalancer
+  selector:
+    app: moonlink-deployment
+  ports:
+    - name: postgres
+      protocol: TCP
+      port: 5432
+      targetPort: 5432

--- a/src/moonlink_service/examples/rest_api_demo.rs
+++ b/src/moonlink_service/examples/rest_api_demo.rs
@@ -23,6 +23,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         if let Err(e) = moonlink_service::start_with_config(ServiceConfig {
             base_path: demo_path.to_string(),
             rest_api_port: Some(3030),
+            tcp_port: None,
         })
         .await
         {

--- a/src/moonlink_service/src/lib.rs
+++ b/src/moonlink_service/src/lib.rs
@@ -62,8 +62,9 @@ pub async fn start_with_config(config: ServiceConfig) -> Result<()> {
         // TODO(hjiang): Implement graceful shutdown for TCP server.
         let handle = tokio::spawn(async move {
             if let Err(e) = rpc_server::start_tcp_server(backend_clone, addr).await {
-                error!("TCP server failed: {}", e);
+                error!("TCP rpc server failed: {}", e);
             }
+            println!("TCP rpc server starts at port {port}");
         });
         Some(handle)
     } else {

--- a/src/moonlink_service/src/lib.rs
+++ b/src/moonlink_service/src/lib.rs
@@ -7,11 +7,15 @@ use moonlink_backend::MoonlinkBackend;
 use moonlink_metadata_store::SqliteMetadataStore;
 use std::sync::Arc;
 use tokio::signal::unix::{signal, SignalKind};
-use tracing::{info, warn};
+use tracing::{info, error};
 
 pub struct ServiceConfig {
+    /// Base location for moonlink storage (including cache files, iceberg tables, etc).
     pub base_path: String,
+    /// Used for REST API as ingestion source.
     pub rest_api_port: Option<u16>,
+    /// Used for moonlink standalone deployment.
+    pub tcp_port: Option<u16>,
 }
 
 pub async fn start_with_config(config: ServiceConfig) -> Result<()> {
@@ -33,7 +37,7 @@ pub async fn start_with_config(config: ServiceConfig) -> Result<()> {
     let rpc_backend = backend.clone();
     let rpc_handle = tokio::spawn(async move {
         if let Err(e) = rpc_server::start_unix_server(rpc_backend, socket_path).await {
-            warn!("RPC server failed: {}", e);
+            error!("RPC server failed: {}", e);
         }
     });
 
@@ -42,7 +46,20 @@ pub async fn start_with_config(config: ServiceConfig) -> Result<()> {
         let api_state = rest_api::ApiState::new(backend.clone());
         Some(tokio::spawn(async move {
             if let Err(e) = rest_api::start_server(api_state, port).await {
-                warn!("REST API server failed: {}", e);
+                error!("REST API server failed: {}", e);
+            }
+        }))
+    } else {
+        None
+    };    
+
+    // Optionally start TCP server.
+    let tcp_api_handle = if let Some(port) = config.tcp_port {
+        let backend_clone = backend.clone();
+        let addr: std::net::SocketAddr = format!("0.0.0.0:{port}").parse().unwrap();
+        Some(tokio::spawn(async move {
+            if let Err(e) = rpc_server::start_tcp_server(backend_clone, addr).await {
+                error!("TCP server failed: {}", e);
             }
         }))
     } else {

--- a/src/moonlink_service/src/main.rs
+++ b/src/moonlink_service/src/main.rs
@@ -11,10 +11,16 @@ struct Cli {
     /// Port for REST API server (optional, defaults to 3030)
     #[arg(long, short = 'p')]
     rest_api_port: Option<u16>,
-
     /// Disable REST API server
     #[arg(long)]
     no_rest_api: bool,
+
+    /// Port for moonlink standalone server (optional, defaults to 3031).
+    #[arg(long, short = 'p')]
+    tcp_port: Option<u16>,
+    /// Disable standalone deployment.
+    #[arg(long)]
+    no_tcp_api: bool,
 }
 
 #[tokio::main]
@@ -28,6 +34,11 @@ pub async fn main() -> Result<()> {
         } else {
             Some(cli.rest_api_port.unwrap_or(3030))
         },
+        tcp_port: if cli.no_tcp_api {
+            None
+        } else {
+            Some(cli.tcp_port.unwrap_or(3031))
+        }
     };
 
     start_with_config(config).await

--- a/src/moonlink_service/src/main.rs
+++ b/src/moonlink_service/src/main.rs
@@ -16,7 +16,7 @@ struct Cli {
     no_rest_api: bool,
 
     /// Port for moonlink standalone server (optional, defaults to 3031).
-    #[arg(long, short = 'p')]
+    #[arg(long)]
     tcp_port: Option<u16>,
     /// Disable standalone deployment.
     #[arg(long)]

--- a/src/moonlink_service/src/rpc_server.rs
+++ b/src/moonlink_service/src/rpc_server.rs
@@ -69,7 +69,8 @@ where
 {
     let mut map = HashMap::new();
     loop {
-        match read(&mut stream).await? {
+        let request = read(&mut stream).await?;
+        match request {
             Request::CreateSnapshot {
                 database_id,
                 table_id,

--- a/src/moonlink_service/src/rpc_server.rs
+++ b/src/moonlink_service/src/rpc_server.rs
@@ -2,11 +2,13 @@ use crate::{error::Error, Result};
 use arrow_ipc::writer::StreamWriter;
 use moonlink_backend::MoonlinkBackend;
 use moonlink_rpc::{read, write, Request, Table};
+use tokio::io::{AsyncRead, AsyncWrite};
+use std::net::SocketAddr;
 use std::collections::HashMap;
 use std::io::ErrorKind::{BrokenPipe, ConnectionReset, UnexpectedEof};
 use std::sync::Arc;
 use tokio::fs;
-use tokio::net::{UnixListener, UnixStream};
+use tokio::net::{TcpListener, UnixListener, UnixStream};
 use tracing::info;
 
 /// Start the Unix socket RPC server and serve requests until the task is aborted.
@@ -37,10 +39,37 @@ pub async fn start_unix_server(
     }
 }
 
-async fn handle_stream(
+/// Start the TCP socket RPC server and serve requests until the task is aborted.
+/// 
+/// TODO(hjiang): Better error handling.
+pub async fn start_tcp_server(
     backend: Arc<MoonlinkBackend<u32, u32>>,
-    mut stream: UnixStream,
+    addr: SocketAddr,
 ) -> Result<()> {
+    let listener = TcpListener::bind(addr).await?;
+    info!("Moonlink RPC server listening on TCP: {}", addr);
+
+    loop {
+        let (stream, _) = listener.accept().await?;
+        let backend = Arc::clone(&backend);
+        tokio::spawn(async move {
+            match handle_stream(backend, stream).await {
+                Err(Error::Rpc(moonlink_rpc::Error::Io(e)))
+                    if matches!(e.kind(), BrokenPipe | ConnectionReset | UnexpectedEof) => {}
+                Err(e) => panic!("{e}"),
+                Ok(()) => {}
+            }
+        });
+    }
+}
+
+async fn handle_stream<S>(
+    backend: Arc<MoonlinkBackend<u32, u32>>,
+    mut stream: S,
+) -> Result<()> 
+where
+    S: AsyncRead + AsyncWrite + Unpin
+{
     let mut map = HashMap::new();
     loop {
         match read(&mut stream).await? {
@@ -127,13 +156,13 @@ async fn handle_stream(
                     .await
                     .unwrap();
                 write(&mut stream, &state.data).await?;
-                map.insert((database_id, table_id), state);
+                assert!(map.insert((database_id, table_id), state).is_none());
             }
             Request::ScanTableEnd {
                 database_id,
                 table_id,
             } => {
-                map.remove(&(database_id, table_id));
+                assert!(map.remove(&(database_id, table_id)).is_some());
                 write(&mut stream, &()).await?;
             }
         }


### PR DESCRIPTION
## Summary

This PR implements an optional TCP server, which allows pg_mooncake to connect to moonlink standalone deployment via TCP request and response, not only unix domain socket.
This PR is a no-op to production env, TCP server is by default disabled.

Initial test setup:
https://docs.google.com/document/d/1h1UUKSJDpsUk6BUbVP9sEAo1x8vwKIgWz9T_glY7M8M/edit?usp=sharing

- I confirmed table creation and snapshot creation works
- Haven't figured out on scan table

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
