### PR TITLE
feat: type support for timestamp in json to moonlink row converter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -836,6 +836,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "chrono-tz"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59ae0466b83e838b81a54256c39d5d7c20b9d7daa10510a242d9b75abd5936e"
+dependencies = [
+ "chrono",
+ "chrono-tz-build",
+ "phf",
+]
+
+[[package]]
+name = "chrono-tz-build"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "433e39f13c9a060046954e0592a8d0a4bcb1040125cbf91cb8ee58964cfb350f"
+dependencies = [
+ "parse-zoneinfo",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
 name = "ciborium"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2771,6 +2793,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "chrono",
+ "chrono-tz",
  "futures",
  "iceberg",
  "moonlink",
@@ -3231,6 +3254,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "parse-zoneinfo"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3287,6 +3319,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
  "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
  "phf_shared",
 ]
 

--- a/src/moonlink_connectors/Cargo.toml
+++ b/src/moonlink_connectors/Cargo.toml
@@ -17,6 +17,7 @@ bigdecimal = { version = "0.4", default-features = false, features = ["std"] }
 byteorder = "1.5"
 bytes = "1.0"
 chrono = { workspace = true }
+chrono-tz = "0.8"
 futures = { workspace = true }
 moonlink = { path = "../moonlink" }
 num-traits = { workspace = true }

--- a/src/moonlink_connectors/src/rest_ingest.rs
+++ b/src/moonlink_connectors/src/rest_ingest.rs
@@ -1,3 +1,4 @@
+pub mod datetime_utils;
 pub mod json_converter;
 pub mod moonlink_rest_sink;
 pub mod rest_source;

--- a/src/moonlink_connectors/src/rest_ingest/datetime_utils.rs
+++ b/src/moonlink_connectors/src/rest_ingest/datetime_utils.rs
@@ -1,0 +1,103 @@
+use chrono::{DateTime, NaiveDate, NaiveTime, Utc};
+use moonlink::row::RowValue;
+
+/// Parse a date string in YYYY-MM-DD format to Date32 (days since epoch)
+pub fn parse_date(date_str: &str) -> Result<RowValue, String> {
+    const ARROW_EPOCH: NaiveDate = match NaiveDate::from_ymd_opt(1970, 1, 1) {
+        Some(date) => date,
+        None => panic!("Failed to create epoch date"),
+    };
+
+    NaiveDate::parse_from_str(date_str, "%Y-%m-%d")
+        .map(|date| {
+            let days_since_epoch = date.signed_duration_since(ARROW_EPOCH).num_days() as i32;
+            RowValue::Int32(days_since_epoch)
+        })
+        .map_err(|e| format!("Invalid date format: {}", e))
+}
+
+/// Parse a time string in HH:MM:SS[.fraction] format to Time64 (microseconds since midnight)
+pub fn parse_time(time_str: &str) -> Result<RowValue, String> {
+    // Try parsing with fractional seconds first, then without
+    let time = NaiveTime::parse_from_str(time_str, "%H:%M:%S%.f")
+        .or_else(|_| NaiveTime::parse_from_str(time_str, "%H:%M:%S"))
+        .map_err(|e| format!("Invalid time format: {}", e))?;
+
+    // Convert to microseconds since midnight
+    let duration = time.signed_duration_since(NaiveTime::from_hms_opt(0, 0, 0).unwrap());
+    let microseconds = duration
+        .num_microseconds()
+        .ok_or_else(|| "Time value too large".to_string())?;
+
+    Ok(RowValue::Int64(microseconds))
+}
+
+/// Parse an RFC3339/ISO8601 timestamp and normalize to UTC
+pub fn parse_timestamp(timestamp_str: &str) -> Result<RowValue, String> {
+    // Parse RFC3339/ISO8601 timestamp
+    let dt = DateTime::parse_from_rfc3339(timestamp_str)
+        .map_err(|e| format!("Invalid timestamp format: {}", e))?;
+
+    // Convert to UTC
+    let utc_dt = dt.with_timezone(&Utc);
+    let timestamp_micros = utc_dt.timestamp_micros();
+
+    Ok(RowValue::Int64(timestamp_micros))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_date() {
+        // Valid date
+        let result = parse_date("2024-03-15").unwrap();
+        let expected_days = NaiveDate::from_ymd_opt(2024, 3, 15)
+            .unwrap()
+            .signed_duration_since(NaiveDate::from_ymd_opt(1970, 1, 1).unwrap())
+            .num_days() as i32;
+        assert_eq!(result, RowValue::Int32(expected_days));
+
+        // Invalid date
+        assert!(parse_date("2024/03/15").is_err());
+    }
+
+    #[test]
+    fn test_parse_time() {
+        // Time without fractional seconds
+        let result = parse_time("14:30:45").unwrap();
+        assert_eq!(result, RowValue::Int64(52245000000));
+
+        // Time with fractional seconds
+        let result = parse_time("09:15:30.123456").unwrap();
+        assert_eq!(result, RowValue::Int64(33330123456));
+
+        // Invalid time
+        assert!(parse_time("25:00:00").is_err());
+    }
+
+    #[test]
+    fn test_parse_timestamp() {
+        // UTC timestamp
+        let result = parse_timestamp("2024-03-15T10:30:45.123Z").unwrap();
+        use chrono::TimeZone;
+        let expected = Utc
+            .with_ymd_and_hms(2024, 3, 15, 10, 30, 45)
+            .unwrap()
+            .timestamp_micros()
+            + 123000;
+        assert_eq!(result, RowValue::Int64(expected));
+
+        // Timestamp with timezone offset
+        let result = parse_timestamp("2024-03-15T10:30:45+05:00").unwrap();
+        let expected = Utc
+            .with_ymd_and_hms(2024, 3, 15, 5, 30, 45)
+            .unwrap()
+            .timestamp_micros();
+        assert_eq!(result, RowValue::Int64(expected));
+
+        // Invalid timestamp
+        assert!(parse_timestamp("2024-03-15 10:30:45").is_err());
+    }
+}

--- a/src/moonlink_connectors/src/rest_ingest/datetime_utils.rs
+++ b/src/moonlink_connectors/src/rest_ingest/datetime_utils.rs
@@ -51,13 +51,9 @@ mod tests {
 
     #[test]
     fn test_parse_date() {
-        // Valid date
+        // Valid date (2024-03-15 is 19797 days since epoch)
         let result = parse_date("2024-03-15").unwrap();
-        let expected_days = NaiveDate::from_ymd_opt(2024, 3, 15)
-            .unwrap()
-            .signed_duration_since(NaiveDate::from_ymd_opt(1970, 1, 1).unwrap())
-            .num_days() as i32;
-        assert_eq!(result, RowValue::Int32(expected_days));
+        assert_eq!(result, RowValue::Int32(19797));
 
         // Invalid date
         assert!(parse_date("2024/03/15").is_err());

--- a/src/moonlink_connectors/src/rest_ingest/datetime_utils.rs
+++ b/src/moonlink_connectors/src/rest_ingest/datetime_utils.rs
@@ -69,7 +69,7 @@ pub fn parse_timestamp_with_timezone(
             let local_dt = tz
                 .from_local_datetime(&naive_dt)
                 .single()
-                .ok_or_else(|| format!("Ambiguous time in timezone {}", tz_str))?;
+                .ok_or_else(|| format!("Ambiguous time in timezone {tz_str}"))?;
             let utc_dt = local_dt.with_timezone(&Utc);
             let timestamp_micros = utc_dt.timestamp_micros();
             return Ok(RowValue::Int64(timestamp_micros));

--- a/src/moonlink_connectors/src/rest_ingest/datetime_utils.rs
+++ b/src/moonlink_connectors/src/rest_ingest/datetime_utils.rs
@@ -93,6 +93,23 @@ mod tests {
             .timestamp_micros();
         assert_eq!(result, RowValue::Int64(expected));
 
+        // Timestamp without timezone (treated as UTC)
+        let result = parse_timestamp("2024-03-15T10:30:45").unwrap();
+        let expected = Utc
+            .with_ymd_and_hms(2024, 3, 15, 10, 30, 45)
+            .unwrap()
+            .timestamp_micros();
+        assert_eq!(result, RowValue::Int64(expected));
+
+        // Timestamp without timezone with fractional seconds
+        let result = parse_timestamp("2024-03-15T10:30:45.123456").unwrap();
+        let expected = Utc
+            .with_ymd_and_hms(2024, 3, 15, 10, 30, 45)
+            .unwrap()
+            .timestamp_micros()
+            + 123456;
+        assert_eq!(result, RowValue::Int64(expected));
+
         // Invalid timestamp
         assert!(parse_timestamp("2024-03-15 10:30:45").is_err());
     }

--- a/src/moonlink_connectors/src/rest_ingest/datetime_utils.rs
+++ b/src/moonlink_connectors/src/rest_ingest/datetime_utils.rs
@@ -13,7 +13,7 @@ pub fn parse_date(date_str: &str) -> Result<RowValue, String> {
             let days_since_epoch = date.signed_duration_since(ARROW_EPOCH).num_days() as i32;
             RowValue::Int32(days_since_epoch)
         })
-        .map_err(|e| format!("Invalid date format: {}", e))
+        .map_err(|e| format!("Invalid date format: {e}"))
 }
 
 /// Parse a time string in HH:MM:SS[.fraction] format to Time64 (microseconds since midnight)
@@ -21,7 +21,7 @@ pub fn parse_time(time_str: &str) -> Result<RowValue, String> {
     // Try parsing with fractional seconds first, then without
     let time = NaiveTime::parse_from_str(time_str, "%H:%M:%S%.f")
         .or_else(|_| NaiveTime::parse_from_str(time_str, "%H:%M:%S"))
-        .map_err(|e| format!("Invalid time format: {}", e))?;
+        .map_err(|e| format!("Invalid time format: {e}"))?;
 
     // Convert to microseconds since midnight
     let duration = time.signed_duration_since(NaiveTime::from_hms_opt(0, 0, 0).unwrap());
@@ -36,7 +36,7 @@ pub fn parse_time(time_str: &str) -> Result<RowValue, String> {
 pub fn parse_timestamp(timestamp_str: &str) -> Result<RowValue, String> {
     // Parse RFC3339/ISO8601 timestamp
     let dt = DateTime::parse_from_rfc3339(timestamp_str)
-        .map_err(|e| format!("Invalid timestamp format: {}", e))?;
+        .map_err(|e| format!("Invalid timestamp format: {e}"))?;
 
     // Convert to UTC
     let utc_dt = dt.with_timezone(&Utc);

--- a/src/moonlink_connectors/src/rest_ingest/json_converter.rs
+++ b/src/moonlink_connectors/src/rest_ingest/json_converter.rs
@@ -1,10 +1,9 @@
+use crate::rest_ingest::datetime_utils::{parse_date, parse_time, parse_timestamp};
 use arrow_schema::{DataType, Field, Schema, TimeUnit};
 use moonlink::row::{MoonlinkRow, RowValue};
 use serde_json::Value;
 use std::sync::Arc;
 use thiserror::Error;
-
-use super::datetime_utils::{parse_date, parse_time, parse_timestamp};
 
 #[derive(Debug, Error)]
 pub enum JsonToMoonlinkRowError {

--- a/src/moonlink_connectors/src/rest_ingest/json_converter.rs
+++ b/src/moonlink_connectors/src/rest_ingest/json_converter.rs
@@ -133,17 +133,21 @@ mod tests {
 
     fn make_datetime_schema() -> Arc<Schema> {
         Arc::new(Schema::new(vec![
-            Field::new("date", DataType::Date32, false),
-            Field::new("time", DataType::Time64(TimeUnit::Microsecond), false),
+            Field::new("date", DataType::Date32, /*nullable=*/ false),
+            Field::new(
+                "time",
+                DataType::Time64(TimeUnit::Microsecond),
+                /*nullable=*/ false,
+            ),
             Field::new(
                 "timestamp",
                 DataType::Timestamp(TimeUnit::Microsecond, None),
-                false,
+                /*nullable=*/ false,
             ),
             Field::new(
                 "timestamp_utc",
                 DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
-                false,
+                /*nullable=*/ false,
             ),
         ]))
     }

--- a/src/moonlink_connectors/src/rest_ingest/json_converter.rs
+++ b/src/moonlink_connectors/src/rest_ingest/json_converter.rs
@@ -1,8 +1,10 @@
-use arrow_schema::{DataType, Field, Schema};
+use arrow_schema::{DataType, Field, Schema, TimeUnit};
 use moonlink::row::{MoonlinkRow, RowValue};
 use serde_json::Value;
 use std::sync::Arc;
 use thiserror::Error;
+
+use super::datetime_utils::{parse_date, parse_time, parse_timestamp};
 
 #[derive(Debug, Error)]
 pub enum JsonToMoonlinkRowError {
@@ -82,7 +84,30 @@ impl JsonToMoonlinkRowConverter {
                     Err(JsonToMoonlinkRowError::TypeMismatch(field.name().clone()))
                 }
             }
-            // TODO: Add more type conversions (Bool, Float, Date, etc.)
+            DataType::Date32 => {
+                if let Some(s) = value.as_str() {
+                    parse_date(s)
+                        .map_err(|_| JsonToMoonlinkRowError::InvalidValue(field.name().clone()))
+                } else {
+                    Err(JsonToMoonlinkRowError::TypeMismatch(field.name().clone()))
+                }
+            }
+            DataType::Time64(TimeUnit::Microsecond) => {
+                if let Some(s) = value.as_str() {
+                    parse_time(s)
+                        .map_err(|_| JsonToMoonlinkRowError::InvalidValue(field.name().clone()))
+                } else {
+                    Err(JsonToMoonlinkRowError::TypeMismatch(field.name().clone()))
+                }
+            }
+            DataType::Timestamp(TimeUnit::Microsecond, _tz) => {
+                if let Some(s) = value.as_str() {
+                    parse_timestamp(s)
+                        .map_err(|_| JsonToMoonlinkRowError::InvalidValue(field.name().clone()))
+                } else {
+                    Err(JsonToMoonlinkRowError::TypeMismatch(field.name().clone()))
+                }
+            }
             _ => Err(JsonToMoonlinkRowError::TypeMismatch(field.name().clone())),
         }
     }
@@ -91,7 +116,8 @@ impl JsonToMoonlinkRowConverter {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use arrow_schema::{DataType, Field, Schema};
+    use arrow_schema::{DataType, Field, Schema, TimeUnit};
+    use chrono::{NaiveDate, TimeZone, Utc};
     use serde_json::json;
     use std::sync::Arc;
 
@@ -103,6 +129,23 @@ mod tests {
             Field::new("score", DataType::Float64, false),
             Field::new("id_int64", DataType::Int64, false),
             Field::new("score_float32", DataType::Float32, false),
+        ]))
+    }
+
+    fn make_datetime_schema() -> Arc<Schema> {
+        Arc::new(Schema::new(vec![
+            Field::new("date", DataType::Date32, false),
+            Field::new("time", DataType::Time64(TimeUnit::Microsecond), false),
+            Field::new(
+                "timestamp",
+                DataType::Timestamp(TimeUnit::Microsecond, None),
+                false,
+            ),
+            Field::new(
+                "timestamp_utc",
+                DataType::Timestamp(TimeUnit::Microsecond, Some("UTC".into())),
+                false,
+            ),
         ]))
     }
 
@@ -211,5 +254,186 @@ mod tests {
             JsonToMoonlinkRowError::TypeMismatch(f) => assert_eq!(f, "id_int64"),
             _ => panic!("unexpected error: {err:?}"),
         }
+    }
+
+    #[test]
+    fn test_date_conversion() {
+        let schema = make_datetime_schema();
+        let converter = JsonToMoonlinkRowConverter::new(schema);
+
+        // Test valid date
+        let input = json!({
+            "date": "2024-03-15",
+            "time": "12:00:00",
+            "timestamp": "2024-03-15T12:00:00Z",
+            "timestamp_utc": "2024-03-15T12:00:00Z",
+        });
+        let row = converter.convert(&input).unwrap();
+
+        // Date: 2024-03-15 is 19797 days since 1970-01-01
+        let expected_days = NaiveDate::from_ymd_opt(2024, 3, 15)
+            .unwrap()
+            .signed_duration_since(NaiveDate::from_ymd_opt(1970, 1, 1).unwrap())
+            .num_days() as i32;
+        assert_eq!(row.values[0], RowValue::Int32(expected_days));
+    }
+
+    #[test]
+    fn test_time_conversion() {
+        let schema = make_datetime_schema();
+        let converter = JsonToMoonlinkRowConverter::new(schema);
+
+        // Test time without fractional seconds
+        let input = json!({
+            "date": "2024-01-01",
+            "time": "14:30:45",
+            "timestamp": "2024-01-01T00:00:00Z",
+            "timestamp_utc": "2024-01-01T00:00:00Z",
+        });
+        let row = converter.convert(&input).unwrap();
+
+        // 14:30:45 = 14*3600 + 30*60 + 45 = 52245 seconds = 52245000000 microseconds
+        assert_eq!(row.values[1], RowValue::Int64(52245000000));
+
+        // Test time with fractional seconds
+        let input = json!({
+            "date": "2024-01-01",
+            "time": "09:15:30.123456",
+            "timestamp": "2024-01-01T00:00:00Z",
+            "timestamp_utc": "2024-01-01T00:00:00Z",
+        });
+        let row = converter.convert(&input).unwrap();
+
+        // 9:15:30.123456 = 33330123456 microseconds
+        assert_eq!(row.values[1], RowValue::Int64(33330123456));
+    }
+
+    #[test]
+    fn test_timestamp_conversion() {
+        let schema = make_datetime_schema();
+        let converter = JsonToMoonlinkRowConverter::new(schema);
+
+        // Test UTC timestamp
+        let input = json!({
+            "date": "2024-01-01",
+            "time": "00:00:00",
+            "timestamp": "2024-03-15T10:30:45.123Z",
+            "timestamp_utc": "2024-03-15T10:30:45.123Z",
+        });
+        let row = converter.convert(&input).unwrap();
+
+        // Verify it's converted to microseconds since epoch
+        // Using chrono to calculate the exact value
+        let dt = Utc
+            .with_ymd_and_hms(2024, 3, 15, 10, 30, 45)
+            .unwrap()
+            .timestamp_micros()
+            + 123000;
+        assert_eq!(row.values[2], RowValue::Int64(dt));
+        assert_eq!(row.values[3], RowValue::Int64(dt));
+
+        // Test timestamp with timezone offset (should be normalized to UTC)
+        let input = json!({
+            "date": "2024-01-01",
+            "time": "00:00:00",
+            "timestamp": "2024-03-15T10:30:45+05:00",
+            "timestamp_utc": "2024-03-15T10:30:45-08:00",
+        });
+        let row = converter.convert(&input).unwrap();
+
+        // Both should be normalized to UTC
+        // 2024-03-15T10:30:45+05:00 -> 2024-03-15T05:30:45Z
+        let expected_micros1 = Utc
+            .with_ymd_and_hms(2024, 3, 15, 5, 30, 45)
+            .unwrap()
+            .timestamp_micros();
+        // 2024-03-15T10:30:45-08:00 -> 2024-03-15T18:30:45Z
+        let expected_micros2 = Utc
+            .with_ymd_and_hms(2024, 3, 15, 18, 30, 45)
+            .unwrap()
+            .timestamp_micros();
+        assert_eq!(row.values[2], RowValue::Int64(expected_micros1));
+        assert_eq!(row.values[3], RowValue::Int64(expected_micros2));
+    }
+
+    #[test]
+    fn test_invalid_date_time_formats() {
+        let schema = make_datetime_schema();
+        let converter = JsonToMoonlinkRowConverter::new(schema);
+
+        // Invalid date format
+        let input = json!({
+            "date": "2024/03/15", // Wrong separator
+            "time": "12:00:00",
+            "timestamp": "2024-03-15T12:00:00Z",
+            "timestamp_utc": "2024-03-15T12:00:00Z",
+        });
+        let err = converter.convert(&input).unwrap_err();
+        match err {
+            JsonToMoonlinkRowError::InvalidValue(f) => assert_eq!(f, "date"),
+            _ => panic!("unexpected error: {err:?}"),
+        }
+
+        // Invalid time format
+        let input = json!({
+            "date": "2024-03-15",
+            "time": "25:00:00", // Invalid hour
+            "timestamp": "2024-03-15T12:00:00Z",
+            "timestamp_utc": "2024-03-15T12:00:00Z",
+        });
+        let err = converter.convert(&input).unwrap_err();
+        match err {
+            JsonToMoonlinkRowError::InvalidValue(f) => assert_eq!(f, "time"),
+            _ => panic!("unexpected error: {err:?}"),
+        }
+
+        // Invalid timestamp format
+        let input = json!({
+            "date": "2024-03-15",
+            "time": "12:00:00",
+            "timestamp": "2024-03-15 12:00:00", // Not RFC3339
+            "timestamp_utc": "2024-03-15T12:00:00Z",
+        });
+        let err = converter.convert(&input).unwrap_err();
+        match err {
+            JsonToMoonlinkRowError::InvalidValue(f) => assert_eq!(f, "timestamp"),
+            _ => panic!("unexpected error: {err:?}"),
+        }
+    }
+
+    #[test]
+    fn test_edge_cases() {
+        let schema = make_datetime_schema();
+        let converter = JsonToMoonlinkRowConverter::new(schema);
+
+        // Test epoch date
+        let input = json!({
+            "date": "1970-01-01",
+            "time": "00:00:00",
+            "timestamp": "1970-01-01T00:00:00Z",
+            "timestamp_utc": "1970-01-01T00:00:00Z",
+        });
+        let row = converter.convert(&input).unwrap();
+        assert_eq!(row.values[0], RowValue::Int32(0)); // 0 days since epoch
+        assert_eq!(row.values[1], RowValue::Int64(0)); // 0 microseconds since midnight
+        assert_eq!(row.values[2], RowValue::Int64(0)); // 0 microseconds since epoch
+
+        // Test leap year date
+        let input = json!({
+            "date": "2024-02-29",
+            "time": "23:59:59.999999",
+            "timestamp": "2024-02-29T23:59:59.999999Z",
+            "timestamp_utc": "2024-02-29T23:59:59.999999Z",
+        });
+        let row = converter.convert(&input).unwrap();
+
+        let expected_days = NaiveDate::from_ymd_opt(2024, 2, 29)
+            .unwrap()
+            .signed_duration_since(NaiveDate::from_ymd_opt(1970, 1, 1).unwrap())
+            .num_days() as i32;
+        assert_eq!(row.values[0], RowValue::Int32(expected_days));
+
+        // 23:59:59.999999 = 86399999999 microseconds
+        assert_eq!(row.values[1], RowValue::Int64(86399999999));
     }
 }


### PR DESCRIPTION
## Summary

Type support for timestamp in json to moonlink row converter

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1284

## Changes

- Add a datatime_utils file with different time string parsing and basic timestamp testing
- make json converter to support Date32, Time64 and Timetamp and add some edge case testing

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [x] Documentation updated if necessary
- [x] I have reviewed my own changes
