### PR TITLE
[storage] Perform filepath remap on read state

### DIFF
--- a/cloud/gcp/deployment/moonlink_deployment.yaml
+++ b/cloud/gcp/deployment/moonlink_deployment.yaml
@@ -15,7 +15,7 @@ spec:
       containers:
       # Moonlink deployment, which serves REST API and TCP rpc requests.
       - name: moonlink-deployment
-        image: us-west1-docker.pkg.dev/coral-ring-465417-r0/moonlink-standalone-experiment/moonlink-deployment:42f29a70-e2f2-4ac2-99f8-95f830464ecc
+        image: us-west1-docker.pkg.dev/coral-ring-465417-r0/moonlink-standalone-experiment/moonlink-deployment:7cb80acf-9d2e-4dfe-b19a-ad8e6578415d
         command: ["/app/moonlink_service"]
         args:
         - "/tmp/moonlink"

--- a/src/moonlink/src/lib.rs
+++ b/src/moonlink/src/lib.rs
@@ -22,7 +22,7 @@ pub use storage::{
 pub use table_handler::TableHandler;
 pub use table_handler_timer::TableHandlerTimer;
 pub use table_notify::TableEvent;
-pub use union_read::{ReadState, ReadStateManager};
+pub use union_read::{ReadState, ReadStateFilepathRemap, ReadStateManager};
 
 #[cfg(any(test, feature = "test-utils"))]
 pub use union_read::decode_read_state_for_testing;

--- a/src/moonlink/src/storage/mooncake_table/data_file_state_tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/data_file_state_tests.rs
@@ -267,7 +267,7 @@ async fn prepare_state_3(
         // Read and increment reference count.
         let snapshot_read_output = perform_read_request_for_test(&mut table).await;
         let read_state = snapshot_read_output
-            .take_as_read_state(get_local_filepath_remap())
+            .take_as_read_state(get_read_state_filepath_remap())
             .await;
 
         // Persist.
@@ -298,7 +298,7 @@ async fn prepare_state_3(
     // Read and increment reference count.
     let snapshot_read_output = perform_read_request_for_test(&mut table).await;
     let read_state = snapshot_read_output
-        .take_as_read_state(get_local_filepath_remap())
+        .take_as_read_state(get_read_state_filepath_remap())
         .await;
 
     (table, table_notify, read_state)
@@ -319,7 +319,7 @@ async fn prepare_state_4(
     // Read and increment reference count.
     let snapshot_read_output = perform_read_request_for_test(&mut table).await;
     let read_state = snapshot_read_output
-        .take_as_read_state(get_local_filepath_remap())
+        .take_as_read_state(get_read_state_filepath_remap())
         .await;
 
     (table, table_notify, read_state)
@@ -448,7 +448,7 @@ async fn test_5_read_4(#[case] optimize_local_filesystem: bool, #[case] use_batc
     assert!(files_to_delete.is_empty());
     let snapshot_read_output = perform_read_request_for_test(&mut table).await;
     let _read_state = snapshot_read_output
-        .take_as_read_state(get_local_filepath_remap())
+        .take_as_read_state(get_read_state_filepath_remap())
         .await;
 
     // Validate end state.
@@ -590,7 +590,7 @@ async fn test_4_read_4(#[case] optimize_local_filesystem: bool, #[case] use_batc
     // Read and increment reference count for the second time.
     let snapshot_read_output_2 = perform_read_request_for_test(&mut table).await;
     let _read_state_2 = snapshot_read_output_2
-        .take_as_read_state(get_local_filepath_remap())
+        .take_as_read_state(get_read_state_filepath_remap())
         .await;
 
     // Validate end state.
@@ -621,7 +621,7 @@ async fn test_4_read_and_read_over_4(
     // Read, increment reference count for the second time.
     let snapshot_read_output_2 = perform_read_request_for_test(&mut table).await;
     let _read_state_2 = snapshot_read_output_2
-        .take_as_read_state(get_local_filepath_remap())
+        .take_as_read_state(get_read_state_filepath_remap())
         .await;
 
     // State input: drop read state and still referenced.
@@ -662,7 +662,7 @@ async fn test_3_read_3_without_filesystem_optimization(#[case] use_batch_write: 
     // State input: read and increment reference count.
     let snapshot_read_output_2 = perform_read_request_for_test(&mut table).await;
     let _read_state_2 = snapshot_read_output_2
-        .take_as_read_state(get_local_filepath_remap())
+        .take_as_read_state(get_read_state_filepath_remap())
         .await;
     // Persist and reflect result to mooncake snapshot.
     create_mooncake_and_persist_for_test(&mut table, &mut table_notify).await;
@@ -703,7 +703,7 @@ async fn test_3_read_3_with_filesystem_optimization(#[case] use_batch_write: boo
     // State input: read and increment reference count.
     let snapshot_read_output_2 = perform_read_request_for_test(&mut table).await;
     let _read_state_2 = snapshot_read_output_2
-        .take_as_read_state(get_local_filepath_remap())
+        .take_as_read_state(get_read_state_filepath_remap())
         .await;
 
     // Validate end state.
@@ -740,7 +740,7 @@ async fn test_3_read_and_read_over_and_pinned_3_without_local_filesystem_optimiz
     // State input: read and increment reference count.
     let snapshot_read_output_2 = perform_read_request_for_test(&mut table).await;
     let read_state_2 = snapshot_read_output_2
-        .take_as_read_state(get_local_filepath_remap())
+        .take_as_read_state(get_read_state_filepath_remap())
         .await;
     drop(read_state_2);
 
@@ -784,7 +784,7 @@ async fn test_3_read_and_read_over_and_pinned_3_with_local_filesystem_optimizati
     // State input: read and increment reference count.
     let snapshot_read_output_2 = perform_read_request_for_test(&mut table).await;
     let read_state_2 = snapshot_read_output_2
-        .take_as_read_state(get_local_filepath_remap())
+        .take_as_read_state(get_read_state_filepath_remap())
         .await;
     drop(read_state_2);
     // Create a mooncake snapshot to reflect read request completion result.
@@ -889,7 +889,7 @@ async fn test_1_read_and_pinned_3_without_local_optimization(#[case] use_batch_w
     // State input: read and increment reference count.
     let snapshot_read_output = perform_read_request_for_test(&mut table).await;
     let _read_state = snapshot_read_output
-        .take_as_read_state(get_local_filepath_remap())
+        .take_as_read_state(get_read_state_filepath_remap())
         .await;
 
     // Validate end state.
@@ -923,7 +923,7 @@ async fn test_1_read_and_pinned_3_with_local_optimization(#[case] use_batch_writ
     // State input: read and increment reference count.
     let snapshot_read_output = perform_read_request_for_test(&mut table).await;
     let _read_state = snapshot_read_output
-        .take_as_read_state(get_local_filepath_remap())
+        .take_as_read_state(get_read_state_filepath_remap())
         .await;
 
     // Validate end state.
@@ -959,7 +959,7 @@ async fn test_1_read_and_unpinned_3_without_local_optimization(#[case] use_batch
     // State input: read and increment reference count.
     let snapshot_read_output = perform_read_request_for_test(&mut table).await;
     let _read_state = snapshot_read_output
-        .take_as_read_state(get_local_filepath_remap())
+        .take_as_read_state(get_read_state_filepath_remap())
         .await;
 
     // Validate end state.
@@ -996,7 +996,7 @@ async fn test_1_read_and_unpinned_3_with_local_optimization(#[case] use_batch_wr
     // State input: read and increment reference count.
     let snapshot_read_output = perform_read_request_for_test(&mut table).await;
     let _read_state = snapshot_read_output
-        .take_as_read_state(get_local_filepath_remap())
+        .take_as_read_state(get_read_state_filepath_remap())
         .await;
 
     // Validate end state.
@@ -1032,7 +1032,7 @@ async fn test_2_read_and_pinned_3_without_local_optimization(#[case] use_batch_w
     // State input: read, but no reference count hold within read state.
     let snapshot_read_output_1 = perform_read_request_for_test(&mut table).await;
     let _read_state_1 = snapshot_read_output_1
-        .take_as_read_state(get_local_filepath_remap())
+        .take_as_read_state(get_read_state_filepath_remap())
         .await;
     // Till now, the state is (remote, no local, in use).
 
@@ -1042,7 +1042,7 @@ async fn test_2_read_and_pinned_3_without_local_optimization(#[case] use_batch_w
 
     let snapshot_read_output_2 = perform_read_request_for_test(&mut table).await;
     let _read_state_2 = snapshot_read_output_2
-        .take_as_read_state(get_local_filepath_remap())
+        .take_as_read_state(get_read_state_filepath_remap())
         .await;
 
     // Check fake file has been evicted.
@@ -1085,7 +1085,7 @@ async fn test_2_read_and_pinned_3_with_local_optimization(#[case] use_batch_writ
     // State input: read, but no reference count hold within read state.
     let snapshot_read_output_1 = perform_read_request_for_test(&mut table).await;
     let _read_state_1 = snapshot_read_output_1
-        .take_as_read_state(get_local_filepath_remap())
+        .take_as_read_state(get_read_state_filepath_remap())
         .await;
     // Till now, the state is (remote, no local, in use).
 
@@ -1095,7 +1095,7 @@ async fn test_2_read_and_pinned_3_with_local_optimization(#[case] use_batch_writ
 
     let snapshot_read_output_2 = perform_read_request_for_test(&mut table).await;
     let _read_state_2 = snapshot_read_output_2
-        .take_as_read_state(get_local_filepath_remap())
+        .take_as_read_state(get_read_state_filepath_remap())
         .await;
 
     // Check fake file has been evicted.
@@ -1137,14 +1137,14 @@ async fn test_2_read_and_unpinned_2_without_local_optimization(#[case] use_batch
     // State input: read, but no reference count hold within read state.
     let snapshot_read_output_1 = perform_read_request_for_test(&mut table).await;
     let read_state_1 = snapshot_read_output_1
-        .take_as_read_state(get_local_filepath_remap())
+        .take_as_read_state(get_read_state_filepath_remap())
         .await;
     // Till now, the state is (remote, no local, in use).
 
     // Read, but no reference count hold within read state.
     let snapshot_read_output_2 = perform_read_request_for_test(&mut table).await;
     let read_state_2 = snapshot_read_output_2
-        .take_as_read_state(get_local_filepath_remap())
+        .take_as_read_state(get_read_state_filepath_remap())
         .await;
 
     // Check data file has been recorded in mooncake table.
@@ -1192,14 +1192,14 @@ async fn test_2_read_and_unpinned_2_with_local_optimization(#[case] use_batch_wr
     // Read, but no reference count hold within read state.
     let snapshot_read_output_1 = perform_read_request_for_test(&mut table).await;
     let read_state_1 = snapshot_read_output_1
-        .take_as_read_state(get_local_filepath_remap())
+        .take_as_read_state(get_read_state_filepath_remap())
         .await;
     // Till now, the state is (remote, no local, in use).
 
     // Read, but no reference count hold within read state.
     let snapshot_read_output_2 = perform_read_request_for_test(&mut table).await;
     let read_state_2 = snapshot_read_output_2
-        .take_as_read_state(get_local_filepath_remap())
+        .take_as_read_state(get_read_state_filepath_remap())
         .await;
 
     // Check data file has been recorded in mooncake table.
@@ -1246,7 +1246,7 @@ async fn test_2_read_over_1_without_local_optimization(#[case] use_batch_write: 
     // Read and increment reference count.
     let snapshot_read_output = perform_read_request_for_test(&mut table).await;
     let read_state = snapshot_read_output
-        .take_as_read_state(get_local_filepath_remap())
+        .take_as_read_state(get_read_state_filepath_remap())
         .await;
     // Till now, the state is (remote, no local, in use).
     drop(read_state);
@@ -1283,7 +1283,7 @@ async fn test_2_read_over_1_with_local_optimization(#[case] use_batch_write: boo
     // Read and increment reference count.
     let snapshot_read_output = perform_read_request_for_test(&mut table).await;
     let read_state = snapshot_read_output
-        .take_as_read_state(get_local_filepath_remap())
+        .take_as_read_state(get_read_state_filepath_remap())
         .await;
     // Till now, the state is (remote, no local, in use).
     drop(read_state);
@@ -1380,7 +1380,7 @@ async fn test_3_compact_3_5_without_local_filesystem_optimization() {
     // Read and increment reference count.
     let snapshot_read_output = perform_read_request_for_test(&mut table).await;
     let read_state = snapshot_read_output
-        .take_as_read_state(get_local_filepath_remap())
+        .take_as_read_state(get_read_state_filepath_remap())
         .await;
 
     // Persist and reflect result to mooncake snapshot.
@@ -1489,7 +1489,7 @@ async fn test_3_compact_3_5_with_local_filesystem_optimization() {
     // Read and increment reference count.
     let snapshot_read_output = perform_read_request_for_test(&mut table).await;
     let read_state = snapshot_read_output
-        .take_as_read_state(get_local_filepath_remap())
+        .take_as_read_state(get_read_state_filepath_remap())
         .await;
 
     // Persist and reflect result to mooncake snapshot.
@@ -1601,7 +1601,7 @@ async fn test_3_compact_1_5_without_local_filesystem_optimization() {
     // Read and increment reference count.
     let snapshot_read_output = perform_read_request_for_test(&mut table).await;
     let read_state = snapshot_read_output
-        .take_as_read_state(get_local_filepath_remap())
+        .take_as_read_state(get_read_state_filepath_remap())
         .await;
 
     // Persist and reflect result to mooncake snapshot.
@@ -1683,7 +1683,7 @@ async fn test_3_compact_1_5_with_local_filesystem_optimization() {
     // Read and increment reference count.
     let snapshot_read_output = perform_read_request_for_test(&mut table).await;
     let read_state = snapshot_read_output
-        .take_as_read_state(get_local_filepath_remap())
+        .take_as_read_state(get_read_state_filepath_remap())
         .await;
 
     // Persist and reflect result to mooncake snapshot.

--- a/src/moonlink/src/storage/mooncake_table/data_file_state_tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/data_file_state_tests.rs
@@ -266,7 +266,9 @@ async fn prepare_state_3(
     if read_then_snapshot {
         // Read and increment reference count.
         let snapshot_read_output = perform_read_request_for_test(&mut table).await;
-        let read_state = snapshot_read_output.take_as_read_state().await;
+        let read_state = snapshot_read_output
+            .take_as_read_state(get_local_filepath_remap())
+            .await;
 
         // Persist.
         create_mooncake_and_persist_for_test(&mut table, &mut table_notify).await;
@@ -295,7 +297,9 @@ async fn prepare_state_3(
 
     // Read and increment reference count.
     let snapshot_read_output = perform_read_request_for_test(&mut table).await;
-    let read_state = snapshot_read_output.take_as_read_state().await;
+    let read_state = snapshot_read_output
+        .take_as_read_state(get_local_filepath_remap())
+        .await;
 
     (table, table_notify, read_state)
 }
@@ -314,7 +318,9 @@ async fn prepare_state_4(
 
     // Read and increment reference count.
     let snapshot_read_output = perform_read_request_for_test(&mut table).await;
-    let read_state = snapshot_read_output.take_as_read_state().await;
+    let read_state = snapshot_read_output
+        .take_as_read_state(get_local_filepath_remap())
+        .await;
 
     (table, table_notify, read_state)
 }
@@ -441,7 +447,9 @@ async fn test_5_read_4(#[case] optimize_local_filesystem: bool, #[case] use_batc
         create_mooncake_snapshot_for_test(&mut table, &mut table_notify).await;
     assert!(files_to_delete.is_empty());
     let snapshot_read_output = perform_read_request_for_test(&mut table).await;
-    let _read_state = snapshot_read_output.take_as_read_state().await;
+    let _read_state = snapshot_read_output
+        .take_as_read_state(get_local_filepath_remap())
+        .await;
 
     // Validate end state.
     validate_state_4(
@@ -581,7 +589,9 @@ async fn test_4_read_4(#[case] optimize_local_filesystem: bool, #[case] use_batc
 
     // Read and increment reference count for the second time.
     let snapshot_read_output_2 = perform_read_request_for_test(&mut table).await;
-    let _read_state_2 = snapshot_read_output_2.take_as_read_state().await;
+    let _read_state_2 = snapshot_read_output_2
+        .take_as_read_state(get_local_filepath_remap())
+        .await;
 
     // Validate end state.
     validate_state_4(
@@ -610,7 +620,9 @@ async fn test_4_read_and_read_over_4(
         prepare_state_4(&temp_dir, cache.clone(), use_batch_write).await;
     // Read, increment reference count for the second time.
     let snapshot_read_output_2 = perform_read_request_for_test(&mut table).await;
-    let _read_state_2 = snapshot_read_output_2.take_as_read_state().await;
+    let _read_state_2 = snapshot_read_output_2
+        .take_as_read_state(get_local_filepath_remap())
+        .await;
 
     // State input: drop read state and still referenced.
     drop(read_state_1);
@@ -649,7 +661,9 @@ async fn test_3_read_3_without_filesystem_optimization(#[case] use_batch_write: 
 
     // State input: read and increment reference count.
     let snapshot_read_output_2 = perform_read_request_for_test(&mut table).await;
-    let _read_state_2 = snapshot_read_output_2.take_as_read_state().await;
+    let _read_state_2 = snapshot_read_output_2
+        .take_as_read_state(get_local_filepath_remap())
+        .await;
     // Persist and reflect result to mooncake snapshot.
     create_mooncake_and_persist_for_test(&mut table, &mut table_notify).await;
     let (_, _, _, _, files_to_delete) =
@@ -688,7 +702,9 @@ async fn test_3_read_3_with_filesystem_optimization(#[case] use_batch_write: boo
 
     // State input: read and increment reference count.
     let snapshot_read_output_2 = perform_read_request_for_test(&mut table).await;
-    let _read_state_2 = snapshot_read_output_2.take_as_read_state().await;
+    let _read_state_2 = snapshot_read_output_2
+        .take_as_read_state(get_local_filepath_remap())
+        .await;
 
     // Validate end state.
     validate_state_3(
@@ -723,7 +739,9 @@ async fn test_3_read_and_read_over_and_pinned_3_without_local_filesystem_optimiz
 
     // State input: read and increment reference count.
     let snapshot_read_output_2 = perform_read_request_for_test(&mut table).await;
-    let read_state_2 = snapshot_read_output_2.take_as_read_state().await;
+    let read_state_2 = snapshot_read_output_2
+        .take_as_read_state(get_local_filepath_remap())
+        .await;
     drop(read_state_2);
 
     // Create a mooncake snapshot to reflect read request completion result.
@@ -765,7 +783,9 @@ async fn test_3_read_and_read_over_and_pinned_3_with_local_filesystem_optimizati
 
     // State input: read and increment reference count.
     let snapshot_read_output_2 = perform_read_request_for_test(&mut table).await;
-    let read_state_2 = snapshot_read_output_2.take_as_read_state().await;
+    let read_state_2 = snapshot_read_output_2
+        .take_as_read_state(get_local_filepath_remap())
+        .await;
     drop(read_state_2);
     // Create a mooncake snapshot to reflect read request completion result.
     let (_, _, _, _, files_to_delete) =
@@ -868,7 +888,9 @@ async fn test_1_read_and_pinned_3_without_local_optimization(#[case] use_batch_w
 
     // State input: read and increment reference count.
     let snapshot_read_output = perform_read_request_for_test(&mut table).await;
-    let _read_state = snapshot_read_output.take_as_read_state().await;
+    let _read_state = snapshot_read_output
+        .take_as_read_state(get_local_filepath_remap())
+        .await;
 
     // Validate end state.
     validate_state_3(
@@ -900,7 +922,9 @@ async fn test_1_read_and_pinned_3_with_local_optimization(#[case] use_batch_writ
 
     // State input: read and increment reference count.
     let snapshot_read_output = perform_read_request_for_test(&mut table).await;
-    let _read_state = snapshot_read_output.take_as_read_state().await;
+    let _read_state = snapshot_read_output
+        .take_as_read_state(get_local_filepath_remap())
+        .await;
 
     // Validate end state.
     validate_state_3(
@@ -934,7 +958,9 @@ async fn test_1_read_and_unpinned_3_without_local_optimization(#[case] use_batch
 
     // State input: read and increment reference count.
     let snapshot_read_output = perform_read_request_for_test(&mut table).await;
-    let _read_state = snapshot_read_output.take_as_read_state().await;
+    let _read_state = snapshot_read_output
+        .take_as_read_state(get_local_filepath_remap())
+        .await;
 
     // Validate end state.
     validate_state_3(
@@ -969,7 +995,9 @@ async fn test_1_read_and_unpinned_3_with_local_optimization(#[case] use_batch_wr
 
     // State input: read and increment reference count.
     let snapshot_read_output = perform_read_request_for_test(&mut table).await;
-    let _read_state = snapshot_read_output.take_as_read_state().await;
+    let _read_state = snapshot_read_output
+        .take_as_read_state(get_local_filepath_remap())
+        .await;
 
     // Validate end state.
     validate_state_3(
@@ -1003,7 +1031,9 @@ async fn test_2_read_and_pinned_3_without_local_optimization(#[case] use_batch_w
 
     // State input: read, but no reference count hold within read state.
     let snapshot_read_output_1 = perform_read_request_for_test(&mut table).await;
-    let _read_state_1 = snapshot_read_output_1.take_as_read_state().await;
+    let _read_state_1 = snapshot_read_output_1
+        .take_as_read_state(get_local_filepath_remap())
+        .await;
     // Till now, the state is (remote, no local, in use).
 
     // Unreference the second cache handle, so we could pin requires files again in cache.
@@ -1011,7 +1041,9 @@ async fn test_2_read_and_pinned_3_without_local_optimization(#[case] use_batch_w
     assert!(evicted_files_to_delete.is_empty());
 
     let snapshot_read_output_2 = perform_read_request_for_test(&mut table).await;
-    let _read_state_2 = snapshot_read_output_2.take_as_read_state().await;
+    let _read_state_2 = snapshot_read_output_2
+        .take_as_read_state(get_local_filepath_remap())
+        .await;
 
     // Check fake file has been evicted.
     let fake_filepath = temp_dir.path().join(FAKE_FILE_NAME);
@@ -1052,7 +1084,9 @@ async fn test_2_read_and_pinned_3_with_local_optimization(#[case] use_batch_writ
 
     // State input: read, but no reference count hold within read state.
     let snapshot_read_output_1 = perform_read_request_for_test(&mut table).await;
-    let _read_state_1 = snapshot_read_output_1.take_as_read_state().await;
+    let _read_state_1 = snapshot_read_output_1
+        .take_as_read_state(get_local_filepath_remap())
+        .await;
     // Till now, the state is (remote, no local, in use).
 
     // Unreference the second cache handle, so we could pin requires files again in cache.
@@ -1060,7 +1094,9 @@ async fn test_2_read_and_pinned_3_with_local_optimization(#[case] use_batch_writ
     assert!(evicted_files_to_delete.is_empty());
 
     let snapshot_read_output_2 = perform_read_request_for_test(&mut table).await;
-    let _read_state_2 = snapshot_read_output_2.take_as_read_state().await;
+    let _read_state_2 = snapshot_read_output_2
+        .take_as_read_state(get_local_filepath_remap())
+        .await;
 
     // Check fake file has been evicted.
     let fake_filepath = temp_dir.path().join(FAKE_FILE_NAME);
@@ -1100,12 +1136,16 @@ async fn test_2_read_and_unpinned_2_without_local_optimization(#[case] use_batch
 
     // State input: read, but no reference count hold within read state.
     let snapshot_read_output_1 = perform_read_request_for_test(&mut table).await;
-    let read_state_1 = snapshot_read_output_1.take_as_read_state().await;
+    let read_state_1 = snapshot_read_output_1
+        .take_as_read_state(get_local_filepath_remap())
+        .await;
     // Till now, the state is (remote, no local, in use).
 
     // Read, but no reference count hold within read state.
     let snapshot_read_output_2 = perform_read_request_for_test(&mut table).await;
-    let read_state_2 = snapshot_read_output_2.take_as_read_state().await;
+    let read_state_2 = snapshot_read_output_2
+        .take_as_read_state(get_local_filepath_remap())
+        .await;
 
     // Check data file has been recorded in mooncake table.
     let data_file_id = get_only_remote_data_file_id(&table, &temp_dir).await;
@@ -1151,12 +1191,16 @@ async fn test_2_read_and_unpinned_2_with_local_optimization(#[case] use_batch_wr
 
     // Read, but no reference count hold within read state.
     let snapshot_read_output_1 = perform_read_request_for_test(&mut table).await;
-    let read_state_1 = snapshot_read_output_1.take_as_read_state().await;
+    let read_state_1 = snapshot_read_output_1
+        .take_as_read_state(get_local_filepath_remap())
+        .await;
     // Till now, the state is (remote, no local, in use).
 
     // Read, but no reference count hold within read state.
     let snapshot_read_output_2 = perform_read_request_for_test(&mut table).await;
-    let read_state_2 = snapshot_read_output_2.take_as_read_state().await;
+    let read_state_2 = snapshot_read_output_2
+        .take_as_read_state(get_local_filepath_remap())
+        .await;
 
     // Check data file has been recorded in mooncake table.
     let data_file_id = get_only_remote_data_file_id(&table, &temp_dir).await;
@@ -1201,7 +1245,9 @@ async fn test_2_read_over_1_without_local_optimization(#[case] use_batch_write: 
 
     // Read and increment reference count.
     let snapshot_read_output = perform_read_request_for_test(&mut table).await;
-    let read_state = snapshot_read_output.take_as_read_state().await;
+    let read_state = snapshot_read_output
+        .take_as_read_state(get_local_filepath_remap())
+        .await;
     // Till now, the state is (remote, no local, in use).
     drop(read_state);
 
@@ -1236,7 +1282,9 @@ async fn test_2_read_over_1_with_local_optimization(#[case] use_batch_write: boo
 
     // Read and increment reference count.
     let snapshot_read_output = perform_read_request_for_test(&mut table).await;
-    let read_state = snapshot_read_output.take_as_read_state().await;
+    let read_state = snapshot_read_output
+        .take_as_read_state(get_local_filepath_remap())
+        .await;
     // Till now, the state is (remote, no local, in use).
     drop(read_state);
 
@@ -1331,7 +1379,9 @@ async fn test_3_compact_3_5_without_local_filesystem_optimization() {
 
     // Read and increment reference count.
     let snapshot_read_output = perform_read_request_for_test(&mut table).await;
-    let read_state = snapshot_read_output.take_as_read_state().await;
+    let read_state = snapshot_read_output
+        .take_as_read_state(get_local_filepath_remap())
+        .await;
 
     // Persist and reflect result to mooncake snapshot.
     create_mooncake_and_persist_for_test(&mut table, &mut table_notify).await;
@@ -1438,7 +1488,9 @@ async fn test_3_compact_3_5_with_local_filesystem_optimization() {
 
     // Read and increment reference count.
     let snapshot_read_output = perform_read_request_for_test(&mut table).await;
-    let read_state = snapshot_read_output.take_as_read_state().await;
+    let read_state = snapshot_read_output
+        .take_as_read_state(get_local_filepath_remap())
+        .await;
 
     // Persist and reflect result to mooncake snapshot.
     create_mooncake_and_persist_for_test(&mut table, &mut table_notify).await;
@@ -1548,7 +1600,9 @@ async fn test_3_compact_1_5_without_local_filesystem_optimization() {
 
     // Read and increment reference count.
     let snapshot_read_output = perform_read_request_for_test(&mut table).await;
-    let read_state = snapshot_read_output.take_as_read_state().await;
+    let read_state = snapshot_read_output
+        .take_as_read_state(get_local_filepath_remap())
+        .await;
 
     // Persist and reflect result to mooncake snapshot.
     create_mooncake_and_persist_for_test(&mut table, &mut table_notify).await;
@@ -1628,7 +1682,9 @@ async fn test_3_compact_1_5_with_local_filesystem_optimization() {
 
     // Read and increment reference count.
     let snapshot_read_output = perform_read_request_for_test(&mut table).await;
-    let read_state = snapshot_read_output.take_as_read_state().await;
+    let read_state = snapshot_read_output
+        .take_as_read_state(get_local_filepath_remap())
+        .await;
 
     // Persist and reflect result to mooncake snapshot.
     create_mooncake_and_persist_for_test(&mut table, &mut table_notify).await;

--- a/src/moonlink/src/storage/mooncake_table/deletion_vector_puffin_state_tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/deletion_vector_puffin_state_tests.rs
@@ -318,7 +318,9 @@ async fn test_2_read_without_local_optimization(#[case] use_batch_write: bool) {
 
     // Use by read.
     let snapshot_read_output = perform_read_request_for_test(&mut table).await;
-    let read_state = snapshot_read_output.take_as_read_state().await;
+    let read_state = snapshot_read_output
+        .take_as_read_state(get_local_filepath_remap())
+        .await;
 
     // Check data file has been pinned in mooncake table.
     let puffin_blob_ref = get_only_puffin_blob_ref_from_table(&table).await;
@@ -372,7 +374,9 @@ async fn test_2_read_with_local_optimization(#[case] use_batch_write: bool) {
 
     // Use by read.
     let snapshot_read_output = perform_read_request_for_test(&mut table).await;
-    let read_state = snapshot_read_output.take_as_read_state().await;
+    let read_state = snapshot_read_output
+        .take_as_read_state(get_local_filepath_remap())
+        .await;
 
     // Check data file has been pinned in mooncake table.
     let puffin_blob_ref = get_only_puffin_blob_ref_from_table(&table).await;

--- a/src/moonlink/src/storage/mooncake_table/deletion_vector_puffin_state_tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/deletion_vector_puffin_state_tests.rs
@@ -319,7 +319,7 @@ async fn test_2_read_without_local_optimization(#[case] use_batch_write: bool) {
     // Use by read.
     let snapshot_read_output = perform_read_request_for_test(&mut table).await;
     let read_state = snapshot_read_output
-        .take_as_read_state(get_local_filepath_remap())
+        .take_as_read_state(get_read_state_filepath_remap())
         .await;
 
     // Check data file has been pinned in mooncake table.
@@ -375,7 +375,7 @@ async fn test_2_read_with_local_optimization(#[case] use_batch_write: bool) {
     // Use by read.
     let snapshot_read_output = perform_read_request_for_test(&mut table).await;
     let read_state = snapshot_read_output
-        .take_as_read_state(get_local_filepath_remap())
+        .take_as_read_state(get_read_state_filepath_remap())
         .await;
 
     // Check data file has been pinned in mooncake table.

--- a/src/moonlink/src/storage/mooncake_table/snapshot_read_output.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot_read_output.rs
@@ -5,6 +5,7 @@ use crate::storage::storage_utils::TableUniqueFileId;
 use crate::storage::PuffinDeletionBlobAtRead;
 use crate::table_notify::EvictedFiles;
 use crate::table_notify::TableEvent;
+use crate::ReadStateFilepathRemap;
 use crate::{NonEvictableHandle, ReadState};
 
 use std::sync::Arc;
@@ -14,7 +15,7 @@ use tokio::sync::mpsc::Sender;
 /// Mooncake snapshot for read.
 ///
 /// Pass out two types of data files to read.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub enum DataFileForRead {
     /// Temporary data file for in-memory unpersisted data, used for union read.
     TemporaryDataFile(String),
@@ -59,7 +60,10 @@ impl ReadOutput {
     /// Resolve all remote filepaths and convert into [`ReadState`] for query usage.
     ///
     /// TODO(hjiang): Parallelize download and pin.
-    pub async fn take_as_read_state(mut self) -> Arc<ReadState> {
+    pub async fn take_as_read_state(
+        mut self,
+        local_filepath_remap: ReadStateFilepathRemap,
+    ) -> Arc<ReadState> {
         // Resolve remote data files.
         let mut resolved_data_files = Vec::with_capacity(self.data_file_paths.len());
         let mut cache_handles = vec![];
@@ -112,6 +116,7 @@ impl ReadOutput {
             // Fields used for read state cleanup after query completion.
             self.associated_files,
             cache_handles,
+            local_filepath_remap,
         ))
     }
 }

--- a/src/moonlink/src/storage/mooncake_table/snapshot_read_output.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot_read_output.rs
@@ -62,7 +62,7 @@ impl ReadOutput {
     /// TODO(hjiang): Parallelize download and pin.
     pub async fn take_as_read_state(
         mut self,
-        local_filepath_remap: ReadStateFilepathRemap,
+        read_state_filepath_remap: ReadStateFilepathRemap,
     ) -> Arc<ReadState> {
         // Resolve remote data files.
         let mut resolved_data_files = Vec::with_capacity(self.data_file_paths.len());
@@ -116,7 +116,7 @@ impl ReadOutput {
             // Fields used for read state cleanup after query completion.
             self.associated_files,
             cache_handles,
-            local_filepath_remap,
+            read_state_filepath_remap,
         ))
     }
 }

--- a/src/moonlink/src/storage/mooncake_table/table_operation_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_operation_test_utils.rs
@@ -14,7 +14,7 @@ use crate::storage::mooncake_table::{
 use crate::table_notify::{
     DataCompactionMaintenanceStatus, IndexMergeMaintenanceStatus, TableEvent,
 };
-use crate::{MooncakeTable, SnapshotReadOutput};
+use crate::{MooncakeTable, ReadStateFilepathRemap, SnapshotReadOutput};
 use crate::{ReadState, Result};
 use tracing::{debug, error};
 
@@ -577,6 +577,10 @@ pub(crate) async fn alter_table_and_persist_to_iceberg(
     } else {
         panic!("Iceberg snapshot payload is not set");
     }
+}
+
+pub(crate) fn get_local_filepath_remap() -> ReadStateFilepathRemap {
+    Arc::new(|local_filepath: String| local_filepath)
 }
 
 pub(crate) async fn alter_table(table: &mut MooncakeTable) {

--- a/src/moonlink/src/storage/mooncake_table/table_operation_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_operation_test_utils.rs
@@ -579,7 +579,7 @@ pub(crate) async fn alter_table_and_persist_to_iceberg(
     }
 }
 
-pub(crate) fn get_local_filepath_remap() -> ReadStateFilepathRemap {
+pub(crate) fn get_read_state_filepath_remap() -> ReadStateFilepathRemap {
     Arc::new(|local_filepath: String| local_filepath)
 }
 

--- a/src/moonlink/src/table_handler/chaos_test.rs
+++ b/src/moonlink/src/table_handler/chaos_test.rs
@@ -606,11 +606,14 @@ impl TestEnvironment {
         .await;
         let (replication_lsn_tx, replication_lsn_rx) = watch::channel(0u64);
         let (last_commit_lsn_tx, last_commit_lsn_rx) = watch::channel(0u64);
-        let read_state_filepath_remap = std::sync::Arc::new(|local_filepath: String| {
-            local_filepath
-        });
-        let read_state_manager =
-            ReadStateManager::new(&table, replication_lsn_rx.clone(), last_commit_lsn_rx, read_state_filepath_remap);
+        let read_state_filepath_remap =
+            std::sync::Arc::new(|local_filepath: String| local_filepath);
+        let read_state_manager = ReadStateManager::new(
+            &table,
+            replication_lsn_rx.clone(),
+            last_commit_lsn_rx,
+            read_state_filepath_remap,
+        );
         let (table_event_sync_sender, table_event_sync_receiver) = create_table_event_syncer();
         let (event_replay_tx, event_replay_rx) = mpsc::unbounded_channel();
         let table_handler = TableHandler::new(
@@ -670,11 +673,13 @@ async fn validate_persisted_iceberg_table(
     .await;
     table.register_table_notify(event_sender).await;
 
-    let read_state_filepath_remap = std::sync::Arc::new(|local_filepath: String| {
-        local_filepath
-    });
-    let read_state_manager =
-        ReadStateManager::new(&table, replication_lsn_rx.clone(), last_commit_lsn_rx, read_state_filepath_remap);
+    let read_state_filepath_remap = std::sync::Arc::new(|local_filepath: String| local_filepath);
+    let read_state_manager = ReadStateManager::new(
+        &table,
+        replication_lsn_rx.clone(),
+        last_commit_lsn_rx,
+        read_state_filepath_remap,
+    );
     check_read_snapshot(
         &read_state_manager,
         Some(snapshot_lsn),

--- a/src/moonlink/src/table_handler/chaos_test.rs
+++ b/src/moonlink/src/table_handler/chaos_test.rs
@@ -606,8 +606,11 @@ impl TestEnvironment {
         .await;
         let (replication_lsn_tx, replication_lsn_rx) = watch::channel(0u64);
         let (last_commit_lsn_tx, last_commit_lsn_rx) = watch::channel(0u64);
+        let read_state_filepath_remap = std::sync::Arc::new(|local_filepath: String| {
+            local_filepath
+        });
         let read_state_manager =
-            ReadStateManager::new(&table, replication_lsn_rx.clone(), last_commit_lsn_rx);
+            ReadStateManager::new(&table, replication_lsn_rx.clone(), last_commit_lsn_rx, read_state_filepath_remap);
         let (table_event_sync_sender, table_event_sync_receiver) = create_table_event_syncer();
         let (event_replay_tx, event_replay_rx) = mpsc::unbounded_channel();
         let table_handler = TableHandler::new(
@@ -667,8 +670,11 @@ async fn validate_persisted_iceberg_table(
     .await;
     table.register_table_notify(event_sender).await;
 
+    let read_state_filepath_remap = std::sync::Arc::new(|local_filepath: String| {
+        local_filepath
+    });
     let read_state_manager =
-        ReadStateManager::new(&table, replication_lsn_rx.clone(), last_commit_lsn_rx);
+        ReadStateManager::new(&table, replication_lsn_rx.clone(), last_commit_lsn_rx, read_state_filepath_remap);
     check_read_snapshot(
         &read_state_manager,
         Some(snapshot_lsn),

--- a/src/moonlink/src/table_handler/test_utils.rs
+++ b/src/moonlink/src/table_handler/test_utils.rs
@@ -4,7 +4,7 @@ use crate::storage::filesystem::accessor::base_filesystem_accessor::BaseFileSyst
 use crate::storage::filesystem::accessor_config::AccessorConfig;
 use crate::storage::mooncake_table::table_creation_test_utils::create_test_arrow_schema;
 use crate::storage::mooncake_table::table_creation_test_utils::*;
-use crate::storage::mooncake_table::table_operation_test_utils::get_local_filepath_remap;
+use crate::storage::mooncake_table::table_operation_test_utils::get_read_state_filepath_remap;
 use crate::storage::mooncake_table::TableMetadata as MooncakeTableMetadata;
 use crate::storage::wal::test_utils::{
     assert_wal_events_contains, assert_wal_events_does_not_contain,
@@ -102,7 +102,7 @@ impl TestEnvironment {
             &mooncake_table,
             replication_rx.clone(),
             last_commit_rx,
-            get_local_filepath_remap(),
+            get_read_state_filepath_remap(),
         )));
         let (table_event_sync_sender, table_event_sync_receiver) = create_table_event_syncer();
         let force_snapshot_completion_rx = table_event_sync_receiver

--- a/src/moonlink/src/table_handler/test_utils.rs
+++ b/src/moonlink/src/table_handler/test_utils.rs
@@ -4,6 +4,7 @@ use crate::storage::filesystem::accessor::base_filesystem_accessor::BaseFileSyst
 use crate::storage::filesystem::accessor_config::AccessorConfig;
 use crate::storage::mooncake_table::table_creation_test_utils::create_test_arrow_schema;
 use crate::storage::mooncake_table::table_creation_test_utils::*;
+use crate::storage::mooncake_table::table_operation_test_utils::get_local_filepath_remap;
 use crate::storage::mooncake_table::TableMetadata as MooncakeTableMetadata;
 use crate::storage::wal::test_utils::{
     assert_wal_events_contains, assert_wal_events_does_not_contain,
@@ -101,6 +102,7 @@ impl TestEnvironment {
             &mooncake_table,
             replication_rx.clone(),
             last_commit_rx,
+            get_local_filepath_remap(),
         )));
         let (table_event_sync_sender, table_event_sync_receiver) = create_table_event_syncer();
         let force_snapshot_completion_rx = table_event_sync_receiver

--- a/src/moonlink/src/union_read.rs
+++ b/src/moonlink/src/union_read.rs
@@ -3,6 +3,7 @@ mod read_state_manager;
 mod table_metadata;
 
 pub use read_state::ReadState;
+pub use read_state::ReadStateFilepathRemap;
 pub use read_state_manager::ReadStateManager;
 
 #[cfg(any(test, feature = "test-utils"))]

--- a/src/moonlink/src/union_read/read_state.rs
+++ b/src/moonlink/src/union_read/read_state.rs
@@ -77,7 +77,7 @@ impl ReadState {
         // Fields used for read state cleanup after query completion.
         associated_files: Vec<String>,
         mut cache_handles: Vec<NonEvictableHandle>, // Cache handles for data files.
-        local_filepath_remap: ReadStateFilepathRemap, // Used to remap local filepath to
+        read_state_filepath_remap: ReadStateFilepathRemap, // Used to remap local filepath to
     ) -> Self {
         deletion_vectors_at_read.sort_by(|dv_1, dv_2| {
             dv_1.data_file_index
@@ -96,11 +96,11 @@ impl ReadState {
         // Map from local filepath to remote file path if needed and if possible.
         let remapped_data_files = data_files
             .into_iter()
-            .map(|path| local_filepath_remap(path))
+            .map(|path| read_state_filepath_remap(path))
             .collect::<Vec<_>>();
         let remapped_puffin_files = puffin_files
             .into_iter()
-            .map(|path| local_filepath_remap(path))
+            .map(|path| read_state_filepath_remap(path))
             .collect::<Vec<_>>();
 
         let metadata = TableMetadata {

--- a/src/moonlink/src/union_read/read_state.rs
+++ b/src/moonlink/src/union_read/read_state.rs
@@ -13,6 +13,9 @@ use tracing::{error, info_span, warn};
 
 const BINCODE_CONFIG: config::Configuration = config::standard();
 
+/// Type alias for filepath remap function, which remaps local filepath to remote for [`ReadState`] if possible.
+pub type ReadStateFilepathRemap = std::sync::Arc<dyn Fn(String) -> String + Send + Sync>;
+
 // TODO(hjiang): A better solution might be wrap clean up in a functor.
 #[derive(Debug)]
 pub struct ReadState {
@@ -74,6 +77,7 @@ impl ReadState {
         // Fields used for read state cleanup after query completion.
         associated_files: Vec<String>,
         mut cache_handles: Vec<NonEvictableHandle>, // Cache handles for data files.
+        local_filepath_remap: ReadStateFilepathRemap, // Used to remap local filepath to
     ) -> Self {
         deletion_vectors_at_read.sort_by(|dv_1, dv_2| {
             dv_1.data_file_index
@@ -88,9 +92,20 @@ impl ReadState {
             .iter()
             .map(|handle| handle.cache_entry.cache_filepath.clone())
             .collect::<Vec<_>>();
+
+        // Map from local filepath to remote file path if needed and if possible.
+        let remapped_data_files = data_files
+            .into_iter()
+            .map(|path| local_filepath_remap(path))
+            .collect::<Vec<_>>();
+        let remapped_puffin_files = puffin_files
+            .into_iter()
+            .map(|path| local_filepath_remap(path))
+            .collect::<Vec<_>>();
+
         let metadata = TableMetadata {
-            data_files,
-            puffin_files,
+            data_files: remapped_data_files,
+            puffin_files: remapped_puffin_files,
             deletion_vectors: deletion_vectors_at_read,
             position_deletes,
         };

--- a/src/moonlink/src/union_read/read_state.rs
+++ b/src/moonlink/src/union_read/read_state.rs
@@ -146,7 +146,7 @@ mod tests {
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn test_read_state_construction() {
         let read_state_filepath_remap = std::sync::Arc::new(|local_filepath: String| {
-            format!("{}/some_non_existent_dir", local_filepath)
+            format!("{local_filepath}/some_non_existent_dir")
         });
 
         let data_files = vec!["/tmp/file_1".to_string(), "/tmp/file_2".to_string()];

--- a/src/moonlink/src/union_read/read_state_manager.rs
+++ b/src/moonlink/src/union_read/read_state_manager.rs
@@ -3,6 +3,7 @@ use crate::error::Result;
 use crate::storage::MooncakeTable;
 use crate::storage::SnapshotTableState;
 use crate::ReadState;
+use crate::ReadStateFilepathRemap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::sync::{watch, RwLock};
@@ -14,6 +15,8 @@ pub struct ReadStateManager {
     table_snapshot_watch_receiver: watch::Receiver<u64>,
     replication_lsn_rx: watch::Receiver<u64>,
     last_commit_lsn_rx: watch::Receiver<u64>,
+    /// Functor which maps local filepath to remote URI if possible, should be applied on all files within [`ReadState`].
+    local_filepath_remap: ReadStateFilepathRemap,
 }
 
 impl ReadStateManager {
@@ -21,6 +24,7 @@ impl ReadStateManager {
         table: &MooncakeTable,
         replication_lsn_rx: watch::Receiver<u64>,
         last_commit_lsn_rx: watch::Receiver<u64>,
+        local_filepath_remap: ReadStateFilepathRemap,
     ) -> Self {
         let (table_snapshot, table_snapshot_watch_receiver) = table.get_state_for_reader();
         ReadStateManager {
@@ -32,11 +36,13 @@ impl ReadStateManager {
                 /*position_deletes=*/ Vec::new(),
                 /*associated_files=*/ Vec::new(),
                 /*cache_handles=*/ Vec::new(),
+                local_filepath_remap.clone(), // Unused
             ))),
             table_snapshot,
             table_snapshot_watch_receiver,
             replication_lsn_rx,
             last_commit_lsn_rx,
+            local_filepath_remap,
         }
     }
 
@@ -169,7 +175,9 @@ impl ReadStateManager {
             let snapshot_read_output = table_state_snapshot.request_read().await?;
 
             self.last_read_lsn.store(effective_lsn, Ordering::Release);
-            *last_read_state_guard = snapshot_read_output.take_as_read_state().await;
+            *last_read_state_guard = snapshot_read_output
+                .take_as_read_state(self.local_filepath_remap.clone())
+                .await;
         }
         Ok(last_read_state_guard.clone())
     }

--- a/src/moonlink/src/union_read/read_state_manager.rs
+++ b/src/moonlink/src/union_read/read_state_manager.rs
@@ -16,7 +16,7 @@ pub struct ReadStateManager {
     replication_lsn_rx: watch::Receiver<u64>,
     last_commit_lsn_rx: watch::Receiver<u64>,
     /// Functor which maps local filepath to remote URI if possible, should be applied on all files within [`ReadState`].
-    local_filepath_remap: ReadStateFilepathRemap,
+    read_state_filepath_remap: ReadStateFilepathRemap,
 }
 
 impl ReadStateManager {
@@ -24,7 +24,7 @@ impl ReadStateManager {
         table: &MooncakeTable,
         replication_lsn_rx: watch::Receiver<u64>,
         last_commit_lsn_rx: watch::Receiver<u64>,
-        local_filepath_remap: ReadStateFilepathRemap,
+        read_state_filepath_remap: ReadStateFilepathRemap,
     ) -> Self {
         let (table_snapshot, table_snapshot_watch_receiver) = table.get_state_for_reader();
         ReadStateManager {
@@ -36,13 +36,13 @@ impl ReadStateManager {
                 /*position_deletes=*/ Vec::new(),
                 /*associated_files=*/ Vec::new(),
                 /*cache_handles=*/ Vec::new(),
-                local_filepath_remap.clone(), // Unused
+                read_state_filepath_remap.clone(), // Unused
             ))),
             table_snapshot,
             table_snapshot_watch_receiver,
             replication_lsn_rx,
             last_commit_lsn_rx,
-            local_filepath_remap,
+            read_state_filepath_remap,
         }
     }
 
@@ -176,7 +176,7 @@ impl ReadStateManager {
 
             self.last_read_lsn.store(effective_lsn, Ordering::Release);
             *last_read_state_guard = snapshot_read_output
-                .take_as_read_state(self.local_filepath_remap.clone())
+                .take_as_read_state(self.read_state_filepath_remap.clone())
                 .await;
         }
         Ok(last_read_state_guard.clone())

--- a/src/moonlink_backend/src/lib.rs
+++ b/src/moonlink_backend/src/lib.rs
@@ -10,7 +10,7 @@ use arrow_schema::Schema;
 pub use error::{Error, Result};
 use mooncake_table_id::MooncakeTableId;
 pub use moonlink::ReadState;
-use moonlink::TableEventManager;
+use moonlink::{ReadStateFilepathRemap, TableEventManager};
 use moonlink_connectors::ReplicationManager;
 pub use moonlink_connectors::{
     rest_ingest::rest_source::{EventOperation, EventRequest},
@@ -31,6 +31,8 @@ pub struct MoonlinkBackend<
 > {
     // Base directory for all tables.
     base_path: String,
+    // Functor used to remap local filepath within [`ReadState`] to data server URI if specified and if possible, so table access is routed to data server.
+    local_filepath_remap: ReadStateFilepathRemap,
     // Directory used to store union read temporary files.
     temp_files_dir: String,
     // Metadata storage accessor.
@@ -48,9 +50,31 @@ where
 {
     pub async fn new(
         base_path: String,
+        data_server_uri: Option<String>,
         metadata_store_accessor: Box<dyn MetadataStoreTrait>,
     ) -> Result<Self> {
         logging::init_logging();
+
+        // Create local filepath remap logic, so IO requests could be routed to data server.
+        let base_path_arc = Arc::new(base_path.clone());
+        let data_server_uri_arc = Arc::new(data_server_uri.clone());
+
+        let local_filepath_remap: Arc<dyn Fn(String) -> String + Send + Sync> = {
+            let base_path_arc = Arc::clone(&base_path_arc);
+            let data_server_uri_arc = Arc::clone(&data_server_uri_arc);
+            Arc::new(move |local_filepath: String| {
+                if let Some(ref data_server_uri) = *data_server_uri_arc {
+                    if let Some(stripped) = local_filepath.strip_prefix(&*base_path_arc) {
+                        return format!(
+                            "{}/{}",
+                            data_server_uri.trim_end_matches('/'),
+                            stripped.trim_start_matches('/')
+                        );
+                    }
+                }
+                local_filepath
+            })
+        };
 
         // Canonicalize moonlink backend directory, so all paths stored are of absolute path.
         tokio::fs::create_dir_all(&base_path).await?;
@@ -74,12 +98,14 @@ where
         recovery_utils::recover_all_tables(
             backend_attributes,
             &*metadata_store_accessor,
+            local_filepath_remap.clone(),
             &mut replication_manager,
         )
         .await?;
 
         Ok(Self {
             base_path: base_path_str.to_string(),
+            local_filepath_remap,
             temp_files_dir: temp_files_dir.to_str().unwrap().to_string(),
             replication_manager: RwLock::new(replication_manager),
             metadata_store_accessor,
@@ -144,6 +170,7 @@ where
                         &src_table_name,
                         input_schema.expect("arrow_schema is required for REST API"),
                         moonlink_table_config.clone(),
+                        self.local_filepath_remap.clone(),
                         /*is_recovery=*/ false,
                     )
                     .await?;
@@ -155,6 +182,7 @@ where
                         table_id,
                         &src_table_name,
                         moonlink_table_config.clone(),
+                        self.local_filepath_remap.clone(),
                         /*is_recovery=*/ false,
                     )
                     .await?;

--- a/src/moonlink_backend/src/recovery_utils.rs
+++ b/src/moonlink_backend/src/recovery_utils.rs
@@ -1,5 +1,6 @@
 use crate::error::Result;
 use crate::mooncake_table_id::MooncakeTableId;
+use moonlink::ReadStateFilepathRemap;
 use moonlink_connectors::ReplicationManager;
 use moonlink_metadata_store::base_metadata_store::{MetadataStoreTrait, TableMetadataEntry};
 
@@ -16,6 +17,7 @@ pub(crate) struct BackendAttributes {
 async fn recover_table<D, T>(
     metadata_entry: TableMetadataEntry,
     replication_manager: &mut ReplicationManager<MooncakeTableId<D, T>>,
+    local_filepath_remap: ReadStateFilepathRemap,
 ) -> Result<()>
 where
     D: std::convert::From<u32> + Eq + Hash + Clone + std::fmt::Display,
@@ -32,6 +34,7 @@ where
             metadata_entry.table_id,
             &metadata_entry.src_table_name,
             metadata_entry.moonlink_table_config,
+            local_filepath_remap,
             /*is_recovery=*/ true,
         )
         .await?;
@@ -44,6 +47,7 @@ where
 pub(super) async fn recover_all_tables<D, T>(
     backend_attributes: BackendAttributes,
     metadata_store_accessor: &dyn MetadataStoreTrait,
+    local_filepath_remap: ReadStateFilepathRemap,
     replication_manager: &mut ReplicationManager<MooncakeTableId<D, T>>,
 ) -> Result<()>
 where
@@ -73,7 +77,12 @@ where
             .temp_files_directory = backend_attributes.temp_files_dir.clone();
         // Recover current table.
         unique_uris.insert(cur_metadata_entry.src_table_uri.clone());
-        recover_table(cur_metadata_entry, replication_manager).await?;
+        recover_table(
+            cur_metadata_entry,
+            replication_manager,
+            local_filepath_remap.clone(),
+        )
+        .await?;
     }
 
     for uri in unique_uris.into_iter() {

--- a/src/moonlink_backend/src/recovery_utils.rs
+++ b/src/moonlink_backend/src/recovery_utils.rs
@@ -17,7 +17,7 @@ pub(crate) struct BackendAttributes {
 async fn recover_table<D, T>(
     metadata_entry: TableMetadataEntry,
     replication_manager: &mut ReplicationManager<MooncakeTableId<D, T>>,
-    local_filepath_remap: ReadStateFilepathRemap,
+    read_state_filepath_remap: ReadStateFilepathRemap,
 ) -> Result<()>
 where
     D: std::convert::From<u32> + Eq + Hash + Clone + std::fmt::Display,
@@ -34,7 +34,7 @@ where
             metadata_entry.table_id,
             &metadata_entry.src_table_name,
             metadata_entry.moonlink_table_config,
-            local_filepath_remap,
+            read_state_filepath_remap,
             /*is_recovery=*/ true,
         )
         .await?;
@@ -47,7 +47,7 @@ where
 pub(super) async fn recover_all_tables<D, T>(
     backend_attributes: BackendAttributes,
     metadata_store_accessor: &dyn MetadataStoreTrait,
-    local_filepath_remap: ReadStateFilepathRemap,
+    read_state_filepath_remap: ReadStateFilepathRemap,
     replication_manager: &mut ReplicationManager<MooncakeTableId<D, T>>,
 ) -> Result<()>
 where
@@ -80,7 +80,7 @@ where
         recover_table(
             cur_metadata_entry,
             replication_manager,
-            local_filepath_remap.clone(),
+            read_state_filepath_remap.clone(),
         )
         .await?;
     }

--- a/src/moonlink_backend/tests/common.rs
+++ b/src/moonlink_backend/tests/common.rs
@@ -297,6 +297,7 @@ async fn setup_backend(
             .unwrap();
     let backend = MoonlinkBackend::<DatabaseId, TableId>::new(
         temp_dir.path().to_str().unwrap().into(),
+        /*data_server_uri=*/ None,
         Box::new(metadata_store_accessor),
     )
     .await

--- a/src/moonlink_backend/tests/test_backend.rs
+++ b/src/moonlink_backend/tests/test_backend.rs
@@ -351,10 +351,13 @@ mod tests {
         let sqlite_metadata_store = SqliteMetadataStore::new_with_directory(&base_path)
             .await
             .unwrap();
-        let backend =
-            MoonlinkBackend::<DatabaseId, TableId>::new(base_path, Box::new(sqlite_metadata_store))
-                .await
-                .unwrap();
+        let backend = MoonlinkBackend::<DatabaseId, TableId>::new(
+            base_path,
+            /*data_server_uri=*/ None,
+            Box::new(sqlite_metadata_store),
+        )
+        .await
+        .unwrap();
         let ids = ids_from_state(
             &backend
                 .scan_table(database_id, TABLE_ID, Some(lsn))

--- a/src/moonlink_connectors/src/pg_replicate.rs
+++ b/src/moonlink_connectors/src/pg_replicate.rs
@@ -346,7 +346,7 @@ impl PostgresConnection {
         moonlink_table_config: MoonlinkTableConfig,
         is_recovery: bool,
         table_base_path: &str,
-        local_filepath_remap: ReadStateFilepathRemap,
+        read_state_filepath_remap: ReadStateFilepathRemap,
         object_storage_cache: ObjectStorageCache,
     ) -> Result<(SrcTableId, crate::pg_replicate::table_init::TableResources)> {
         debug!(table_name, "adding table");
@@ -369,7 +369,7 @@ impl PostgresConnection {
             table_schema.src_table_id,
             &table_base_path.to_string(),
             &self.replication_state,
-            local_filepath_remap,
+            read_state_filepath_remap,
             object_storage_cache,
             moonlink_table_config,
         )

--- a/src/moonlink_connectors/src/pg_replicate.rs
+++ b/src/moonlink_connectors/src/pg_replicate.rs
@@ -22,7 +22,7 @@ use crate::pg_replicate::table::{SrcTableId, TableSchema};
 use crate::pg_replicate::table_init::build_table_components;
 use crate::Result;
 use futures::StreamExt;
-use moonlink::{MoonlinkTableConfig, ObjectStorageCache, TableEvent};
+use moonlink::{MoonlinkTableConfig, ObjectStorageCache, ReadStateFilepathRemap, TableEvent};
 use std::collections::HashMap;
 use std::io::{Error, ErrorKind};
 use std::mem::take;
@@ -346,6 +346,7 @@ impl PostgresConnection {
         moonlink_table_config: MoonlinkTableConfig,
         is_recovery: bool,
         table_base_path: &str,
+        local_filepath_remap: ReadStateFilepathRemap,
         object_storage_cache: ObjectStorageCache,
     ) -> Result<(SrcTableId, crate::pg_replicate::table_init::TableResources)> {
         debug!(table_name, "adding table");
@@ -368,6 +369,7 @@ impl PostgresConnection {
             table_schema.src_table_id,
             &table_base_path.to_string(),
             &self.replication_state,
+            local_filepath_remap,
             object_storage_cache,
             moonlink_table_config,
         )

--- a/src/moonlink_connectors/src/pg_replicate/table_init.rs
+++ b/src/moonlink_connectors/src/pg_replicate/table_init.rs
@@ -4,6 +4,7 @@ use crate::{Error, Result};
 use arrow_schema::Schema as ArrowSchema;
 use moonlink::event_sync::create_table_event_syncer;
 use moonlink::table_handler_timer::create_table_handler_timers;
+use moonlink::ReadStateFilepathRemap;
 use moonlink::{
     row::IdentityProp, AccessorConfig, EventSyncReceiver, EventSyncSender, FileSystemAccessor,
     IcebergTableConfig, MooncakeTable, MooncakeTableConfig, MoonlinkSecretType,
@@ -59,6 +60,7 @@ pub async fn build_table_components(
     src_table_id: SrcTableId,
     base_path: &String,
     replication_state: &ReplicationState,
+    local_filepath_remap: ReadStateFilepathRemap,
     object_storage_cache: ObjectStorageCache,
     moonlink_table_config: MoonlinkTableConfig,
 ) -> Result<TableResources> {
@@ -95,8 +97,12 @@ pub async fn build_table_components(
     .await?;
 
     let (commit_lsn_tx, commit_lsn_rx) = watch::channel(0u64);
-    let read_state_manager =
-        ReadStateManager::new(&table, replication_state.subscribe(), commit_lsn_rx);
+    let read_state_manager = ReadStateManager::new(
+        &table,
+        replication_state.subscribe(),
+        commit_lsn_rx,
+        local_filepath_remap,
+    );
     let table_status_reader =
         TableStatusReader::new(&moonlink_table_config.iceberg_table_config, &table);
     let (event_sync_sender, event_sync_receiver) = create_table_event_syncer();

--- a/src/moonlink_connectors/src/pg_replicate/table_init.rs
+++ b/src/moonlink_connectors/src/pg_replicate/table_init.rs
@@ -60,7 +60,7 @@ pub async fn build_table_components(
     src_table_id: SrcTableId,
     base_path: &String,
     replication_state: &ReplicationState,
-    local_filepath_remap: ReadStateFilepathRemap,
+    read_state_filepath_remap: ReadStateFilepathRemap,
     object_storage_cache: ObjectStorageCache,
     moonlink_table_config: MoonlinkTableConfig,
 ) -> Result<TableResources> {
@@ -101,7 +101,7 @@ pub async fn build_table_components(
         &table,
         replication_state.subscribe(),
         commit_lsn_rx,
-        local_filepath_remap,
+        read_state_filepath_remap,
     );
     let table_status_reader =
         TableStatusReader::new(&moonlink_table_config.iceberg_table_config, &table);

--- a/src/moonlink_connectors/src/replication_connection.rs
+++ b/src/moonlink_connectors/src/replication_connection.rs
@@ -6,7 +6,8 @@ use crate::rest_ingest::RestApiConnection;
 use crate::Result;
 use arrow_schema::Schema as ArrowSchema;
 use moonlink::{
-    MoonlinkTableConfig, ObjectStorageCache, ReadStateManager, TableEventManager, TableStatusReader,
+    MoonlinkTableConfig, ObjectStorageCache, ReadStateFilepathRemap, ReadStateManager,
+    TableEventManager, TableStatusReader,
 };
 use std::collections::HashMap;
 use tokio::sync::mpsc;
@@ -154,6 +155,7 @@ impl ReplicationConnection {
         mooncake_table_id: &T,
         table_id: u32,
         moonlink_table_config: MoonlinkTableConfig,
+        local_filepath_remap: ReadStateFilepathRemap,
         is_recovery: bool,
     ) -> Result<SrcTableId> {
         match &mut self.source {
@@ -168,6 +170,7 @@ impl ReplicationConnection {
                         moonlink_table_config,
                         is_recovery,
                         &self.table_base_path,
+                        local_filepath_remap,
                         self.object_storage_cache.clone(),
                     )
                     .await?;
@@ -198,6 +201,7 @@ impl ReplicationConnection {
         table_id: u32,
         arrow_schema: ArrowSchema,
         moonlink_table_config: MoonlinkTableConfig,
+        local_filepath_remap: ReadStateFilepathRemap,
         _is_recovery: bool,
     ) -> Result<SrcTableId> {
         match &mut self.source {
@@ -217,6 +221,7 @@ impl ReplicationConnection {
                     &self.table_base_path,
                     // REST API doesn't have replication state, create a dummy one
                     &crate::pg_replicate::replication_state::ReplicationState::new(),
+                    local_filepath_remap,
                     self.object_storage_cache.clone(),
                     moonlink_table_config,
                 )

--- a/src/moonlink_connectors/src/replication_connection.rs
+++ b/src/moonlink_connectors/src/replication_connection.rs
@@ -155,7 +155,7 @@ impl ReplicationConnection {
         mooncake_table_id: &T,
         table_id: u32,
         moonlink_table_config: MoonlinkTableConfig,
-        local_filepath_remap: ReadStateFilepathRemap,
+        read_state_filepath_remap: ReadStateFilepathRemap,
         is_recovery: bool,
     ) -> Result<SrcTableId> {
         match &mut self.source {
@@ -170,7 +170,7 @@ impl ReplicationConnection {
                         moonlink_table_config,
                         is_recovery,
                         &self.table_base_path,
-                        local_filepath_remap,
+                        read_state_filepath_remap,
                         self.object_storage_cache.clone(),
                     )
                     .await?;
@@ -201,7 +201,7 @@ impl ReplicationConnection {
         table_id: u32,
         arrow_schema: ArrowSchema,
         moonlink_table_config: MoonlinkTableConfig,
-        local_filepath_remap: ReadStateFilepathRemap,
+        read_state_filepath_remap: ReadStateFilepathRemap,
         _is_recovery: bool,
     ) -> Result<SrcTableId> {
         match &mut self.source {
@@ -221,7 +221,7 @@ impl ReplicationConnection {
                     &self.table_base_path,
                     // REST API doesn't have replication state, create a dummy one
                     &crate::pg_replicate::replication_state::ReplicationState::new(),
-                    local_filepath_remap,
+                    read_state_filepath_remap,
                     self.object_storage_cache.clone(),
                     moonlink_table_config,
                 )

--- a/src/moonlink_connectors/src/replication_manager.rs
+++ b/src/moonlink_connectors/src/replication_manager.rs
@@ -56,7 +56,7 @@ impl<T: Clone + Eq + Hash + std::fmt::Display> ReplicationManager<T> {
         table_id: u32,
         table_name: &str,
         moonlink_table_config: MoonlinkTableConfig,
-        local_filepath_remap: ReadStateFilepathRemap,
+        read_state_filepath_remap: ReadStateFilepathRemap,
         is_recovery: bool,
     ) -> Result<()> {
         debug!(%src_uri, table_name, "adding table through manager");
@@ -83,7 +83,7 @@ impl<T: Clone + Eq + Hash + std::fmt::Display> ReplicationManager<T> {
                 &mooncake_table_id,
                 table_id,
                 moonlink_table_config,
-                local_filepath_remap,
+                read_state_filepath_remap,
                 is_recovery,
             )
             .await?;
@@ -112,7 +112,7 @@ impl<T: Clone + Eq + Hash + std::fmt::Display> ReplicationManager<T> {
         table_name: &str,
         arrow_schema: arrow_schema::Schema,
         moonlink_table_config: MoonlinkTableConfig,
-        local_filepath_remap: ReadStateFilepathRemap,
+        read_state_filepath_remap: ReadStateFilepathRemap,
         is_recovery: bool,
     ) -> Result<()> {
         debug!(%src_uri, table_name, "adding REST API table through manager");
@@ -133,7 +133,7 @@ impl<T: Clone + Eq + Hash + std::fmt::Display> ReplicationManager<T> {
                 table_id,
                 arrow_schema,
                 moonlink_table_config,
-                local_filepath_remap,
+                read_state_filepath_remap,
                 is_recovery,
             )
             .await?;

--- a/src/moonlink_connectors/src/replication_manager.rs
+++ b/src/moonlink_connectors/src/replication_manager.rs
@@ -1,8 +1,8 @@
 use crate::pg_replicate::table::SrcTableId;
 use crate::ReplicationConnection;
 use crate::{Error, Result};
-use moonlink::TableStatusReader;
 use moonlink::{MoonlinkTableConfig, ObjectStorageCache, ReadStateManager, TableEventManager};
+use moonlink::{ReadStateFilepathRemap, TableStatusReader};
 use std::collections::HashMap;
 use std::hash::Hash;
 use tokio::task::JoinHandle;
@@ -56,6 +56,7 @@ impl<T: Clone + Eq + Hash + std::fmt::Display> ReplicationManager<T> {
         table_id: u32,
         table_name: &str,
         moonlink_table_config: MoonlinkTableConfig,
+        local_filepath_remap: ReadStateFilepathRemap,
         is_recovery: bool,
     ) -> Result<()> {
         debug!(%src_uri, table_name, "adding table through manager");
@@ -82,6 +83,7 @@ impl<T: Clone + Eq + Hash + std::fmt::Display> ReplicationManager<T> {
                 &mooncake_table_id,
                 table_id,
                 moonlink_table_config,
+                local_filepath_remap,
                 is_recovery,
             )
             .await?;
@@ -110,6 +112,7 @@ impl<T: Clone + Eq + Hash + std::fmt::Display> ReplicationManager<T> {
         table_name: &str,
         arrow_schema: arrow_schema::Schema,
         moonlink_table_config: MoonlinkTableConfig,
+        local_filepath_remap: ReadStateFilepathRemap,
         is_recovery: bool,
     ) -> Result<()> {
         debug!(%src_uri, table_name, "adding REST API table through manager");
@@ -130,6 +133,7 @@ impl<T: Clone + Eq + Hash + std::fmt::Display> ReplicationManager<T> {
                 table_id,
                 arrow_schema,
                 moonlink_table_config,
+                local_filepath_remap,
                 is_recovery,
             )
             .await?;

--- a/src/moonlink_service/examples/rest_api_demo.rs
+++ b/src/moonlink_service/examples/rest_api_demo.rs
@@ -24,6 +24,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             base_path: demo_path.to_string(),
             rest_api_port: Some(3030),
             tcp_port: None,
+            data_server_uri: None,
         })
         .await
         {

--- a/src/moonlink_service/src/main.rs
+++ b/src/moonlink_service/src/main.rs
@@ -21,6 +21,11 @@ struct Cli {
     /// Disable standalone deployment.
     #[arg(long)]
     no_tcp_api: bool,
+
+    /// IP/port for data server.
+    /// For example: http://34.19.1.175:8080.
+    #[arg(long)]
+    data_server_uri: Option<String>,
 }
 
 #[tokio::main]
@@ -31,6 +36,7 @@ pub async fn main() -> Result<()> {
     let cli = Cli::parse();
     let config = ServiceConfig {
         base_path: cli.base_path,
+        data_server_uri: cli.data_server_uri,
         rest_api_port: if cli.no_rest_api {
             None
         } else {


### PR DESCRIPTION
## Summary

When moonlink is deployed standalone, all requests are split into two catagories: control plane and data plane.
- control plane requests are served by moonlink server TCP connections
- data plane requests are served by nginx data server via HTTP connections

The roundtrip looks like:
- pg_mooncake asks control plane for table files
- duckdb requests content for these file via data plane
- so all these table files needs to be remapped: (1) with http scheme, so duckdb-httpfs handles certain request; (2) update filepath so data server could access

Standalone testing setup:
- remote postgres deployed at GCP
- remote moonlink and nginx deployment
- local devcontainer postgres with pg_mooncake

Standalone testing result (at pg_mooncake side):
```sh
pg_mooncake (pid: 1547) =# CREATE EXTENSION pg_mooncake;
CREATE EXTENSION
pg_mooncake (pid: 1547) =# CALL mooncake.create_table('c3', 'r3', 'postgresql://postgres:password@34.187.201.2:5432/postgres');
CALL
pg_mooncake (pid: 1547) =# SELECT * FROM c3;
 a  |   b    
----+--------
  1 | val_1
  2 | val_2
  3 | val_3
  4 | val_4
  5 | val_5
  6 | val_6
  7 | val_7
  8 | val_8
  9 | val_9
 10 | val_10
(10 rows)
```

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1221

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
