### PR TITLE
fixed initial copy insert test

### DIFF
--- a/src/moonlink_backend/tests/test_initial_copy.rs
+++ b/src/moonlink_backend/tests/test_initial_copy.rs
@@ -178,7 +178,7 @@ mod tests {
         // Start create_table without awaiting so we can modify data during copy
         let backend_clone = Arc::clone(&backend);
         let table_config = guard.get_serialized_table_config();
-        tokio::spawn(async move {
+        let create_handle = tokio::spawn(async move {
             backend_clone
                 .create_table(
                     guard.database_id,
@@ -203,6 +203,7 @@ mod tests {
             .unwrap();
 
         let lsn = current_wal_lsn(&initial_client).await;
+        create_handle.await.unwrap();
         let ids = ids_from_state(
             &backend
                 .scan_table(guard.database_id, TABLE_ID, Some(lsn))


### PR DESCRIPTION
Fixed failing test:
```
vscode ➜ /workspaces/moonlink (ba3267d ✗) $ RUST_BACKTRACE='1' cargo test --package moonlink_backend --test test_initial_copy -- tests::test_initial_copy_handles_inserts_during_copy --exact --show-output 
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.34s
     Running tests/test_initial_copy.rs (target/debug/deps/test_initial_copy-4974a560a7f54ba6)

running 1 test

thread 'tests::test_initial_copy_handles_inserts_during_copy' panicked at src/moonlink_backend/tests/test_initial_copy.rs:210:18:
called `Result::unwrap()` on an `Err` value: MoonlinkConnectorError { source: TableNotFound("5.0") }
stack backtrace:
```
Closes #920 