### PR TITLE
Fix remap partition

### DIFF
--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -716,8 +716,8 @@ impl SnapshotTableState {
             // In the case a streaming transaction commits before flush, we assign disk_slice.writer_lsn = commit_lsn.
             // The corresponding deletions have lsn = commit_lsn - 1, so we need >= write_lsn - 1
             // to ensure these deletions get remapped from memory to disk locations.
-            // Use wrapping_sub(1) for the special initial copy case where write_lsn is 0. In this case we still want to remap the deletion log.
-            let threshold = write_lsn.wrapping_sub(1);
+            // Use saturating_sub(1) for the special initial copy case where write_lsn is 0. In this case we still want to remap the deletion log.
+            let threshold = write_lsn.saturating_sub(1);
             for deletion in self.committed_deletion_log.iter_mut() {
                 if deletion.lsn < threshold {
                     continue;

--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -711,17 +711,17 @@ impl SnapshotTableState {
                     .is_none());
             }
 
-            // remap deletions written *after* this slice’s LSN
+            // Remap deletions written *after* this slice’s LSN
             // We set to write_lsn - 1 to maintain consistency with deletion LSNs from the streaming case.
             // In the case a streaming transaction commits before flush, we assign disk_slice.writer_lsn = commit_lsn.
             // The corresponding deletions have lsn = commit_lsn - 1, so we need >= write_lsn - 1
             // to ensure these deletions get remapped from memory to disk locations.
             // Use wrapping_sub(1) for the special initial copy case where write_lsn is 0. In this case we still want to remap the deletion log.
-            let cut = self
-                .committed_deletion_log
-                .partition_point(|d| d.lsn < write_lsn.wrapping_sub(1));
-
-            for deletion in self.committed_deletion_log[cut..].iter_mut() {
+            let threshold = write_lsn.wrapping_sub(1);
+            for deletion in self.committed_deletion_log.iter_mut() {
+                if deletion.lsn < threshold {
+                    continue;
+                }
                 if let Some(RecordLocation::DiskFile(file_id, row_idx)) =
                     slice.remap_deletion_if_needed(deletion)
                 {


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

We are incorrectly assuming that `committed_deletion_log` is LSN ordered. We now have multiple producers appending to this log (streaming and non-streaming transactions) therefore we cannot assume it is by default ordered by increasing LSN.

When computing the cut point we should iterate the entire log and filter rows that don't meet the condition rather than scanning for some partition point.

## Related Issues

## Changes

- 
- 
- 

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
