### PR TITLE
add update table schema

### DIFF
--- a/src/moonlink_connectors/src/pg_replicate.rs
+++ b/src/moonlink_connectors/src/pg_replicate.rs
@@ -595,7 +595,7 @@ pub async fn run_event_loop(
                         if let Some(SchemaChangeRequest(src_table_id)) = res {
                             let table_schema = postgres_source.fetch_table_schema(Some(src_table_id), None, None).await?;
                             sink.alter_table(src_table_id, &table_schema).await;
-                            stream.as_mut().add_table_schema(table_schema);
+                            stream.as_mut().update_table_schema(table_schema);
                         }
                     }
                 }

--- a/src/moonlink_connectors/src/pg_replicate/postgres_source.rs
+++ b/src/moonlink_connectors/src/pg_replicate/postgres_source.rs
@@ -343,6 +343,14 @@ impl CdcStream {
             .is_none());
     }
 
+    pub fn update_table_schema(self: Pin<&mut Self>, schema: TableSchema) {
+        let this = self.project();
+        assert!(this
+            .table_schemas
+            .insert(schema.src_table_id, schema)
+            .is_some());
+    }
+
     pub fn remove_table_schema(self: Pin<&mut Self>, src_table_id: SrcTableId) {
         let this = self.project();
         assert!(this.table_schemas.remove(&src_table_id).is_some());


### PR DESCRIPTION
## Summary

Fixes a previous bug that had an assertion that checked that a table did not exist in CdcStream's table schemas when calling add_table_schema, even though this was not true for schema evolution. Added a function called update_table_schema. 

## Related Issues

Closes #<issue-number> or links to related issues.

## Changes

- 
- 
- 

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
