### PR TITLE
[CI] Use mold and cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ steps.toolchain.outputs.cachekey }}
+
+      - uses: rui314/setup-mold@v1
+        with:
+          mold-version: 2.40.3
+          make-default: true
+
       # ─────────────────────── Start Fake S3 Server ──────────────────────────
       - name: Start Fake S3 Server
         run: |
@@ -181,6 +190,11 @@ jobs:
         with:
           shared-key: ${{ steps.toolchain.outputs.cachekey }}
 
+      - uses: rui314/setup-mold@v1
+        with:
+          mold-version: 2.40.3
+          make-default: true
+
       - uses: taiki-e/install-action@v2
         with: { tool: cargo-llvm-cov }
       - uses: taiki-e/install-action@v2
@@ -228,6 +242,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ steps.toolchain.outputs.cachekey }}
+
+      - uses: rui314/setup-mold@v1
+        with:
+          mold-version: 2.40.3
+          make-default: true
+
       - name: Start chaos test
         timeout-minutes: 10
         run: |
@@ -254,6 +277,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ steps.toolchain.outputs.cachekey }}
+
+      - uses: rui314/setup-mold@v1
+        with:
+          mold-version: 2.40.3
+          make-default: true
+
       - name: Start chaos test
         timeout-minutes: 10
         run: |
@@ -266,6 +298,15 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - uses: swatinem/rust-cache@v2
+        with:
+          shared-key: ${{ steps.toolchain.outputs.cachekey }}
+
+      - uses: rui314/setup-mold@v1
+        with:
+          mold-version: 2.40.3
+          make-default: true
 
       - name: Start chaos test
         timeout-minutes: 10


### PR DESCRIPTION
## Summary

This PR uses mold as the default linker on CI, and enable rust-cache for all rust-based tests.

Some benchmarks for mold, 10% improvement for build stage
- the most stable part in CI is unit test, all others are built based on random events
- prev-1: 2m 38s
  + https://github.com/Mooncake-Labs/moonlink/actions/runs/16907359960/job/47900133709
- prev-2: 2m 36s
  + https://github.com/Mooncake-Labs/moonlink/actions/runs/16905391171/job/47893853718
- prev-3: 2m 44s
  + https://github.com/Mooncake-Labs/moonlink/actions/runs/16904814138/job/47892007192
- now-1: 2m 19s
  + https://github.com/Mooncake-Labs/moonlink/actions/runs/16917421042/job/47934749480?pr=1389
- now-2: 2m 21s
  + https://github.com/Mooncake-Labs/moonlink/actions/runs/16917421042/job/47935555770

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
