### PR TITLE
snapshot read: avoid unwrap potential IO error

### DIFF
--- a/src/moonlink/src/storage/mooncake_table/data_file_state_tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/data_file_state_tests.rs
@@ -268,7 +268,8 @@ async fn prepare_state_3(
         let snapshot_read_output = perform_read_request_for_test(&mut table).await;
         let read_state = snapshot_read_output
             .take_as_read_state(get_read_state_filepath_remap())
-            .await;
+            .await
+            .unwrap();
 
         // Persist.
         create_mooncake_and_persist_for_test(&mut table, &mut table_notify).await;
@@ -299,7 +300,8 @@ async fn prepare_state_3(
     let snapshot_read_output = perform_read_request_for_test(&mut table).await;
     let read_state = snapshot_read_output
         .take_as_read_state(get_read_state_filepath_remap())
-        .await;
+        .await
+        .unwrap();
 
     (table, table_notify, read_state)
 }
@@ -320,7 +322,8 @@ async fn prepare_state_4(
     let snapshot_read_output = perform_read_request_for_test(&mut table).await;
     let read_state = snapshot_read_output
         .take_as_read_state(get_read_state_filepath_remap())
-        .await;
+        .await
+        .unwrap();
 
     (table, table_notify, read_state)
 }
@@ -1138,14 +1141,16 @@ async fn test_2_read_and_unpinned_2_without_local_optimization(#[case] use_batch
     let snapshot_read_output_1 = perform_read_request_for_test(&mut table).await;
     let read_state_1 = snapshot_read_output_1
         .take_as_read_state(get_read_state_filepath_remap())
-        .await;
+        .await
+        .unwrap();
     // Till now, the state is (remote, no local, in use).
 
     // Read, but no reference count hold within read state.
     let snapshot_read_output_2 = perform_read_request_for_test(&mut table).await;
     let read_state_2 = snapshot_read_output_2
         .take_as_read_state(get_read_state_filepath_remap())
-        .await;
+        .await
+        .unwrap();
 
     // Check data file has been recorded in mooncake table.
     let data_file_id = get_only_remote_data_file_id(&table, &temp_dir).await;
@@ -1193,14 +1198,16 @@ async fn test_2_read_and_unpinned_2_with_local_optimization(#[case] use_batch_wr
     let snapshot_read_output_1 = perform_read_request_for_test(&mut table).await;
     let read_state_1 = snapshot_read_output_1
         .take_as_read_state(get_read_state_filepath_remap())
-        .await;
+        .await
+        .unwrap();
     // Till now, the state is (remote, no local, in use).
 
     // Read, but no reference count hold within read state.
     let snapshot_read_output_2 = perform_read_request_for_test(&mut table).await;
     let read_state_2 = snapshot_read_output_2
         .take_as_read_state(get_read_state_filepath_remap())
-        .await;
+        .await
+        .unwrap();
 
     // Check data file has been recorded in mooncake table.
     let data_file_id = get_only_remote_data_file_id(&table, &temp_dir).await;
@@ -1247,7 +1254,8 @@ async fn test_2_read_over_1_without_local_optimization(#[case] use_batch_write: 
     let snapshot_read_output = perform_read_request_for_test(&mut table).await;
     let read_state = snapshot_read_output
         .take_as_read_state(get_read_state_filepath_remap())
-        .await;
+        .await
+        .unwrap();
     // Till now, the state is (remote, no local, in use).
     drop(read_state);
 
@@ -1284,7 +1292,8 @@ async fn test_2_read_over_1_with_local_optimization(#[case] use_batch_write: boo
     let snapshot_read_output = perform_read_request_for_test(&mut table).await;
     let read_state = snapshot_read_output
         .take_as_read_state(get_read_state_filepath_remap())
-        .await;
+        .await
+        .unwrap();
     // Till now, the state is (remote, no local, in use).
     drop(read_state);
 
@@ -1381,7 +1390,8 @@ async fn test_3_compact_3_5_without_local_filesystem_optimization() {
     let snapshot_read_output = perform_read_request_for_test(&mut table).await;
     let read_state = snapshot_read_output
         .take_as_read_state(get_read_state_filepath_remap())
-        .await;
+        .await
+        .unwrap();
 
     // Persist and reflect result to mooncake snapshot.
     create_mooncake_and_persist_for_test(&mut table, &mut table_notify).await;
@@ -1490,7 +1500,8 @@ async fn test_3_compact_3_5_with_local_filesystem_optimization() {
     let snapshot_read_output = perform_read_request_for_test(&mut table).await;
     let read_state = snapshot_read_output
         .take_as_read_state(get_read_state_filepath_remap())
-        .await;
+        .await
+        .unwrap();
 
     // Persist and reflect result to mooncake snapshot.
     create_mooncake_and_persist_for_test(&mut table, &mut table_notify).await;
@@ -1602,7 +1613,8 @@ async fn test_3_compact_1_5_without_local_filesystem_optimization() {
     let snapshot_read_output = perform_read_request_for_test(&mut table).await;
     let read_state = snapshot_read_output
         .take_as_read_state(get_read_state_filepath_remap())
-        .await;
+        .await
+        .unwrap();
 
     // Persist and reflect result to mooncake snapshot.
     create_mooncake_and_persist_for_test(&mut table, &mut table_notify).await;
@@ -1684,7 +1696,8 @@ async fn test_3_compact_1_5_with_local_filesystem_optimization() {
     let snapshot_read_output = perform_read_request_for_test(&mut table).await;
     let read_state = snapshot_read_output
         .take_as_read_state(get_read_state_filepath_remap())
-        .await;
+        .await
+        .unwrap();
 
     // Persist and reflect result to mooncake snapshot.
     create_mooncake_and_persist_for_test(&mut table, &mut table_notify).await;

--- a/src/moonlink/src/storage/mooncake_table/deletion_vector_puffin_state_tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/deletion_vector_puffin_state_tests.rs
@@ -320,7 +320,8 @@ async fn test_2_read_without_local_optimization(#[case] use_batch_write: bool) {
     let snapshot_read_output = perform_read_request_for_test(&mut table).await;
     let read_state = snapshot_read_output
         .take_as_read_state(get_read_state_filepath_remap())
-        .await;
+        .await
+        .unwrap();
 
     // Check data file has been pinned in mooncake table.
     let puffin_blob_ref = get_only_puffin_blob_ref_from_table(&table).await;
@@ -376,7 +377,8 @@ async fn test_2_read_with_local_optimization(#[case] use_batch_write: bool) {
     let snapshot_read_output = perform_read_request_for_test(&mut table).await;
     let read_state = snapshot_read_output
         .take_as_read_state(get_read_state_filepath_remap())
-        .await;
+        .await
+        .unwrap();
 
     // Check data file has been pinned in mooncake table.
     let puffin_blob_ref = get_only_puffin_blob_ref_from_table(&table).await;

--- a/src/moonlink/src/storage/mooncake_table/snapshot_read_output.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot_read_output.rs
@@ -6,7 +6,7 @@ use crate::storage::PuffinDeletionBlobAtRead;
 use crate::table_notify::EvictedFiles;
 use crate::table_notify::TableEvent;
 use crate::ReadStateFilepathRemap;
-use crate::{NonEvictableHandle, ReadState};
+use crate::{NonEvictableHandle, ReadState, Result};
 
 use std::sync::Arc;
 
@@ -63,7 +63,7 @@ impl ReadOutput {
     pub async fn take_as_read_state(
         mut self,
         read_state_filepath_remap: ReadStateFilepathRemap,
-    ) -> Arc<ReadState> {
+    ) -> Result<Arc<ReadState>> {
         // Resolve remote data files.
         let mut resolved_data_files = Vec::with_capacity(self.data_file_paths.len());
         let mut cache_handles = vec![];
@@ -71,7 +71,6 @@ impl ReadOutput {
             match cur_data_file {
                 DataFileForRead::TemporaryDataFile(file) => resolved_data_files.push(file),
                 DataFileForRead::RemoteFilePath((file_id, remote_filepath)) => {
-                    // TODO(hjiang): Better error propagation.
                     let (cache_handle, files_to_delete) = self
                         .object_storage_cache
                         .as_mut()
@@ -81,8 +80,7 @@ impl ReadOutput {
                             &remote_filepath,
                             self.filesystem_accessor.as_ref().unwrap().as_ref(),
                         )
-                        .await
-                        .unwrap();
+                        .await?;
                     if let Some(cache_handle) = cache_handle {
                         resolved_data_files.push(cache_handle.get_cache_filepath().to_string());
                         cache_handles.push(cache_handle);
@@ -107,7 +105,7 @@ impl ReadOutput {
         }
 
         // Construct read state.
-        Arc::new(ReadState::new(
+        Ok(Arc::new(ReadState::new(
             // Data file and positional deletes for query.
             resolved_data_files,
             self.puffin_cache_handles,
@@ -117,6 +115,6 @@ impl ReadOutput {
             self.associated_files,
             cache_handles,
             read_state_filepath_remap,
-        ))
+        )))
     }
 }

--- a/src/moonlink/src/union_read/read_state_manager.rs
+++ b/src/moonlink/src/union_read/read_state_manager.rs
@@ -1,5 +1,4 @@
-use crate::error::Error;
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::storage::MooncakeTable;
 use crate::storage::SnapshotTableState;
 use crate::ReadState;
@@ -177,7 +176,7 @@ impl ReadStateManager {
             self.last_read_lsn.store(effective_lsn, Ordering::Release);
             *last_read_state_guard = snapshot_read_output
                 .take_as_read_state(self.read_state_filepath_remap.clone())
-                .await;
+                .await?;
         }
         Ok(last_read_state_guard.clone())
     }


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

https://github.com/Mooncake-Labs/moonlink/blob/6437db10c8b191d2b4553fbc5216e1e944c3307f/src/moonlink/src/storage/mooncake_table/snapshot_read_output.rs#L74-L85

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1488

## Changes

- return Result instead of unwrap and panic if IO error happened.

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [x] Documentation updated if necessary
- [x] I have reviewed my own changes
