### PR TITLE
Fix iceberg error propagation

### DIFF
--- a/src/moonlink/src/error.rs
+++ b/src/moonlink/src/error.rs
@@ -27,10 +27,6 @@ pub enum Error {
     #[error("{0}")]
     IcebergError(ErrorStruct),
 
-    // TODO(hjiang): Improve error propagation.
-    #[error("Iceberg error: {0}")]
-    IcebergMessage(String),
-
     #[error("{0}")]
     OpenDal(ErrorStruct),
 
@@ -233,7 +229,7 @@ mod tests {
         if let Error::Io(ref inner) = io_error {
             let loc = inner.location.unwrap();
             assert_eq!(loc.file(), "src/moonlink/src/error.rs");
-            assert_eq!(loc.line(), 217);
+            assert_eq!(loc.line(), 213);
             assert_eq!(loc.column(), 9);
         }
     }

--- a/src/moonlink/src/storage/iceberg/mock_filesystem_test.rs
+++ b/src/moonlink/src/storage/iceberg/mock_filesystem_test.rs
@@ -1,3 +1,5 @@
+use moonlink_error::ErrorStruct;
+
 use crate::storage::filesystem::accessor::base_filesystem_accessor::{
     BaseFileSystemAccess, MockBaseFileSystemAccess,
 };
@@ -36,9 +38,12 @@ async fn test_failed_iceberg_table_manager_drop_table() {
         .times(1)
         .returning(|_| {
             Box::pin(async move {
-                Err(Error::IcebergMessage(String::from(
-                    "Failed to delete object",
-                )))
+                Err(Error::IcebergError(ErrorStruct {
+                    message: "iceberg operation failure".to_string(),
+                    status: moonlink_error::ErrorStatus::Permanent,
+                    source: None,
+                    location: None,
+                }))
             })
         });
     let mut iceberg_table_manager =
@@ -55,9 +60,12 @@ async fn test_failed_recover_from_iceberg_table() {
         .times(1)
         .returning(|_| {
             Box::pin(async move {
-                Err(Error::IcebergMessage(String::from(
-                    "Failed to check object existence",
-                )))
+                Err(Error::IcebergError(ErrorStruct {
+                    message: "iceberg operation failure".to_string(),
+                    status: moonlink_error::ErrorStatus::Permanent,
+                    source: None,
+                    location: None,
+                }))
             })
         });
     let mut iceberg_table_manager =

--- a/src/moonlink/src/table_handler.rs
+++ b/src/moonlink/src/table_handler.rs
@@ -17,7 +17,6 @@ use crate::storage::snapshot_options::SnapshotOption;
 use crate::storage::{io_utils, MooncakeTable};
 use crate::table_handler_timer::TableHandlerTimer;
 use crate::table_notify::TableEvent;
-use crate::Error;
 use tokio::sync::mpsc::{self, Receiver, Sender};
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
@@ -580,9 +579,7 @@ impl TableHandler {
                                 .update_iceberg_persisted_lsn(iceberg_flush_lsn, replication_lsn);
                         }
                         Err(e) => {
-                            let err = Err(Error::IcebergMessage(format!(
-                                "Failed to create iceberg snapshot: {e:?}"
-                            )));
+                            let err = Err(e.clone());
                             if table_handler_state.has_pending_force_snapshot_request() {
                                 if let Err(send_err) = table_handler_state
                                     .force_snapshot_completion_tx


### PR DESCRIPTION
## Summary

To keep source location information during error propagation, we should avoid wrapping ourselves.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1487

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
