### PR TITLE
chore: alias smallvec to evict files

### DIFF
--- a/src/moonlink/src/storage/cache/object_storage/base_cache.rs
+++ b/src/moonlink/src/storage/cache/object_storage/base_cache.rs
@@ -11,6 +11,8 @@ use crate::storage::storage_utils::TableUniqueFileId;
 use crate::Result;
 use smallvec::SmallVec;
 
+pub type InlineEvictedFiles = SmallVec<[String; 1]>;
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct FileMetadata {
     /// Size of the current file.
@@ -35,13 +37,12 @@ pub trait CacheTrait {
         &mut self,
         file_id: TableUniqueFileId,
         cache_entry: CacheEntry,
-    ) -> (NonEvictableHandle, SmallVec<[String; 1]>);
+    ) -> (NonEvictableHandle, InlineEvictedFiles);
 
     /// Similar to [`delete_cache_entry`], but doesn't panic if requested entry doesn't exist.
     #[must_use]
     #[allow(async_fn_in_trait)]
-    async fn try_delete_cache_entry(&mut self, file_id: TableUniqueFileId)
-        -> SmallVec<[String; 1]>;
+    async fn try_delete_cache_entry(&mut self, file_id: TableUniqueFileId) -> InlineEvictedFiles;
 
     /// Attempt to get a pinned cache file entry.
     ///
@@ -57,6 +58,6 @@ pub trait CacheTrait {
         filesystem_accessor: &dyn BaseFileSystemAccess,
     ) -> Result<(
         Option<NonEvictableHandle>,
-        SmallVec<[String; 1]>, /*files_to_delete*/
+        InlineEvictedFiles, /*files_to_delete*/
     )>;
 }

--- a/src/moonlink/src/storage/cache/object_storage/cache_handle.rs
+++ b/src/moonlink/src/storage/cache/object_storage/cache_handle.rs
@@ -4,7 +4,7 @@ use crate::storage::cache::object_storage::base_cache::CacheEntry;
 use crate::storage::cache::object_storage::object_storage_cache::ObjectStorageCacheInternal;
 use crate::storage::storage_utils::TableUniqueFileId;
 
-use smallvec::SmallVec;
+use crate::storage::cache::object_storage::base_cache::InlineEvictedFiles;
 use tokio::sync::RwLock;
 
 #[derive(Clone)]
@@ -53,7 +53,7 @@ impl NonEvictableHandle {
 
     /// Unreference and pinned cache file and mark it as deleted.
     #[must_use]
-    pub(crate) async fn unreference_and_delete(&mut self) -> SmallVec<[String; 1]> {
+    pub(crate) async fn unreference_and_delete(&mut self) -> InlineEvictedFiles {
         let mut guard = self.cache.write().await;
 
         // Total bytes within cache doesn't change, so current cache entry not evicted.


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

Previously, Moonlink used raw SmallVec<[String; 1]> to represent paths scheduled for deletion, which wasn’t self-descriptive. This change introduces a type EvictedFiles = SmallVec<[String; INLINE_FILE_SLOTS]>; alias and applies it throughout the codebase for clearer intent and easier future capacity tuning.

## Related Issues

Closes #1312

## Changes

- alias smallvec to evict files

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [x] Documentation updated if necessary
- [x] I have reviewed my own changes
