### PR TITLE
Configure default Parquet writer settings

### DIFF
--- a/src/moonlink/src/storage/parquet_utils.rs
+++ b/src/moonlink/src/storage/parquet_utils.rs
@@ -12,8 +12,6 @@ pub(crate) fn get_default_parquet_properties() -> WriterProperties {
         .set_compression(DEFAULT_COMPRESSION)
         .set_dictionary_enabled(true)
         .set_dictionary_page_size_limit(DEFAULT_ROW_GROUP_SIZE / 100)
-        // .set_bloom_filter_enabled(true)
-        // .set_bloom_filter_fpp(0.01)
         .set_writer_version(parquet::file::properties::WriterVersion::PARQUET_1_0)
         .build()
 }

--- a/src/moonlink/src/storage/parquet_utils.rs
+++ b/src/moonlink/src/storage/parquet_utils.rs
@@ -11,9 +11,9 @@ pub(crate) fn get_default_parquet_properties() -> WriterProperties {
     WriterProperties::builder()
         .set_compression(DEFAULT_COMPRESSION)
         .set_dictionary_enabled(true)
-        .set_bloom_filter_enabled(true)
         .set_dictionary_page_size_limit(DEFAULT_ROW_GROUP_SIZE / 100)
-        .set_bloom_filter_fpp(0.01)
+        // .set_bloom_filter_enabled(true)
+        // .set_bloom_filter_fpp(0.01)
         .set_writer_version(parquet::file::properties::WriterVersion::PARQUET_1_0)
         .build()
 }

--- a/src/moonlink/src/storage/parquet_utils.rs
+++ b/src/moonlink/src/storage/parquet_utils.rs
@@ -4,9 +4,16 @@ use parquet::{basic::Compression, file::properties::WriterProperties};
 /// Default compression.
 const DEFAULT_COMPRESSION: Compression = parquet::basic::Compression::SNAPPY;
 
+// Default row group size from duckdb.
+const DEFAULT_ROW_GROUP_SIZE: usize = 122880;
+
 pub(crate) fn get_default_parquet_properties() -> WriterProperties {
     WriterProperties::builder()
         .set_compression(DEFAULT_COMPRESSION)
         .set_dictionary_enabled(true)
+        .set_bloom_filter_enabled(true)
+        .set_dictionary_page_size_limit(DEFAULT_ROW_GROUP_SIZE / 100)
+        .set_bloom_filter_fpp(0.01)
+        .set_writer_version(parquet::file::properties::WriterVersion::PARQUET_1_0)
         .build()
 }


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

Configure default Parquet writer settings.

Related https://github.com/Mooncake-Labs/moonlink/issues/525

## Changes

```
.set_compression(DEFAULT_COMPRESSION)
.set_dictionary_enabled(true)
.set_dictionary_page_size_limit(DEFAULT_ROW_GROUP_SIZE / 100)
// .set_bloom_filter_enabled(true)
// .set_bloom_filter_fpp(0.01)
.set_writer_version(parquet::file::properties::WriterVersion::PARQUET_1_0)
```

Not found in setting options:
```
ZStdFileSystem::DefaultCompressionLevel() /*compression_level*/, 
true /*debug_use_openssl*/,
```

Enables these changes may cause the following integration test error..
```
// .set_bloom_filter_enabled(true)
// .set_bloom_filter_fpp(0.01)
```

```
test storage::iceberg::compaction_tests::test_compaction_1_1_1 ... FAILED
test storage::iceberg::compaction_tests::test_compaction_1_1_2 ... FAILED
test storage::iceberg::compaction_tests::test_compaction_1_2_1 ... FAILED
test storage::iceberg::compaction_tests::test_compaction_1_2_2 ... FAILED
test storage::iceberg::compaction_tests::test_compaction_2_2_1 ... FAILED
test storage::iceberg::compaction_tests::test_compaction_2_2_2 ... FAILED
test storage::iceberg::compaction_tests::test_compaction_2_3_1 ... FAILED
test storage::iceberg::compaction_tests::test_compaction_3_2_1 ... FAILED
test storage::iceberg::compaction_tests::test_compaction_3_3_1 ... FAILED
```

## Checklist

- [✓] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [✓] I have reviewed my own changes
