### PR TITLE
Refine moonlink_service errors with new Error struct

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4401,6 +4401,7 @@ dependencies = [
  "clap",
  "moonlink",
  "moonlink_backend",
+ "moonlink_error",
  "moonlink_metadata_store",
  "moonlink_rpc",
  "reqwest",

--- a/src/moonlink_service/Cargo.toml
+++ b/src/moonlink_service/Cargo.toml
@@ -15,6 +15,7 @@ axum = "0.8"
 clap = { workspace = true }
 moonlink = { path = "../moonlink" }
 moonlink_backend = { path = "../moonlink_backend" }
+moonlink_error = { path = "../moonlink_error" }
 moonlink_metadata_store = { path = "../moonlink_metadata_store" }
 moonlink_rpc = { path = "../moonlink_rpc" }
 reqwest = { version = "0.12", features = ["json"], optional = true }

--- a/src/moonlink_service/src/error.rs
+++ b/src/moonlink_service/src/error.rs
@@ -34,7 +34,7 @@ impl From<ArrowError> for Error {
             _ => ErrorStatus::Permanent,
         };
 
-        Error::Arrow(ErrorStruct::new(format!("Arrow error: {source}"), status).with_source(source))
+        Error::Arrow(ErrorStruct::new("Arrow error".to_string(), status).with_source(source))
     }
 }
 
@@ -42,7 +42,7 @@ impl From<moonlink_backend::Error> for Error {
     #[track_caller]
     fn from(source: moonlink_backend::Error) -> Self {
         Error::Backend(
-            ErrorStruct::new(format!("Backend error: {source}"), ErrorStatus::Permanent)
+            ErrorStruct::new("Backend error".to_string(), ErrorStatus::Permanent)
                 .with_source(source),
         )
     }
@@ -67,7 +67,7 @@ impl From<io::Error> for Error {
             _ => ErrorStatus::Permanent,
         };
 
-        Error::Io(ErrorStruct::new(format!("IO error: {source}"), status).with_source(source))
+        Error::Io(ErrorStruct::new("IO error".to_string(), status).with_source(source))
     }
 }
 
@@ -76,7 +76,7 @@ impl From<moonlink_rpc::Error> for Error {
     fn from(source: moonlink_rpc::Error) -> Self {
         Error::Rpc(
             ErrorStruct::new(
-                format!("RPC error: {source}"),
+                "RPC error".to_string(),
                 match &source {
                     moonlink_rpc::Error::Io(err) => err.status,
                     moonlink_rpc::Error::Decode(err) => err.status,
@@ -93,7 +93,7 @@ impl From<tokio::task::JoinError> for Error {
     #[track_caller]
     fn from(source: tokio::task::JoinError) -> Self {
         Error::TaskJoin(
-            ErrorStruct::new(format!("Join error: {source}"), ErrorStatus::Permanent)
+            ErrorStruct::new("Join error".to_string(), ErrorStatus::Permanent)
                 .with_source(source),
         )
     }

--- a/src/moonlink_service/src/error.rs
+++ b/src/moonlink_service/src/error.rs
@@ -1,15 +1,118 @@
-#[derive(Debug, thiserror::Error)]
+use arrow_schema::ArrowError;
+use moonlink_error::{ErrorStatus, ErrorStruct};
+use std::io;
+use std::panic::Location;
+use std::result;
+use std::sync::Arc;
+use thiserror::Error;
+
+#[derive(Clone, Debug, Error)]
 pub enum Error {
-    #[error("Arrow schema error: {0}")]
-    ArrowSchema(#[from] arrow_schema::ArrowError),
-    #[error("Backend error: {0}")]
-    Backend(#[from] moonlink_backend::Error),
-    #[error("IO error: {0}")]
-    Io(#[from] std::io::Error),
-    #[error("RPC error: {0}")]
-    Rpc(#[from] moonlink_rpc::Error),
-    #[error("Join error: {0}.")]
-    TokioTaskJoin(#[from] tokio::task::JoinError),
+    #[error("{0}")]
+    Arrow(ErrorStruct),
+
+    #[error("{0}")]
+    Backend(ErrorStruct),
+
+    #[error("{0}")]
+    Io(ErrorStruct),
+
+    #[error("{0}")]
+    Rpc(ErrorStruct),
+
+    #[error("{0}")]
+    JoinError(ErrorStruct),
 }
 
-pub type Result<T> = std::result::Result<T, Error>;
+pub type Result<T> = result::Result<T, Error>;
+
+impl From<ArrowError> for Error {
+    #[track_caller]
+    fn from(source: ArrowError) -> Self {
+        let status = match source {
+            ArrowError::IoError(_, _) => ErrorStatus::Temporary,
+
+            // All other errors are regard as permanent
+            _ => ErrorStatus::Permanent,
+        };
+
+        Error::Arrow(ErrorStruct {
+            message: format!("Arrow error: {source}"),
+            status,
+            source: Some(Arc::new(source.into())),
+            location: Some(Location::caller()),
+        })
+    }
+}
+
+impl From<moonlink_backend::Error> for Error {
+    #[track_caller]
+    fn from(source: moonlink_backend::Error) -> Self {
+        Error::Backend(ErrorStruct {
+            message: format!("Backend error: {source}"),
+            status: ErrorStatus::Permanent,
+            source: Some(Arc::new(source.into())),
+            location: Some(Location::caller()),
+        })
+    }
+}
+
+impl From<io::Error> for Error {
+    #[track_caller]
+    fn from(source: io::Error) -> Self {
+        let status = match source.kind() {
+            io::ErrorKind::TimedOut
+            | io::ErrorKind::Interrupted
+            | io::ErrorKind::WouldBlock
+            | io::ErrorKind::ConnectionRefused
+            | io::ErrorKind::ConnectionAborted
+            | io::ErrorKind::ConnectionReset
+            | io::ErrorKind::BrokenPipe
+            | io::ErrorKind::NetworkDown
+            | io::ErrorKind::ResourceBusy
+            | io::ErrorKind::QuotaExceeded => ErrorStatus::Temporary,
+
+            // All other errors are permanent
+            _ => ErrorStatus::Permanent,
+        };
+
+        Error::Io(ErrorStruct {
+            message: format!("IO error: {source}"),
+            status,
+            source: Some(Arc::new(source.into())),
+            location: Some(Location::caller()),
+        })
+    }
+}
+
+impl From<moonlink_rpc::Error> for Error {
+    #[track_caller]
+    fn from(source: moonlink_rpc::Error) -> Self {
+        let status = match &source {
+            // Use the status that was already determined in the moonlink_rpc crate
+            moonlink_rpc::Error::Io(err) => err.status,
+
+            // All other errors are permanent
+            _ => ErrorStatus::Permanent,
+        };
+
+        Error::Rpc(ErrorStruct {
+            message: format!("RPC error: {source}"),
+            status,
+            source: Some(Arc::new(source.into())),
+            location: Some(Location::caller()),
+        })
+    }
+}
+
+impl From<tokio::task::JoinError> for Error {
+    #[track_caller]
+    fn from(source: tokio::task::JoinError) -> Self {
+        Error::JoinError(ErrorStruct {
+            message: format!("Join error: {source}"),
+            status: ErrorStatus::Permanent,
+            source: Some(Arc::new(source.into())),
+            location: Some(Location::caller()),
+        })
+    }
+}

--- a/src/moonlink_service/src/error.rs
+++ b/src/moonlink_service/src/error.rs
@@ -21,7 +21,7 @@ pub enum Error {
     Rpc(ErrorStruct),
 
     #[error("{0}")]
-    JoinError(ErrorStruct),
+    TaskJoin(ErrorStruct),
 }
 
 pub type Result<T> = result::Result<T, Error>;
@@ -108,7 +108,7 @@ impl From<moonlink_rpc::Error> for Error {
 impl From<tokio::task::JoinError> for Error {
     #[track_caller]
     fn from(source: tokio::task::JoinError) -> Self {
-        Error::JoinError(ErrorStruct {
+        Error::TaskJoin(ErrorStruct {
             message: format!("Join error: {source}"),
             status: ErrorStatus::Permanent,
             source: Some(Arc::new(source.into())),

--- a/src/moonlink_service/src/rpc_server.rs
+++ b/src/moonlink_service/src/rpc_server.rs
@@ -3,6 +3,7 @@ use arrow_ipc::writer::StreamWriter;
 use moonlink_backend::MoonlinkBackend;
 use moonlink_rpc::{read, write, Request, Table};
 use std::collections::HashMap;
+use std::error::Error as StdError;
 use std::io::ErrorKind::{BrokenPipe, ConnectionReset, UnexpectedEof};
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -31,7 +32,8 @@ pub async fn start_unix_server(
         tokio::spawn(async move {
             match handle_stream(backend, stream).await {
                 Err(Error::Rpc(error_struct))
-                    if error::Error::source(&error_struct)
+                    if error_struct
+                        .source()
                         .and_then(|src| src.downcast_ref::<std::io::Error>())
                         .map(|io_err| {
                             matches!(io_err.kind(), BrokenPipe | ConnectionReset | UnexpectedEof)
@@ -55,7 +57,8 @@ pub async fn start_tcp_server(backend: Arc<MoonlinkBackend>, addr: SocketAddr) -
         tokio::spawn(async move {
             match handle_stream(backend, stream).await {
                 Err(Error::Rpc(error_struct))
-                    if error::Error::source(&error_struct)
+                    if error_struct
+                        .source()
                         .and_then(|src| src.downcast_ref::<std::io::Error>())
                         .map(|io_err| {
                             matches!(io_err.kind(), BrokenPipe | ConnectionReset | UnexpectedEof)

--- a/src/moonlink_service/src/rpc_server.rs
+++ b/src/moonlink_service/src/rpc_server.rs
@@ -39,9 +39,9 @@ pub async fn start_unix_server(
                             }
                         }
                     }
-                    panic!("{error_struct}");
+                    panic!("Unix RPC server error: {error_struct}");
                 }
-                Err(e) => panic!("{e}"),
+                Err(e) => panic!("Unexpected Unix RPC server error: {e}"),
                 Ok(()) => {}
             }
         });
@@ -67,9 +67,9 @@ pub async fn start_tcp_server(backend: Arc<MoonlinkBackend>, addr: SocketAddr) -
                             }
                         }
                     }
-                    panic!("{error_struct}");
+                    panic!("TCP RPC server error: {error_struct}");
                 }
-                Err(e) => panic!("{e}"),
+                Err(e) => panic!("Unexpected TCP RPC server error: {e}"),
                 Ok(()) => {}
             }
         });


### PR DESCRIPTION
## Summary

Apply ErrorStruct to error types in moonlink_service.

Can simply follow what we have done for the src/moonlink_rpc/src/error.rs in PR https://github.com/Mooncake-Labs/moonlink/pull/1422, and apply changes to [src/moonlink_service/src/error.rs](https://github.com/Mooncake-Labs/moonlink/blob/main/src/moonlink_service/src/error.rs?rgh-link-date=2025-08-14T11%3A32%3A12.000Z)

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1457

## Changes

- Apply ErrorStruct to error types in moonlink_service and implement proper error conversion 
- Adapt this new error interface in the rpc_server

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [x] Documentation updated if necessary
- [x] I have reviewed my own changes
