### PR TITLE
REST: Type support for list

### DIFF
--- a/src/moonlink_connectors/src/rest_ingest/json_converter.rs
+++ b/src/moonlink_connectors/src/rest_ingest/json_converter.rs
@@ -683,7 +683,7 @@ mod tests {
         let int_values = vec![1, 2, 3, 42];
         let string_values = vec!["hello", "world", "moonlink"];
         let bool_values = vec![true, false, true];
-        let float_values = vec![1.1, 2.2, 3.14];
+        let float_values = vec![1.1, 2.2, 3.3];
 
         let schema = make_list_schema();
         let converter = JsonToMoonlinkRowConverter::new(schema);

--- a/src/moonlink_connectors/src/rest_ingest/json_converter.rs
+++ b/src/moonlink_connectors/src/rest_ingest/json_converter.rs
@@ -124,6 +124,18 @@ impl JsonToMoonlinkRowConverter {
                     field.name().clone(),
                 ))
             }
+            DataType::List(child_field) => {
+                if let Some(array) = value.as_array() {
+                    let mut converted_elements = Vec::with_capacity(array.len());
+                    for ele in array {
+                        let converted_element = Self::convert_value(child_field, ele)?;
+                        converted_elements.push(converted_element);
+                    }
+                    Ok(RowValue::Array(converted_elements))
+                } else {
+                    Err(JsonToMoonlinkRowError::TypeMismatch(field.name().clone()))
+                }
+            }
             _ => Err(JsonToMoonlinkRowError::TypeMismatch(field.name().clone())),
         }
     }


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

Extend src/moonlink_connectors/src/rest_ingest/json_converter.rs to support list to JSON array conversion

## Related Issues

Closes #1285

## Changes

- Perform element wise type conversion from List to Array recurrsively
- Add test for converting list with different element types and nested list

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
