### PR TITLE
[CI] increase CI test timeout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
         with: { tool: nextest }
 
       - name: Run tests via llvm-cov/nextest
-        timeout-minutes: 5
+        timeout-minutes: 10
         run: |
           cargo llvm-cov \
             --locked \


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

increase some CI test's timeout to prevent timeout error encountered here: https://github.com/Mooncake-Labs/moonlink/actions/runs/16897094874/job/47868824503

## Related Issues


## Changes

- increase timeout from 5 to 10 minutes for GCS feature test, S3 feature test, and llvm-cov test

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
