### PR TITLE
Increase mpsc channel size

### DIFF
--- a/src/moonlink/src/table_handler.rs
+++ b/src/moonlink/src/table_handler.rs
@@ -28,6 +28,8 @@ use table_handler_state::{
     MaintenanceProcessStatus, MaintenanceRequestStatus, SpecialTableState, TableHandlerState,
 };
 
+const MAX_BUFFERED_TABLE_EVENTS: usize = 32_768;
+
 /// Handler for table operations
 pub struct TableHandler {
     /// Handle to periodical events.
@@ -51,7 +53,7 @@ impl TableHandler {
         table_event_replay_tx: Option<mpsc::UnboundedSender<MooncakeTableEvent>>,
     ) -> Self {
         // Create channel for events
-        let (event_sender, event_receiver) = mpsc::channel(100);
+        let (event_sender, event_receiver) = mpsc::channel(MAX_BUFFERED_TABLE_EVENTS);
 
         // Register channel for internal control events.
         table.register_table_notify(event_sender.clone()).await;


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

The table handler’s event queue is a bounded `mpsc::channel` with capacity `100`. If the handler processes events slower than pg produces them, the replication sink must `.await` available capacity, stalling ingestion. When considering 100M inserts our current channel size is extremely small. 

Did some very rough testing and the max ingest rate I saw during 100M insert was around 0.7M events/s. At channel size of `2^15` that should absorb ~47ms of stall time on the moonlink side, which should be more than enough while still keeping the in-memory footprint reasonable in the event that the queue fills (it should really never). 

## Related Issues

Closes #<issue-number> or links to related issues.

## Changes

- 
- 
- 

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
