### PR TITLE
[chaos] Fix non-deterministic filesystem accessor chaos

### DIFF
--- a/src/moonlink/src/storage/filesystem/accessor/chaos_generator.rs
+++ b/src/moonlink/src/storage/filesystem/accessor/chaos_generator.rs
@@ -19,11 +19,16 @@ pub(crate) struct ChaosGenerator {
 impl ChaosGenerator {
     pub(crate) fn new(option: ChaosConfig) -> Self {
         option.validate();
-        let nanos = SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        let rng = Arc::new(Mutex::new(StdRng::seed_from_u64(nanos as u64)));
+        let random_seed = if let Some(random_seed) = option.random_seed {
+            random_seed
+        } else {
+            let nanos = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_nanos();
+            nanos as u64
+        };
+        let rng = Arc::new(Mutex::new(StdRng::seed_from_u64(random_seed)));
 
         Self { rng, option }
     }

--- a/src/moonlink/src/storage/filesystem/accessor/chaos_generator.rs
+++ b/src/moonlink/src/storage/filesystem/accessor/chaos_generator.rs
@@ -79,6 +79,7 @@ mod tests {
     #[tokio::test]
     async fn test_no_delay_no_error() {
         let option = ChaosConfig {
+            random_seed: None,
             min_latency: std::time::Duration::from_millis(0),
             max_latency: std::time::Duration::from_millis(0),
             err_prob: 0,
@@ -90,6 +91,7 @@ mod tests {
     #[tokio::test]
     async fn test_delay_no_error() {
         let option = ChaosConfig {
+            random_seed: None,
             min_latency: std::time::Duration::from_millis(100),
             max_latency: std::time::Duration::from_millis(200),
             err_prob: 0,
@@ -103,6 +105,7 @@ mod tests {
         const ATTEMPT_COUNT: usize = 10;
 
         let option = ChaosConfig {
+            random_seed: None,
             min_latency: std::time::Duration::from_millis(0),
             max_latency: std::time::Duration::from_millis(0),
             err_prob: 100,

--- a/src/moonlink/src/storage/filesystem/accessor/filesystem_accessor_chaos_wrapper.rs
+++ b/src/moonlink/src/storage/filesystem/accessor/filesystem_accessor_chaos_wrapper.rs
@@ -193,6 +193,7 @@ mod tests {
     async fn test_no_delay_no_error() {
         let temp_dir = tempdir().unwrap();
         let chaos_config = ChaosConfig {
+            random_seed: None,
             min_latency: std::time::Duration::ZERO,
             max_latency: std::time::Duration::ZERO,
             err_prob: 0,
@@ -206,6 +207,7 @@ mod tests {
     async fn test_delay_injected() {
         let temp_dir = tempdir().unwrap();
         let chaos_config = ChaosConfig {
+            random_seed: None,
             min_latency: std::time::Duration::from_millis(5000),
             max_latency: std::time::Duration::from_millis(5000),
             err_prob: 0,

--- a/src/moonlink/src/storage/filesystem/accessor_config.rs
+++ b/src/moonlink/src/storage/filesystem/accessor_config.rs
@@ -62,6 +62,9 @@ impl Default for RetryConfig {
 ///
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ChaosConfig {
+    /// Random seed; if unassigned, use current timestamp as random seed.
+    pub random_seed: Option<u64>,
+
     /// Min and max latency introduced to all operation access, both inclusive.
     pub min_latency: std::time::Duration,
     pub max_latency: std::time::Duration,

--- a/src/moonlink/src/storage/mooncake_table/table_creation_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_creation_test_utils.rs
@@ -69,10 +69,12 @@ pub(crate) fn get_iceberg_table_config_with_storage_config(
 #[cfg(feature = "chaos-test")]
 pub(crate) fn get_iceberg_table_config_with_chaos_injection(
     storage_config: StorageConfig,
+    random_seed: u64,
 ) -> IcebergTableConfig {
     use crate::storage::filesystem::accessor_config::{ChaosConfig, RetryConfig, TimeoutConfig};
 
     let chaos_config = ChaosConfig {
+        random_seed: Some(random_seed),
         min_latency: std::time::Duration::from_secs(0),
         max_latency: std::time::Duration::from_secs(1),
         err_prob: 5, // 5% error probability, a few retry attempts should work


### PR DESCRIPTION
## Summary

This PR fixes a non-deterministic cause of chaos test: filesystem chaos layer is using its own random seed, we should pass the same seed everywhere.

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
