### PR TITLE
Wal recovery reads only files stored in metadata

### DIFF
--- a/src/moonlink/src/storage/wal/test_utils.rs
+++ b/src/moonlink/src/storage/wal/test_utils.rs
@@ -2,7 +2,7 @@ use crate::storage::filesystem::accessor::base_filesystem_accessor::BaseFileSyst
 use crate::storage::mooncake_table::test_utils::test_row;
 use crate::storage::wal::{WalEvent, WalManager};
 use crate::table_notify::TableEvent;
-use crate::{Result, WalConfig};
+use crate::{PersistentWalMetadata, Result, WalConfig};
 use futures::StreamExt;
 use std::sync::Arc;
 
@@ -211,11 +211,11 @@ pub fn assert_wal_events_does_not_contain(
 
 pub async fn get_table_events_vector_recovery(
     file_system_accessor: Arc<dyn BaseFileSystemAccess>,
-    start_file_name: u64,
+    wal_metadata: &PersistentWalMetadata,
 ) -> Vec<TableEvent> {
     // Recover events using flat stream
     let mut recovered_events = Vec::new();
-    let mut stream = WalManager::recover_flushed_wals_flat(file_system_accessor, start_file_name);
+    let mut stream = WalManager::recover_flushed_wals_flat(file_system_accessor, wal_metadata);
     while let Some(result) = stream.next().await {
         match result {
             Ok(event) => recovered_events.push(event),

--- a/src/moonlink/src/storage/wal/tests.rs
+++ b/src/moonlink/src/storage/wal/tests.rs
@@ -3,6 +3,7 @@ use crate::storage::wal::test_utils::WAL_TEST_TABLE_ID;
 use crate::storage::wal::test_utils::*;
 use crate::storage::wal::WalManager;
 use crate::storage::wal::{PersistentWalMetadata, WalTransactionState};
+use crate::TableEvent;
 use crate::WalConfig;
 use crate::{assert_wal_file_does_not_exist, assert_wal_file_exists, assert_wal_logs_equal};
 
@@ -515,4 +516,92 @@ async fn test_main_tracker_keeps_highest_subset_commit_per_file() {
         }
         other => panic!("unexpected main tracker state[1]: {other:?}"),
     }
+}
+
+/// Motivation:
+/// The WAL persistence sequence is: persist file -> persist metadata -> truncate old files
+/// (see wal_persist_truncate_async). If a crash happens after persisting a WAL file but
+/// before metadata is updated, the WAL directory can contain more events than what the
+/// metadata describes. Recovery must treat metadata as the source of truth to avoid
+/// reapplying untracked events (which could cause duplication or order violations).
+/// This test simulates that crash window and asserts that recovery only replays events
+/// referenced by persisted metadata.
+#[tokio::test]
+async fn test_recovery_uses_metadata_as_source_of_truth_when_file_persisted_but_metadata_not() {
+    // Scenario:
+    // - First round: persist file 0 and metadata
+    // - Second round: persist file 1 only (simulate crash before metadata/truncation)
+    // Expectation: recovery should only replay events tracked by metadata (i.e., file 0),
+    // ignoring events from file 1 that are not yet referenced in metadata.
+
+    let context = TestContext::new("wal_recovery_metadata_source_of_truth");
+    let wal_config =
+        WalConfig::default_wal_config_local(WAL_TEST_TABLE_ID, &context.path().to_path_buf());
+
+    // Create initial WAL with a batch of events and persist (writes file 0 + metadata)
+    let (mut wal, expected_events_file0) = create_test_wal(wal_config).await;
+    wal.do_wal_persistence_update_for_test(None).await.unwrap();
+
+    // Prepare a second batch and simulate crash after persisting the file but before metadata
+    // Add some events to be flushed to file 1
+    let mut _unused = Vec::new();
+    add_new_example_append_event(200, None, &mut wal, &mut _unused);
+    add_new_example_commit_event(201, None, &mut wal, &mut _unused);
+
+    // Extract next file to persist (file 1) without updating metadata/tracking
+    let (wal_events_file1, wal_file_info_file1) = wal
+        .extract_next_persistence_file()
+        .expect("expected next persistence file (file 1)");
+
+    // Persist the WAL file directly, simulating a crash before metadata persistence
+    WalManager::persist_new_wal_file(
+        wal.get_file_system_accessor(),
+        &wal_events_file1,
+        &wal_file_info_file1,
+    )
+    .await
+    .unwrap();
+
+    // Metadata on disk should still reflect only file 0
+    let metadata = WalManager::recover_from_persistent_wal_metadata(wal.get_file_system_accessor())
+        .await
+        .expect("metadata should exist for file 0");
+
+    // Now perform recovery using the metadata as source of truth
+    let (tx, mut rx) = tokio::sync::mpsc::channel::<TableEvent>(100);
+    WalManager::replay_recovery_from_wal(
+        tx,
+        Some(metadata.clone()),
+        wal.get_file_system_accessor(),
+        None,
+    )
+    .await
+    .unwrap();
+
+    // Collect replayed events (excluding the FinishRecovery signal) and verify they match file 0
+    let mut replayed_events: Vec<TableEvent> = Vec::new();
+    let mut saw_finish_recovery = false;
+    while let Some(event) = rx.recv().await {
+        match event {
+            TableEvent::FinishRecovery {
+                highest_completion_lsn,
+            } => {
+                assert_eq!(
+                    highest_completion_lsn,
+                    metadata.get_highest_completion_lsn(),
+                    "FinishRecovery should report highest LSN from metadata"
+                );
+                saw_finish_recovery = true;
+            }
+            other => replayed_events.push(other),
+        }
+    }
+
+    assert!(
+        saw_finish_recovery,
+        "expected a FinishRecovery event to be emitted"
+    );
+
+    // Ensure only metadata-tracked events were replayed (i.e., exactly file 0's events)
+    assert_ingestion_events_vectors_equal(&replayed_events, &expected_events_file0);
 }

--- a/src/moonlink/src/storage/wal/tests.rs
+++ b/src/moonlink/src/storage/wal/tests.rs
@@ -359,8 +359,12 @@ async fn test_wal_recovery_basic() {
     wal.do_wal_persistence_update_for_test(None).await.unwrap();
 
     // Recover events using flat stream
+    let wal_metadata =
+        WalManager::recover_from_persistent_wal_metadata(wal.get_file_system_accessor())
+            .await
+            .unwrap();
     let recovered_events =
-        get_table_events_vector_recovery(wal.get_file_system_accessor(), 0).await;
+        get_table_events_vector_recovery(wal.get_file_system_accessor(), &wal_metadata).await;
 
     assert_ingestion_events_vectors_equal(&recovered_events, &expected_events);
 }

--- a/src/moonlink/src/table_handler/tests.rs
+++ b/src/moonlink/src/table_handler/tests.rs
@@ -1727,7 +1727,9 @@ async fn test_wal_persists_events() {
 
     env.force_wal_persistence(1).await;
 
-    env.check_wal_events_inferring_lowest_file_number(&expected_events, &[])
+    let wal_metadata = env.get_latest_wal_metadata().await.unwrap();
+
+    env.check_wal_events_from_metadata(&wal_metadata, &expected_events, &[])
         .await;
 }
 
@@ -1761,7 +1763,9 @@ async fn test_wal_truncates_events_after_snapshot() {
 
     env.force_wal_persistence(2).await;
 
-    env.check_wal_events_inferring_lowest_file_number(&expected_events, &not_expected_events)
+    let wal_metadata = env.get_latest_wal_metadata().await.unwrap();
+
+    env.check_wal_events_from_metadata(&wal_metadata, &expected_events, &not_expected_events)
         .await;
 }
 
@@ -1806,7 +1810,9 @@ async fn test_wal_keeps_multiple_streaming_xacts() {
     env.force_wal_persistence(7).await;
 
     // we should be keeping all WAL after the flush at LSN 2 because we have a streaming xact that is not committed
-    env.check_wal_events_inferring_lowest_file_number(&expected_events, &not_expected_events)
+    let wal_metadata = env.get_latest_wal_metadata().await.unwrap();
+
+    env.check_wal_events_from_metadata(&wal_metadata, &expected_events, &not_expected_events)
         .await;
 }
 


### PR DESCRIPTION
Closes #1387 

This PR fixes a possible duplication issue during recovery - currently, during recovery we read in ascending file order until a WAL file no longer exists.  We then use the metadata file 'highest confirmed lsn' to filter out any events from postgres so we do not replay them. However, it is possible that we persisted a WAL file but crashed before persisting the metadata file, resulting in us applying events from both the latest WAL file and postgres. 

The latest metadata file should be the single source of truth. Therefore, we should only read from the file range stored in the metadata file, and not read in ascending WAL file number until a file no longer exists. This change is reflected in this PR. 