### PR TITLE
[CI] Split CI crate test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,10 +188,13 @@ jobs:
 
       - name: Run tests via llvm-cov/nextest
         timeout-minutes: 10
+        # Remove moonlink_datafusion from unit test pipeline, since it takes long to build (2x longer than all other crates), and it doesn't contain any unit tests.
         run: |
           cargo llvm-cov \
             --locked \
             --lib \
+            --workspace \
+            --exclude moonlink_datafusion \
             --lcov --output-path lcov.info \
             nextest \
               --profile ci \


### PR DESCRIPTION
## Summary

moonlink-datafusion is taking 5min to build on CI, which exceeds all others crate's build + tests.
Currently the crate doesn't contain ANY unit test, we could add it back when the author adds any.

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
