### PR TITLE
fix another edge case in deletion index lookup

### DIFF
--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -820,7 +820,7 @@ impl SnapshotTableState {
                 .map(|(loc, deletion)| Self::build_processed_deletion(deletion, loc))
                 .collect(),
             Ordering::Less => {
-                panic!("find less than expected candidates to deletions {deletions:?}")
+                panic!("find less than expected candidates to deletions {deletions:?}, candidates: {candidates:?}, batch_id_to_lsn: {batch_id_to_lsn:?}, file_id_to_lsn: {file_id_to_lsn:?}")
             }
             Ordering::Greater => {
                 let mut processed_deletions = Vec::new();
@@ -1004,7 +1004,7 @@ impl SnapshotTableState {
             }
         });
         self.add_processed_deletion(already_processed, task.commit_lsn_baseline);
-        new_deletions.sort_by_key(|deletion| deletion.lookup_key);
+        new_deletions.sort_by(|a, b| a.lookup_key.cmp(&b.lookup_key).then(a.lsn.cmp(&b.lsn)));
         if new_deletions.is_empty() {
             return;
         }

--- a/src/moonlink/src/storage/mooncake_table/tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/tests.rs
@@ -2782,7 +2782,7 @@ async fn test_two_deletes_same_key_after_flush() -> Result<()> {
 
     table.delete(row1.clone(), 103).await;
     table.commit(104);
-    // Create a snapshot and verify only the non-deleted row remains.
+    // Create a snapshot and verify all the rows are deleted.
     create_mooncake_snapshot_for_test(&mut table, &mut event_completion_rx).await;
 
     let mut snapshot = table.snapshot.write().await;


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

Deletion of the same value need to be process in the LSN order.
Otherwise, the deletion with larger LSN will see multiple candidates, and the one with smaller LSN will see less.

This normally never happens, because in general we add records to new_deletions in LSN order.

But streamingXact that delete's row in memslice, 
and the memslice got flushed before streamingXact finishes, 
may cause them to be added in different order.

Briefly explain what this PR does.

## Related Issues

Closes #<issue-number> or links to related issues.

## Changes

- 
- 
- 

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
