### PR TITLE
[chaos] Validate chaos choices

### DIFF
--- a/src/moonlink/src/table_handler/chaos_test.rs
+++ b/src/moonlink/src/table_handler/chaos_test.rs
@@ -577,6 +577,7 @@ impl ChaosState {
             choices.push(EventKind::EndWithFlush);
             choices.push(EventKind::EndNoFlush);
         }
+        assert!(!choices.is_empty());
 
         match *choices.choose(&mut self.rng).unwrap() {
             EventKind::ReadSnapshot => {


### PR DESCRIPTION
## Summary

We have mysterious stalls in chaos test, add assertion to make sure chaos test always generate events.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1505

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
