### PR TITLE
Fix/error handling 1225

### DIFF
--- a/src/moonlink/src/row/column_array_builder.rs
+++ b/src/moonlink/src/row/column_array_builder.rs
@@ -388,21 +388,21 @@ mod tests {
     fn test_column_array_builder() {
         // Test Int32 type
         let mut builder = ColumnArrayBuilder::new(&DataType::Int32, /*capacity=*/ 2);
-        builder.append_value(&RowValue::Int32(1)).unwrap();
-        builder.append_value(&RowValue::Int32(2)).unwrap();
+        builder.append_value(&RowValue::Int32(1)).expect("Failed to append value");
+        builder.append_value(&RowValue::Int32(2)).expect("Failed to append value");
         let array = builder.finish(&DataType::Int32);
         assert_eq!(array.len(), 2);
-        let int32_array = array.as_any().downcast_ref::<Int32Array>().unwrap();
+        let int32_array = array.as_any().downcast_ref::<Int32Array>().expect("Failed to downcast");
         assert_eq!(int32_array.value(0), 1);
         assert_eq!(int32_array.value(1), 2);
 
         // Test Int64 type
         let mut builder = ColumnArrayBuilder::new(&DataType::Int64, /*capacity=*/ 2);
-        builder.append_value(&RowValue::Int64(100)).unwrap();
-        builder.append_value(&RowValue::Int64(200)).unwrap();
+        builder.append_value(&RowValue::Int64(100)).expect("Failed to append value");
+        builder.append_value(&RowValue::Int64(200)).expect("Failed to append value");
         let array = builder.finish(&DataType::Int64);
         assert_eq!(array.len(), 2);
-        let int64_array = array.as_any().downcast_ref::<Int64Array>().unwrap();
+        let int64_array = array.as_any().downcast_ref::<Int64Array>().expect("Failed to downcast");
         assert_eq!(int64_array.value(0), 100);
         assert_eq!(int64_array.value(1), 200);
 
@@ -410,13 +410,13 @@ mod tests {
         let mut builder = ColumnArrayBuilder::new(&DataType::Float32, /*capacity=*/ 2);
         builder
             .append_value(&RowValue::Float32(std::f32::consts::PI))
-            .unwrap();
+            .expect("Failed to append value");
         builder
             .append_value(&RowValue::Float32(std::f32::consts::E))
-            .unwrap();
+            .expect("Failed to append value");
         let array = builder.finish(&DataType::Float32);
         assert_eq!(array.len(), 2);
-        let float32_array = array.as_any().downcast_ref::<Float32Array>().unwrap();
+        let float32_array = array.as_any().downcast_ref::<Float32Array>().expect("Failed to downcast");
         assert!((float32_array.value(0) - std::f32::consts::PI).abs() < 0.0001);
         assert!((float32_array.value(1) - std::f32::consts::E).abs() < 0.0001);
 
@@ -424,23 +424,23 @@ mod tests {
         let mut builder = ColumnArrayBuilder::new(&DataType::Float64, /*capacity=*/ 2);
         builder
             .append_value(&RowValue::Float64(std::f64::consts::PI))
-            .unwrap();
+            .expect("Failed to append value");
         builder
             .append_value(&RowValue::Float64(std::f64::consts::E))
-            .unwrap();
+            .expect("Failed to append value");
         let array = builder.finish(&DataType::Float64);
         assert_eq!(array.len(), 2);
-        let float64_array = array.as_any().downcast_ref::<Float64Array>().unwrap();
+        let float64_array = array.as_any().downcast_ref::<Float64Array>().expect("Failed to downcast");
         assert!((float64_array.value(0) - std::f64::consts::PI).abs() < 0.00001);
         assert!((float64_array.value(1) - std::f64::consts::E).abs() < 0.00001);
 
         // Test Boolean type
         let mut builder = ColumnArrayBuilder::new(&DataType::Boolean, /*capacity=*/ 2);
-        builder.append_value(&RowValue::Bool(true)).unwrap();
-        builder.append_value(&RowValue::Bool(false)).unwrap();
+        builder.append_value(&RowValue::Bool(true)).expect("Failed to append value");
+        builder.append_value(&RowValue::Bool(false)).expect("Failed to append value");
         let array = builder.finish(&DataType::Boolean);
         assert_eq!(array.len(), 2);
-        let bool_array = array.as_any().downcast_ref::<BooleanArray>().unwrap();
+        let bool_array = array.as_any().downcast_ref::<BooleanArray>().expect("Failed to downcast");
         assert!(bool_array.value(0));
         assert!(!bool_array.value(1));
 
@@ -448,13 +448,13 @@ mod tests {
         let mut builder = ColumnArrayBuilder::new(&DataType::Utf8, /*capacity=*/ 2);
         builder
             .append_value(&RowValue::ByteArray("hello".as_bytes().to_vec()))
-            .unwrap();
+            .expect("Failed to append value");
         builder
             .append_value(&RowValue::ByteArray("world".as_bytes().to_vec()))
-            .unwrap();
+            .expect("Failed to append value");
         let array = builder.finish(&DataType::Utf8);
         assert_eq!(array.len(), 2);
-        let string_array = array.as_any().downcast_ref::<StringArray>().unwrap();
+        let string_array = array.as_any().downcast_ref::<StringArray>().expect("Failed to downcast");
         assert_eq!(string_array.value(0), "hello");
         assert_eq!(string_array.value(1), "world");
 
@@ -465,39 +465,39 @@ mod tests {
         let bytes2 = [16, 15, 14, 13, 12, 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1];
         builder
             .append_value(&RowValue::FixedLenByteArray(bytes1))
-            .unwrap();
+            .expect("Failed to append value");
         builder
             .append_value(&RowValue::FixedLenByteArray(bytes2))
-            .unwrap();
+            .expect("Failed to append value");
         let array = builder.finish(&DataType::FixedSizeBinary(16));
         assert_eq!(array.len(), 2);
         let binary_array = array
             .as_any()
             .downcast_ref::<FixedSizeBinaryArray>()
-            .unwrap();
+            .expect("Failed to downcast");
         assert_eq!(binary_array.value(0), bytes1);
         assert_eq!(binary_array.value(1), bytes2);
 
         // Test null values
         let mut builder = ColumnArrayBuilder::new(&DataType::Int32, /*capacity=*/ 3);
-        builder.append_value(&RowValue::Int32(1)).unwrap();
-        builder.append_value(&RowValue::Null).unwrap();
-        builder.append_value(&RowValue::Int32(3)).unwrap();
+        builder.append_value(&RowValue::Int32(1)).expect("Failed to append value");
+        builder.append_value(&RowValue::Null).expect("Failed to append null");
+        builder.append_value(&RowValue::Int32(3)).expect("Failed to append value");
         let array = builder.finish(&DataType::Int32);
         assert_eq!(array.len(), 3);
-        let int32_array = array.as_any().downcast_ref::<Int32Array>().unwrap();
+        let int32_array = array.as_any().downcast_ref::<Int32Array>().expect("Failed to downcast");
         assert_eq!(int32_array.value(0), 1);
         assert!(int32_array.is_null(1));
         assert_eq!(int32_array.value(2), 3);
 
         // Test using null values directly from RowValue::Null
         let mut builder = ColumnArrayBuilder::new(&DataType::Int32, /*capacity=*/ 3);
-        builder.append_value(&RowValue::Int32(1)).unwrap();
-        builder.append_value(&RowValue::Null).unwrap();
-        builder.append_value(&RowValue::Int32(3)).unwrap();
+        builder.append_value(&RowValue::Int32(1)).expect("Failed to append value");
+        builder.append_value(&RowValue::Null).expect("Failed to append null");
+        builder.append_value(&RowValue::Int32(3)).expect("Failed to append value");
         let array = builder.finish(&DataType::Int32);
         assert_eq!(array.len(), 3);
-        let int32_array = array.as_any().downcast_ref::<Int32Array>().unwrap();
+        let int32_array = array.as_any().downcast_ref::<Int32Array>().expect("Failed to downcast");
         assert_eq!(int32_array.value(0), 1);
         assert!(int32_array.is_null(1));
         assert_eq!(int32_array.value(2), 3);
@@ -522,7 +522,7 @@ mod tests {
                 RowValue::Int32(2),
                 RowValue::Int32(3),
             ]))
-            .unwrap();
+            .expect("Failed to append value");
 
         // Add another list of integers [4, 5]
         builder
@@ -530,7 +530,7 @@ mod tests {
                 RowValue::Int32(4),
                 RowValue::Int32(5),
             ]))
-            .unwrap();
+            .expect("Failed to append value");
 
         let array = builder.finish(&DataType::List(Arc::new(arrow::datatypes::Field::new(
             "item",
@@ -539,11 +539,11 @@ mod tests {
         ))));
 
         assert_eq!(array.len(), 2);
-        let list_array = array.as_any().downcast_ref::<ListArray>().unwrap();
+        let list_array = array.as_any().downcast_ref::<ListArray>().expect("Failed to downcast");
 
         // Check first list [1, 2, 3]
         let first_list = list_array.value(0);
-        let first_int_array = first_list.as_any().downcast_ref::<Int32Array>().unwrap();
+        let first_int_array = first_list.as_any().downcast_ref::<Int32Array>().expect("Failed to downcast");
         assert_eq!(first_int_array.len(), 3);
         assert_eq!(first_int_array.value(0), 1);
         assert_eq!(first_int_array.value(1), 2);
@@ -551,7 +551,7 @@ mod tests {
 
         // Check second list [4, 5]
         let second_list = list_array.value(1);
-        let second_int_array = second_list.as_any().downcast_ref::<Int32Array>().unwrap();
+        let second_int_array = second_list.as_any().downcast_ref::<Int32Array>().expect("Failed to downcast");
         assert_eq!(second_int_array.len(), 2);
         assert_eq!(second_int_array.value(0), 4);
         assert_eq!(second_int_array.value(1), 5);

--- a/src/moonlink/src/row/moonlink_row.rs
+++ b/src/moonlink/src/row/moonlink_row.rs
@@ -519,16 +519,16 @@ mod tests {
         )
         .unwrap();
 
-        let tmp_dir = tempdir().expect("Failed to create temporary directory for parquet test");
+        let tmp_dir = tempdir().unwrap();
         let file_path = tmp_dir.path().join("output.parquet");
-        let file = tokio::fs::File::create(&file_path).await.expect("Failed to create file for parquet test");
+        let file = tokio::fs::File::create(&file_path).await.unwrap();
         let props = WriterProperties::builder()
             .set_compression(parquet::basic::Compression::UNCOMPRESSED)
             .build();
 
-        let mut writer = AsyncArrowWriter::try_new(file, schema, Some(props)).expect("Failed to create parquet writer");
-        writer.write(&record_batch).await.expect("Failed to write record batch to parquet");
-        writer.close().await.expect("Failed to close parquet writer");
+        let mut writer = AsyncArrowWriter::try_new(file, schema, Some(props)).unwrap();
+        writer.write(&record_batch).await.unwrap();
+        writer.close().await.unwrap();
 
         // Create moonlink row to match against, which matches the second row in the parquet file.
         let row = MoonlinkRow::new(vec![RowValue::Int32(2), RowValue::Int64(20)]);
@@ -536,7 +536,7 @@ mod tests {
         // Check cases with full row as identity property.
         assert!(
             row.equals_parquet_at_offset(
-                file_path.to_str().expect("Failed to convert file path to str"),
+                file_path.to_str().unwrap(),
                 /*offset=*/ 1,
                 &IdentityProp::FullRow
             )
@@ -544,7 +544,7 @@ mod tests {
         );
         assert!(
             !row.equals_parquet_at_offset(
-                file_path.to_str().expect("Failed to convert file path to str"),
+                file_path.to_str().unwrap(),
                 /*offset=*/ 0,
                 &IdentityProp::FullRow
             )
@@ -553,12 +553,12 @@ mod tests {
 
         let identity = IdentityProp::Keys(vec![1])
             .extract_identity_columns(row.clone())
-            .expect("Failed to extract identity columns for parquet test");
+            .unwrap();
         // Check cases with specified keys.
         assert!(
             identity
                 .equals_parquet_at_offset(
-                    file_path.to_str().expect("Failed to convert file path to str"),
+                    file_path.to_str().unwrap(),
                     /*offset=*/ 1,
                     &IdentityProp::Keys(vec![1])
                 )
@@ -567,7 +567,7 @@ mod tests {
         assert!(
             !identity
                 .equals_parquet_at_offset(
-                    file_path.to_str().expect("Failed to convert file path to str"),
+                    file_path.to_str().unwrap(),
                     /*offset=*/ 0,
                     &IdentityProp::Keys(vec![1])
                 )

--- a/src/moonlink/src/row/moonlink_row.rs
+++ b/src/moonlink/src/row/moonlink_row.rs
@@ -179,7 +179,7 @@ impl MoonlinkRow {
             IdentityProp::Keys(keys) => batch.project(keys.as_slice()),
             IdentityProp::FullRow => Ok(batch.clone()),
         }
-        .unwrap();
+        .expect("Failed to project batch for identity check at offset");
         self.equals_record_batch_at_offset_impl(&indices, offset)
     }
 
@@ -190,8 +190,8 @@ impl MoonlinkRow {
         identity: &IdentityProp,
     ) -> bool {
         assert!(self.is_extracted_identity_row(identity));
-        let file = tokio::fs::File::open(file_name).await.unwrap();
-        let stream_builder = ParquetRecordBatchStreamBuilder::new(file).await.unwrap();
+        let file = tokio::fs::File::open(file_name).await.expect("Failed to open file for parquet read at offset");
+        let stream_builder = ParquetRecordBatchStreamBuilder::new(file).await.expect("Failed to create stream builder for parquet read at offset");
         let row_groups = stream_builder.metadata().row_groups();
         let mut target_row_group = 0;
         let mut row_count: usize = 0;
@@ -213,9 +213,9 @@ impl MoonlinkRow {
             .with_batch_size(1)
             .with_projection(proj_mask.clone())
             .build()
-            .unwrap();
-        let mut batch_reader = reader.next_row_group().await.unwrap().unwrap();
-        let batch = batch_reader.next().unwrap().unwrap();
+            .expect("Failed to build parquet reader at offset for identity check");
+        let mut batch_reader = reader.next_row_group().await.expect("Failed to read next row group at offset for identity check").unwrap();
+        let batch = batch_reader.next().expect("Failed to read next batch at offset for identity check").unwrap();
         self.equals_record_batch_at_offset_impl(&batch, 0)
     }
 
@@ -384,7 +384,7 @@ mod tests {
                 Arc::new(Int64Array::from(vec![10, 20, 30, 40])),
             ],
         )
-        .unwrap();
+        .expect("Failed to create record batch for testing");
 
         // Create moonlink row to match against, which matches the second row in the parquet file.
         let row = MoonlinkRow::new(vec![RowValue::Int32(2), RowValue::Int64(20)]);
@@ -519,16 +519,16 @@ mod tests {
         )
         .unwrap();
 
-        let tmp_dir = tempdir().unwrap();
+        let tmp_dir = tempdir().expect("Failed to create temporary directory for parquet test");
         let file_path = tmp_dir.path().join("output.parquet");
-        let file = tokio::fs::File::create(&file_path).await.unwrap();
+        let file = tokio::fs::File::create(&file_path).await.expect("Failed to create file for parquet test");
         let props = WriterProperties::builder()
             .set_compression(parquet::basic::Compression::UNCOMPRESSED)
             .build();
 
-        let mut writer = AsyncArrowWriter::try_new(file, schema, Some(props)).unwrap();
-        writer.write(&record_batch).await.unwrap();
-        writer.close().await.unwrap();
+        let mut writer = AsyncArrowWriter::try_new(file, schema, Some(props)).expect("Failed to create parquet writer");
+        writer.write(&record_batch).await.expect("Failed to write record batch to parquet");
+        writer.close().await.expect("Failed to close parquet writer");
 
         // Create moonlink row to match against, which matches the second row in the parquet file.
         let row = MoonlinkRow::new(vec![RowValue::Int32(2), RowValue::Int64(20)]);
@@ -536,7 +536,7 @@ mod tests {
         // Check cases with full row as identity property.
         assert!(
             row.equals_parquet_at_offset(
-                file_path.to_str().unwrap(),
+                file_path.to_str().expect("Failed to convert file path to str"),
                 /*offset=*/ 1,
                 &IdentityProp::FullRow
             )
@@ -544,7 +544,7 @@ mod tests {
         );
         assert!(
             !row.equals_parquet_at_offset(
-                file_path.to_str().unwrap(),
+                file_path.to_str().expect("Failed to convert file path to str"),
                 /*offset=*/ 0,
                 &IdentityProp::FullRow
             )
@@ -553,12 +553,12 @@ mod tests {
 
         let identity = IdentityProp::Keys(vec![1])
             .extract_identity_columns(row.clone())
-            .unwrap();
+            .expect("Failed to extract identity columns for parquet test");
         // Check cases with specified keys.
         assert!(
             identity
                 .equals_parquet_at_offset(
-                    file_path.to_str().unwrap(),
+                    file_path.to_str().expect("Failed to convert file path to str"),
                     /*offset=*/ 1,
                     &IdentityProp::Keys(vec![1])
                 )
@@ -567,7 +567,7 @@ mod tests {
         assert!(
             !identity
                 .equals_parquet_at_offset(
-                    file_path.to_str().unwrap(),
+                    file_path.to_str().expect("Failed to convert file path to str"),
                     /*offset=*/ 0,
                     &IdentityProp::Keys(vec![1])
                 )

--- a/src/moonlink/src/storage/cache/object_storage/cache_config.rs
+++ b/src/moonlink/src/storage/cache/object_storage/cache_config.rs
@@ -49,7 +49,7 @@ impl ObjectStorageCacheConfig {
                 }
             }
         }
-        std::fs::create_dir_all(DEFAULT_CACHE_DIRECTORY).unwrap();
+        std::fs::create_dir_all(DEFAULT_CACHE_DIRECTORY).expect("Failed to create cache directory");
 
         Self {
             max_bytes: DEFAULT_MAX_BYTES_FOR_TEST,

--- a/src/moonlink/src/storage/cache/object_storage/local_file_optimization_state_tests.rs
+++ b/src/moonlink/src/storage/cache/object_storage/local_file_optimization_state_tests.rs
@@ -48,7 +48,7 @@ fn create_object_storage_cache_with_local_optimization(tmp_dir: &TempDir) -> Obj
 // (3) + persist + no reference count => (2)
 #[tokio::test]
 async fn test_cache_state_3_persist_and_unreferenced_2() {
-    let cache_file_directory = tempdir().unwrap();
+    let cache_file_directory = tempdir().expect("Failed to create temporary directory for cache test");
     let test_cache_file =
         create_test_file(cache_file_directory.path(), TEST_CACHE_FILENAME_1).await;
     let test_remote_file =
@@ -90,7 +90,7 @@ async fn test_cache_state_3_persist_and_unreferenced_2() {
 // (3) + persist + still reference count => (2)
 #[tokio::test]
 async fn test_cache_state_3_persist_and_referenced_3() {
-    let cache_file_directory = tempdir().unwrap();
+    let cache_file_directory = tempdir().expect("Failed to create temporary directory for cache test");
     let filesystem_accessor = FileSystemAccessor::default_for_test(&cache_file_directory);
     let test_cache_file =
         create_test_file(cache_file_directory.path(), TEST_CACHE_FILENAME_1).await;
@@ -123,7 +123,7 @@ async fn test_cache_state_3_persist_and_referenced_3() {
             filesystem_accessor.as_ref(),
         )
         .await
-        .unwrap();
+        .expect("Failed to get cache entry for second reference");
     assert_eq!(
         cache_handle_2.as_ref().unwrap().cache_entry.cache_filepath,
         test_cache_file.to_str().unwrap().to_string()
@@ -145,7 +145,7 @@ async fn test_cache_state_3_persist_and_referenced_3() {
 // (1) + requested to read + sufficient space => (3)
 #[tokio::test]
 async fn test_cache_state_1_request_read_with_sufficient_space_3() {
-    let cache_file_directory = tempdir().unwrap();
+    let cache_file_directory = tempdir().expect("Failed to create temporary directory for cache test for cache test");
     let filesystem_accessor = FileSystemAccessor::default_for_test(&cache_file_directory);
     let test_remote_file =
         create_test_file(cache_file_directory.path(), TEST_REMOTE_FILENAME_1).await;
@@ -158,7 +158,7 @@ async fn test_cache_state_1_request_read_with_sufficient_space_3() {
             filesystem_accessor.as_ref(),
         )
         .await
-        .unwrap();
+        .expect("Failed to get cache entry for read request with sufficient space");
     assert!(evicted_files_to_delete.is_empty());
     assert_eq!(
         cache_handle.as_ref().unwrap().cache_entry.cache_filepath,
@@ -174,7 +174,7 @@ async fn test_cache_state_1_request_read_with_sufficient_space_3() {
 // (1) + requested to read + insufficient space => (2)
 #[tokio::test]
 async fn test_cache_state_1_request_read_with_insufficient_space_3() {
-    let cache_file_directory = tempdir().unwrap();
+    let cache_file_directory = tempdir().expect("Failed to create temporary directory for cache test");
     let filesystem_accessor = FileSystemAccessor::default_for_test(&cache_file_directory);
     let test_remote_file =
         create_test_file(cache_file_directory.path(), TEST_REMOTE_FILENAME_1).await;
@@ -191,7 +191,7 @@ async fn test_cache_state_1_request_read_with_insufficient_space_3() {
             filesystem_accessor.as_ref(),
         )
         .await
-        .unwrap();
+        .expect("Failed to get cache entry for read request with insufficient space");
     assert!(evicted_files_to_delete.is_empty());
     assert!(cache_handle.is_none());
 
@@ -204,7 +204,7 @@ async fn test_cache_state_1_request_read_with_insufficient_space_3() {
 // (2) + requested to delete => (4)
 #[tokio::test]
 async fn test_cache_state_2_request_to_delete_4() {
-    let cache_file_directory = tempdir().unwrap();
+    let cache_file_directory = tempdir().expect("Failed to create temporary directory for cache test");
     let filesystem_accessor = FileSystemAccessor::default_for_test(&cache_file_directory);
     let test_cache_file =
         create_test_file(cache_file_directory.path(), TEST_CACHE_FILENAME_1).await;
@@ -246,7 +246,7 @@ async fn test_cache_state_2_request_to_delete_4() {
             filesystem_accessor.as_ref(),
         )
         .await
-        .unwrap();
+        .expect("Failed to get cache entry for second reference");
     assert!(evicted_files_to_delete.is_empty());
     assert_eq!(
         cache_handle.as_ref().unwrap().cache_entry.cache_filepath,
@@ -270,7 +270,7 @@ async fn test_cache_state_2_request_to_delete_4() {
 // (3) + requested to delete => (5)
 #[tokio::test]
 async fn test_cache_state_3_request_to_delete_5() {
-    let cache_file_directory = tempdir().unwrap();
+    let cache_file_directory = tempdir().expect("Failed to create temporary directory for cache test");
     let filesystem_accessor = FileSystemAccessor::default_for_test(&cache_file_directory);
     let test_cache_file =
         create_test_file(cache_file_directory.path(), TEST_CACHE_FILENAME_1).await;
@@ -302,7 +302,7 @@ async fn test_cache_state_3_request_to_delete_5() {
             filesystem_accessor.as_ref(),
         )
         .await
-        .unwrap();
+        .expect("Failed to get cache entry for second reference count");
     assert_eq!(
         cache_handle_2.as_ref().unwrap().cache_entry.cache_filepath,
         test_cache_file.to_str().unwrap().to_string()
@@ -323,7 +323,7 @@ async fn test_cache_state_3_request_to_delete_5() {
 // (5) + usage finishes + no reference count => (4)
 #[tokio::test]
 async fn test_cache_state_5_unreference_4() {
-    let cache_file_directory = tempdir().unwrap();
+    let cache_file_directory = tempdir().expect("Failed to create temporary directory for cache test");
     let filesystem_accessor = FileSystemAccessor::default_for_test(&cache_file_directory);
     let test_cache_file =
         create_test_file(cache_file_directory.path(), TEST_CACHE_FILENAME_1).await;
@@ -352,7 +352,7 @@ async fn test_cache_state_5_unreference_4() {
             filesystem_accessor.as_ref(),
         )
         .await
-        .unwrap();
+        .expect("Failed to get cache entry for first reference count");
     let (mut cache_handle_2, _) = cache
         .get_cache_entry(
             file_id,
@@ -360,7 +360,7 @@ async fn test_cache_state_5_unreference_4() {
             filesystem_accessor.as_ref(),
         )
         .await
-        .unwrap();
+        .expect("Failed to get cache entry for second reference count");
     // Till now, the state is (3).
 
     // Delete the first cache handle.
@@ -384,7 +384,7 @@ async fn test_cache_state_5_unreference_4() {
 // (2) + new entry + sufficient space => (2)
 #[tokio::test]
 async fn test_cache_state_2_new_entry_with_sufficient_space_4() {
-    let cache_file_directory = tempdir().unwrap();
+    let cache_file_directory = tempdir().expect("Failed to create temporary directory for cache test");
     let test_cache_file_1 =
         create_test_file(cache_file_directory.path(), TEST_CACHE_FILENAME_1).await;
     let test_remote_file_1 =
@@ -446,7 +446,7 @@ async fn test_cache_state_2_new_entry_with_sufficient_space_4() {
 // (2) + new entry + insufficient space => (1)
 #[tokio::test]
 async fn test_cache_state_2_new_entry_with_insufficient_space_1() {
-    let cache_file_directory = tempdir().unwrap();
+    let cache_file_directory = tempdir().expect("Failed to create temporary directory for cache test");
     let test_cache_file_1 =
         create_test_file(cache_file_directory.path(), TEST_CACHE_FILENAME_1).await;
     let test_remote_file_1 =
@@ -503,7 +503,7 @@ async fn test_cache_state_2_new_entry_with_insufficient_space_1() {
 // (2) + requested to read + sufficient space => (3)
 #[tokio::test]
 async fn test_cache_state_2_request_to_read_sufficient_space_4() {
-    let cache_file_directory = tempdir().unwrap();
+    let cache_file_directory = tempdir().expect("Failed to create temporary directory for cache test");
     let filesystem_accessor = FileSystemAccessor::default_for_test(&cache_file_directory);
     let test_cache_file =
         create_test_file(cache_file_directory.path(), TEST_CACHE_FILENAME_1).await;
@@ -545,7 +545,7 @@ async fn test_cache_state_2_request_to_read_sufficient_space_4() {
             filesystem_accessor.as_ref(),
         )
         .await
-        .unwrap();
+        .expect("Failed to get cache entry for read request with sufficient space");
     assert!(evicted_files_to_delete.is_empty());
     assert_eq!(
         cache_handle.as_ref().unwrap().cache_entry.cache_filepath,
@@ -571,7 +571,7 @@ async fn test_cache_state_2_request_to_read_sufficient_space_4() {
 /// (2) + replace with remote => (2)
 #[tokio::test]
 async fn test_cache_state_2_replace_with_remote_2() {
-    let cache_file_directory = tempdir().unwrap();
+    let cache_file_directory = tempdir().expect("Failed to create temporary directory for cache test");
     let test_cache_file =
         create_test_file(cache_file_directory.path(), TEST_CACHE_FILENAME_1).await;
     let test_remote_file =

--- a/src/moonlink/src/storage/cache/object_storage/object_storage_cache.rs
+++ b/src/moonlink/src/storage/cache/object_storage/object_storage_cache.rs
@@ -73,7 +73,7 @@ impl ObjectStorageCacheInternal {
                 );
                 return (false, evicted_files_to_delete);
             }
-            let (_, mut cache_entry_wrapper) = self.evictable_cache.pop_lru().unwrap();
+            let (_, mut cache_entry_wrapper) = self.evictable_cache.pop_lru().expect("Evictable cache should not be empty");
             assert_eq!(cache_entry_wrapper.reference_count, 0);
             self.cur_bytes -= cache_entry_wrapper.cache_entry.file_metadata.file_size;
 
@@ -149,7 +149,7 @@ impl ObjectStorageCacheInternal {
     /// Unreference the given cache entry.
     pub(super) fn unreference(&mut self, file_id: TableUniqueFileId) -> Vec<String> {
         let cache_entry_wrapper = self.non_evictable_cache.get_mut(&file_id);
-        let cache_entry_wrapper = cache_entry_wrapper.unwrap();
+        let cache_entry_wrapper = cache_entry_wrapper.expect("Cache entry should exist for unreference operation");
         cache_entry_wrapper.reference_count -= 1;
 
         // Aggregate cache entries to delete.
@@ -157,7 +157,7 @@ impl ObjectStorageCacheInternal {
 
         // Down-level to evictable if reference count goes away.
         if cache_entry_wrapper.reference_count == 0 {
-            let cache_entry_wrapper = self.non_evictable_cache.remove(&file_id).unwrap();
+            let cache_entry_wrapper = self.non_evictable_cache.remove(&file_id).expect("Cache entry should exist for unreference operation");
 
             // If the current entry has already been requested to delete.
             if self.evicted_entries.remove(&file_id) {
@@ -303,7 +303,7 @@ impl ObjectStorageCache {
         filesystem_accessor: &dyn BaseFileSystemAccess,
     ) -> Result<CacheEntry> {
         let src_pathbuf = std::path::PathBuf::from(src);
-        let suffix = src_pathbuf.extension().unwrap().to_str().unwrap();
+        let suffix = src_pathbuf.extension().unwrap().to_str().expect("Failed to get file extension from path buffer for cache entry");
         let mut dst_pathbuf = std::path::PathBuf::from(&self.config.cache_directory);
         dst_pathbuf.push(format!("{}.{}", Uuid::now_v7(), suffix));
         let dst_filepath = dst_pathbuf.to_str().unwrap().to_string();
@@ -534,9 +534,9 @@ mod tests {
         let (cache_handle, cache_to_delete) = object_storage_cache
             .get_cache_entry(unique_file_id, data_file.file_path(), filesystem_accessor)
             .await
-            .unwrap();
+            .expect("Failed to get cache entry for read request with sufficient space");
         assert!(cache_to_delete.is_empty());
-        cache_handle.unwrap()
+        cache_handle.expect("Cache handle should not be empty for read request")
     }
 
     #[tokio::test]
@@ -544,8 +544,8 @@ mod tests {
         const PARALLEL_TASK_NUM: usize = 10;
         let mut handle_futures = Vec::with_capacity(PARALLEL_TASK_NUM);
 
-        let cache_file_directory = tempdir().unwrap();
-        let remote_file_directory = tempdir().unwrap();
+        let cache_file_directory = tempdir().expect("Failed to create cache file directory for test");
+        let remote_file_directory = tempdir().expect("Failed to create remote file directory for test");
 
         let config = ObjectStorageCacheConfig {
             // Set max bytes larger than one file, but less than two files.
@@ -595,8 +595,8 @@ mod tests {
         const PARALLEL_TASK_NUM: usize = 10;
         let mut handle_futures = Vec::with_capacity(PARALLEL_TASK_NUM);
 
-        let cache_file_directory = tempdir().unwrap();
-        let remote_file_directory = tempdir().unwrap();
+        let cache_file_directory = tempdir().expect("Failed to create cache file directory for test");
+        let remote_file_directory = tempdir().expect("Failed to create remote file directory for test");
 
         let config = ObjectStorageCacheConfig {
             // Set max bytes larger than one file, but less than two files.

--- a/src/moonlink/src/storage/compaction/compactor.rs
+++ b/src/moonlink/src/storage/compaction/compactor.rs
@@ -200,7 +200,7 @@ impl CompactionBuilder {
             .iter()
             .map(|cur_row_group| cur_row_group.num_rows() as usize)
             .sum();
-        let mut reader = builder.build().unwrap();
+        let mut reader = builder.build().expect("Failed to build parquet reader for deletion vector application during compaction");
 
         let batch_deletion_vector =
             if let Some(puffin_blob_ref) = data_file_to_compact.deletion_vector {
@@ -216,7 +216,7 @@ impl CompactionBuilder {
             }
             batch_deletion_vector
                 .apply_to_batch_with_slice(&record_batch, start_row_idx)
-                .unwrap()
+                .expect("Failed to apply deletion vector to record batch during compaction operation")
         };
 
         let mut old_start_row_idx = 0;

--- a/src/moonlink/src/storage/filesystem/accessor/chaos_generator.rs
+++ b/src/moonlink/src/storage/filesystem/accessor/chaos_generator.rs
@@ -24,7 +24,7 @@ impl ChaosGenerator {
         } else {
             let nanos = SystemTime::now()
                 .duration_since(UNIX_EPOCH)
-                .unwrap()
+                .expect("Failed to get system time since epoch during chaos generator initialization")
                 .as_nanos();
             nanos as u64
         };

--- a/src/moonlink/src/storage/filesystem/accessor/unbuffered_stream_writer.rs
+++ b/src/moonlink/src/storage/filesystem/accessor/unbuffered_stream_writer.rs
@@ -44,7 +44,7 @@ impl UnbufferedStreamWriter {
 #[async_trait]
 impl BaseUnbufferedStreamWriter for UnbufferedStreamWriter {
     async fn append_non_blocking(&mut self, data: Vec<u8>) -> Result<()> {
-        self.request_tx.send(data).await.unwrap();
+        self.request_tx.send(data).await.expect("Failed to send data to background task for writing during append operation");
         Ok(())
     }
 

--- a/src/moonlink/src/storage/iceberg/deletion_vector.rs
+++ b/src/moonlink/src/storage/iceberg/deletion_vector.rs
@@ -44,7 +44,7 @@ impl DeletionVector {
     /// Pre-requisite: row indices must be in ascending order.
     pub fn mark_rows_deleted(&mut self, rows: Vec<u64>) {
         let row_count = rows.len();
-        let appended_num = self.bitmap.append(rows).unwrap();
+        let appended_num = self.bitmap.append(rows).expect("Failed to append rows to deletion vector bitmap");
         assert_eq!(appended_num as usize, row_count);
     }
 
@@ -128,7 +128,7 @@ impl DeletionVector {
         let bitmap_slice =
             unsafe { std::slice::from_raw_parts_mut(ptr.add(offset), serialized_bitmap_size) };
         let mut bitmap_writer = std::io::Cursor::new(bitmap_slice);
-        self.bitmap.serialize_into(&mut bitmap_writer).unwrap();
+        self.bitmap.serialize_into(&mut bitmap_writer).expect("Failed to serialize roaring bitmap into deletion vector blob");
         offset += serialized_bitmap_size;
 
         // Calculate CRC (magic bytes + serialized bitmap).
@@ -222,7 +222,7 @@ impl DeletionVector {
             .get(MOONCAKE_DELETION_VECTOR_NUM_ROWS)
             .unwrap()
             .parse()
-            .unwrap();
+            .expect("Failed to parse max number of rows from deletion vector properties during deserialization");
 
         // Deserialize the bitmap.
         DeletionVector::deserialize_roaring_map(bitmap_data, max_num_rows)

--- a/src/moonlink/src/storage/iceberg/deletion_vector_manifest_manager.rs
+++ b/src/moonlink/src/storage/iceberg/deletion_vector_manifest_manager.rs
@@ -151,7 +151,7 @@ fn get_data_file_for_deletion_vector(
             .get(DELETION_VECTOR_CADINALITY)
             .unwrap()
             .parse()
-            .unwrap(),
+            .expect("Failed to parse deletion vector cardinality from properties during deserialization"),
         file_size_in_bytes: 0, // TODO(hjiang): Not necessary for puffin blob, but worth double confirm.
         column_sizes: HashMap::new(),
         value_counts: HashMap::new(),

--- a/src/moonlink/src/storage/iceberg/file_catalog.rs
+++ b/src/moonlink/src/storage/iceberg/file_catalog.rs
@@ -392,7 +392,7 @@ impl Catalog for FileCatalog {
             let cur_namespace_ident = if let Some(parent_namespace_ident) = parent {
                 let mut parent_namespace_segments = parent_namespace_ident.clone().to_vec();
                 parent_namespace_segments.push(cur_subdir.to_string());
-                NamespaceIdent::from_vec(parent_namespace_segments).unwrap()
+                NamespaceIdent::from_vec(parent_namespace_segments).expect("Failed to create namespace ident from segments during list namespaces")
             } else {
                 NamespaceIdent::new(cur_subdir.to_string())
             };
@@ -408,7 +408,7 @@ impl Catalog for FileCatalog {
                 let cur_namespace_ident = if let Some(parent_namespace_ident) = parent {
                     let mut parent_namespace_segments = parent_namespace_ident.clone().to_vec();
                     parent_namespace_segments.push(cur_subdir.to_string());
-                    NamespaceIdent::from_vec(parent_namespace_segments).unwrap()
+                    NamespaceIdent::from_vec(parent_namespace_segments).expect("Failed to create namespace ident from segments during list namespaces")
                 } else {
                     NamespaceIdent::new(cur_subdir.to_string())
                 };

--- a/src/moonlink/src/storage/iceberg/file_index_manifest_manager.rs
+++ b/src/moonlink/src/storage/iceberg/file_index_manifest_manager.rs
@@ -117,7 +117,7 @@ fn get_data_file_for_file_index(
             .get(MOONCAKE_HASH_INDEX_V1_CARDINALITY)
             .unwrap()
             .parse()
-            .unwrap(),
+            .expect("Failed to parse cardinality from properties during file index blob creation"),
         file_size_in_bytes: 0, // TODO(hjiang): Not necessary for puffin blob, but worth double confirm.
         column_sizes: HashMap::new(),
         value_counts: HashMap::new(),

--- a/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
@@ -128,7 +128,7 @@ impl IcebergTableManager {
     /// Get table identity.
     pub(super) fn get_table_ident(&self) -> TableIdent {
         TableIdent {
-            namespace: NamespaceIdent::from_strs(&self.config.namespace).unwrap(),
+            namespace: NamespaceIdent::from_strs(&self.config.namespace).expect("Failed to create namespace ident from segments during get table ident"),
             name: self.config.table_name.clone(),
         }
     }
@@ -137,14 +137,14 @@ impl IcebergTableManager {
     pub(super) fn get_unique_deletion_vector_filepath(&self) -> String {
         let location_generator =
             DefaultLocationGenerator::new(self.iceberg_table.as_ref().unwrap().metadata().clone())
-                .unwrap();
+                .expect("Failed to create default location generator for deletion vector filepath generation");
         location_generator
             .generate_location(&format!("{}-deletion-vector-v1-puffin.bin", Uuid::now_v7()))
     }
     pub(super) fn get_unique_hash_index_v1_filepath(&self) -> String {
         let location_generator =
             DefaultLocationGenerator::new(self.iceberg_table.as_ref().unwrap().metadata().clone())
-                .unwrap();
+                .expect("Failed to create default location generator for hash index v1 filepath generation");
         location_generator
             .generate_location(&format!("{}-hash-index-v1-puffin.bin", Uuid::now_v7()))
     }
@@ -213,7 +213,7 @@ impl TableManager for IcebergTableManager {
 
     async fn drop_table(&mut self) -> IcebergResult<()> {
         let table_ident = TableIdent::new(
-            NamespaceIdent::from_strs(&self.config.namespace).unwrap(),
+            NamespaceIdent::from_strs(&self.config.namespace).expect("Failed to create namespace ident from segments during drop table ident"),
             self.config.table_name.clone(),
         );
         self.catalog.drop_table(&table_ident).await

--- a/src/moonlink/src/storage/iceberg/io_utils.rs
+++ b/src/moonlink/src/storage/iceberg/io_utils.rs
@@ -65,7 +65,7 @@ pub(crate) async fn upload_index_file(
         .to_str()
         .unwrap()
         .to_string();
-    let location_generator = DefaultLocationGenerator::new(table.metadata().clone()).unwrap();
+    let location_generator = DefaultLocationGenerator::new(table.metadata().clone()).expect("Failed to create default location generator for index file upload during iceberg table manager");
     let remote_filepath = location_generator.generate_location(&filename);
     filesystem_accessor
         .copy_from_local_to_remote(local_index_filepath, &remote_filepath)

--- a/src/moonlink/src/storage/iceberg/parquet_stats_utils.rs
+++ b/src/moonlink/src/storage/iceberg/parquet_stats_utils.rs
@@ -123,7 +123,7 @@ pub(crate) fn get_parquet_stat_min_as_datum(
         ) => stats.min_opt().map(|val| {
             // TODO(hjiang): Add unit test.
             let value = i128::from(*val);
-            Datum::decimal(value).unwrap()
+            Datum::decimal(value).expect("Failed to create decimal datum from i128 value")
         }),
         (
             PrimitiveType::Decimal {
@@ -134,7 +134,7 @@ pub(crate) fn get_parquet_stat_min_as_datum(
         ) => stats.min_opt().map(|val| {
             // TODO(hjiang): Add unit test.
             let value = i128::from(*val);
-            Datum::decimal(value).unwrap()
+            Datum::decimal(value).expect("Failed to create decimal datum from i64 value")
         }),
         (PrimitiveType::Uuid, Statistics::FixedLenByteArray(stats)) => {
             let Some(bytes) = stats.min_bytes_opt() else {
@@ -147,7 +147,7 @@ pub(crate) fn get_parquet_stat_min_as_datum(
                 ));
             }
             Some(Datum::uuid(Uuid::from_bytes(
-                bytes[..16].try_into().unwrap(),
+                bytes[..16].try_into().expect("Failed to convert bytes to Uuid during parquet stat min conversion"),
             )))
         }
         (PrimitiveType::Fixed(len), Statistics::FixedLenByteArray(stat)) => {
@@ -269,7 +269,7 @@ pub(crate) fn get_parquet_stat_max_as_datum(
         ) => stats.max_opt().map(|val| {
             // TODO(hjiang): Add unit test.
             let value = i128::from(*val);
-            Datum::decimal(value).unwrap()
+            Datum::decimal(value).expect("Failed to create decimal datum from i128 value")
         }),
         (
             PrimitiveType::Decimal {
@@ -280,7 +280,7 @@ pub(crate) fn get_parquet_stat_max_as_datum(
         ) => stats.max_opt().map(|val| {
             // TODO(hjiang): Add unit test.
             let value = i128::from(*val);
-            Datum::decimal(value).unwrap()
+            Datum::decimal(value).expect("Failed to create decimal datum from i64 value")
         }),
         (PrimitiveType::Uuid, Statistics::FixedLenByteArray(stats)) => {
             let Some(bytes) = stats.max_bytes_opt() else {
@@ -293,7 +293,7 @@ pub(crate) fn get_parquet_stat_max_as_datum(
                 ));
             }
             Some(Datum::uuid(Uuid::from_bytes(
-                bytes[..16].try_into().unwrap(),
+                bytes[..16].try_into().expect("Failed to convert bytes to Uuid during parquet stat max conversion"),
             )))
         }
         (PrimitiveType::Fixed(len), Statistics::FixedLenByteArray(stat)) => {

--- a/src/moonlink/src/storage/iceberg/parquet_utils.rs
+++ b/src/moonlink/src/storage/iceberg/parquet_utils.rs
@@ -251,7 +251,7 @@ fn parquet_to_data_file_builder(
 async fn get_parquet_metadata(
     local_parquet_file: &str,
 ) -> IcebergResult<(ParquetMetaData, usize /*file size*/)> {
-    let file_io = FileIOBuilder::new_fs_io().build().unwrap();
+    let file_io = FileIOBuilder::new_fs_io().build().expect("Failed to create file IO builder for parquet metadata retrieval");
     let input_file = file_io.new_input(local_parquet_file)?;
     let file_metadata = input_file.metadata().await?;
     let file_size = file_metadata.size as usize;

--- a/src/moonlink/src/storage/iceberg/snapshot_utils.rs
+++ b/src/moonlink/src/storage/iceberg/snapshot_utils.rs
@@ -24,7 +24,7 @@ pub(super) fn get_snapshot_properties(
         .additional_properties
         .get(MOONCAKE_TABLE_FLUSH_LSN)
     {
-        flush_lsn = Some(lsn.parse().unwrap());
+        flush_lsn = Some(lsn.parse().expect("Failed to parse flush LSN from snapshot summary during iceberg snapshot property retrieval"));
     }
     Ok(SnapshotProperty { flush_lsn })
 }

--- a/src/moonlink/src/storage/iceberg/table_event_manager.rs
+++ b/src/moonlink/src/storage/iceberg/table_event_manager.rs
@@ -43,7 +43,7 @@ impl TableEventManager {
         self.table_event_tx
             .send(TableEvent::ForceSnapshot { lsn: Some(lsn) })
             .await
-            .unwrap();
+            .expect("Failed to send force snapshot event to table event manager");
         self.force_snapshot_completion_rx.clone()
     }
 
@@ -71,7 +71,7 @@ impl TableEventManager {
 
         // Otherwise falls back to loop until requested LSN is met.
         loop {
-            rx.changed().await.unwrap();
+            rx.changed().await.expect("Failed to change watch receiver during force snapshot synchronization loop");
             if Self::is_iceberg_snapshot_ready(&rx.borrow(), requested_lsn)? {
                 break;
             }
@@ -87,7 +87,7 @@ impl TableEventManager {
         self.table_event_tx
             .send(TableEvent::ForceRegularIndexMerge)
             .await
-            .unwrap();
+            .expect("Failed to send force regular index merge event to table event manager during index merge initiation");
         subscriber
     }
 
@@ -97,7 +97,7 @@ impl TableEventManager {
         self.table_event_tx
             .send(TableEvent::ForceRegularDataCompaction)
             .await
-            .unwrap();
+            .expect("Failed to send force regular data compaction event to table event manager during data compaction initiation");
         subscriber
     }
 
@@ -107,7 +107,7 @@ impl TableEventManager {
         self.table_event_tx
             .send(TableEvent::ForceFullMaintenance)
             .await
-            .unwrap();
+            .expect("Failed to send force full maintenance event to table event manager during full compaction initiation");
         subscriber
     }
 
@@ -117,7 +117,7 @@ impl TableEventManager {
         self.table_event_tx
             .send(TableEvent::DropTable)
             .await
-            .unwrap();
-        self.drop_table_completion_rx.take().unwrap().await.unwrap()
+            .expect("Failed to send drop table event to table event manager during drop table operation");
+        self.drop_table_completion_rx.take().unwrap().await.expect("Failed to receive drop table completion during drop table operation synchronization")
     }
 }

--- a/src/moonlink/src/storage/iceberg/utils.rs
+++ b/src/moonlink/src/storage/iceberg/utils.rs
@@ -96,7 +96,7 @@ pub(crate) async fn get_or_create_iceberg_table<C: MoonlinkCatalog + ?Sized>(
     table_name: &str,
     arrow_schema: &ArrowSchema,
 ) -> IcebergResult<IcebergTable> {
-    let namespace_ident = NamespaceIdent::from_strs(namespace).unwrap();
+    let namespace_ident = NamespaceIdent::from_strs(namespace).expect("Failed to create namespace ident from segments during iceberg table creation or retrieval");
     let table_ident = TableIdent::new(namespace_ident.clone(), table_name.to_string());
     let should_create = match catalog.load_table(&table_ident).await {
         Ok(existing_table) => {
@@ -125,7 +125,7 @@ pub(crate) async fn get_table_if_exists<C: MoonlinkCatalog + ?Sized>(
     namespace: &Vec<String>,
     table_name: &str,
 ) -> IcebergResult<Option<IcebergTable>> {
-    let namespace_ident = NamespaceIdent::from_strs(namespace).unwrap();
+    let namespace_ident = NamespaceIdent::from_strs(namespace).expect("Failed to create namespace ident from segments during iceberg table retrieval or existence check");
     let table_ident = TableIdent::new(namespace_ident.clone(), table_name.to_string());
 
     let table_exists = catalog.table_exists(&table_ident).await?;

--- a/src/moonlink/src/storage/mooncake_table/data_batches.rs
+++ b/src/moonlink/src/storage/mooncake_table/data_batches.rs
@@ -201,7 +201,7 @@ impl ColumnStoreBuffer {
             let idx = self
                 .in_memory_batches
                 .binary_search_by_key(batch_id, |x| x.id)
-                .unwrap();
+                .expect("Failed to find batch by ID during row search by record");
             if !self.in_memory_batches[idx]
                 .batch
                 .deletions
@@ -229,7 +229,7 @@ impl ColumnStoreBuffer {
             let idx = self
                 .in_memory_batches
                 .binary_search_by_key(batch_id, |x| x.id)
-                .unwrap();
+                .expect("Failed to find batch by ID during row deletion by record operation");
             if !self.in_memory_batches[idx]
                 .batch
                 .deletions
@@ -280,7 +280,7 @@ impl ColumnStoreBuffer {
             .in_memory_batches
             .binary_search_by_key(&pos.0, |x| x.id);
         if idx.is_ok() {
-            let res = self.in_memory_batches[idx.unwrap()]
+            let res = self.in_memory_batches[idx.expect("Failed to find batch by ID during row deletion at position")]
                 .batch
                 .deletions
                 .delete_row(pos.1);
@@ -315,7 +315,7 @@ pub(super) fn create_batch_from_rows(
         .zip(schema.fields())
         .map(|(builder, field)| builder.finish(field.data_type()))
         .collect();
-    RecordBatch::try_new(Arc::clone(&schema), columns).unwrap()
+    RecordBatch::try_new(Arc::clone(&schema), columns).expect("Failed to create record batch from rows during batch creation")
 }
 
 #[cfg(test)]

--- a/src/moonlink/src/storage/mooncake_table/snapshot_read.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot_read.rs
@@ -86,7 +86,7 @@ impl SnapshotTableState {
                     /*filesystem_accessor*/ self.filesystem_accessor.as_ref(),
                 )
                 .await
-                .unwrap();
+                .expect("Failed to get puffin cache entry during deletion vector read operation");
             assert!(cur_evicted.is_empty());
             puffin_cache_handles.push(new_puffin_cache_handle.unwrap());
 

--- a/src/moonlink/src/storage/mooncake_table/snapshot_read_output.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot_read_output.rs
@@ -82,7 +82,7 @@ impl ReadOutput {
                             self.filesystem_accessor.as_ref().unwrap().as_ref(),
                         )
                         .await
-                        .unwrap();
+                        .expect("Failed to get cache entry for remote data file during read operation");
                     if let Some(cache_handle) = cache_handle {
                         resolved_data_files.push(cache_handle.get_cache_filepath().to_string());
                         cache_handles.push(cache_handle);
@@ -100,7 +100,7 @@ impl ReadOutput {
                                 },
                             })
                             .await
-                            .unwrap();
+                            .expect("Failed to send evicted files to delete event during read operation");
                     }
                 }
             }

--- a/src/moonlink/src/storage/wal.rs
+++ b/src/moonlink/src/storage/wal.rs
@@ -864,7 +864,7 @@ impl WalManager {
                 result: persistence_update_result,
             })
             .await
-            .unwrap();
+            .expect("Failed to send WAL persistence update result to table notify channel");
     }
 
     // ------------------------------

--- a/src/moonlink/src/table_handler/table_handler_state.rs
+++ b/src/moonlink/src/table_handler/table_handler_state.rs
@@ -513,7 +513,7 @@ impl TableHandlerState {
                 self.table_maintenance_process_status = MaintenanceProcessStatus::Unrequested;
                 self.table_maintenance_completion_tx
                     .send(Err(err.clone()))
-                    .unwrap();
+                    .expect("Failed to send data compaction completion result during table maintenance");
             }
         }
     }

--- a/src/moonlink/src/union_read/table_metadata.rs
+++ b/src/moonlink/src/union_read/table_metadata.rs
@@ -151,7 +151,7 @@ impl TableMetadata {
         for i in 0..data_files_len {
             let start = data_file_offsets[i];
             let end = data_file_offsets[i + 1];
-            let s = String::from_utf8(data[cursor + start..cursor + end].to_vec()).unwrap();
+            let s = String::from_utf8(data[cursor + start..cursor + end].to_vec()).expect("Invalid UTF-8 in data filepath data blob during decode operation");
             data_files.push(s);
         }
         if data_files_len > 0 {
@@ -164,7 +164,7 @@ impl TableMetadata {
             let start = puffin_file_offsets[i];
             let end = puffin_file_offsets[i + 1];
             let cur_puffin_filepath =
-                String::from_utf8(data[cursor + start..cursor + end].to_vec()).unwrap();
+                String::from_utf8(data[cursor + start..cursor + end].to_vec()).expect("Invalid UTF-8 in puffin filepath data blob during decode");
             puffin_files.push(cur_puffin_filepath);
         }
         if data_files_len > 0 {


### PR DESCRIPTION
## Summary

Replaced **_unwrap()_** with **_expect()_** in the **_src/moonlink_** which provides additional string context, which is usually better for debugging and logging purpose.

## Related Issues

Refs #1225.

## Changes

- Replaced unwrap() calls in production code with expect() calls containing descriptive error messages .

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
