### PR TITLE
[deployment] Setup readiness probe

### DIFF
--- a/cloud/gcp/dev/deployment/moonlink_deployment.yaml
+++ b/cloud/gcp/dev/deployment/moonlink_deployment.yaml
@@ -30,6 +30,16 @@ spec:
         - containerPort: 3030
         # Port number for TCP rpc server.
         - containerPort: 3031
+        # Port number for readiness probe.
+        - containerPort: 5050 
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 5050
+          initialDelaySeconds: 2
+          periodSeconds: 5
+          timeoutSeconds: 1
+          failureThreshold: 3
 
       # Data server, which serves data plane requests.
       - name: nginx

--- a/cloud/gcp/dev/service/moonlink_service.yaml
+++ b/cloud/gcp/dev/service/moonlink_service.yaml
@@ -23,3 +23,8 @@ spec:
     protocol: TCP
     port: 3031
     targetPort: 3031
+  # Exposed port for readiness check.
+  - name: readiness
+    protocol: TCP
+    port: 5050
+    targetPort: 5050

--- a/cloud/gcp/prod/deployment/moonlink_deployment.yaml
+++ b/cloud/gcp/prod/deployment/moonlink_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       containers:
       # Moonlink deployment, which serves REST API and TCP rpc requests.
       - name: moonlink-deployment
-        image: us-west1-docker.pkg.dev/coral-ring-465417-r0/moonlink-standalone-experiment/moonlink-deployment:7cb80acf-9d2e-4dfe-b19a-ad8e6578415d
+        image: us-west1-docker.pkg.dev/coral-ring-465417-r0/moonlink-standalone-experiment/moonlink-deployment:478dc9ee-cc19-48f9-b741-21e6e8b27de7
         command: ["/app/moonlink_service"]
         args:
         - "/tmp/moonlink"
@@ -42,6 +42,16 @@ spec:
         - containerPort: 3030
         # Port number for TCP rpc server.
         - containerPort: 3031
+        # Port number for readiness probe.
+        - containerPort: 5050 
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 5050
+          initialDelaySeconds: 2
+          periodSeconds: 5
+          timeoutSeconds: 1
+          failureThreshold: 3
 
       # Data server, which serves data plane requests.
       - name: nginx

--- a/cloud/gcp/prod/service/moonlink_service.yaml
+++ b/cloud/gcp/prod/service/moonlink_service.yaml
@@ -23,3 +23,8 @@ spec:
     protocol: TCP
     port: 3031
     targetPort: 3031
+  # Exposed port for readiness check.
+  - name: readiness
+    protocol: TCP
+    port: 5050
+    targetPort: 5050

--- a/cloud/gcp/staging/deployment/moonlink_deployment.yaml
+++ b/cloud/gcp/staging/deployment/moonlink_deployment.yaml
@@ -42,6 +42,16 @@ spec:
         - containerPort: 3030
         # Port number for TCP rpc server.
         - containerPort: 3031
+        # Port number for readiness probe.
+        - containerPort: 5050 
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 5050
+          initialDelaySeconds: 2
+          periodSeconds: 5
+          timeoutSeconds: 1
+          failureThreshold: 3
 
       # Data server, which serves data plane requests.
       - name: nginx

--- a/cloud/gcp/staging/service/moonlink_service.yaml
+++ b/cloud/gcp/staging/service/moonlink_service.yaml
@@ -23,3 +23,8 @@ spec:
     protocol: TCP
     port: 3031
     targetPort: 3031
+  # Exposed port for readiness check.
+  - name: readiness
+    protocol: TCP
+    port: 5050
+    targetPort: 5050

--- a/src/moonlink_service/src/lib.rs
+++ b/src/moonlink_service/src/lib.rs
@@ -3,11 +3,26 @@ mod rest_api;
 mod rpc_server;
 
 pub use error::Result;
+
 use moonlink_backend::MoonlinkBackend;
 use moonlink_metadata_store::SqliteMetadataStore;
-use std::sync::Arc;
-use tokio::signal::unix::{signal, SignalKind};
+use std::net::SocketAddr;
+use std::sync::atomic::AtomicBool;
+use std::sync::{atomic::Ordering, Arc};
+use tokio::{
+    net::TcpListener,
+    signal::unix::{signal, SignalKind},
+};
 use tracing::{error, info};
+
+/// Default readiness probe port number.
+const READINESS_PROBE_PORT: u16 = 5050;
+
+/// Service initiation and execution status.
+struct ServiceStatus {
+    /// Whether the service starts up successfully.
+    ready: AtomicBool,
+}
 
 pub struct ServiceConfig {
     /// Base location for moonlink storage (including cache files, iceberg tables, etc).
@@ -20,7 +35,49 @@ pub struct ServiceConfig {
     pub tcp_port: Option<u16>,
 }
 
+impl ServiceConfig {
+    /// Whether moonlink is deployed as a standalone service.
+    pub fn in_standalone_deployment_mode(&self) -> bool {
+        self.rest_api_port.is_some() || self.tcp_port.is_some()
+    }
+}
+
+async fn service_ready(
+    axum::extract::State(state): axum::extract::State<Arc<ServiceStatus>>,
+) -> impl axum::response::IntoResponse {
+    if !state.ready.load(Ordering::SeqCst) {
+        return (axum::http::StatusCode::SERVICE_UNAVAILABLE, "not ready");
+    }
+    (axum::http::StatusCode::OK, "ready")
+}
+
+/// Setup readiness probe for moonlink backend service.
+fn setup_readiness_probe() -> Arc<ServiceStatus> {
+    let service_status = Arc::new(ServiceStatus {
+        ready: AtomicBool::new(false),
+    });
+    let service_status_clone = service_status.clone();
+    tokio::spawn(async move {
+        let app = axum::Router::new()
+            .route("/ready", axum::routing::get(service_ready))
+            .with_state(service_status_clone);
+        let addr = SocketAddr::from(([0, 0, 0, 0], READINESS_PROBE_PORT));
+        let listener = TcpListener::bind(addr).await.unwrap();
+        axum::serve(listener, app).await.unwrap();
+        info!("health server on {addr}");
+    });
+    service_status
+}
+
 pub async fn start_with_config(config: ServiceConfig) -> Result<()> {
+    // Register HTTP endpoint for readiness probe.
+    let service_status = if config.in_standalone_deployment_mode() {
+        Some(setup_readiness_probe())
+    } else {
+        None
+    };
+
+    // Initialize moonlink backend.
     let mut sigterm = signal(SignalKind::terminate()).unwrap();
     let sqlite_metadata_accessor = SqliteMetadataStore::new_with_directory(&config.base_path)
         .await
@@ -77,6 +134,10 @@ pub async fn start_with_config(config: ServiceConfig) -> Result<()> {
         None
     };
 
+    // Moonlink and backend services have started.
+    if let Some(service_status) = service_status {
+        service_status.ready.store(true, Ordering::SeqCst);
+    }
     info!("Moonlink service started successfully");
 
     // Wait for termination signal


### PR DESCRIPTION
## Summary

This PR setups the readiness probe for deployment and expose HTTP endpoint for later uptime check usage.

How I tested:
- I deployed to GKE, deployment startup successfully with no issue
- Checked with exposed HTTP endpoint
```sh
(myenv) hjiang@hjiangs-MacBook-Pro moonlink % curl http://34.168.174.231:5050/ready                                      
ready%      
```

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1259

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
