### PR TITLE
[2/N] Remove table id concepts from connector

### DIFF
--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -87,6 +87,7 @@ pub struct TableMetadata {
     /// table name
     pub(crate) name: String,
     /// table id
+    /// Notice it's transient, which means it's subject to change after recovery.
     pub(crate) table_id: u32,
     /// table schema
     pub(crate) schema: Arc<Schema>,

--- a/src/moonlink_backend/src/lib.rs
+++ b/src/moonlink_backend/src/lib.rs
@@ -165,7 +165,6 @@ where
                     .add_rest_table(
                         &src_uri,
                         mooncake_table_id,
-                        table_id,
                         &src_table_name,
                         input_schema.expect("arrow_schema is required for REST API"),
                         moonlink_table_config.clone(),
@@ -178,7 +177,6 @@ where
                     .add_table(
                         &src_uri,
                         mooncake_table_id,
-                        table_id,
                         &src_table_name,
                         moonlink_table_config.clone(),
                         self.read_state_filepath_remap.clone(),

--- a/src/moonlink_backend/src/recovery_utils.rs
+++ b/src/moonlink_backend/src/recovery_utils.rs
@@ -38,15 +38,10 @@ where
                 .unwrap_or_else(|_| panic!("not a valid value: {}", metadata_entry.table)),
         ),
     };
-    let table_id: u32 = metadata_entry
-        .table
-        .parse()
-        .unwrap_or_else(|_| panic!("not a valid value: {}", metadata_entry.table));
     replication_manager
         .add_table(
             &metadata_entry.src_table_uri,
             mooncake_table_id,
-            table_id,
             &metadata_entry.src_table_name,
             metadata_entry.moonlink_table_config,
             read_state_filepath_remap,

--- a/src/moonlink_connectors/src/pg_replicate.rs
+++ b/src/moonlink_connectors/src/pg_replicate.rs
@@ -346,7 +346,6 @@ impl PostgresConnection {
         &self,
         table_name: &str,
         mooncake_table_id: &T,
-        table_id: u32,
         moonlink_table_config: MoonlinkTableConfig,
         is_recovery: bool,
         table_base_path: &str,
@@ -371,7 +370,6 @@ impl PostgresConnection {
 
         let mut table_resources = build_table_components(
             mooncake_table_id.to_string(),
-            table_id,
             arrow_schema,
             identity,
             table_name.to_string(),

--- a/src/moonlink_connectors/src/replication_manager.rs
+++ b/src/moonlink_connectors/src/replication_manager.rs
@@ -53,7 +53,6 @@ impl<T: Clone + Eq + Hash + std::fmt::Display> ReplicationManager<T> {
         &mut self,
         src_uri: &str,
         mooncake_table_id: T,
-        table_id: u32,
         table_name: &str,
         moonlink_table_config: MoonlinkTableConfig,
         read_state_filepath_remap: ReadStateFilepathRemap,
@@ -81,7 +80,6 @@ impl<T: Clone + Eq + Hash + std::fmt::Display> ReplicationManager<T> {
             .add_table_replication(
                 table_name,
                 &mooncake_table_id,
-                table_id,
                 moonlink_table_config,
                 read_state_filepath_remap,
                 is_recovery,
@@ -108,14 +106,13 @@ impl<T: Clone + Eq + Hash + std::fmt::Display> ReplicationManager<T> {
         &mut self,
         src_uri: &str,
         mooncake_table_id: T,
-        table_id: u32,
-        table_name: &str,
+        src_table_name: &str,
         arrow_schema: arrow_schema::Schema,
         moonlink_table_config: MoonlinkTableConfig,
         read_state_filepath_remap: ReadStateFilepathRemap,
         is_recovery: bool,
     ) -> Result<()> {
-        debug!(%src_uri, table_name, "adding REST API table through manager");
+        debug!(%src_uri, src_table_name, "adding REST API table through manager");
 
         // Fail if REST API connection doesn't exist
         if !self.connections.contains_key(src_uri) {
@@ -128,9 +125,8 @@ impl<T: Clone + Eq + Hash + std::fmt::Display> ReplicationManager<T> {
 
         let src_table_id = replication_connection
             .add_table_api(
-                table_name,
+                src_table_name,
                 &mooncake_table_id,
-                table_id,
                 arrow_schema,
                 moonlink_table_config,
                 read_state_filepath_remap,


### PR DESCRIPTION
## Summary

Table id (mooncake table id, the integer part, without database id) is used in a few places:
- It's part of the write cache directory and WAL directory, will replace with schema and table name
- It's used to globally uniquely identify a cache entry, I assign a temporary table id to compensate
  + temporary means it's subject to change after recovery

This PR is supposed to be a no-op change functionality-wise, existing integration tests should be enough.

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
