### PR TITLE
test: add more tests for composite types with nested arrays in PG replication client

### DIFF
--- a/src/moonlink_connectors/src/pg_replicate/tests/pg_type_tests.rs
+++ b/src/moonlink_connectors/src/pg_replicate/tests/pg_type_tests.rs
@@ -223,3 +223,242 @@ async fn test_array_of_composite_types() {
         result
     );
 }
+
+#[tokio::test]
+#[serial]
+async fn test_composite_with_nested_array() {
+    let client = setup_connection().await;
+
+    // Create composite type with array field
+    client
+        .simple_query(
+            "DROP TYPE IF EXISTS test_skill CASCADE;
+             DROP TYPE IF EXISTS test_person CASCADE;
+             CREATE TYPE test_skill AS (name TEXT, level INTEGER);
+             CREATE TYPE test_person AS (name TEXT, skills test_skill[]);
+             
+             DROP TABLE IF EXISTS test_nested_array CASCADE;
+             CREATE TABLE test_nested_array (
+                 id INTEGER PRIMARY KEY,
+                 person test_person
+             );
+             
+             INSERT INTO test_nested_array VALUES 
+             (1, ROW('Alice', ARRAY[ROW('Python', 5)::test_skill, ROW('Rust', 3)::test_skill])::test_person);",
+        )
+        .await
+        .unwrap();
+
+    let table_id = get_table_id(&client, "test_nested_array").await;
+    let replication_client = ReplicationClient::from_client(client);
+    let schema = replication_client
+        .get_table_schema(
+            table_id,
+            TableName {
+                schema: "public".to_string(),
+                name: "test_nested_array".to_string(),
+            },
+            /*publication=*/ None,
+        )
+        .await
+        .unwrap();
+
+    let person_col = schema
+        .column_schemas
+        .iter()
+        .find(|c| c.name == "person")
+        .unwrap();
+
+    if let Kind::Composite(person_fields) = person_col.typ.kind() {
+        let skills_field = person_fields.iter().find(|f| f.name() == "skills").unwrap();
+
+        if let Kind::Array(skill_type) = skills_field.type_().kind() {
+            if let Kind::Composite(skill_fields) = skill_type.kind() {
+                assert_eq!(skill_fields.len(), 2);
+                assert_eq!(*skill_fields[0].type_(), Type::TEXT);
+                assert_eq!(*skill_fields[1].type_(), Type::INT4);
+            } else {
+                panic!("Expected skill array element to be composite");
+            }
+        } else {
+            panic!("Expected skills to be array");
+        }
+    } else {
+        panic!("Expected person to be composite");
+    }
+
+    // Test parsing - composite with nested array of composites
+    // Format: outer composite uses parens, array uses braces with escaped quotes for composite elements
+    let test_value = r#"(Alice,"{\"(Python,5)\",\"(Rust,3)\"}")"#;
+    let result = TextFormatConverter::try_from_str(&person_col.typ, test_value);
+    assert!(
+        result.is_ok(),
+        "Failed to parse composite with nested array: {:?}",
+        result
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_deeply_nested_composites() {
+    let client = setup_connection().await;
+
+    // Create deeply nested composite types (3+ levels)
+    client
+        .simple_query(
+            "DROP TYPE IF EXISTS test_coords CASCADE;
+             DROP TYPE IF EXISTS test_address CASCADE;
+             DROP TYPE IF EXISTS test_location CASCADE;
+             DROP TYPE IF EXISTS test_venue CASCADE;
+             
+             CREATE TYPE test_coords AS (lat FLOAT8, lon FLOAT8);
+             CREATE TYPE test_address AS (street TEXT, coords test_coords);
+             CREATE TYPE test_location AS (name TEXT, addr test_address);
+             CREATE TYPE test_venue AS (id INTEGER, loc test_location);
+             
+             DROP TABLE IF EXISTS test_deep CASCADE;
+             CREATE TABLE test_deep (
+                 id INTEGER PRIMARY KEY,
+                 venue test_venue
+             );
+             
+             INSERT INTO test_deep VALUES 
+             (1, ROW(100, ROW('Stadium', ROW('123 Main', ROW(40.7, -74.0)::test_coords)::test_address)::test_location)::test_venue);",
+        )
+        .await
+        .unwrap();
+
+    let table_id = get_table_id(&client, "test_deep").await;
+    let replication_client = ReplicationClient::from_client(client);
+    let schema = replication_client
+        .get_table_schema(
+            table_id,
+            TableName {
+                schema: "public".to_string(),
+                name: "test_deep".to_string(),
+            },
+            /*publication=*/ None,
+        )
+        .await
+        .unwrap();
+
+    let venue_col = schema
+        .column_schemas
+        .iter()
+        .find(|c| c.name == "venue")
+        .unwrap();
+
+    // Verify 4 levels of nesting
+    if let Kind::Composite(venue_fields) = venue_col.typ.kind() {
+        let loc_field = venue_fields.iter().find(|f| f.name() == "loc").unwrap();
+
+        if let Kind::Composite(loc_fields) = loc_field.type_().kind() {
+            let addr_field = loc_fields.iter().find(|f| f.name() == "addr").unwrap();
+
+            if let Kind::Composite(addr_fields) = addr_field.type_().kind() {
+                let coords_field = addr_fields.iter().find(|f| f.name() == "coords").unwrap();
+
+                if let Kind::Composite(coords_fields) = coords_field.type_().kind() {
+                    assert_eq!(coords_fields.len(), 2);
+                    assert_eq!(*coords_fields[0].type_(), Type::FLOAT8);
+                } else {
+                    panic!("Expected coords to be composite");
+                }
+            } else {
+                panic!("Expected addr to be composite");
+            }
+        } else {
+            panic!("Expected loc to be composite");
+        }
+    } else {
+        panic!("Expected venue to be composite");
+    }
+
+    // Test parsing - deeply nested composites require proper escaping
+    // Each level of nesting doubles the quotes
+    let test_value = r#"(100,"(Stadium,\"(123 Main,\\\"(40.7,-74.0)\\\")\")")"#;
+    let result = TextFormatConverter::try_from_str(&venue_col.typ, test_value);
+    assert!(
+        result.is_ok(),
+        "Failed to parse deeply nested composite: {:?}",
+        result
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn test_complex_mixed_nesting() {
+    let client = setup_connection().await;
+
+    // Test array of composites with nested arrays
+    client
+        .simple_query(
+            "DROP TYPE IF EXISTS test_tag CASCADE;
+             DROP TYPE IF EXISTS test_meta CASCADE;
+             DROP TYPE IF EXISTS test_doc CASCADE;
+             
+             CREATE TYPE test_tag AS (name TEXT, score INTEGER);
+             CREATE TYPE test_meta AS (tags test_tag[], author TEXT);
+             CREATE TYPE test_doc AS (title TEXT, meta test_meta, refs INTEGER[]);
+             
+             DROP TABLE IF EXISTS test_mixed CASCADE;
+             CREATE TABLE test_mixed (
+                 id INTEGER PRIMARY KEY,
+                 docs test_doc[]
+             );
+             
+             INSERT INTO test_mixed VALUES 
+             (1, ARRAY[
+                 ROW('Doc1', ROW(ARRAY[ROW('tag1', 5)::test_tag], 'Alice')::test_meta, ARRAY[1,2])::test_doc
+             ]);",
+        )
+        .await
+        .unwrap();
+
+    let table_id = get_table_id(&client, "test_mixed").await;
+    let replication_client = ReplicationClient::from_client(client);
+    let schema = replication_client
+        .get_table_schema(
+            table_id,
+            TableName {
+                schema: "public".to_string(),
+                name: "test_mixed".to_string(),
+            },
+            /*publication=*/ None,
+        )
+        .await
+        .unwrap();
+
+    let docs_col = schema
+        .column_schemas
+        .iter()
+        .find(|c| c.name == "docs")
+        .unwrap();
+
+    // Verify: Array[Composite[Composite[Array[Composite]], Array]]
+    if let Kind::Array(doc_type) = docs_col.typ.kind() {
+        if let Kind::Composite(doc_fields) = doc_type.kind() {
+            let meta_field = doc_fields.iter().find(|f| f.name() == "meta").unwrap();
+
+            if let Kind::Composite(meta_fields) = meta_field.type_().kind() {
+                let tags_field = meta_fields.iter().find(|f| f.name() == "tags").unwrap();
+
+                if let Kind::Array(tag_type) = tags_field.type_().kind() {
+                    assert!(matches!(tag_type.kind(), Kind::Composite(_)));
+                } else {
+                    panic!("Expected tags to be array");
+                }
+            } else {
+                panic!("Expected meta to be composite");
+            }
+
+            // Verify refs is a simple array
+            let refs_field = doc_fields.iter().find(|f| f.name() == "refs").unwrap();
+            assert!(matches!(refs_field.type_().kind(), Kind::Array(_)));
+        } else {
+            panic!("Expected doc array element to be composite");
+        }
+    } else {
+        panic!("Expected docs to be array");
+    }
+}


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

Add follow up test for https://github.com/Mooncake-Labs/moonlink/pull/1455

## Related Issues

follow up of https://github.com/Mooncake-Labs/moonlink/pull/1455

## Changes

Add test:
- nested array in composite
- deeper nested composite
- mixed: `Array[Composite[Composite[Array[Composite]], Array]]`

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [x] Documentation updated if necessary
- [x] I have reviewed my own changes
