### PR TITLE
Remove clippy fix

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,13 +15,6 @@ repos:
         files: '\.toml$'
         entry: cargo sort --workspace
         pass_filenames: false
-      # Split clippy command into two parts, because `--fix` suppress the "warning to error" conversion.
-      - id: clipper-fixlint
-        name: clipper-fixlint
-        language: system
-        files: '\.rs$'
-        entry: cargo clippy --all-targets --all-features --fix --allow-dirty --allow-staged
-        pass_filenames: false
       - id: clipper-check
         name: clipper-check
         language: system

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,11 +15,11 @@ repos:
         files: '\.toml$'
         entry: cargo sort --workspace
         pass_filenames: false
-      - id: clipper-check
-        name: clipper-check
+      - id: clipper-check-fix
+        name: clipper-check-fix
         language: system
         files: '\.rs$'
-        entry: cargo clippy --all-targets --all-features -- -D warnings
+        entry: bash -c 'cargo clippy --all-targets --all-features -- -D warnings || cargo clippy --all-targets --all-features --fix --allow-dirty --allow-staged'
         pass_filenames: false
       - id: check-dependency-license
         name: check-dependency-license


### PR DESCRIPTION
## Summary

I searched for repositories such as **datafusion-ray** and **arrow-rs** and found that most of them don’t use the `--fix` option. Removing it can save us around 12 seconds during Clippy checks.

## Other Considerations

The total time for the Clippy check is about 120 seconds, with the bottleneck being dependency build time (~100 seconds).  
By removing `--all-targets --all-features`, the total time is reduced to about 43 seconds. (This is the approach used by **arrow-rs**.)  I’ll leave the decision on this change to the repository owner.

## Related Issues

Related: https://github.com/Mooncake-Labs/moonlink/issues/1304

## Changes

- Remove Clippy `--fix` from pre-commit hook

## Checklist

- [✓] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [✓] I have reviewed my own changes