### PR TITLE
[chaos] Move table events record to mooncake table

### DIFF
--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -774,26 +774,8 @@ impl MooncakeTable {
         }
 
         let mut disk_slice_clone = disk_slice.clone();
-        let event_replay_tx = self.event_replay_tx.clone();
         tokio::task::spawn(async move {
             let flush_result = disk_slice_clone.write().await;
-
-            // Record events for flush completion.
-            if let Some(event_replay_tx) = event_replay_tx {
-                let table_event = replay_events::create_flush_event_completion(
-                    flush_event_id,
-                    disk_slice_clone
-                        .output_files()
-                        .iter()
-                        .map(|(file, _)| file.file_id)
-                        .collect(),
-                );
-                event_replay_tx
-                    .send(MooncakeTableEvent::FlushCompletion(table_event))
-                    .unwrap();
-            }
-
-            // Perform table flush completion notification.
             match flush_result {
                 Ok(()) => {
                     table_notify_tx
@@ -821,7 +803,27 @@ impl MooncakeTable {
 
     /// Applies the result of a flush to the snapshot task.
     /// Adds the disk slice to `next_snapshot_task`.
-    pub fn apply_flush_result(&mut self, disk_slice: DiskSliceWriter) {
+    pub fn apply_flush_result(
+        &mut self,
+        disk_slice: DiskSliceWriter,
+        flush_event_id: BackgroundEventId,
+    ) {
+        // Record events for flush completion.
+        if let Some(event_replay_tx) = &self.event_replay_tx {
+            let table_event = replay_events::create_flush_event_completion(
+                flush_event_id,
+                disk_slice
+                    .output_files()
+                    .iter()
+                    .map(|(file, _)| file.file_id)
+                    .collect(),
+            );
+            event_replay_tx
+                .send(MooncakeTableEvent::FlushCompletion(table_event))
+                .unwrap();
+        }
+
+        // Perform table flush completion notification.
         let lsn = disk_slice
             .lsn()
             .expect("LSN should never be none for non streaming flush");
@@ -1105,20 +1107,6 @@ impl MooncakeTable {
     /// Flushes the disk slice.
     /// Adds the disk slice to `next_snapshot_task`.
     pub fn flush(&mut self, lsn: u64) -> Result<()> {
-        // Record events for flush initiation.
-        let flush_event_id = self.event_id_assigner.get_next_event_id();
-        if let Some(event_replay_tx) = &self.event_replay_tx {
-            let table_event = replay_events::create_flush_event_initiation(
-                flush_event_id,
-                /*xact_id=*/ None,
-                Some(lsn),
-                self.mem_slice.get_commit_check_point(),
-            );
-            event_replay_tx
-                .send(MooncakeTableEvent::FlushInitiation(table_event))
-                .unwrap();
-        }
-
         // Sanity check flush LSN doesn't regress.
         assert!(
             self.next_snapshot_task.new_flush_lsn.is_none()
@@ -1129,18 +1117,9 @@ impl MooncakeTable {
         );
 
         let table_notify_tx = self.table_notify.as_ref().unwrap().clone();
+        let flush_event_id = self.event_id_assigner.get_next_event_id();
 
         if self.mem_slice.is_empty() || self.ongoing_flush_lsns.contains(&lsn) {
-            // Record events for flush completion.
-            if let Some(event_replay_tx) = &self.event_replay_tx {
-                let table_event =
-                    replay_events::create_flush_event_completion(flush_event_id, vec![]);
-                event_replay_tx
-                    .send(MooncakeTableEvent::FlushCompletion(table_event))
-                    .unwrap();
-            }
-
-            // Perform table flush completion operation.
             self.try_set_next_flush_lsn(lsn);
             tokio::task::spawn(async move {
                 table_notify_tx
@@ -1155,8 +1134,20 @@ impl MooncakeTable {
             return Ok(());
         }
 
-        let mut disk_slice = self.prepare_disk_slice(lsn)?;
+        // Record events for flush initialization.
+        if let Some(event_replay_tx) = &self.event_replay_tx {
+            let table_event = replay_events::create_flush_event_initiation(
+                flush_event_id,
+                /*xact_id=*/ None,
+                Some(lsn),
+                self.mem_slice.get_commit_check_point(),
+            );
+            event_replay_tx
+                .send(MooncakeTableEvent::FlushInitiation(table_event))
+                .unwrap();
+        }
 
+        let mut disk_slice = self.prepare_disk_slice(lsn)?;
         self.flush_disk_slice(
             &mut disk_slice,
             table_notify_tx,

--- a/src/moonlink/src/storage/mooncake_table/table_operation_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_operation_test_utils.rs
@@ -6,6 +6,7 @@ use tokio::sync::mpsc::Receiver;
 use crate::row::MoonlinkRow;
 use crate::storage::io_utils;
 use crate::storage::mooncake_table::disk_slice::DiskSliceWriter;
+use crate::storage::mooncake_table::test_utils_commons::DUMMY_EVENT_ID;
 use crate::storage::mooncake_table::{
     AlterTableRequest, DataCompactionPayload, DataCompactionResult, FileIndiceMergePayload,
     FileIndiceMergeResult, IcebergSnapshotPayload, IcebergSnapshotResult,
@@ -40,7 +41,7 @@ pub(crate) async fn flush_table_and_sync(
             flush_result,
         } => match flush_result {
             Some(Ok(disk_slice)) => {
-                table.apply_flush_result(disk_slice);
+                table.apply_flush_result(disk_slice, DUMMY_EVENT_ID);
             }
             Some(Err(e)) => {
                 error!(error = ?e, "failed to flush disk slice");
@@ -137,7 +138,7 @@ pub(crate) async fn commit_transaction_stream_and_sync(
             flush_result,
         } => match flush_result {
             Some(Ok(disk_slice)) => {
-                table.apply_stream_flush_result(xact_id, disk_slice);
+                table.apply_stream_flush_result(xact_id, disk_slice, DUMMY_EVENT_ID);
             }
             Some(Err(e)) => {
                 error!(error = ?e, "failed to flush disk slice");

--- a/src/moonlink/src/storage/mooncake_table/test_utils_commons.rs
+++ b/src/moonlink/src/storage/mooncake_table/test_utils_commons.rs
@@ -1,6 +1,9 @@
 use tempfile::TempDir;
 
-use crate::storage::storage_utils::{FileId, MooncakeDataFileRef, TableId, TableUniqueFileId};
+use crate::storage::{
+    mooncake_table::replay::replay_events::BackgroundEventId,
+    storage_utils::{FileId, MooncakeDataFileRef, TableId, TableUniqueFileId},
+};
 
 /// Test constant to mimic an infinitely large object storage cache.
 pub(crate) const INFINITE_LARGE_OBJECT_STORAGE_CACHE_SIZE: u64 = u64::MAX;
@@ -24,6 +27,8 @@ pub(crate) const FAKE_FILE_ID: TableUniqueFileId = TableUniqueFileId {
 pub(crate) const FAKE_FILE_SIZE: u64 = 1 << 30; // 1GiB
 /// Fake filename.
 pub(crate) const FAKE_FILE_NAME: &str = "fake-file-name";
+/// Background events are attached with an event id for replay, not needed for unit tests.
+pub(crate) const DUMMY_EVENT_ID: BackgroundEventId = 0;
 
 /// Test util function to get unique table file id.
 pub(crate) fn get_unique_table_file_id(file_id: FileId) -> TableUniqueFileId {

--- a/src/moonlink/src/storage/mooncake_table/tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/tests.rs
@@ -4,6 +4,7 @@ use crate::storage::iceberg::table_manager::MockTableManager;
 use crate::storage::mooncake_table::table_creation_test_utils::*;
 use crate::storage::mooncake_table::table_operation_test_utils::*;
 use crate::storage::mooncake_table::test_utils::{append_rows, test_row, test_table, TestContext};
+use crate::storage::mooncake_table::test_utils_commons::DUMMY_EVENT_ID;
 use crate::storage::mooncake_table::Snapshot as MooncakeSnapshot;
 use crate::storage::snapshot_options::MaintenanceOption;
 use crate::storage::snapshot_options::SnapshotOption;
@@ -757,7 +758,7 @@ async fn test_streaming_begin_flush_commit_end_flush() {
     }
 
     // Apply the flush
-    table.apply_stream_flush_result(xact_id, disk_slice);
+    table.apply_stream_flush_result(xact_id, disk_slice, DUMMY_EVENT_ID);
 
     // Make sure we can still read the row after flush
     {
@@ -837,13 +838,13 @@ async fn test_streaming_begin_flush_commit_end_flush_multiple() {
     }
 
     // Apply the flush
-    table.apply_stream_flush_result(xact_id, disk_slice1);
+    table.apply_stream_flush_result(xact_id, disk_slice1, DUMMY_EVENT_ID);
 
     // Make sure the stream state is still present since we have outstanding flush
     assert!(table.transaction_stream_states.contains_key(&xact_id));
 
     // Apply the second flush
-    table.apply_stream_flush_result(xact_id, disk_slice2);
+    table.apply_stream_flush_result(xact_id, disk_slice2, DUMMY_EVENT_ID);
 
     // Assert the stream state is removed
     assert!(!table.transaction_stream_states.contains_key(&xact_id));
@@ -915,7 +916,7 @@ async fn test_streaming_begin_flush_commit_delete_end_flush() {
     }
 
     // Finish the flush
-    table.apply_stream_flush_result(xact_id, disk_slice);
+    table.apply_stream_flush_result(xact_id, disk_slice, DUMMY_EVENT_ID);
 
     // Commit the transaction
     table.commit_transaction_stream_impl(xact_id, lsn).unwrap();
@@ -1007,8 +1008,8 @@ async fn test_streaming_begin_flush_delete_commit_end_flush() {
             .await
             .unwrap();
 
-    table.apply_stream_flush_result(xact_id, disk_slice);
-    table.apply_stream_flush_result(xact_id2, disk_slice2);
+    table.apply_stream_flush_result(xact_id, disk_slice, DUMMY_EVENT_ID);
+    table.apply_stream_flush_result(xact_id2, disk_slice2, DUMMY_EVENT_ID);
 
     // Make sure we only have one row in the snapshot
     create_mooncake_snapshot_for_test(&mut table, &mut event_completion_rx).await;
@@ -1069,7 +1070,7 @@ async fn test_streaming_begin_flush_commit_end_flush_delete() {
     table.commit_transaction_stream_impl(xact_id, lsn).unwrap();
 
     // Apply the flush
-    table.apply_stream_flush_result(xact_id, disk_slice);
+    table.apply_stream_flush_result(xact_id, disk_slice, DUMMY_EVENT_ID);
 
     // Make sure the rows are visible in snapshot before commit finishes
     create_mooncake_snapshot_for_test(&mut table, &mut event_completion_rx).await;
@@ -1148,7 +1149,7 @@ async fn test_streaming_begin_flush_abort_end_flush() {
     table.abort_in_stream_batch(xact_id);
 
     // Apply the flush
-    table.apply_stream_flush_result(xact_id, disk_slice);
+    table.apply_stream_flush_result(xact_id, disk_slice, DUMMY_EVENT_ID);
 
     // Make sure we can't read the row after flush
     create_mooncake_snapshot_for_test(&mut table, &mut event_completion_rx).await;
@@ -1199,13 +1200,13 @@ async fn test_streaming_begin_flush_abort_end_flush_multiple() {
     table.abort_in_stream_batch(xact_id);
 
     // Apply the first flush
-    table.apply_stream_flush_result(xact_id, disk_slice1);
+    table.apply_stream_flush_result(xact_id, disk_slice1, DUMMY_EVENT_ID);
 
     // Make sure the stream state is still present since we have outstanding flush
     assert!(table.transaction_stream_states.contains_key(&xact_id));
 
     // Apply the second flush
-    table.apply_stream_flush_result(xact_id, disk_slice2);
+    table.apply_stream_flush_result(xact_id, disk_slice2, DUMMY_EVENT_ID);
 
     // Assert the stream state is removed
     assert!(!table.transaction_stream_states.contains_key(&xact_id));
@@ -1265,20 +1266,20 @@ async fn test_ongoing_flush_lsns_tracking() -> Result<()> {
     assert_eq!(table.get_min_ongoing_flush_lsn(), 5);
 
     // Complete flush with LSN 10 (out of order completion)
-    table.apply_flush_result(disk_slice_2);
+    table.apply_flush_result(disk_slice_2, DUMMY_EVENT_ID);
     assert!(table.ongoing_flush_lsns.contains(&5));
     assert!(!table.ongoing_flush_lsns.contains(&10));
     assert!(table.ongoing_flush_lsns.contains(&15));
     assert_eq!(table.get_min_ongoing_flush_lsn(), 5); // Still 5
 
     // Complete flush with LSN 5
-    table.apply_flush_result(disk_slice_1);
+    table.apply_flush_result(disk_slice_1, DUMMY_EVENT_ID);
     assert!(!table.ongoing_flush_lsns.contains(&5));
     assert!(table.ongoing_flush_lsns.contains(&15));
     assert_eq!(table.get_min_ongoing_flush_lsn(), 15); // Now 15
 
     // Complete last flush
-    table.apply_flush_result(disk_slice_3);
+    table.apply_flush_result(disk_slice_3, DUMMY_EVENT_ID);
     assert!(table.ongoing_flush_lsns.is_empty());
     assert_eq!(table.get_min_ongoing_flush_lsn(), u64::MAX);
 
@@ -1329,9 +1330,9 @@ async fn test_streaming_flush_lsns_tracking() -> Result<()> {
     assert_eq!(table.get_min_ongoing_flush_lsn(), 50);
 
     // Complete streaming flushes
-    table.apply_stream_flush_result(xact_id_1, disk_slice_1);
-    table.apply_stream_flush_result(xact_id_2, disk_slice_2);
-    table.apply_flush_result(disk_slice_3);
+    table.apply_stream_flush_result(xact_id_1, disk_slice_1, DUMMY_EVENT_ID);
+    table.apply_stream_flush_result(xact_id_2, disk_slice_2, DUMMY_EVENT_ID);
+    table.apply_flush_result(disk_slice_3, DUMMY_EVENT_ID);
 
     // Verify all pending flushes are cleared
     assert!(table.ongoing_flush_lsns.is_empty());
@@ -1447,7 +1448,7 @@ async fn test_lsn_ordering_constraint_with_real_table_handler_state() -> Result<
     ));
 
     // Complete the flush with LSN 30
-    table.apply_flush_result(disk_slice_1);
+    table.apply_flush_result(disk_slice_1, DUMMY_EVENT_ID);
     let min_pending = table.get_min_ongoing_flush_lsn();
     assert_eq!(min_pending, 50);
 
@@ -1480,7 +1481,7 @@ async fn test_lsn_ordering_constraint_with_real_table_handler_state() -> Result<
     ));
 
     // Complete the remaining flush
-    table.apply_flush_result(disk_slice_2);
+    table.apply_flush_result(disk_slice_2, DUMMY_EVENT_ID);
     let min_pending = table.get_min_ongoing_flush_lsn();
     assert_eq!(min_pending, u64::MAX);
 
@@ -1534,20 +1535,20 @@ async fn test_out_of_order_flush_completion() -> Result<()> {
     assert_eq!(table.get_min_ongoing_flush_lsn(), 10);
 
     // Complete flush 30 first (out of order)
-    table.apply_flush_result(disk_slice_30);
+    table.apply_flush_result(disk_slice_30, DUMMY_EVENT_ID);
     assert!(!table.ongoing_flush_lsns.contains(&30));
     assert!(table.ongoing_flush_lsns.contains(&10));
     assert!(table.ongoing_flush_lsns.contains(&20));
     assert_eq!(table.get_min_ongoing_flush_lsn(), 10); // Still 10
 
     // Complete flush 10 (should update min to 20)
-    table.apply_flush_result(disk_slice_10);
+    table.apply_flush_result(disk_slice_10, DUMMY_EVENT_ID);
     assert!(!table.ongoing_flush_lsns.contains(&10));
     assert!(table.ongoing_flush_lsns.contains(&20));
     assert_eq!(table.get_min_ongoing_flush_lsn(), 20);
 
     // Complete flush 20 (should clear all)
-    table.apply_flush_result(disk_slice_20);
+    table.apply_flush_result(disk_slice_20, DUMMY_EVENT_ID);
     assert!(table.ongoing_flush_lsns.is_empty());
     assert_eq!(table.get_min_ongoing_flush_lsn(), u64::MAX);
 
@@ -1605,7 +1606,7 @@ async fn test_mixed_regular_and_streaming_lsn_ordering() -> Result<()> {
     )); // Allowed
 
     // Complete streaming flush first
-    table.apply_stream_flush_result(xact_id, streaming_disk_slice);
+    table.apply_stream_flush_result(xact_id, streaming_disk_slice, DUMMY_EVENT_ID);
     assert!(!table.ongoing_flush_lsns.contains(&50));
     assert!(table.ongoing_flush_lsns.contains(&100));
     assert_eq!(table.get_min_ongoing_flush_lsn(), 100);
@@ -1626,7 +1627,7 @@ async fn test_mixed_regular_and_streaming_lsn_ordering() -> Result<()> {
     )); // Still blocked
 
     // Complete regular flush
-    table.apply_flush_result(regular_disk_slice);
+    table.apply_flush_result(regular_disk_slice, DUMMY_EVENT_ID);
     assert!(table.ongoing_flush_lsns.is_empty());
     assert_eq!(table.get_min_ongoing_flush_lsn(), u64::MAX);
 
@@ -1756,7 +1757,7 @@ async fn test_lsn_ordering_both_functions_in_tandem() -> Result<()> {
     )); // Blocked by LSN ordering
 
     // Test case 3: Complete first flush and test again
-    table.apply_flush_result(disk_slice_1);
+    table.apply_flush_result(disk_slice_1, DUMMY_EVENT_ID);
     let min_pending = table.get_min_ongoing_flush_lsn();
     assert_eq!(min_pending, 50);
 
@@ -1860,7 +1861,7 @@ async fn test_lsn_ordering_both_functions_in_tandem() -> Result<()> {
     )); // LSN 30 >= requested (25) and < min_pending (50), should be allowed
 
     // Complete the remaining flush
-    table.apply_flush_result(disk_slice_2);
+    table.apply_flush_result(disk_slice_2, DUMMY_EVENT_ID);
     let min_pending = table.get_min_ongoing_flush_lsn();
     assert_eq!(min_pending, u64::MAX);
 
@@ -1967,7 +1968,7 @@ async fn test_iceberg_snapshot_blocked_by_ongoing_flushes() -> Result<()> {
     }
 
     // Complete the pending flush
-    table.apply_flush_result(disk_slice_1);
+    table.apply_flush_result(disk_slice_1, DUMMY_EVENT_ID);
     assert!(table.ongoing_flush_lsns.is_empty());
 
     // Now test that iceberg snapshots can proceed
@@ -2075,14 +2076,14 @@ async fn test_out_of_order_flush_completion_with_iceberg_snapshots() -> Result<(
     }
 
     // Complete flushes OUT OF ORDER - complete middle one first (LSN 20)
-    table.apply_flush_result(disk_slice_2);
+    table.apply_flush_result(disk_slice_2, DUMMY_EVENT_ID);
     assert_eq!(table.get_min_ongoing_flush_lsn(), 10); // Should still be 10
     assert!(table.ongoing_flush_lsns.contains(&10));
     assert!(!table.ongoing_flush_lsns.contains(&20));
     assert!(table.ongoing_flush_lsns.contains(&30));
 
     // Complete the first flush (LSN 10) - now min should be 30
-    table.apply_flush_result(disk_slice_1);
+    table.apply_flush_result(disk_slice_1, DUMMY_EVENT_ID);
     assert_eq!(table.get_min_ongoing_flush_lsn(), 30); // Now should be 30
     assert!(!table.ongoing_flush_lsns.contains(&10));
     assert!(!table.ongoing_flush_lsns.contains(&20));
@@ -2110,7 +2111,7 @@ async fn test_out_of_order_flush_completion_with_iceberg_snapshots() -> Result<(
     );
 
     // Complete the last flush
-    table.apply_flush_result(disk_slice_3);
+    table.apply_flush_result(disk_slice_3, DUMMY_EVENT_ID);
     assert!(table.ongoing_flush_lsns.is_empty());
     assert_eq!(table.get_min_ongoing_flush_lsn(), u64::MAX);
 
@@ -2175,7 +2176,7 @@ async fn test_streaming_batch_id_mismatch_with_data_compaction() -> Result<()> {
 
     // Step 6: Apply the flush result
     // The disk slice still contains the original batch IDs
-    table.apply_stream_flush_result(xact_id, disk_slice);
+    table.apply_stream_flush_result(xact_id, disk_slice, DUMMY_EVENT_ID);
 
     // Step 7: Create a mooncake snapshot
     create_mooncake_snapshot_for_test(&mut table, &mut event_completion_rx).await;
@@ -2245,7 +2246,7 @@ async fn test_streaming_empty_batch_filtering() -> Result<()> {
 
     // Commit stream 1
     table.commit_transaction_stream_impl(xact_id1, 11)?;
-    table.apply_stream_flush_result(xact_id1, disk_slice1);
+    table.apply_stream_flush_result(xact_id1, disk_slice1, DUMMY_EVENT_ID);
 
     // Stream 2: Normal operations
     table.append_in_stream_batch(test_row(4, "Keep", 23), xact_id2)?;
@@ -2309,7 +2310,7 @@ async fn test_batch_id_removal_assertion_direct() -> Result<()> {
     table.commit_transaction_stream_impl(xact_id, 11)?;
 
     // Step 5: Apply the stream flush result
-    table.apply_stream_flush_result(xact_id, disk_slice);
+    table.apply_stream_flush_result(xact_id, disk_slice, DUMMY_EVENT_ID);
 
     // Step 6: Create a simple snapshot
     let created = table.create_snapshot(SnapshotOption {
@@ -2447,7 +2448,7 @@ async fn test_stream_commit_with_ongoing_flush_deletion_remapping() -> Result<()
 
     // Step 6: Apply the stream flush result
     // This adds the disk slice to snapshot_task for later processing
-    table.apply_stream_flush_result(xact_id, disk_slice);
+    table.apply_stream_flush_result(xact_id, disk_slice, DUMMY_EVENT_ID);
 
     // Step 7: Create a snapshot to trigger integrate_disk_slices
     // Without the fix, this would fail because deletions in committed_deletion_log
@@ -2649,7 +2650,7 @@ async fn test_streaming_deletion_remap_sets_batch_deletion_vector() {
 
     // Apply the stream flush result BEFORE committing the transaction.
     // This must remap the MemoryBatch deletion into the new disk file and set the batch deletion vector.
-    table.apply_stream_flush_result(xact_id, disk_slice);
+    table.apply_stream_flush_result(xact_id, disk_slice, DUMMY_EVENT_ID);
 
     // Assert the in-memory stream state's flushed file deletion vector reflects the delete BEFORE commit.
     {
@@ -2726,7 +2727,7 @@ async fn test_streaming_commit_before_flush_finishes_sets_flush_lsn() -> Result<
         .unwrap();
 
     // Apply the flush after commit; this should set next flush LSN to commit_lsn
-    table.apply_stream_flush_result(xact_id, disk_slice);
+    table.apply_stream_flush_result(xact_id, disk_slice, DUMMY_EVENT_ID);
 
     // Create a snapshot to integrate the flush LSN into the current snapshot state
     create_mooncake_snapshot_for_test(&mut table, &mut event_completion_rx).await;

--- a/src/moonlink/src/table_handler.rs
+++ b/src/moonlink/src/table_handler.rs
@@ -660,15 +660,15 @@ impl TableHandler {
                     }
                 }
                 TableEvent::FlushResult {
-                    id: _,
+                    id,
                     xact_id,
                     flush_result,
                 } => match flush_result {
                     Some(Ok(disk_slice)) => {
                         if let Some(xact_id) = xact_id {
-                            table.apply_stream_flush_result(xact_id, disk_slice);
+                            table.apply_stream_flush_result(xact_id, disk_slice, id);
                         } else {
-                            table.apply_flush_result(disk_slice);
+                            table.apply_flush_result(disk_slice, id);
                         }
                     }
                     Some(Err(e)) => {

--- a/src/moonlink/src/table_handler/chaos_replay.rs
+++ b/src/moonlink/src/table_handler/chaos_replay.rs
@@ -83,7 +83,7 @@ async fn create_mooncake_table_for_replay(
 
 pub(crate) async fn replay() {
     // TODO(hjiang): Take an command line argument.
-    let replay_filepath = "/tmp/chaos_test_judqduy6fjd3";
+    let replay_filepath = "/tmp/chaos_test_iyo52k8tsoj1";
     let cache_temp_dir = tempdir().unwrap();
     let table_temp_dir = tempdir().unwrap();
     let replay_env = ReplayEnvironment {
@@ -231,9 +231,13 @@ pub(crate) async fn replay() {
                                 .map(|f| f.0.file_id())
                                 .collect::<Vec<_>>();
                             if let Some(xact_id) = completed_flush_event.xact_id {
-                                table.apply_stream_flush_result(xact_id, disk_slice);
+                                table.apply_stream_flush_result(
+                                    xact_id,
+                                    disk_slice,
+                                    flush_completion_event.id,
+                                );
                             } else {
-                                table.apply_flush_result(disk_slice);
+                                table.apply_flush_result(disk_slice, flush_completion_event.id);
                             }
                             // Check newly persisted disk files.
                             let expected_disk_files_count =


### PR DESCRIPTION
## Summary

All events recording should happen at mooncake table level, instead of in the background threads, otherwise it's still non-deterministic.
Also remove the event recording for empty flush, which doesn't do any updates to mooncake table.

Issue created to add a unit test for replay program: https://github.com/Mooncake-Labs/moonlink/issues/1448

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
