### PR TITLE
Add comment on timestamp type conversion

### DIFF
--- a/src/moonlink/src/row/moonlink_type.rs
+++ b/src/moonlink/src/row/moonlink_type.rs
@@ -5,6 +5,8 @@ use std::hash::{Hash, Hasher};
 #[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
 pub enum RowValue {
     Int32(i32),
+    // When used to represent [`Time`] type, it indicates microseconds from midnight.
+    // When used to represent [`TimeStamp`] or [`TimeStampTz`] type, it indicates microseconds since UNIX timestamp, after canonicalizing to UTC timezone.
     Int64(i64),
     Float32(f32),
     Float64(f64),


### PR DESCRIPTION
## Summary

Add comment to clarify timestamp types -> int types conversion, a few key points:
- For timestamp types, which timezone do we convert to?
- For all time/timestamp types, which time unit do we use?

The comment illustrates the implementation at https://github.com/Mooncake-Labs/moonlink/blob/70f102a173cbf8cc536d7d8acfac3e0126ad614a/src/moonlink_connectors/src/pg_replicate/util.rs#L260-L285, so we could have a unified definition across the codebase.

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
