### PR TITLE
Include unsupported type in conversion failure

### DIFF
--- a/src/moonlink_connectors/src/pg_replicate/conversions/text.rs
+++ b/src/moonlink_connectors/src/pg_replicate/conversions/text.rs
@@ -16,7 +16,7 @@ use super::{bool::ParseBoolError, hex::ByteaHexParseError, numeric::PgNumeric, A
 
 #[derive(Debug, Error)]
 pub enum FromTextError {
-    #[error("invalid text conversion, Unsupported type: {0}")]
+    #[error("invalid text conversion, unsupported type: {0}")]
     InvalidConversion(String),
 
     #[error("invalid bool value")]
@@ -358,13 +358,13 @@ impl TextFormatConverter {
                                 "multi-dimensional arrays"
                             )))
                         }
-                        other => Err(FromTextError::InvalidConversion(format!(
+                        _ => Err(FromTextError::InvalidConversion(format!(
                             "Array<{:?}>",
-                            other
+                            inner_type
                         ))),
                     }
                 }
-                other => Err(FromTextError::InvalidConversion(format!("{:?}", other))),
+                _ => Err(FromTextError::InvalidConversion(format!("{:?}", typ))),
             },
         }
     }
@@ -1063,7 +1063,7 @@ mod tests {
     fn test_composite_parse_errors() {
         use tokio_postgres::types::Field;
 
-        let fields = vec![
+        let mut fields = vec![
             Field::new("id".to_string(), Type::INT4),
             Field::new("name".to_string(), Type::TEXT),
         ];

--- a/src/moonlink_connectors/src/pg_replicate/conversions/text.rs
+++ b/src/moonlink_connectors/src/pg_replicate/conversions/text.rs
@@ -344,23 +344,18 @@ impl TextFormatConverter {
             }
             _ => match typ.kind() {
                 Kind::Composite(fields) => TextFormatConverter::parse_composite(str, fields),
-                Kind::Array(inner_type) => {
+                Kind::Array(typ) => {
                     // Check if the array contains composite types.
                     // PostgreSQL supports multi-dimensional arrays (e.g., int[][], text[][]),
                     // but here we currently only handle arrays of composite types.
-                    match inner_type.kind() {
+                    match typ.kind() {
                         Kind::Composite(fields) => {
                             TextFormatConverter::parse_composite_array(str, fields)
                         }
-                        Kind::Array(_) => {
-                            // TODO: Multi-dimensional arrays not yet implemented
-                            Err(FromTextError::InvalidConversion(format!(
-                                "multi-dimensional arrays"
-                            )))
-                        }
+                        // TODO: Multi-dimensional arrays not yet implemented
                         _ => Err(FromTextError::InvalidConversion(format!(
                             "Array<{:?}>",
-                            inner_type
+                            typ
                         ))),
                     }
                 }
@@ -1063,7 +1058,7 @@ mod tests {
     fn test_composite_parse_errors() {
         use tokio_postgres::types::Field;
 
-        let mut fields = vec![
+        let fields = vec![
             Field::new("id".to_string(), Type::INT4),
             Field::new("name".to_string(), Type::TEXT),
         ];

--- a/src/moonlink_connectors/src/pg_replicate/conversions/text.rs
+++ b/src/moonlink_connectors/src/pg_replicate/conversions/text.rs
@@ -1,5 +1,8 @@
 use core::str;
-use std::num::{ParseFloatError, ParseIntError};
+use std::{
+    fmt::format,
+    num::{ParseFloatError, ParseIntError},
+};
 
 use bigdecimal::ParseBigDecimalError;
 use chrono::{DateTime, FixedOffset, NaiveDate, NaiveDateTime, NaiveTime, Utc};
@@ -13,8 +16,8 @@ use super::{bool::ParseBoolError, hex::ByteaHexParseError, numeric::PgNumeric, A
 
 #[derive(Debug, Error)]
 pub enum FromTextError {
-    #[error("invalid text conversion")]
-    InvalidConversion(),
+    #[error("invalid text conversion, Unsupported type: {0}")]
+    InvalidConversion(String),
 
     #[error("invalid bool value")]
     InvalidBool(#[from] ParseBoolError),
@@ -351,13 +354,17 @@ impl TextFormatConverter {
                         }
                         Kind::Array(_) => {
                             // TODO: Multi-dimensional arrays not yet implemented
-                            // TODO: Need to print out the unsupported type (included in error type)
-                            Err(FromTextError::InvalidConversion())
+                            Err(FromTextError::InvalidConversion(format!(
+                                "multi-dimensional arrays"
+                            )))
                         }
-                        _ => Err(FromTextError::InvalidConversion()),
+                        other => Err(FromTextError::InvalidConversion(format!(
+                            "Array<{:?}>",
+                            other
+                        ))),
                     }
                 }
-                _ => Err(FromTextError::InvalidConversion()),
+                other => Err(FromTextError::InvalidConversion(format!("{:?}", other))),
             },
         }
     }

--- a/src/moonlink_connectors/src/pg_replicate/conversions/text.rs
+++ b/src/moonlink_connectors/src/pg_replicate/conversions/text.rs
@@ -354,7 +354,7 @@ impl TextFormatConverter {
                         }
                         // TODO: Multi-dimensional arrays not yet implemented
                         _ => Err(FromTextError::InvalidConversion(format!(
-                            "{} with inner type: {}>",
+                            "{} with inner type: {}",
                             typ, inner_type
                         ))),
                     }

--- a/src/moonlink_connectors/src/pg_replicate/conversions/text.rs
+++ b/src/moonlink_connectors/src/pg_replicate/conversions/text.rs
@@ -344,18 +344,18 @@ impl TextFormatConverter {
             }
             _ => match typ.kind() {
                 Kind::Composite(fields) => TextFormatConverter::parse_composite(str, fields),
-                Kind::Array(typ) => {
+                Kind::Array(inner_type) => {
                     // Check if the array contains composite types.
                     // PostgreSQL supports multi-dimensional arrays (e.g., int[][], text[][]),
                     // but here we currently only handle arrays of composite types.
-                    match typ.kind() {
+                    match inner_type.kind() {
                         Kind::Composite(fields) => {
                             TextFormatConverter::parse_composite_array(str, fields)
                         }
                         // TODO: Multi-dimensional arrays not yet implemented
                         _ => Err(FromTextError::InvalidConversion(format!(
-                            "Array<{:?}>",
-                            typ
+                            "{} with inner type: {}>",
+                            typ, inner_type
                         ))),
                     }
                 }


### PR DESCRIPTION
## Summary
Change error message format from
`#[error("invalid text conversion")]`
to
`#[error("invalid text conversion, Unsupported type: {0}")]`.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1489

## Checklist

- [✓] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [✓] I have reviewed my own changes
