### PR TITLE
[CI] Use association instead of checking membership

### DIFF
--- a/.github/workflows/community_auto_label.yml
+++ b/.github/workflows/community_auto_label.yml
@@ -44,26 +44,6 @@ jobs:
               return;
             }
 
-            // Ensure the label exists (create if missing)
-            try {
-              await github.rest.issues.getLabel({ owner, repo, name: labelName });
-            } catch (e) {
-              if (e.status === 404) {
-                await github.rest.issues.createLabel({
-                  owner,
-                  repo,
-                  name: labelName,
-                  color: 'ededed', // neutral gray
-                  description: 'External contributor PR',
-                });
-                core.info(`Created label "${labelName}".`);
-              } else {
-                core.setFailed(`Failed to ensure label exists: ${e.status} ${e.message}`);
-                return;
-              }
-            }
-
-            // Add label
             await github.rest.issues.addLabels({
               owner,
               repo,


### PR DESCRIPTION
## Summary

Membership checking doesn't work somehow (gpt told me CI workflow token still lacks certain permission);
This PR switches to association checking, still a tentative merge since there's no real good (and convenient) way to debug.


## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
