### PR TITLE
[chaos] Add chaos config for disk slice writer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -255,3 +255,16 @@ jobs:
         timeout-minutes: 10
         run: |
           RUST_BACKTRACE=1 cargo test table_handler::chaos_test::test_chaos_injection --features=chaos-test -p moonlink -- --nocapture
+
+  # ───────────── 8 · Chaos test for disk slice write ─────────────
+  disk_slice_write_with_chaos:
+    name: Chaos test for disk slice write
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Start chaos test
+        timeout-minutes: 10
+        run: |
+          RUST_BACKTRACE=1 cargo test table_handler::chaos_test::test_disk_slice_chaos --features=chaos-test -p moonlink -- --nocapture

--- a/src/moonlink/src/lib.rs
+++ b/src/moonlink/src/lib.rs
@@ -12,12 +12,12 @@ pub use event_sync::EventSyncSender;
 pub use storage::storage_utils::create_data_file;
 pub(crate) use storage::NonEvictableHandle;
 pub use storage::{
-    AccessorConfig, DataCompactionConfig, EventSyncReceiver, FileIndexMergeConfig,
-    FileSystemAccessor, IcebergPersistenceConfig, IcebergTableConfig, IcebergTableManager,
-    MooncakeTable, MooncakeTableConfig, MoonlinkSecretType, MoonlinkTableConfig,
-    MoonlinkTableSecret, ObjectStorageCache, ObjectStorageCacheConfig, SnapshotReadOutput,
-    StorageConfig, TableEventManager, TableManager, TableSnapshotStatus, TableStatusReader,
-    WalConfig, WalManager, WalTransactionState,
+    AccessorConfig, DataCompactionConfig, DiskSliceWriterConfig, EventSyncReceiver,
+    FileIndexMergeConfig, FileSystemAccessor, IcebergPersistenceConfig, IcebergTableConfig,
+    IcebergTableManager, MooncakeTable, MooncakeTableConfig, MoonlinkSecretType,
+    MoonlinkTableConfig, MoonlinkTableSecret, ObjectStorageCache, ObjectStorageCacheConfig,
+    SnapshotReadOutput, StorageConfig, TableEventManager, TableManager, TableSnapshotStatus,
+    TableStatusReader, WalConfig, WalManager, WalTransactionState,
 };
 pub use table_handler::TableHandler;
 pub use table_handler_timer::TableHandlerTimer;

--- a/src/moonlink/src/storage.rs
+++ b/src/moonlink/src/storage.rs
@@ -35,6 +35,7 @@ pub use mooncake_table::table_status_reader::TableStatusReader;
 pub use mooncake_table::MooncakeTable;
 pub use mooncake_table::SnapshotReadOutput;
 pub(crate) use mooncake_table::{PuffinDeletionBlobAtRead, SnapshotTableState};
+pub use mooncake_table_config::DiskSliceWriterConfig;
 pub use mooncake_table_config::IcebergPersistenceConfig;
 pub use mooncake_table_config::MooncakeTableConfig;
 pub use wal::{WalConfig, WalManager, WalTransactionState};

--- a/src/moonlink/src/storage/iceberg/tests.rs
+++ b/src/moonlink/src/storage/iceberg/tests.rs
@@ -1525,7 +1525,7 @@ async fn test_multiple_table_ids_for_deletion_vector() {
         mem_slice_size: 1,
         // At flush, place each row in a separate parquet file.
         disk_slice_writer_config: DiskSliceWriterConfig {
-            parquet_file_size: 1000,
+            parquet_file_size: 1,
             chaos_config: None,
         },
         ..Default::default()

--- a/src/moonlink/src/storage/iceberg/tests.rs
+++ b/src/moonlink/src/storage/iceberg/tests.rs
@@ -31,6 +31,7 @@ use crate::storage::mooncake_table::{
     IcebergSnapshotDataCompactionPayload, IcebergSnapshotImportPayload,
     IcebergSnapshotIndexMergePayload,
 };
+use crate::storage::mooncake_table_config::DiskSliceWriterConfig;
 use crate::storage::mooncake_table_config::IcebergPersistenceConfig;
 use crate::storage::mooncake_table_config::MooncakeTableConfig;
 use crate::storage::storage_utils;
@@ -1440,7 +1441,10 @@ async fn test_small_batch_size_and_large_parquet_size() {
     let schema = create_test_arrow_schema();
     let mooncake_table_config = MooncakeTableConfig {
         batch_size: 1,
-        disk_slice_parquet_file_size: 1000,
+        disk_slice_writer_config: DiskSliceWriterConfig {
+            parquet_file_size: 1000,
+            chaos_config: None,
+        },
         // Trigger iceberg snapshot as long as there're any commit deletion log.
         persistence_config: IcebergPersistenceConfig {
             new_committed_deletion_log: 1,
@@ -1520,7 +1524,10 @@ async fn test_multiple_table_ids_for_deletion_vector() {
         // Flush as long as there's new rows appended at commit.
         mem_slice_size: 1,
         // At flush, place each row in a separate parquet file.
-        disk_slice_parquet_file_size: 1,
+        disk_slice_writer_config: DiskSliceWriterConfig {
+            parquet_file_size: 1000,
+            chaos_config: None,
+        },
         ..Default::default()
     };
     let mooncake_table_metadata = create_test_table_metadata_with_config(

--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -802,7 +802,6 @@ impl MooncakeTable {
         self.next_snapshot_task.new_mem_indices.push(index.clone());
 
         let path = self.metadata.path.clone();
-        let parquet_flush_threshold_size = self.metadata.config.disk_slice_parquet_file_size;
         let next_file_id = self.next_file_id;
         self.next_file_id += 1;
 
@@ -813,7 +812,7 @@ impl MooncakeTable {
             Some(lsn),
             next_file_id,
             index,
-            parquet_flush_threshold_size,
+            self.metadata.config.disk_slice_writer_config.clone(),
         );
 
         Ok(disk_slice)

--- a/src/moonlink/src/storage/mooncake_table/table_creation_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_creation_test_utils.rs
@@ -194,11 +194,13 @@ pub(crate) fn create_test_table_metadata_with_config(
 #[cfg(feature = "chaos-test")]
 pub(crate) fn create_disk_slice_write_option(
     enable_disk_slice_write_chaos: bool,
+    random_seed: u64,
 ) -> DiskSliceWriterConfig {
     use crate::storage::filesystem::accessor_config::ChaosConfig;
 
     let chaos_config = if enable_disk_slice_write_chaos {
         Some(ChaosConfig {
+            random_seed: Some(random_seed),
             err_prob: 0,
             // Injected latency is comparable to mooncake snapshot interval.
             min_latency: std::time::Duration::from_millis(50),

--- a/src/moonlink/src/storage/mooncake_table/table_creation_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_creation_test_utils.rs
@@ -18,6 +18,8 @@ use crate::storage::mooncake_table_config::IcebergPersistenceConfig;
 use crate::storage::wal::test_utils::WAL_TEST_TABLE_ID;
 use crate::storage::MooncakeTable;
 use crate::table_notify::TableEvent;
+#[cfg(feature = "chaos-test")]
+use crate::DiskSliceWriterConfig;
 use crate::ObjectStorageCache;
 use crate::StorageConfig;
 use crate::WalConfig;
@@ -186,13 +188,39 @@ pub(crate) fn create_test_table_metadata_with_config(
     })
 }
 
+/// Test util function to create disk slice write option.
+#[cfg(feature = "chaos-test")]
+pub(crate) fn create_disk_slice_write_option(
+    enable_disk_slice_write_chaos: bool,
+) -> DiskSliceWriterConfig {
+    use crate::storage::filesystem::accessor_config::ChaosConfig;
+
+    let chaos_config = if enable_disk_slice_write_chaos {
+        Some(ChaosConfig {
+            err_prob: 0,
+            // Injected latency is comparable to mooncake snapshot interval.
+            min_latency: std::time::Duration::from_millis(50),
+            max_latency: std::time::Duration::from_millis(750),
+        })
+    } else {
+        None
+    };
+
+    DiskSliceWriterConfig {
+        parquet_file_size: DiskSliceWriterConfig::DEFAULT_DISK_SLICE_PARQUET_FILE_SIZE,
+        chaos_config,
+    }
+}
+
 /// Test util function to create mooncake table metadata, which disables flush at commit.
 #[cfg(feature = "chaos-test")]
 pub(crate) fn create_test_table_metadata_disable_flush(
     local_table_directory: String,
+    disk_slice_write_config: DiskSliceWriterConfig,
 ) -> Arc<MooncakeTableMetadata> {
     let mut config = MooncakeTableConfig::new(local_table_directory.clone());
     config.mem_slice_size = usize::MAX; // Disable flush at commit if not force flush.
+    config.disk_slice_writer_config = disk_slice_write_config;
     create_test_table_metadata_with_config(local_table_directory, config)
 }
 
@@ -200,6 +228,7 @@ pub(crate) fn create_test_table_metadata_disable_flush(
 #[cfg(feature = "chaos-test")]
 pub(crate) fn create_test_table_metadata_with_index_merge_disable_flush(
     local_table_directory: String,
+    disk_slice_write_config: DiskSliceWriterConfig,
 ) -> Arc<MooncakeTableMetadata> {
     let file_index_config = FileIndexMergeConfig {
         min_file_indices_to_merge: 2,
@@ -207,6 +236,7 @@ pub(crate) fn create_test_table_metadata_with_index_merge_disable_flush(
         index_block_final_size: u64::MAX,
     };
     let mut config = MooncakeTableConfig::new(local_table_directory.clone());
+    config.disk_slice_writer_config = disk_slice_write_config;
     config.file_index_config = file_index_config;
     config.mem_slice_size = usize::MAX; // Disable flush at commit if not force flush.
     create_test_table_metadata_with_config(local_table_directory, config)
@@ -216,6 +246,7 @@ pub(crate) fn create_test_table_metadata_with_index_merge_disable_flush(
 #[cfg(feature = "chaos-test")]
 pub(crate) fn create_test_table_metadata_with_data_compaction_disable_flush(
     local_table_directory: String,
+    disk_slice_write_config: DiskSliceWriterConfig,
 ) -> Arc<MooncakeTableMetadata> {
     let data_compaction_config = DataCompactionConfig {
         min_data_file_to_compact: 2,
@@ -224,6 +255,7 @@ pub(crate) fn create_test_table_metadata_with_data_compaction_disable_flush(
         data_file_deletion_percentage: 0,
     };
     let mut config = MooncakeTableConfig::new(local_table_directory.clone());
+    config.disk_slice_writer_config = disk_slice_write_config;
     config.data_compaction_config = data_compaction_config;
     config.mem_slice_size = usize::MAX; // Disable flush at commit if not force flush.
     create_test_table_metadata_with_config(local_table_directory, config)

--- a/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
+++ b/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
@@ -327,7 +327,6 @@ impl MooncakeTable {
             .insert_memory_index(index.clone());
 
         let path = self.metadata.path.clone();
-        let parquet_flush_threshold_size = self.metadata.config.disk_slice_parquet_file_size;
 
         let disk_slice = DiskSliceWriter::new(
             self.metadata.schema.clone(),
@@ -336,7 +335,7 @@ impl MooncakeTable {
             lsn,
             next_file_id,
             index,
-            parquet_flush_threshold_size,
+            self.metadata.config.disk_slice_writer_config.clone(),
         );
 
         Ok(disk_slice)

--- a/src/moonlink/src/storage/mooncake_table_config.rs
+++ b/src/moonlink/src/storage/mooncake_table_config.rs
@@ -1,7 +1,42 @@
 use crate::storage::compaction::compaction_config::DataCompactionConfig;
+use crate::storage::filesystem::accessor_config::ChaosConfig;
 use crate::storage::index::index_merge_config::FileIndexMergeConfig;
 
 use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct DiskSliceWriterConfig {
+    /// Disk slice parquet file flush threshold.
+    #[serde(default = "IcebergPersistenceConfig::default_new_data_file_count")]
+    pub parquet_file_size: usize,
+
+    /// Chaos config on disk write.
+    #[serde(default)]
+    pub chaos_config: Option<ChaosConfig>,
+}
+
+impl DiskSliceWriterConfig {
+    #[cfg(debug_assertions)]
+    pub(crate) const DEFAULT_DISK_SLICE_PARQUET_FILE_SIZE: usize = 1024 * 1024 * 2; // 2MiB
+
+    #[cfg(not(debug_assertions))]
+    pub(crate) const DEFAULT_DISK_SLICE_PARQUET_FILE_SIZE: usize = 1024 * 1024 * 128; // 128MiB
+
+    pub fn validate(&self) {
+        if let Some(chaos_config) = &self.chaos_config {
+            chaos_config.validate();
+        }
+    }
+}
+
+impl Default for DiskSliceWriterConfig {
+    fn default() -> Self {
+        Self {
+            parquet_file_size: Self::DEFAULT_DISK_SLICE_PARQUET_FILE_SIZE,
+            chaos_config: None,
+        }
+    }
+}
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct IcebergPersistenceConfig {
@@ -86,9 +121,9 @@ pub struct MooncakeTableConfig {
     pub snapshot_deletion_record_count: usize,
     /// Max number of rows in each record batch within MemSlice.
     pub batch_size: usize,
-    /// Disk slice parquet file flush threshold.
-    pub disk_slice_parquet_file_size: usize,
-    /// Config for iceberg persistence config.
+    /// Config for disk slice write on mooncake table.
+    pub disk_slice_writer_config: DiskSliceWriterConfig,
+    /// Config for iceberg persistence.
     pub persistence_config: IcebergPersistenceConfig,
     /// Config for data compaction.
     pub data_compaction_config: DataCompactionConfig,
@@ -111,8 +146,6 @@ impl MooncakeTableConfig {
     pub(super) const DEFAULT_SNAPSHOT_DELETION_RECORD_COUNT: usize = 1000;
     #[cfg(debug_assertions)]
     pub(crate) const DEFAULT_BATCH_SIZE: usize = 128;
-    #[cfg(debug_assertions)]
-    pub(crate) const DEFAULT_DISK_SLICE_PARQUET_FILE_SIZE: usize = 1024 * 1024 * 2; // 2MiB
 
     #[cfg(not(debug_assertions))]
     pub(crate) const DEFAULT_MEM_SLICE_SIZE: usize = MooncakeTableConfig::DEFAULT_BATCH_SIZE * 32;
@@ -120,8 +153,6 @@ impl MooncakeTableConfig {
     pub(super) const DEFAULT_SNAPSHOT_DELETION_RECORD_COUNT: usize = 1000;
     #[cfg(not(debug_assertions))]
     pub(crate) const DEFAULT_BATCH_SIZE: usize = 4096;
-    #[cfg(not(debug_assertions))]
-    pub(crate) const DEFAULT_DISK_SLICE_PARQUET_FILE_SIZE: usize = 1024 * 1024 * 128; // 128MiB
 
     /// Default local directory to hold temporary files for union read.
     pub const DEFAULT_TEMP_FILE_DIRECTORY: &str = "/tmp/moonlink_temp_file";
@@ -131,7 +162,7 @@ impl MooncakeTableConfig {
             mem_slice_size: Self::DEFAULT_MEM_SLICE_SIZE,
             snapshot_deletion_record_count: Self::DEFAULT_SNAPSHOT_DELETION_RECORD_COUNT,
             batch_size: Self::DEFAULT_BATCH_SIZE,
-            disk_slice_parquet_file_size: Self::DEFAULT_DISK_SLICE_PARQUET_FILE_SIZE,
+            disk_slice_writer_config: DiskSliceWriterConfig::default(),
             persistence_config: IcebergPersistenceConfig::default(),
             data_compaction_config: DataCompactionConfig::default(),
             file_index_config: FileIndexMergeConfig::default(),
@@ -150,11 +181,12 @@ impl MooncakeTableConfig {
         Self::DEFAULT_BATCH_SIZE
     }
     pub fn default_disk_slice_parquet_file_size() -> usize {
-        Self::DEFAULT_DISK_SLICE_PARQUET_FILE_SIZE
+        DiskSliceWriterConfig::DEFAULT_DISK_SLICE_PARQUET_FILE_SIZE
     }
 
     // Validation util function.
     pub fn validate(&self) {
+        self.disk_slice_writer_config.validate();
         self.file_index_config.validate();
         self.data_compaction_config.validate();
     }
@@ -162,6 +194,9 @@ impl MooncakeTableConfig {
     // Accessor functions.
     pub fn batch_size(&self) -> usize {
         self.batch_size
+    }
+    pub fn disk_write_parquet_flush_threshold(&self) -> usize {
+        self.disk_slice_writer_config.parquet_file_size
     }
     pub fn iceberg_snapshot_new_data_file_count(&self) -> usize {
         self.persistence_config.new_data_file_count

--- a/src/moonlink/src/storage/mooncake_table_config.rs
+++ b/src/moonlink/src/storage/mooncake_table_config.rs
@@ -10,7 +10,7 @@ pub struct DiskSliceWriterConfig {
     #[serde(default = "IcebergPersistenceConfig::default_new_data_file_count")]
     pub parquet_file_size: usize,
 
-    /// Chaos config on disk write.
+    /// Chaos config on disk write flush.
     #[serde(default)]
     pub chaos_config: Option<ChaosConfig>,
 }

--- a/src/moonlink/src/storage/mooncake_table_config.rs
+++ b/src/moonlink/src/storage/mooncake_table_config.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct DiskSliceWriterConfig {
     /// Disk slice parquet file flush threshold.
-    #[serde(default = "IcebergPersistenceConfig::default_new_data_file_count")]
+    #[serde(default = "DiskSliceWriterConfig::default_disk_slice_parquet_file_size")]
     pub parquet_file_size: usize,
 
     /// Chaos config on disk write flush.
@@ -22,6 +22,9 @@ impl DiskSliceWriterConfig {
     #[cfg(not(debug_assertions))]
     pub(crate) const DEFAULT_DISK_SLICE_PARQUET_FILE_SIZE: usize = 1024 * 1024 * 128; // 128MiB
 
+    pub fn default_disk_slice_parquet_file_size() -> usize {
+        Self::DEFAULT_DISK_SLICE_PARQUET_FILE_SIZE
+    }
     pub fn validate(&self) {
         if let Some(chaos_config) = &self.chaos_config {
             chaos_config.validate();

--- a/src/moonlink/src/table_handler/chaos_test.rs
+++ b/src/moonlink/src/table_handler/chaos_test.rs
@@ -566,8 +566,11 @@ struct TestEnvironment {
 impl TestEnvironment {
     async fn new(config: TestEnvConfig) -> Self {
         let table_temp_dir = tempdir().unwrap();
-        let disk_slice_write_config =
-            create_disk_slice_write_option(config.disk_slice_write_chaos_enabled);
+        let chaos_test_arg = parse_chaos_test_args();
+        let disk_slice_write_config = create_disk_slice_write_option(
+            config.disk_slice_write_chaos_enabled,
+            chaos_test_arg.seed,
+        );
         let mooncake_table_metadata = match &config.maintenance_option {
             TableMaintenanceOption::NoTableMaintenance => create_test_table_metadata_disable_flush(
                 table_temp_dir.path().to_str().unwrap().to_string(),
@@ -601,7 +604,6 @@ impl TestEnvironment {
         };
 
         // Create mooncake table and table event notification receiver.
-        let chaos_test_arg = parse_chaos_test_args();
         let iceberg_table_config = if config.error_injection_enabled {
             get_iceberg_table_config_with_chaos_injection(
                 config.storage_config.clone(),

--- a/src/moonlink/src/table_handler/tests.rs
+++ b/src/moonlink/src/table_handler/tests.rs
@@ -12,6 +12,7 @@ use crate::storage::mooncake_table::table_creation_test_utils::*;
 use crate::storage::mooncake_table::validation_test_utils::*;
 use crate::storage::mooncake_table::Snapshot as MooncakeSnapshot;
 use crate::storage::mooncake_table::TableMetadata as MooncakeTableMetadata;
+use crate::storage::mooncake_table_config::DiskSliceWriterConfig;
 use crate::storage::mooncake_table_config::IcebergPersistenceConfig;
 use crate::storage::mooncake_table_config::MooncakeTableConfig;
 use crate::storage::wal::test_utils::WAL_TEST_TABLE_ID;
@@ -67,11 +68,14 @@ async fn test_table_handler_flush() {
 async fn test_append_with_small_disk_slice() {
     let temp_dir = tempdir().unwrap();
     let mooncake_table_config = MooncakeTableConfig {
-        batch_size: 1,                   // One mem slice only contains one row.
-        disk_slice_parquet_file_size: 1, // One parquet file only contains one arrow record.
+        batch_size: 1, // One mem slice only contains one row.
         mem_slice_size: 1000,
         snapshot_deletion_record_count: 1000,
         temp_files_directory: temp_dir.path().to_str().unwrap().to_string(),
+        disk_slice_writer_config: DiskSliceWriterConfig {
+            parquet_file_size: 1,
+            chaos_config: None,
+        },
         data_compaction_config: DataCompactionConfig::default(),
         file_index_config: FileIndexMergeConfig::default(),
         persistence_config: IcebergPersistenceConfig {
@@ -624,10 +628,10 @@ async fn test_iceberg_snapshot_creation_for_batch_write() {
     let temp_dir = tempdir().unwrap();
     let mooncake_table_config = MooncakeTableConfig {
         batch_size: MooncakeTableConfig::DEFAULT_BATCH_SIZE,
-        disk_slice_parquet_file_size: MooncakeTableConfig::DEFAULT_DISK_SLICE_PARQUET_FILE_SIZE,
         mem_slice_size: 1000,
         snapshot_deletion_record_count: 1000,
         temp_files_directory: temp_dir.path().to_str().unwrap().to_string(),
+        disk_slice_writer_config: DiskSliceWriterConfig::default(),
         data_compaction_config: DataCompactionConfig::default(),
         file_index_config: FileIndexMergeConfig::default(),
         persistence_config: IcebergPersistenceConfig {
@@ -826,10 +830,10 @@ async fn test_iceberg_snapshot_creation_for_streaming_write() {
     let temp_dir = tempdir().unwrap();
     let mooncake_table_config = MooncakeTableConfig {
         batch_size: MooncakeTableConfig::DEFAULT_BATCH_SIZE,
-        disk_slice_parquet_file_size: MooncakeTableConfig::DEFAULT_DISK_SLICE_PARQUET_FILE_SIZE,
         mem_slice_size: 1000,
         snapshot_deletion_record_count: 1000,
         temp_files_directory: temp_dir.path().to_str().unwrap().to_string(),
+        disk_slice_writer_config: DiskSliceWriterConfig::default(),
         data_compaction_config: DataCompactionConfig::default(),
         file_index_config: FileIndexMergeConfig::default(),
         persistence_config: IcebergPersistenceConfig {
@@ -1059,10 +1063,10 @@ async fn test_multiple_snapshot_requests() {
     let temp_dir = tempdir().unwrap();
     let mooncake_table_config = MooncakeTableConfig {
         batch_size: MooncakeTableConfig::DEFAULT_BATCH_SIZE,
-        disk_slice_parquet_file_size: MooncakeTableConfig::DEFAULT_DISK_SLICE_PARQUET_FILE_SIZE,
         mem_slice_size: 1000,
         snapshot_deletion_record_count: 1000,
         temp_files_directory: temp_dir.path().to_str().unwrap().to_string(),
+        disk_slice_writer_config: DiskSliceWriterConfig::default(),
         data_compaction_config: DataCompactionConfig::default(),
         file_index_config: FileIndexMergeConfig::default(),
         persistence_config: IcebergPersistenceConfig {

--- a/src/moonlink_metadata_store/src/config_utils.rs
+++ b/src/moonlink_metadata_store/src/config_utils.rs
@@ -1,8 +1,8 @@
 use crate::error::Result;
 use moonlink::{
-    AccessorConfig, DataCompactionConfig, FileIndexMergeConfig, IcebergPersistenceConfig,
-    IcebergTableConfig, MooncakeTableConfig, MoonlinkSecretType, MoonlinkTableConfig,
-    MoonlinkTableSecret, StorageConfig,
+    AccessorConfig, DataCompactionConfig, DiskSliceWriterConfig, FileIndexMergeConfig,
+    IcebergPersistenceConfig, IcebergTableConfig, MooncakeTableConfig, MoonlinkSecretType,
+    MoonlinkTableConfig, MoonlinkTableSecret, StorageConfig,
 };
 /// This module contains util functions related to moonlink config.
 use serde::{Deserialize, Serialize};
@@ -84,7 +84,10 @@ impl MoonlinkTableConfigForPersistence {
                 .mooncake_table_config
                 .snapshot_deletion_record_count,
             batch_size: self.mooncake_table_config.batch_size,
-            disk_slice_parquet_file_size: self.mooncake_table_config.disk_slice_parquet_file_size,
+            disk_slice_writer_config: DiskSliceWriterConfig {
+                parquet_file_size: self.mooncake_table_config.disk_slice_parquet_file_size,
+                chaos_config: None,
+            },
             persistence_config: self.mooncake_table_config.persistence_config.clone(),
             data_compaction_config: self.mooncake_table_config.data_compaction_config.clone(),
             file_index_config: self.mooncake_table_config.file_index_config.clone(),
@@ -111,7 +114,9 @@ pub(crate) fn parse_moonlink_table_config(
             mem_slice_size: mooncake_config.mem_slice_size,
             snapshot_deletion_record_count: mooncake_config.snapshot_deletion_record_count,
             batch_size: mooncake_config.batch_size,
-            disk_slice_parquet_file_size: mooncake_config.disk_slice_parquet_file_size,
+            disk_slice_parquet_file_size: mooncake_config
+                .disk_slice_writer_config
+                .parquet_file_size,
             data_compaction_config: mooncake_config.data_compaction_config.clone(),
             file_index_config: mooncake_config.file_index_config.clone(),
             persistence_config: mooncake_config.persistence_config.clone(),


### PR DESCRIPTION
## Summary

This PR adds intentional random timeout to disk slice write, so we could trigger late-arriving completed disk write easier.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1326

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
