### PR TITLE
more data types on json ingestion

### DIFF
--- a/src/moonlink_connectors/src/rest_ingest/json_converter.rs
+++ b/src/moonlink_connectors/src/rest_ingest/json_converter.rs
@@ -148,11 +148,67 @@ mod tests {
         let converter = JsonToMoonlinkRowConverter::new(schema);
         let input = json!({
             "id": "not_an_int",
-            "name": "moonlink"
+            "name": "moonlink",
+            "is_active": true,
+            "score": 100.0,
+            "id_int64": 123,
+            "score_float32": 100.0,
         });
         let err = converter.convert(&input).unwrap_err();
         match err {
             JsonToMoonlinkRowError::TypeMismatch(f) => assert_eq!(f, "id"),
+            _ => panic!("unexpected error: {err:?}"),
+        }
+        let input = json!({
+            "is_active": "true",
+            "name": "moonlink",
+            "score": 100.0,
+            "id_int64": 123,
+            "score_float32": 100.0,
+            "id": 1,
+        });
+        let err = converter.convert(&input).unwrap_err();
+        match err {
+            JsonToMoonlinkRowError::TypeMismatch(f) => assert_eq!(f, "is_active"),
+            _ => panic!("unexpected error: {err:?}"),
+        }
+        let input = json!({
+            "score": "not_a_float",
+            "name": "moonlink",
+            "is_active": true,
+            "id_int64": 123,
+            "score_float32": 100.0,
+            "id": 1,
+        });
+        let err = converter.convert(&input).unwrap_err();
+        match err {
+            JsonToMoonlinkRowError::TypeMismatch(f) => assert_eq!(f, "score"),
+            _ => panic!("unexpected error: {err:?}"),
+        }
+        let input = json!({
+            "score_float32": "not_a_float",
+            "name": "moonlink",
+            "is_active": true,
+            "id_int64": 123,
+            "score": 100.0,
+            "id": 1,
+        });
+        let err = converter.convert(&input).unwrap_err();
+        match err {
+            JsonToMoonlinkRowError::TypeMismatch(f) => assert_eq!(f, "score_float32"),
+            _ => panic!("unexpected error: {err:?}"),
+        }
+        let input = json!({
+            "id_int64": "not_an_int",
+            "name": "moonlink",
+            "is_active": true,
+            "score": 100.0,
+            "score_float32": 100.0,
+            "id": 1,
+        });
+        let err = converter.convert(&input).unwrap_err();
+        match err {
+            JsonToMoonlinkRowError::TypeMismatch(f) => assert_eq!(f, "id_int64"),
             _ => panic!("unexpected error: {err:?}"),
         }
     }

--- a/src/moonlink_connectors/src/rest_ingest/json_converter.rs
+++ b/src/moonlink_connectors/src/rest_ingest/json_converter.rs
@@ -54,6 +54,34 @@ impl JsonToMoonlinkRowConverter {
                     Err(JsonToMoonlinkRowError::TypeMismatch(field.name().clone()))
                 }
             }
+            DataType::Boolean => {
+                if let Some(b) = value.as_bool() {
+                    Ok(RowValue::Bool(b))
+                } else {
+                    Err(JsonToMoonlinkRowError::TypeMismatch(field.name().clone()))
+                }
+            }
+            DataType::Float32 => {
+                if let Some(f) = value.as_f64() {
+                    Ok(RowValue::Float32(f as f32))
+                } else {
+                    Err(JsonToMoonlinkRowError::TypeMismatch(field.name().clone()))
+                }
+            }
+            DataType::Float64 => {
+                if let Some(f) = value.as_f64() {
+                    Ok(RowValue::Float64(f))
+                } else {
+                    Err(JsonToMoonlinkRowError::TypeMismatch(field.name().clone()))
+                }
+            }
+            DataType::Int64 => {
+                if let Some(i) = value.as_i64() {
+                    Ok(RowValue::Int64(i))
+                } else {
+                    Err(JsonToMoonlinkRowError::TypeMismatch(field.name().clone()))
+                }
+            }
             // TODO: Add more type conversions (Bool, Float, Date, etc.)
             _ => Err(JsonToMoonlinkRowError::TypeMismatch(field.name().clone())),
         }
@@ -71,6 +99,10 @@ mod tests {
         Arc::new(Schema::new(vec![
             Field::new("id", DataType::Int32, false),
             Field::new("name", DataType::Utf8, false),
+            Field::new("is_active", DataType::Boolean, false),
+            Field::new("score", DataType::Float64, false),
+            Field::new("id_int64", DataType::Int64, false),
+            Field::new("score_float32", DataType::Float32, false),
         ]))
     }
 
@@ -80,12 +112,20 @@ mod tests {
         let converter = JsonToMoonlinkRowConverter::new(schema);
         let input = json!({
             "id": 42,
-            "name": "moonlink"
+            "name": "moonlink",
+            "is_active": true,
+            "score": 100.0,
+            "id_int64": 123,
+            "score_float32": 100.0,
         });
         let row = converter.convert(&input).unwrap();
-        assert_eq!(row.values.len(), 2);
+        assert_eq!(row.values.len(), 6);
         assert_eq!(row.values[0], RowValue::Int32(42));
         assert_eq!(row.values[1], RowValue::ByteArray(b"moonlink".to_vec()));
+        assert_eq!(row.values[2], RowValue::Bool(true));
+        assert_eq!(row.values[3], RowValue::Float64(100.0));
+        assert_eq!(row.values[4], RowValue::Int64(123));
+        assert_eq!(row.values[5], RowValue::Float32(100.0));
     }
 
     #[test]


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

Support bool/i64/f32/f64 for JsonToMooklinkConverter

## Related Issues

ref https://github.com/Mooncake-Labs/moonlink/issues/1282

## Changes

- Add type conversion for those data types.
- Update test case to reflect the changes.

Not sure if this works end-to-end; would be great if there's some pointer on where I can find e2e tests for those ingestions.

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
