### PR TITLE
Refine moonlink_connectors errors with new error structure.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4318,6 +4318,7 @@ dependencies = [
  "futures",
  "iceberg",
  "moonlink",
+ "moonlink_error",
  "num-traits",
  "pg_escape",
  "pin-project-lite",

--- a/src/moonlink_connectors/Cargo.toml
+++ b/src/moonlink_connectors/Cargo.toml
@@ -21,6 +21,7 @@ chrono = { workspace = true }
 chrono-tz = "0.8"
 futures = { workspace = true }
 moonlink = { path = "../moonlink" }
+moonlink_error = { path = "../moonlink_error" }
 num-traits = { workspace = true }
 pg_escape = "0.1"
 pin-project-lite = "0.2"

--- a/src/moonlink_connectors/src/error.rs
+++ b/src/moonlink_connectors/src/error.rs
@@ -2,6 +2,8 @@ use crate::pg_replicate::postgres_source::{
     CdcStreamError, PostgresSourceError, TableCopyStreamError,
 };
 use moonlink::Error as MoonlinkError;
+use moonlink_error::{ErrorStatus, ErrorStruct};
+use std::panic::Location;
 use std::result;
 use std::sync::Arc;
 use thiserror::Error;
@@ -9,23 +11,23 @@ use tokio_postgres::Error as TokioPostgresError;
 
 #[derive(Clone, Debug, Error)]
 pub enum Error {
-    #[error("Postgres source error: {source}")]
-    PostgresSourceError { source: Arc<PostgresSourceError> },
+    #[error("{0}")]
+    PostgresSourceError(ErrorStruct),
 
-    #[error("tokio postgres error: {source}")]
-    TokioPostgres { source: Arc<TokioPostgresError> },
+    #[error("{0}")]
+    TokioPostgres(ErrorStruct),
 
-    #[error("Postgres cdc stream error: {source}")]
-    CdcStream { source: Arc<CdcStreamError> },
+    #[error("{0}")]
+    CdcStream(ErrorStruct),
 
-    #[error("Table copy stream error: {source}")]
-    TableCopyStream { source: Arc<TableCopyStreamError> },
+    #[error("{0}")]
+    TableCopyStream(ErrorStruct),
 
-    #[error("Moonlink source error: {source}")]
-    MoonlinkError { source: MoonlinkError },
+    #[error("{0}")]
+    MoonlinkError(ErrorStruct),
 
-    #[error("IO error: {source}")]
-    Io { source: Arc<std::io::Error> },
+    #[error("{0}")]
+    Io(ErrorStruct),
 
     // Requested database table not found.
     #[error("Table {0} not found")]
@@ -43,55 +45,100 @@ pub enum Error {
 pub type Result<T> = result::Result<T, Error>;
 
 impl From<MoonlinkError> for Error {
+    #[track_caller]
     fn from(source: MoonlinkError) -> Self {
-        Error::MoonlinkError { source }
+        Error::MoonlinkError(ErrorStruct {
+            message: format!("Moonlink source error: {source}"),
+            status: ErrorStatus::Permanent,
+            source: Some(Arc::new(source.into())),
+            location: Some(Location::caller()),
+        })
     }
 }
 
 impl From<PostgresSourceError> for Error {
+    #[track_caller]
     fn from(source: PostgresSourceError) -> Self {
-        Error::PostgresSourceError {
-            source: Arc::new(source),
-        }
+        Error::PostgresSourceError(ErrorStruct {
+            message: format!("Postgres source error: {source}"),
+            status: ErrorStatus::Permanent,
+            source: Some(Arc::new(source.into())),
+            location: Some(Location::caller()),
+        })
     }
 }
 
 impl From<TokioPostgresError> for Error {
+    #[track_caller]
     fn from(source: TokioPostgresError) -> Self {
-        Error::TokioPostgres {
-            source: Arc::new(source),
-        }
+        Error::TokioPostgres(ErrorStruct {
+            message: format!("tokio postgres error: {source}"),
+            status: ErrorStatus::Permanent,
+            source: Some(Arc::new(source.into())),
+            location: Some(Location::caller()),
+        })
     }
 }
 
 impl From<CdcStreamError> for Error {
+    #[track_caller]
     fn from(source: CdcStreamError) -> Self {
-        Error::CdcStream {
-            source: Arc::new(source),
-        }
+        Error::CdcStream(ErrorStruct {
+            message: format!("Postgres cdc stream error: {source}"),
+            status: ErrorStatus::Permanent,
+            source: Some(Arc::new(source.into())),
+            location: Some(Location::caller()),
+        })
     }
 }
 
 impl From<TableCopyStreamError> for Error {
+    #[track_caller]
     fn from(source: TableCopyStreamError) -> Self {
-        Error::TableCopyStream {
-            source: Arc::new(source),
-        }
+        Error::TableCopyStream(ErrorStruct {
+            message: format!("Table copy stream error: {source}"),
+            status: ErrorStatus::Permanent,
+            source: Some(Arc::new(source.into())),
+            location: Some(Location::caller()),
+        })
     }
 }
 
 impl From<std::io::Error> for Error {
+    #[track_caller]
     fn from(source: std::io::Error) -> Self {
-        Error::Io {
-            source: Arc::new(source),
-        }
+        let status = match source.kind() {
+            std::io::ErrorKind::TimedOut
+            | std::io::ErrorKind::Interrupted
+            | std::io::ErrorKind::WouldBlock
+            | std::io::ErrorKind::ConnectionRefused
+            | std::io::ErrorKind::ConnectionAborted
+            | std::io::ErrorKind::ConnectionReset
+            | std::io::ErrorKind::BrokenPipe
+            | std::io::ErrorKind::NetworkDown
+            | std::io::ErrorKind::ResourceBusy
+            | std::io::ErrorKind::QuotaExceeded => ErrorStatus::Temporary,
+
+            _ => ErrorStatus::Permanent,
+        };
+
+        Error::Io(ErrorStruct {
+            message: format!("IO error: {source}"),
+            status,
+            source: Some(Arc::new(source.into())),
+            location: Some(Location::caller()),
+        })
     }
 }
 
 impl<T> From<tokio::sync::mpsc::error::SendError<T>> for Error {
+    #[track_caller]
     fn from(err: tokio::sync::mpsc::error::SendError<T>) -> Self {
-        Error::Io {
-            source: Arc::new(std::io::Error::other(format!("Channel send error: {err}"))),
-        }
+        Error::Io(ErrorStruct {
+            message: format!("Channel send error: {err}"),
+            status: ErrorStatus::Permanent,
+            source: None,
+            location: Some(Location::caller()),
+        })
     }
 }

--- a/src/moonlink_connectors/src/pg_replicate/initial_copy.rs
+++ b/src/moonlink_connectors/src/pg_replicate/initial_copy.rs
@@ -95,9 +95,12 @@ where
 /// Tests for the initial copy functionality
 #[cfg(test)]
 mod tests {
+    use std::panic::Location;
+
     use super::*;
     use crate::pg_replicate::table::{ColumnSchema, LookupKey, TableName};
     use futures::stream;
+    use moonlink_error::ErrorStruct;
     use tokio::sync::mpsc;
     use tokio::time::{timeout, Duration};
     use tokio_postgres::types::Type;
@@ -126,11 +129,15 @@ mod tests {
 
     /// Create a simple test error for testing error propagation
     fn make_test_error() -> crate::Error {
-        crate::Error::PostgresSourceError {
-            source: Arc::new(
-                crate::pg_replicate::postgres_source::PostgresSourceError::MissingPublication,
-            ),
-        }
+        crate::Error::PostgresSourceError(ErrorStruct {
+            message: "test error".to_string(),
+            status: moonlink_error::ErrorStatus::Permanent,
+            source: Some(Arc::new(
+                crate::pg_replicate::postgres_source::PostgresSourceError::MissingPublication
+                    .into(),
+            )),
+            location: Some(Location::caller()),
+        })
     }
 
     //----------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Apply ErrorStruct to error types in moonlink_connectors.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1458

## Changes
 - Apply ErrorStruct to error types in moonlink_service and implement proper error conversion

## Checklist

- [✓] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [✓] I have reviewed my own changes
