### PR TITLE
[storage] Move event replay to table main thread

### DIFF
--- a/src/moonlink/src/storage/compaction/compactor.rs
+++ b/src/moonlink/src/storage/compaction/compactor.rs
@@ -393,6 +393,7 @@ impl CompactionBuilder {
         // All rows have been deleted.
         if old_record_loc_to_new_mapping.is_empty() {
             return Ok(DataCompactionResult {
+                id: self.compaction_payload.id,
                 uuid: self.compaction_payload.uuid,
                 remapped_data_files: old_record_loc_to_new_mapping,
                 old_data_files,
@@ -417,6 +418,7 @@ impl CompactionBuilder {
             .await;
 
         Ok(DataCompactionResult {
+            id: self.compaction_payload.id,
             uuid: self.compaction_payload.uuid,
             remapped_data_files: old_record_loc_to_new_mapping,
             old_data_files,

--- a/src/moonlink/src/storage/compaction/table_compaction.rs
+++ b/src/moonlink/src/storage/compaction/table_compaction.rs
@@ -1,6 +1,7 @@
 use crate::storage::filesystem::accessor::base_filesystem_accessor::BaseFileSystemAccess;
 use crate::storage::iceberg::puffin_utils::PuffinBlobRef;
 use crate::storage::index::FileIndex;
+use crate::storage::mooncake_table::replay::replay_events::BackgroundEventId;
 use crate::storage::storage_utils::MooncakeDataFileRef;
 use crate::storage::storage_utils::RecordLocation;
 use crate::storage::storage_utils::TableUniqueFileId;
@@ -45,6 +46,8 @@ impl Eq for SingleFileToCompact {}
 /// Payload to trigger a compaction operation.
 #[derive(Clone)]
 pub struct DataCompactionPayload {
+    /// Table event id.
+    pub(crate) id: BackgroundEventId,
     /// UUID for current compaction operation, used for observability purpose.
     pub(crate) uuid: uuid::Uuid,
     /// Object storage cache.
@@ -60,6 +63,7 @@ pub struct DataCompactionPayload {
 impl std::fmt::Debug for DataCompactionPayload {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("DataCompactionPayload")
+            .field("id", &self.id)
             .field("uuid", &self.uuid)
             .field("object_storage_cache", &self.object_storage_cache)
             .field("filesystem_accessor", &self.filesystem_accessor)
@@ -96,6 +100,8 @@ pub(crate) struct RemappedRecordLocation {
 /// Result for a compaction operation.
 #[derive(Clone, Default, PartialEq)]
 pub struct DataCompactionResult {
+    /// Event id.
+    pub(crate) id: BackgroundEventId,
     /// UUID for current compaction operation, used for observability purpose.
     pub(crate) uuid: uuid::Uuid,
     /// Data files which get compacted, maps from old record location to new one.
@@ -135,6 +141,7 @@ impl DataCompactionResult {
 impl std::fmt::Debug for DataCompactionResult {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("DataCompactionResult")
+            .field("id", &self.id)
             .field("uuid", &self.uuid)
             .field("remapped data files count", &self.remapped_data_files.len())
             .field("old data files count", &self.old_data_files.len())

--- a/src/moonlink/src/storage/compaction/tests.rs
+++ b/src/moonlink/src/storage/compaction/tests.rs
@@ -66,6 +66,7 @@ async fn test_data_file_compaction_1() {
 
     // Prepare compaction payload.
     let payload = DataCompactionPayload {
+        id: 0, // Unused.
         uuid: uuid::Uuid::new_v4(),
         object_storage_cache: ObjectStorageCache::default_for_test(&temp_dir),
         filesystem_accessor: FileSystemAccessor::default_for_test(&temp_dir),
@@ -150,6 +151,7 @@ async fn test_data_file_compaction_2() {
 
     // Prepare compaction payload.
     let payload = DataCompactionPayload {
+        id: 0, // Unused.
         uuid: uuid::Uuid::new_v4(),
         object_storage_cache: ObjectStorageCache::default_for_test(&temp_dir),
         filesystem_accessor: filesystem_accessor.clone(),
@@ -238,6 +240,7 @@ async fn test_data_file_compaction_3() {
 
     // Prepare compaction payload.
     let payload = DataCompactionPayload {
+        id: 0, // Unused.
         uuid: uuid::Uuid::new_v4(),
         object_storage_cache: ObjectStorageCache::default_for_test(&temp_dir),
         filesystem_accessor: filesystem_accessor.clone(),
@@ -319,6 +322,7 @@ async fn test_data_file_compaction_4() {
 
     // Prepare compaction payload.
     let payload = DataCompactionPayload {
+        id: 0, // Unused.
         uuid: uuid::Uuid::new_v4(),
         object_storage_cache: ObjectStorageCache::default_for_test(&temp_dir),
         filesystem_accessor: FileSystemAccessor::default_for_test(&temp_dir),
@@ -435,6 +439,7 @@ async fn test_data_file_compaction_5() {
 
     // Prepare compaction payload.
     let payload = DataCompactionPayload {
+        id: 0, // Unused.
         uuid: uuid::Uuid::new_v4(),
         object_storage_cache: ObjectStorageCache::default_for_test(&temp_dir),
         filesystem_accessor: filesystem_accessor.clone(),
@@ -558,6 +563,7 @@ async fn test_data_file_compaction_6() {
 
     // Prepare compaction payload.
     let payload = DataCompactionPayload {
+        id: 0, // Unused.
         uuid: uuid::Uuid::new_v4(),
         object_storage_cache: ObjectStorageCache::default_for_test(&temp_dir),
         filesystem_accessor: filesystem_accessor.clone(),
@@ -648,6 +654,7 @@ async fn test_data_file_compaction_7() {
 
     // Prepare compaction payload.
     let payload = DataCompactionPayload {
+        id: 0, // Unused.
         uuid: uuid::Uuid::new_v4(),
         object_storage_cache: ObjectStorageCache::default_for_test(&temp_dir),
         filesystem_accessor: filesystem_accessor.clone(),
@@ -721,6 +728,7 @@ async fn test_data_file_compaction_8() {
 
     // Prepare compaction payload.
     let payload = DataCompactionPayload {
+        id: 0, // Unused.
         uuid: uuid::Uuid::new_v4(),
         object_storage_cache: ObjectStorageCache::default_for_test(&temp_dir),
         filesystem_accessor: filesystem_accessor.clone(),
@@ -815,6 +823,7 @@ async fn test_data_file_compaction_9() {
 
     // Prepare compaction payload.
     let payload = DataCompactionPayload {
+        id: 0, // Unused.
         uuid: uuid::Uuid::new_v4(),
         object_storage_cache: ObjectStorageCache::default_for_test(&temp_dir),
         filesystem_accessor: filesystem_accessor.clone(),
@@ -911,6 +920,7 @@ async fn test_data_file_compaction_10() {
 
     // Prepare compaction payload.
     let payload = DataCompactionPayload {
+        id: 0, // Unused.
         uuid: uuid::Uuid::new_v4(),
         object_storage_cache: ObjectStorageCache::default_for_test(&temp_dir),
         filesystem_accessor: filesystem_accessor.clone(),
@@ -1031,6 +1041,7 @@ async fn test_multiple_compacted_data_files_1() {
 
     // Prepare compaction payload.
     let payload = DataCompactionPayload {
+        id: 0, // Unused.
         uuid: uuid::Uuid::new_v4(),
         object_storage_cache: ObjectStorageCache::default_for_test(&temp_dir),
         filesystem_accessor: filesystem_accessor.clone(),
@@ -1167,6 +1178,7 @@ async fn test_multiple_compacted_data_files_2() {
 
     // Prepare compaction payload.
     let payload = DataCompactionPayload {
+        id: 0, // Unused.
         uuid: uuid::Uuid::new_v4(),
         object_storage_cache: ObjectStorageCache::default_for_test(&temp_dir),
         filesystem_accessor: filesystem_accessor.clone(),
@@ -1230,6 +1242,7 @@ async fn test_large_number_of_data_files() {
 
     // Prepare compaction payload.
     let payload = DataCompactionPayload {
+        id: 0, // Unused.
         uuid: uuid::Uuid::new_v4(),
         object_storage_cache: ObjectStorageCache::default_for_test(&temp_dir),
         filesystem_accessor: FileSystemAccessor::default_for_test(&temp_dir),

--- a/src/moonlink/src/storage/iceberg/state_tests.rs
+++ b/src/moonlink/src/storage/iceberg/state_tests.rs
@@ -418,7 +418,7 @@ async fn test_state_1_1() {
 
     // Request to persist.
     assert!(!table.create_snapshot(SnapshotOption {
-        id: 0,
+        id: None,
         uuid: uuid::Uuid::new_v4(),
         dump_snapshot: false,
         force_create: false,
@@ -447,7 +447,7 @@ async fn test_state_1_2() {
 
     // Request to persist.
     assert!(!table.create_snapshot(SnapshotOption {
-        id: 0,
+        id: None,
         uuid: uuid::Uuid::new_v4(),
         dump_snapshot: false,
         force_create: false,

--- a/src/moonlink/src/storage/iceberg/state_tests.rs
+++ b/src/moonlink/src/storage/iceberg/state_tests.rs
@@ -45,6 +45,7 @@ use crate::storage::mooncake_table::table_creation_test_utils::*;
 use crate::storage::mooncake_table::table_operation_test_utils::*;
 use crate::storage::mooncake_table::validation_test_utils::*;
 use crate::storage::mooncake_table::Snapshot;
+use crate::storage::snapshot_options::MaintenanceOption;
 use crate::storage::snapshot_options::SnapshotOption;
 use crate::storage::MooncakeTable;
 use crate::table_notify::TableEvent;
@@ -416,7 +417,15 @@ async fn test_state_1_1() {
     table.append(row).unwrap();
 
     // Request to persist.
-    assert!(!table.create_snapshot(SnapshotOption::default()));
+    assert!(!table.create_snapshot(SnapshotOption {
+        id: 0,
+        uuid: uuid::Uuid::new_v4(),
+        dump_snapshot: false,
+        force_create: false,
+        skip_iceberg_snapshot: false,
+        index_merge_option: MaintenanceOption::BestEffort,
+        data_compaction_option: MaintenanceOption::BestEffort,
+    }));
 
     // Validate end state.
     validate_no_snapshot(&mut iceberg_table_manager, filesystem_accessor.as_ref()).await;
@@ -437,7 +446,15 @@ async fn test_state_1_2() {
     table.delete(row.clone(), /*lsn=*/ 1).await;
 
     // Request to persist.
-    assert!(!table.create_snapshot(SnapshotOption::default()));
+    assert!(!table.create_snapshot(SnapshotOption {
+        id: 0,
+        uuid: uuid::Uuid::new_v4(),
+        dump_snapshot: false,
+        force_create: false,
+        skip_iceberg_snapshot: false,
+        index_merge_option: MaintenanceOption::BestEffort,
+        data_compaction_option: MaintenanceOption::BestEffort,
+    }));
 
     // Validate end state.
     validate_no_snapshot(&mut iceberg_table_manager, filesystem_accessor.as_ref()).await;

--- a/src/moonlink/src/storage/iceberg/tests.rs
+++ b/src/moonlink/src/storage/iceberg/tests.rs
@@ -288,6 +288,7 @@ async fn test_skip_iceberg_snapshot() {
 
     // Create mooncake snapshot.
     assert!(table.create_snapshot(SnapshotOption {
+        id: None,
         uuid: uuid::Uuid::new_v4(),
         force_create: false,
         dump_snapshot: false,

--- a/src/moonlink/src/storage/mooncake_table/replay/event_id_assigner.rs
+++ b/src/moonlink/src/storage/mooncake_table/replay/event_id_assigner.rs
@@ -1,6 +1,7 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 /// Class which assigns monotonically increasing id for background events.
+#[derive(Clone)]
 pub(crate) struct EventIdAssigner {
     counter: Arc<AtomicU64>,
 }

--- a/src/moonlink/src/storage/mooncake_table/snapshot_maintenance.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot_maintenance.rs
@@ -174,6 +174,7 @@ impl SnapshotTableState {
         }
 
         let payload = DataCompactionPayload {
+            id: self.event_id_assigner.get_next_event_id(),
             uuid: uuid::Uuid::new_v4(),
             object_storage_cache: self.object_storage_cache.clone(),
             filesystem_accessor: self.filesystem_accessor.clone(),
@@ -276,6 +277,7 @@ impl SnapshotTableState {
         // To avoid too many small IO operations, only attempt an index merge when accumulated small indices exceeds the threshold.
         if file_indices_to_merge.len() >= min_index_merge_file_num_threshold {
             let payload = FileIndiceMergePayload {
+                id: self.event_id_assigner.get_next_event_id(),
                 uuid: uuid::Uuid::new_v4(),
                 file_indices: file_indices_to_merge
                     .into_iter()

--- a/src/moonlink/src/storage/mooncake_table/table_operation_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_operation_test_utils.rs
@@ -191,6 +191,7 @@ pub(crate) async fn perform_index_merge_for_test(
 
     table.set_file_indices_merge_res(index_merge_result);
     assert!(table.create_snapshot(SnapshotOption {
+        id: None,
         uuid: uuid::Uuid::new_v4(),
         force_create: true,
         dump_snapshot: false,
@@ -224,6 +225,7 @@ pub(crate) async fn perform_data_compaction_for_test(
 
     table.set_data_compaction_res(data_compaction_result);
     assert!(table.create_snapshot(SnapshotOption {
+        id: None,
         uuid: uuid::Uuid::new_v4(),
         force_create: true,
         dump_snapshot: false,
@@ -258,22 +260,15 @@ pub(crate) async fn sync_mooncake_snapshot(
     let notification = receiver.recv().await.unwrap();
     table.mark_mooncake_snapshot_completed();
     if let TableEvent::MooncakeTableSnapshotResult {
-        uuid: _,
-        id: _,
-        lsn,
-        current_snapshot: _,
-        iceberg_snapshot_payload,
-        file_indice_merge_payload,
-        data_compaction_payload,
-        evicted_files_to_delete,
+        mooncake_snapshot_result
     } = notification
     {
         (
-            lsn,
-            iceberg_snapshot_payload,
-            file_indice_merge_payload,
-            data_compaction_payload,
-            evicted_files_to_delete.files,
+            mooncake_snapshot_result.lsn,
+            mooncake_snapshot_result.iceberg_snapshot_payload,
+            mooncake_snapshot_result.file_indice_merge_payload,
+            mooncake_snapshot_result.data_compaction_payload,
+            mooncake_snapshot_result.evicted_files_to_delete.files,
         )
     } else {
         panic!("Expected mooncake snapshot completion notification, but get others.");

--- a/src/moonlink/src/storage/mooncake_table/table_operation_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_operation_test_utils.rs
@@ -260,15 +260,15 @@ pub(crate) async fn sync_mooncake_snapshot(
     let notification = receiver.recv().await.unwrap();
     table.mark_mooncake_snapshot_completed();
     if let TableEvent::MooncakeTableSnapshotResult {
-        mooncake_snapshot_result
+        mooncake_snapshot_result,
     } = notification
     {
         (
-            mooncake_snapshot_result.lsn,
+            mooncake_snapshot_result.commit_lsn,
             mooncake_snapshot_result.iceberg_snapshot_payload,
-            mooncake_snapshot_result.file_indice_merge_payload,
+            mooncake_snapshot_result.file_indices_merge_payload,
             mooncake_snapshot_result.data_compaction_payload,
-            mooncake_snapshot_result.evicted_files_to_delete.files,
+            mooncake_snapshot_result.evicted_data_files_to_delete,
         )
     } else {
         panic!("Expected mooncake snapshot completion notification, but get others.");
@@ -323,6 +323,7 @@ pub(crate) async fn create_mooncake_snapshot_for_test(
     Vec<String>,
 ) {
     let mooncake_snapshot_created = table.create_snapshot(SnapshotOption {
+        id: None,
         uuid: uuid::Uuid::new_v4(),
         force_create: true,
         dump_snapshot: false,
@@ -375,6 +376,7 @@ async fn sync_mooncake_snapshot_and_create_new_by_iceberg_payload(
 
     // Create mooncake snapshot after buffering iceberg snapshot result, to make sure mooncake snapshot is at a consistent state.
     assert!(table.create_snapshot(SnapshotOption {
+        id: None,
         uuid: uuid::Uuid::new_v4(),
         force_create: true,
         dump_snapshot: false,
@@ -421,6 +423,7 @@ pub(crate) async fn create_mooncake_and_persist_for_data_compaction_for_test(
 ) {
     // Create mooncake snapshot.
     let force_snapshot_option = SnapshotOption {
+        id: None,
         uuid: uuid::Uuid::new_v4(),
         force_create: true,
         dump_snapshot: false,
@@ -472,6 +475,7 @@ pub(crate) async fn create_mooncake_and_persist_for_data_compaction_for_test(
     // Set data compaction result and trigger another iceberg snapshot.
     table.set_data_compaction_res(data_compaction_result);
     assert!(table.create_snapshot(SnapshotOption {
+        id: None,
         uuid: uuid::Uuid::new_v4(),
         force_create: true,
         dump_snapshot: false,
@@ -490,6 +494,7 @@ pub(crate) async fn create_mooncake_and_iceberg_snapshot_for_index_merge_for_tes
 ) {
     // Create mooncake snapshot.
     let force_snapshot_option = SnapshotOption {
+        id: None,
         uuid: uuid::Uuid::new_v4(),
         force_create: true,
         dump_snapshot: false,
@@ -529,6 +534,7 @@ pub(crate) async fn create_mooncake_and_iceberg_snapshot_for_index_merge_for_tes
     let index_merge_result = sync_index_merge(receiver).await;
     table.set_file_indices_merge_res(index_merge_result);
     assert!(table.create_snapshot(SnapshotOption {
+        id: None,
         uuid: uuid::Uuid::new_v4(),
         force_create: true,
         dump_snapshot: false,

--- a/src/moonlink/src/storage/mooncake_table/table_snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_snapshot.rs
@@ -3,6 +3,7 @@ use crate::storage::index::persisted_bucket_hash_map::GlobalIndex;
 /// Items needed for iceberg snapshot.
 use crate::storage::index::FileIndex as MooncakeFileIndex;
 use crate::storage::mooncake_table::delete_vector::BatchDeletionVector;
+use crate::storage::mooncake_table::replay::replay_events::BackgroundEventId;
 use crate::storage::mooncake_table::TableMetadata as MooncakeTableMetadata;
 use crate::storage::storage_utils::FileId;
 use crate::storage::storage_utils::MooncakeDataFileRef;
@@ -352,6 +353,8 @@ impl std::fmt::Debug for IcebergSnapshotDataCompactionResult {
 }
 
 pub struct IcebergSnapshotResult {
+    /// Table event id.
+    pub(crate) id: BackgroundEventId,
     /// UUID for the current persistence operation, used for observability purpose.
     pub(crate) uuid: uuid::Uuid,
     /// Table manager is (1) not `Sync` safe; (2) only used at iceberg snapshot creation, so we `move` it around every snapshot.
@@ -373,6 +376,7 @@ pub struct IcebergSnapshotResult {
 impl Clone for IcebergSnapshotResult {
     fn clone(&self) -> Self {
         IcebergSnapshotResult {
+            id: self.id,
             uuid: self.uuid,
             table_manager: None,
             flush_lsn: self.flush_lsn,
@@ -401,6 +405,7 @@ impl IcebergSnapshotResult {
 impl std::fmt::Debug for IcebergSnapshotResult {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("IcebergSnapshotResult")
+            .field("id", &self.id)
             .field("uuid", &self.uuid)
             .field("flush_lsn", &self.flush_lsn)
             .field(
@@ -437,6 +442,8 @@ impl std::fmt::Debug for FileIndiceMergePayload {
 
 #[derive(Clone, Default)]
 pub struct FileIndiceMergeResult {
+    /// Table event id.
+    pub(crate) id: BackgroundEventId,
     /// UUID for current index merge operation, used for observability purpose.
     pub(crate) uuid: uuid::Uuid,
     /// Old file indices being merged.
@@ -459,6 +466,7 @@ impl FileIndiceMergeResult {
 impl std::fmt::Debug for FileIndiceMergeResult {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("FileIndiceMergeResult")
+            .field("id", &self.id)
             .field("uuid", &self.uuid)
             .field("old file indices count", &self.old_file_indices.len())
             .field("new file indices count", &self.new_file_indices.len())

--- a/src/moonlink/src/storage/mooncake_table/table_snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_snapshot.rs
@@ -425,6 +425,8 @@ impl std::fmt::Debug for IcebergSnapshotResult {
 ///
 #[derive(Clone)]
 pub struct FileIndiceMergePayload {
+    /// Table event id.
+    pub(crate) id: BackgroundEventId,
     /// UUID for current index merge operation, used for observability purpose.
     pub(crate) uuid: uuid::Uuid,
     /// File indices to merge.
@@ -434,6 +436,7 @@ pub struct FileIndiceMergePayload {
 impl std::fmt::Debug for FileIndiceMergePayload {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("FileIndiceMergePayload")
+            .field("id", &self.id)
             .field("uuid", &self.uuid)
             .field("file indices count", &self.file_indices.len())
             .finish()

--- a/src/moonlink/src/storage/mooncake_table/tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/tests.rs
@@ -1937,6 +1937,7 @@ async fn test_iceberg_snapshot_blocked_by_ongoing_flushes() -> Result<()> {
 
     // Create a mooncake snapshot - this will create an iceberg payload
     let created = table.create_snapshot(SnapshotOption {
+        id: None,
         uuid: uuid::Uuid::new_v4(),
         force_create: true,
         dump_snapshot: false,
@@ -1975,6 +1976,7 @@ async fn test_iceberg_snapshot_blocked_by_ongoing_flushes() -> Result<()> {
 
     // Now test that iceberg snapshots can proceed
     let created = table.create_snapshot(SnapshotOption {
+        id: None,
         uuid: uuid::Uuid::new_v4(),
         force_create: true,
         dump_snapshot: false,
@@ -2040,6 +2042,7 @@ async fn test_out_of_order_flush_completion_with_iceberg_snapshots() -> Result<(
 
     // Create snapshot and test constraint with min_ongoing_flush_lsn = 10
     let created = table.create_snapshot(SnapshotOption {
+        id: None,
         uuid: uuid::Uuid::new_v4(),
         force_create: true,
         dump_snapshot: false,
@@ -2190,6 +2193,7 @@ async fn test_streaming_batch_id_mismatch_with_data_compaction() -> Result<()> {
 
     // Step 9: Force data compaction
     let created = table.create_snapshot(SnapshotOption {
+        id: None,
         uuid: uuid::Uuid::new_v4(),
         force_create: true,
         dump_snapshot: false,
@@ -2261,6 +2265,7 @@ async fn test_streaming_empty_batch_filtering() -> Result<()> {
 
     // Create snapshot with data compaction
     let created = table.create_snapshot(SnapshotOption {
+        id: None,
         uuid: uuid::Uuid::new_v4(),
         force_create: true,
         dump_snapshot: false,
@@ -2316,6 +2321,7 @@ async fn test_batch_id_removal_assertion_direct() -> Result<()> {
 
     // Step 6: Create a simple snapshot
     let created = table.create_snapshot(SnapshotOption {
+        id: None,
         uuid: uuid::Uuid::new_v4(),
         force_create: true,
         dump_snapshot: false,
@@ -2394,6 +2400,7 @@ async fn test_puffin_deletion_blob_inconsistency_assertion() -> Result<()> {
 
     // Step 7: Force data compaction
     let created = table.create_snapshot(SnapshotOption {
+        id: None,
         uuid: uuid::Uuid::new_v4(),
         force_create: true,
         dump_snapshot: false,
@@ -2456,6 +2463,7 @@ async fn test_stream_commit_with_ongoing_flush_deletion_remapping() -> Result<()
     // Without the fix, this would fail because deletions in committed_deletion_log
     // get remapped but not applied to batch_deletion_vector
     let created = table.create_snapshot(SnapshotOption {
+        id: None,
         uuid: uuid::Uuid::new_v4(),
         force_create: true,
         dump_snapshot: false,
@@ -2505,6 +2513,7 @@ async fn test_deletion_align_with_batch() -> Result<()> {
     commit_transaction_stream_and_sync(&mut table, &mut event_completion_rx, xact_id_1, 10).await; // LSN 10 - CommitFlush
 
     let created = table.create_snapshot(SnapshotOption {
+        id: None,
         uuid: uuid::Uuid::new_v4(),
         force_create: true,
         dump_snapshot: false,

--- a/src/moonlink/src/storage/snapshot_options.rs
+++ b/src/moonlink/src/storage/snapshot_options.rs
@@ -25,7 +25,7 @@ pub enum MaintenanceOption {
 /// Options to create mooncake snapshot.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SnapshotOption {
-    /// Table event id, only assigned when a mooncake snapshot creation operation gets created. 
+    /// Table event id, only assigned when a mooncake snapshot creation operation gets created.
     pub(crate) id: Option<BackgroundEventId>,
     /// UUID for the current mooncake snapshot operation.
     pub(crate) uuid: uuid::Uuid,

--- a/src/moonlink/src/storage/snapshot_options.rs
+++ b/src/moonlink/src/storage/snapshot_options.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use crate::storage::mooncake_table::replay::replay_events::BackgroundEventId;
+
 /// Option for a maintenance option.
 ///
 /// For all types of maintenance tasks, we have two basic dimensions:
@@ -23,6 +25,8 @@ pub enum MaintenanceOption {
 /// Options to create mooncake snapshot.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct SnapshotOption {
+    /// Table event id, only assigned when a mooncake snapshot creation operation gets created. 
+    pub(crate) id: Option<BackgroundEventId>,
     /// UUID for the current mooncake snapshot operation.
     pub(crate) uuid: uuid::Uuid,
     /// Whether to return mooncake snapshot status in the snapshot result.
@@ -36,17 +40,4 @@ pub struct SnapshotOption {
     pub(crate) index_merge_option: MaintenanceOption,
     /// Data compaction operation option.
     pub(crate) data_compaction_option: MaintenanceOption,
-}
-
-impl SnapshotOption {
-    pub fn default() -> SnapshotOption {
-        Self {
-            uuid: uuid::Uuid::new_v4(),
-            dump_snapshot: false,
-            force_create: false,
-            skip_iceberg_snapshot: false,
-            index_merge_option: MaintenanceOption::BestEffort,
-            data_compaction_option: MaintenanceOption::BestEffort,
-        }
-    }
 }

--- a/src/moonlink/src/table_handler/chaos_replay.rs
+++ b/src/moonlink/src/table_handler/chaos_replay.rs
@@ -139,17 +139,16 @@ pub(crate) async fn replay() {
                     event_notification.notify_waiters();
                 }
                 TableEvent::MooncakeTableSnapshotResult {
-                    lsn,
-                    id,
-                    current_snapshot,
-                    ..
+                    mooncake_snapshot_result,
                 } => {
                     let completed_mooncake_snapshot = CompletedMooncakeSnapshot {
-                        lsn,
-                        current_snapshot: current_snapshot.unwrap(),
+                        lsn: mooncake_snapshot_result.commit_lsn,
+                        current_snapshot: mooncake_snapshot_result.current_snapshot.unwrap(),
                     };
                     let mut guard = completed_mooncake_snapshots_clone.lock().await;
-                    assert!(guard.insert(id, completed_mooncake_snapshot).is_none());
+                    assert!(guard
+                        .insert(mooncake_snapshot_result.id, completed_mooncake_snapshot)
+                        .is_none());
                     event_notification.notify_waiters();
                 }
                 // TODO(hjiang): Implement other background events.

--- a/src/moonlink/src/table_handler/table_handler_state.rs
+++ b/src/moonlink/src/table_handler/table_handler_state.rs
@@ -1,4 +1,3 @@
-use crate::storage::mooncake_table::replay::replay_events::BackgroundEventId;
 /// Table handler state manages table event process states.
 use crate::storage::mooncake_table::AlterTableRequest;
 use crate::storage::mooncake_table::DataCompactionResult;

--- a/src/moonlink/src/table_handler/table_handler_state.rs
+++ b/src/moonlink/src/table_handler/table_handler_state.rs
@@ -1,3 +1,4 @@
+use crate::storage::mooncake_table::replay::replay_events::BackgroundEventId;
 /// Table handler state manages table event process states.
 use crate::storage::mooncake_table::AlterTableRequest;
 use crate::storage::mooncake_table::DataCompactionResult;
@@ -213,6 +214,7 @@ impl TableHandlerState {
             force_create = true;
         }
         SnapshotOption {
+            id: None,
             uuid,
             force_create,
             dump_snapshot: false,

--- a/src/moonlink/src/table_notify.rs
+++ b/src/moonlink/src/table_notify.rs
@@ -1,5 +1,6 @@
 use crate::row::MoonlinkRow;
 use crate::storage::mooncake_table::replay::replay_events::BackgroundEventId;
+use crate::storage::mooncake_table::snapshot::MooncakeSnapshotOutput;
 use crate::storage::mooncake_table::DataCompactionPayload;
 use crate::storage::mooncake_table::DataCompactionResult;
 use crate::storage::mooncake_table::DiskSliceWriter;
@@ -7,7 +8,6 @@ use crate::storage::mooncake_table::FileIndiceMergePayload;
 use crate::storage::mooncake_table::FileIndiceMergeResult;
 use crate::storage::mooncake_table::IcebergSnapshotPayload;
 use crate::storage::mooncake_table::IcebergSnapshotResult;
-
 use crate::storage::mooncake_table::Snapshot as MooncakeSnapshot;
 use crate::storage::wal::WalPersistenceUpdateResult;
 use crate::Result;
@@ -158,22 +158,8 @@ pub enum TableEvent {
     PeriodicalMooncakeTableSnapshot(uuid::Uuid),
     /// Mooncake snapshot completes.
     MooncakeTableSnapshotResult {
-        /// UUID for the current mooncake snapshot operation, used for observability purpose.
-        uuid: uuid::Uuid,
-        /// Background event id.
-        id: BackgroundEventId,
-        /// Mooncake snapshot LSN.
-        lsn: u64,
-        /// Payload used to create an iceberg snapshot.
-        iceberg_snapshot_payload: Option<IcebergSnapshotPayload>,
-        /// Payload used to trigger an index merge.
-        file_indice_merge_payload: IndexMergeMaintenanceStatus,
-        /// Payload used to trigger a data compaction.
-        data_compaction_payload: DataCompactionMaintenanceStatus,
-        /// Evicted files to delete.
-        evicted_files_to_delete: EvictedFiles,
-        /// Optional snapshot dump.
-        current_snapshot: Option<MooncakeSnapshot>,
+        /// Mooncake snapshot result.
+        mooncake_snapshot_result: MooncakeSnapshotOutput,
     },
     /// Regular iceberg persistence.
     RegularIcebergSnapshot {

--- a/src/moonlink/src/table_notify.rs
+++ b/src/moonlink/src/table_notify.rs
@@ -8,7 +8,6 @@ use crate::storage::mooncake_table::FileIndiceMergePayload;
 use crate::storage::mooncake_table::FileIndiceMergeResult;
 use crate::storage::mooncake_table::IcebergSnapshotPayload;
 use crate::storage::mooncake_table::IcebergSnapshotResult;
-use crate::storage::mooncake_table::Snapshot as MooncakeSnapshot;
 use crate::storage::wal::WalPersistenceUpdateResult;
 use crate::Result;
 


### PR DESCRIPTION
## Summary

If event completion is reported in background threads, we could have race between different threads, so replay system is still not deterministic.

This PR should be a no-op refactor to production.

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
