### PR TITLE
refactor before obj store changes

### DIFF
--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -451,6 +451,8 @@ pub struct MooncakeTable {
 impl MooncakeTable {
     /// foreground functions
     ///
+    /// Note that wal manager is constructed outside of the constructor as
+    /// it may be recovered from persistent wal metadata.
     /// TODO(hjiang): Provide a struct to hold all parameters.
     #[allow(clippy::too_many_arguments)]
     pub async fn new(

--- a/src/moonlink/src/storage/wal.rs
+++ b/src/moonlink/src/storage/wal.rs
@@ -15,11 +15,12 @@ use std::pin::Pin;
 use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
 
-pub const DEFAULT_WAL_FOLDER: &str = "wal";
+pub const DEFAULT_WAL_FOLDER: &str = "_wal";
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct WalConfig {
     accessor_config: AccessorConfig,
+    mooncake_table_id: String,
 }
 
 impl WalConfig {
@@ -29,22 +30,39 @@ impl WalConfig {
     /// within moonlink.
     pub fn default_wal_config_local(mooncake_table_id: &str, base_path: &Path) -> WalConfig {
         let wal_storage_config = StorageConfig::FileSystem {
-            root_directory: base_path
-                .join(DEFAULT_WAL_FOLDER)
-                .join(mooncake_table_id)
-                .to_str()
-                .unwrap()
-                .to_string(),
+            root_directory: base_path.to_str().unwrap().to_string(),
             // TODO(paul): evaluate atomic write option.
             atomic_write_dir: None,
         };
         Self {
             accessor_config: AccessorConfig::new_with_storage_config(wal_storage_config),
+            mooncake_table_id: mooncake_table_id.to_string(),
+        }
+    }
+
+    /// Create WAL config with provided accessor (root must be bucket/root path).
+    pub fn new(accessor_config: AccessorConfig, mooncake_table_id: &str) -> WalConfig {
+        Self {
+            accessor_config,
+            mooncake_table_id: mooncake_table_id.to_string(),
         }
     }
 
     pub fn get_accessor_config(&self) -> &AccessorConfig {
         &self.accessor_config
+    }
+
+    pub fn get_mooncake_table_id(&self) -> &str {
+        &self.mooncake_table_id
+    }
+}
+
+const DEFAULT_MOONCAKE_TABLE_ID: &str = "default_mooncake_table_id";
+const DEFAULT_BASE_PATH: &str = "tmp/default_wal_dir";
+
+impl Default for WalConfig {
+    fn default() -> Self {
+        Self::default_wal_config_local(DEFAULT_MOONCAKE_TABLE_ID, Path::new(DEFAULT_BASE_PATH))
     }
 }
 
@@ -299,6 +317,8 @@ pub struct PersistentWalMetadata {
     main_transaction_tracker: Vec<WalTransactionState>,
     /// The LSN of the last iceberg snapshot that was persisted just before the WAL was persisted.
     iceberg_snapshot_lsn: Option<u64>,
+    /// The mooncake table ID for this WAL.
+    mooncake_table_id: String,
 }
 
 impl PersistentWalMetadata {
@@ -309,6 +329,7 @@ impl PersistentWalMetadata {
         active_transactions: HashMap<u32, WalTransactionState>,
         main_transaction_tracker: Vec<WalTransactionState>,
         iceberg_snapshot_lsn: Option<u64>,
+        mooncake_table_id: String,
     ) -> Self {
         Self {
             curr_file_number,
@@ -317,6 +338,7 @@ impl PersistentWalMetadata {
             active_transactions,
             main_transaction_tracker,
             iceberg_snapshot_lsn,
+            mooncake_table_id,
         }
     }
 
@@ -342,6 +364,10 @@ impl PersistentWalMetadata {
 
     pub fn get_iceberg_snapshot_lsn(&self) -> Option<u64> {
         self.iceberg_snapshot_lsn
+    }
+
+    pub fn get_mooncake_table_id(&self) -> &str {
+        &self.mooncake_table_id
     }
 }
 
@@ -402,12 +428,13 @@ pub struct WalManager {
     main_transaction_tracker: Vec<WalTransactionState>,
 
     file_system_accessor: Arc<dyn BaseFileSystemAccess>,
+    wal_config: WalConfig,
 }
 
 impl WalManager {
     pub fn new(config: &WalConfig) -> Self {
         // TODO(Paul): Add a more robust constructor when implementing recovery
-        let accessor_config = config.accessor_config.clone();
+        let accessor_config = config.get_accessor_config().clone();
         Self {
             in_mem_buf: Vec::new(),
             highest_completion_lsn: 0,
@@ -417,21 +444,40 @@ impl WalManager {
             main_transaction_tracker: Vec::new(),
             // TODO(Paul): Implement object storage
             file_system_accessor: create_filesystem_accessor(accessor_config),
+            wal_config: config.clone(),
         }
     }
 
-    pub fn get_file_name(file_number: u64) -> String {
-        format!("wal_{file_number}.json")
+    pub fn get_wal_file_path_for_mooncake_table(
+        file_number: u64,
+        mooncake_table_id: &str,
+    ) -> String {
+        format!("{DEFAULT_WAL_FOLDER}/{mooncake_table_id}/wal_{file_number}.json")
     }
 
-    pub fn get_metadata_file_name() -> String {
-        "metadata_wal.json".to_string()
+    pub fn get_wal_file_path(&self, file_number: u64) -> String {
+        Self::get_wal_file_path_for_mooncake_table(
+            file_number,
+            self.wal_config.get_mooncake_table_id(),
+        )
+    }
+
+    /// Static helper to compute metadata file name for a given mooncake table id.
+    pub fn get_metadata_file_path_for_mooncake_table(mooncake_table_id: &str) -> String {
+        format!("{DEFAULT_WAL_FOLDER}/{mooncake_table_id}/metadata_wal.json")
+    }
+
+    pub fn get_metadata_file_path(&self) -> String {
+        Self::get_metadata_file_path_for_mooncake_table(self.wal_config.get_mooncake_table_id())
     }
 
     pub fn get_file_system_accessor(&self) -> Arc<dyn BaseFileSystemAccess> {
         self.file_system_accessor.clone()
     }
 
+    pub fn get_mooncake_table_id(&self) -> &str {
+        self.wal_config.get_mooncake_table_id()
+    }
     pub fn get_highest_completion_lsn(&self) -> u64 {
         self.highest_completion_lsn
     }
@@ -753,6 +799,7 @@ impl WalManager {
             cleanedup_xacts,
             cleanedup_main_xacts,
             iceberg_snapshot_lsn,
+            self.wal_config.get_mooncake_table_id().to_string(),
         )
     }
 
@@ -796,10 +843,16 @@ impl WalManager {
     pub async fn delete_files(
         file_system_accessor: Arc<dyn BaseFileSystemAccess>,
         wal_file_numbers: &[WalFileInfo],
+        mooncake_table_id: &str,
     ) -> Result<()> {
         let file_names = wal_file_numbers
             .iter()
-            .map(|wal_file_info| WalManager::get_file_name(wal_file_info.file_number))
+            .map(|wal_file_info| {
+                WalManager::get_wal_file_path_for_mooncake_table(
+                    wal_file_info.file_number,
+                    mooncake_table_id,
+                )
+            })
             .collect::<Vec<String>>();
         let delete_futures = file_names
             .iter()
@@ -812,17 +865,21 @@ impl WalManager {
     }
 
     /// Persist a series of wal events to the file system.
-    /// Should be called asynchronously using the most recent wal data extracted form the
+    /// Should be called as part of an asynchronous job using the most recent wal data extracted form the
     /// in-memory buffer.
     pub async fn persist_new_wal_file(
         file_system_accessor: Arc<dyn BaseFileSystemAccess>,
         wal_to_persist: &Vec<WalEvent>,
         wal_file_info: &WalFileInfo,
+        mooncake_table_id: &str,
     ) -> Result<()> {
         if !wal_to_persist.is_empty() {
             let wal_json = serde_json::to_vec(&wal_to_persist)?;
 
-            let wal_file_path = WalManager::get_file_name(wal_file_info.file_number);
+            let wal_file_path = WalManager::get_wal_file_path_for_mooncake_table(
+                wal_file_info.file_number,
+                mooncake_table_id,
+            );
             file_system_accessor
                 .write_object(&wal_file_path, wal_json)
                 .await?;
@@ -834,7 +891,9 @@ impl WalManager {
         persistent_wal_metadata: &PersistentWalMetadata,
         file_system_accessor: Arc<dyn BaseFileSystemAccess>,
     ) -> Result<()> {
-        let metadata_file_name = WalManager::get_metadata_file_name();
+        let metadata_file_name = WalManager::get_metadata_file_path_for_mooncake_table(
+            persistent_wal_metadata.get_mooncake_table_id(),
+        );
         let metadata_bytes = serde_json::to_vec(&persistent_wal_metadata).unwrap();
         file_system_accessor
             .write_object(&metadata_file_name, metadata_bytes)
@@ -846,12 +905,17 @@ impl WalManager {
     /// It persists any new events in the WAL, and deletes any old WAL files following an iceberg snapshot.
     ///
     /// iceberg snapshot info is None only if there has not been an iceberg snapshot yet.
+    /// TODO(Paul): Rename to persistent update async.
     pub async fn wal_persist_truncate_async(
         uuid: uuid::Uuid,
         prepare_persistent_update: PreparePersistentUpdate,
         file_system_accessor: Arc<dyn BaseFileSystemAccess>,
         table_notify: Sender<TableEvent>,
     ) {
+        let mooncake_table_id = prepare_persistent_update
+            .persistent_wal_metadata
+            .get_mooncake_table_id();
+
         // Execute WAL operations
         let result = async {
             let file_system_accessor_persist = file_system_accessor.clone();
@@ -865,6 +929,7 @@ impl WalManager {
                     file_system_accessor_persist.clone(),
                     wal_events,
                     wal_file_info,
+                    mooncake_table_id,
                 )
                 .await?;
             }
@@ -881,6 +946,7 @@ impl WalManager {
                 WalManager::delete_files(
                     file_system_accessor_persist,
                     &prepare_persistent_update.files_to_delete,
+                    mooncake_table_id,
                 )
                 .await?;
             }
@@ -1025,19 +1091,24 @@ impl WalManager {
     // Drop WAL files
     // ------------------------------
     /// Drops all WAL files by removing the entire WAL directory for this table.
+    /// TODO(Paul): This should be reworked for object storage.
     pub async fn drop_wal(&mut self) -> Result<()> {
-        self.file_system_accessor.remove_directory("").await?;
+        self.file_system_accessor
+            .remove_directory(DEFAULT_WAL_FOLDER)
+            .await?;
         Ok(())
     }
 
     // ------------------------------
     // Recovery
     // ------------------------------
-    #[allow(dead_code)]
     pub async fn recover_from_persistent_wal_metadata(
         file_system_accessor: Arc<dyn BaseFileSystemAccess>,
+        wal_config: WalConfig,
     ) -> Option<PersistentWalMetadata> {
-        let metadata_file_name = WalManager::get_metadata_file_name();
+        let metadata_file_name = WalManager::get_metadata_file_path_for_mooncake_table(
+            wal_config.get_mooncake_table_id(),
+        );
         if !file_system_accessor
             .object_exists(&metadata_file_name)
             .await
@@ -1054,11 +1125,18 @@ impl WalManager {
         Some(serde_json::from_slice(&metadata_bytes).expect("failed to parse wal metadata"))
     }
 
-    #[allow(dead_code)]
     pub fn from_persistent_wal_metadata(
         file_system_accessor: Arc<dyn BaseFileSystemAccess>,
         persistent_wal_metadata: PersistentWalMetadata,
+        wal_config: WalConfig,
     ) -> Self {
+        // Validate that the mooncake_table_id in the config matches the one in metadata
+        assert_eq!(
+            wal_config.get_mooncake_table_id(),
+            persistent_wal_metadata.get_mooncake_table_id(),
+            "WalConfig mooncake_table_id must match PersistentWalMetadata mooncake_table_id"
+        );
+
         Self {
             in_mem_buf: Vec::new(),
             highest_completion_lsn: persistent_wal_metadata.highest_completion_lsn,
@@ -1067,17 +1145,15 @@ impl WalManager {
             active_transactions: persistent_wal_metadata.active_transactions,
             main_transaction_tracker: persistent_wal_metadata.main_transaction_tracker,
             file_system_accessor,
+            wal_config,
         }
     }
 
-    /// Recover the flushed WALs from the file system.
-    fn recover_flushed_wals(
+    /// Recover the flushed WALs from the file system as a stream of vectors of table events.
+    pub fn recover_flushed_wals(
         file_system_accessor: Arc<dyn BaseFileSystemAccess>,
         wal_persistence_metadata: &PersistentWalMetadata,
     ) -> Pin<Box<dyn Stream<Item = Result<Vec<TableEvent>>> + Send>> {
-        if wal_persistence_metadata.live_wal_files_tracker.is_empty() {
-            return Box::pin(stream::empty());
-        }
         let start_file_number = wal_persistence_metadata
             .live_wal_files_tracker
             .first()
@@ -1088,10 +1164,15 @@ impl WalManager {
             .last()
             .unwrap()
             .file_number;
+        let mooncake_table_id = wal_persistence_metadata.get_mooncake_table_id().to_string();
         Box::pin(stream::unfold(start_file_number, move |file_number| {
             let file_system_accessor = file_system_accessor.clone();
+            let mooncake_table_id = mooncake_table_id.clone();
             async move {
-                let file_name = WalManager::get_file_name(file_number);
+                let file_name = WalManager::get_wal_file_path_for_mooncake_table(
+                    file_number,
+                    &mooncake_table_id,
+                );
                 if file_number > end_file_number {
                     return None;
                 }

--- a/src/moonlink/src/storage/wal.rs
+++ b/src/moonlink/src/storage/wal.rs
@@ -41,6 +41,7 @@ impl WalConfig {
     }
 
     /// Create WAL config with provided accessor (root must be bucket/root path).
+    #[allow(dead_code)]
     pub fn new(accessor_config: AccessorConfig, mooncake_table_id: &str) -> WalConfig {
         Self {
             accessor_config,
@@ -54,15 +55,6 @@ impl WalConfig {
 
     pub fn get_mooncake_table_id(&self) -> &str {
         &self.mooncake_table_id
-    }
-}
-
-const DEFAULT_MOONCAKE_TABLE_ID: &str = "default_mooncake_table_id";
-const DEFAULT_BASE_PATH: &str = "tmp/default_wal_dir";
-
-impl Default for WalConfig {
-    fn default() -> Self {
-        Self::default_wal_config_local(DEFAULT_MOONCAKE_TABLE_ID, Path::new(DEFAULT_BASE_PATH))
     }
 }
 

--- a/src/moonlink/src/storage/wal/tests.rs
+++ b/src/moonlink/src/storage/wal/tests.rs
@@ -12,16 +12,21 @@ async fn test_wal_insert_persist_files() {
     let context = TestContext::new("wal_persist");
     let wal_config =
         WalConfig::default_wal_config_local(WAL_TEST_TABLE_ID, &context.path().to_path_buf());
-    let (mut wal, expected_events) = create_test_wal(wal_config).await;
+    let (mut wal, expected_events) = create_test_wal(wal_config.clone()).await;
 
     // Persist and verify file number
     wal.do_wal_persistence_update_for_test(None).await.unwrap();
 
     // Check file exists and has content
-    assert_wal_file_exists!(wal.get_file_system_accessor(), 0);
+    assert_wal_file_exists!(0, wal.get_file_system_accessor(), &wal_config);
 
     let expected_wal_events = convert_to_wal_events_vector(&expected_events);
-    assert_wal_logs_equal!(&[0], wal.get_file_system_accessor(), expected_wal_events);
+    assert_wal_logs_equal!(
+        &[0],
+        expected_wal_events,
+        wal.get_file_system_accessor(),
+        &wal_config
+    );
 }
 
 #[tokio::test]
@@ -35,7 +40,7 @@ async fn test_wal_empty_persist() {
     wal.do_wal_persistence_update_for_test(None).await.unwrap();
 
     // No file should be created for empty WAL
-    assert!(!wal_file_exists(wal.get_file_system_accessor(), 0).await);
+    assert!(!wal_file_exists(0, wal.get_file_system_accessor(), &wal_config).await);
 }
 
 #[tokio::test]
@@ -56,8 +61,13 @@ async fn test_wal_file_numbering_sequence() {
     // Second loop: check file existence and contents
     for i in 0..3 {
         let expected_wal_events = convert_to_wal_events_vector(&events[i as usize..=(i as usize)]);
-        assert_wal_file_exists!(wal.get_file_system_accessor(), i);
-        assert_wal_logs_equal!(&[i], wal.get_file_system_accessor(), expected_wal_events);
+        assert_wal_file_exists!(i, wal.get_file_system_accessor(), &wal_config);
+        assert_wal_logs_equal!(
+            &[i],
+            expected_wal_events,
+            wal.get_file_system_accessor(),
+            &wal_config
+        );
     }
 }
 
@@ -91,15 +101,20 @@ async fn test_wal_truncation_deletes_files() {
 
     // Verify files 0, 1, 2 are deleted
     for i in 0..3 {
-        assert_wal_file_does_not_exist!(wal.get_file_system_accessor(), i);
+        assert_wal_file_does_not_exist!(i, wal.get_file_system_accessor(), &wal_config);
     }
 
     // Verify files 3, 4 still exist and contain correct content
     for i in 3..5 {
-        assert_wal_file_exists!(wal.get_file_system_accessor(), i);
+        assert_wal_file_exists!(i, wal.get_file_system_accessor(), &wal_config);
 
         let expected_events = convert_to_wal_events_vector(&events[i as usize..=(i as usize)]);
-        assert_wal_logs_equal!(&[i], wal.get_file_system_accessor(), expected_events);
+        assert_wal_logs_equal!(
+            &[i],
+            expected_events,
+            wal.get_file_system_accessor(),
+            &wal_config
+        );
     }
 }
 
@@ -136,8 +151,8 @@ async fn test_wal_truncation_deletes_all_files() {
         .unwrap(); // Higher than any LSN
 
     // check that the files are deleted
-    assert!(!wal_file_exists(wal.get_file_system_accessor(), 0).await);
-    assert!(!wal_file_exists(wal.get_file_system_accessor(), 1).await);
+    assert!(!wal_file_exists(0, wal.get_file_system_accessor(), &wal_config).await);
+    assert!(!wal_file_exists(1, wal.get_file_system_accessor(), &wal_config).await);
 }
 
 // ------------------------------------------------------------
@@ -164,7 +179,12 @@ async fn test_wal_truncate_incomplete_main_xact() {
         .unwrap();
 
     let expected_events = convert_to_wal_events_vector(&events);
-    assert_wal_logs_equal!(&[0], wal.get_file_system_accessor(), expected_events);
+    assert_wal_logs_equal!(
+        &[0],
+        expected_events,
+        wal.get_file_system_accessor(),
+        &wal_config
+    );
 }
 
 #[tokio::test]
@@ -197,12 +217,17 @@ async fn test_wal_truncate_unfinished_main_xact_multiple_commits() {
         .unwrap();
 
     // verify the first and second file are deleted
-    assert_wal_file_does_not_exist!(wal.get_file_system_accessor(), 0);
-    assert_wal_file_does_not_exist!(wal.get_file_system_accessor(), 1);
-    assert_wal_file_exists!(wal.get_file_system_accessor(), 2);
+    assert_wal_file_does_not_exist!(0, wal.get_file_system_accessor(), &wal_config);
+    assert_wal_file_does_not_exist!(1, wal.get_file_system_accessor(), &wal_config);
+    assert_wal_file_exists!(2, wal.get_file_system_accessor(), &wal_config);
 
     let expected_events = convert_to_wal_events_vector(&events[6..]);
-    assert_wal_logs_equal!(&[2], wal.get_file_system_accessor(), expected_events);
+    assert_wal_logs_equal!(
+        &[2],
+        expected_events,
+        wal.get_file_system_accessor(),
+        &wal_config
+    );
 }
 
 #[tokio::test]
@@ -240,11 +265,16 @@ async fn test_wal_truncate_main_and_streaming_xact_interleave() {
         .unwrap();
 
     // we should only have file 1, 2 and 3
-    assert_wal_file_does_not_exist!(wal.get_file_system_accessor(), 0);
-    assert_wal_file_exists!(wal.get_file_system_accessor(), 1);
+    assert_wal_file_does_not_exist!(0, wal.get_file_system_accessor(), &wal_config);
+    assert_wal_file_exists!(1, wal.get_file_system_accessor(), &wal_config);
 
     let expected_events = convert_to_wal_events_vector(&events[1..]);
-    assert_wal_logs_equal!(&[1, 2, 3], wal.get_file_system_accessor(), expected_events);
+    assert_wal_logs_equal!(
+        &[1, 2, 3],
+        expected_events,
+        wal.get_file_system_accessor(),
+        &wal_config
+    );
 }
 
 #[tokio::test]
@@ -296,15 +326,20 @@ async fn test_wal_multiple_interleaved_truncations() {
     // main: 100 -> 101, 102 -> 103
 
     // we should only  have file 2 and 3
-    assert_wal_file_does_not_exist!(wal.get_file_system_accessor(), 0);
-    assert_wal_file_does_not_exist!(wal.get_file_system_accessor(), 1);
+    assert_wal_file_does_not_exist!(0, wal.get_file_system_accessor(), &wal_config);
+    assert_wal_file_does_not_exist!(1, wal.get_file_system_accessor(), &wal_config);
 
-    assert_wal_file_exists!(wal.get_file_system_accessor(), 2);
-    assert_wal_file_exists!(wal.get_file_system_accessor(), 3);
+    assert_wal_file_exists!(2, wal.get_file_system_accessor(), &wal_config);
+    assert_wal_file_exists!(3, wal.get_file_system_accessor(), &wal_config);
 
     // truncate up to the main xact
     let expected_events = convert_to_wal_events_vector(&events[6..]);
-    assert_wal_logs_equal!(&[2, 3], wal.get_file_system_accessor(), expected_events);
+    assert_wal_logs_equal!(
+        &[2, 3],
+        expected_events,
+        wal.get_file_system_accessor(),
+        &wal_config
+    );
 }
 
 #[tokio::test]
@@ -339,14 +374,19 @@ async fn test_wal_stream_abort() {
         .unwrap();
 
     // we should only  have file 2 (abort should 'complete' transaction 1)
-    assert_wal_file_does_not_exist!(wal.get_file_system_accessor(), 0);
-    assert_wal_file_does_not_exist!(wal.get_file_system_accessor(), 1);
+    assert_wal_file_does_not_exist!(0, wal.get_file_system_accessor(), &wal_config);
+    assert_wal_file_does_not_exist!(1, wal.get_file_system_accessor(), &wal_config);
 
-    assert_wal_file_exists!(wal.get_file_system_accessor(), 2);
+    assert_wal_file_exists!(2, wal.get_file_system_accessor(), &wal_config);
 
     // truncate up to the main xact
     let expected_events = convert_to_wal_events_vector(&events[5..]);
-    assert_wal_logs_equal!(&[2], wal.get_file_system_accessor(), expected_events);
+    assert_wal_logs_equal!(
+        &[2],
+        expected_events,
+        wal.get_file_system_accessor(),
+        &wal_config
+    );
 }
 
 #[tokio::test]
@@ -354,16 +394,18 @@ async fn test_wal_recovery_basic() {
     let context = TestContext::new("wal_recovery_basic");
     let wal_config =
         WalConfig::default_wal_config_local(WAL_TEST_TABLE_ID, &context.path().to_path_buf());
-    let (mut wal, expected_events) = create_test_wal(wal_config).await;
+    let (mut wal, expected_events) = create_test_wal(wal_config.clone()).await;
 
     // Persist the events first
     wal.do_wal_persistence_update_for_test(None).await.unwrap();
 
     // Recover events using flat stream
-    let wal_metadata =
-        WalManager::recover_from_persistent_wal_metadata(wal.get_file_system_accessor())
-            .await
-            .unwrap();
+    let wal_metadata = WalManager::recover_from_persistent_wal_metadata(
+        wal.get_file_system_accessor(),
+        wal_config.clone(),
+    )
+    .await
+    .unwrap();
     let recovered_events =
         get_table_events_vector_recovery(wal.get_file_system_accessor(), &wal_metadata).await;
 
@@ -387,10 +429,12 @@ async fn test_main_tracker_merges_multiple_subset_commits_in_same_file() {
     wal.do_wal_persistence_update_for_test(None).await.unwrap();
 
     // Read persisted metadata and verify the invariant
-    let metadata: PersistentWalMetadata =
-        WalManager::recover_from_persistent_wal_metadata(wal.get_file_system_accessor())
-            .await
-            .expect("metadata should exist");
+    let metadata: PersistentWalMetadata = WalManager::recover_from_persistent_wal_metadata(
+        wal.get_file_system_accessor(),
+        wal_config.clone(),
+    )
+    .await
+    .expect("metadata should exist");
 
     let main = metadata.get_main_transaction_tracker();
     // Only one subset commit for file 0 should remain
@@ -431,10 +475,12 @@ async fn test_main_tracker_allows_one_spanning_and_one_subset_per_file() {
 
     wal.do_wal_persistence_update_for_test(None).await.unwrap();
 
-    let metadata: PersistentWalMetadata =
-        WalManager::recover_from_persistent_wal_metadata(wal.get_file_system_accessor())
-            .await
-            .expect("metadata should exist");
+    let metadata: PersistentWalMetadata = WalManager::recover_from_persistent_wal_metadata(
+        wal.get_file_system_accessor(),
+        wal_config.clone(),
+    )
+    .await
+    .expect("metadata should exist");
 
     let main = metadata.get_main_transaction_tracker();
     assert_eq!(main.len(), 2, "expected two commits tracked in total");
@@ -485,10 +531,12 @@ async fn test_main_tracker_keeps_highest_subset_commit_per_file() {
 
     wal.do_wal_persistence_update_for_test(None).await.unwrap();
 
-    let metadata: PersistentWalMetadata =
-        WalManager::recover_from_persistent_wal_metadata(wal.get_file_system_accessor())
-            .await
-            .expect("metadata should exist");
+    let metadata: PersistentWalMetadata = WalManager::recover_from_persistent_wal_metadata(
+        wal.get_file_system_accessor(),
+        wal_config.clone(),
+    )
+    .await
+    .expect("metadata should exist");
 
     let main = metadata.get_main_transaction_tracker();
     assert_eq!(main.len(), 2, "expected two commits tracked in total");
@@ -539,7 +587,7 @@ async fn test_recovery_uses_metadata_as_source_of_truth_when_file_persisted_but_
         WalConfig::default_wal_config_local(WAL_TEST_TABLE_ID, &context.path().to_path_buf());
 
     // Create initial WAL with a batch of events and persist (writes file 0 + metadata)
-    let (mut wal, expected_events_file0) = create_test_wal(wal_config).await;
+    let (mut wal, expected_events_file0) = create_test_wal(wal_config.clone()).await;
     wal.do_wal_persistence_update_for_test(None).await.unwrap();
 
     // Prepare a second batch and simulate crash after persisting the file but before metadata
@@ -558,14 +606,18 @@ async fn test_recovery_uses_metadata_as_source_of_truth_when_file_persisted_but_
         wal.get_file_system_accessor(),
         &wal_events_file1,
         &wal_file_info_file1,
+        wal_config.get_mooncake_table_id(),
     )
     .await
     .unwrap();
 
     // Metadata on disk should still reflect only file 0
-    let metadata = WalManager::recover_from_persistent_wal_metadata(wal.get_file_system_accessor())
-        .await
-        .expect("metadata should exist for file 0");
+    let metadata = WalManager::recover_from_persistent_wal_metadata(
+        wal.get_file_system_accessor(),
+        wal_config.clone(),
+    )
+    .await
+    .expect("metadata should exist for file 0");
 
     // Now perform recovery using the metadata as source of truth
     let (tx, mut rx) = tokio::sync::mpsc::channel::<TableEvent>(100);

--- a/src/moonlink/src/table_handler/tests.rs
+++ b/src/moonlink/src/table_handler/tests.rs
@@ -1835,7 +1835,12 @@ async fn test_wal_drop_table_removes_files() {
     let wal_filesystem_accessor = env.wal_filesystem_accessor.clone();
     let file_names = [0, 1]
         .iter()
-        .map(|i| WalManager::get_file_name(*i))
+        .map(|i| {
+            WalManager::get_wal_file_path_for_mooncake_table(
+                *i,
+                env.wal_config.get_mooncake_table_id(),
+            )
+        })
         .collect::<Vec<String>>();
     for file_name in file_names {
         assert!(!wal_filesystem_accessor

--- a/src/moonlink_connectors/src/pg_replicate/table_init.rs
+++ b/src/moonlink_connectors/src/pg_replicate/table_init.rs
@@ -100,8 +100,11 @@ pub async fn build_table_components(
 
     let wal_persistence_metadata = {
         if is_recovery {
-            let recovered_wal_metadata =
-                WalManager::recover_from_persistent_wal_metadata(wal_file_accessor.clone()).await;
+            let recovered_wal_metadata = WalManager::recover_from_persistent_wal_metadata(
+                wal_file_accessor.clone(),
+                wal_config.clone(),
+            )
+            .await;
             recovered_wal_metadata
         } else {
             None
@@ -112,6 +115,7 @@ pub async fn build_table_components(
         WalManager::from_persistent_wal_metadata(
             wal_file_accessor.clone(),
             wal_persistence_metadata,
+            wal_config.clone(),
         )
     } else {
         WalManager::new(&wal_config)


### PR DESCRIPTION
## Summary

Refactoring to use WalConfig and to make any reads / writes in testing go through the wal file system accessor instead of directly using the file system.  

## Related Issues

#974 

## Checklist

- [X ] Code builds correctly
- [ X] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
