### PR TITLE
[storage] Propagate iceberg error

### DIFF
--- a/src/moonlink/src/storage/iceberg/iceberg_schema_manager.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_schema_manager.rs
@@ -1,8 +1,8 @@
 use crate::storage::iceberg::iceberg_table_manager::*;
 use crate::storage::mooncake_table::TableMetadata as MooncakeTableMetadata;
+use crate::Result;
 
 use iceberg::arrow as IcebergArrow;
-use iceberg::Result as IcebergResult;
 
 use std::sync::Arc;
 
@@ -10,7 +10,7 @@ impl IcebergTableManager {
     pub(super) async fn alter_table_schema_impl(
         &mut self,
         updated_table_metadata: Arc<MooncakeTableMetadata>,
-    ) -> IcebergResult<()> {
+    ) -> Result<()> {
         // Initialize iceberg table on access.
         self.initialize_iceberg_table_for_once().await?;
 

--- a/src/moonlink/src/storage/iceberg/iceberg_table_loader.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_loader.rs
@@ -14,6 +14,7 @@ use crate::storage::mooncake_table::delete_vector::BatchDeletionVector;
 use crate::storage::mooncake_table::DiskFileEntry;
 use crate::storage::mooncake_table::Snapshot as MooncakeSnapshot;
 use crate::storage::storage_utils::{create_data_file, FileId, TableId, TableUniqueFileId};
+use crate::Result;
 
 use std::collections::{HashMap, HashSet};
 use std::vec;
@@ -220,7 +221,7 @@ impl IcebergTableManager {
 
     pub(crate) async fn load_snapshot_from_table_impl(
         &mut self,
-    ) -> IcebergResult<(u32, MooncakeSnapshot)> {
+    ) -> Result<(u32, MooncakeSnapshot)> {
         assert!(!self.snapshot_loaded);
         self.snapshot_loaded = true;
 

--- a/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
@@ -11,6 +11,7 @@ use crate::storage::mooncake_table::IcebergSnapshotPayload;
 use crate::storage::mooncake_table::Snapshot as MooncakeSnapshot;
 use crate::storage::mooncake_table::TableMetadata as MooncakeTableMetadata;
 use crate::storage::storage_utils::FileId;
+use crate::Result;
 use crate::{IcebergTableConfig, ObjectStorageCache};
 
 use std::collections::HashMap;
@@ -193,7 +194,7 @@ impl TableManager for IcebergTableManager {
         &mut self,
         mut snapshot_payload: IcebergSnapshotPayload,
         file_params: PersistenceFileParams,
-    ) -> IcebergResult<PersistenceResult> {
+    ) -> Result<PersistenceResult> {
         // Persist data files, deletion vectors, and file indices.
         let new_table_schema = std::mem::take(&mut snapshot_payload.new_table_schema);
         let persistence_result = self
@@ -207,15 +208,17 @@ impl TableManager for IcebergTableManager {
         Ok(persistence_result)
     }
 
-    async fn load_snapshot_from_table(&mut self) -> IcebergResult<(u32, MooncakeSnapshot)> {
-        self.load_snapshot_from_table_impl().await
+    async fn load_snapshot_from_table(&mut self) -> Result<(u32, MooncakeSnapshot)> {
+        let snapshot = self.load_snapshot_from_table_impl().await?;
+        Ok(snapshot)
     }
 
-    async fn drop_table(&mut self) -> IcebergResult<()> {
+    async fn drop_table(&mut self) -> Result<()> {
         let table_ident = TableIdent::new(
             NamespaceIdent::from_strs(&self.config.namespace).unwrap(),
             self.config.table_name.clone(),
         );
-        self.catalog.drop_table(&table_ident).await
+        self.catalog.drop_table(&table_ident).await?;
+        Ok(())
     }
 }

--- a/src/moonlink/src/storage/iceberg/iceberg_table_syncer.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_syncer.rs
@@ -27,6 +27,7 @@ use crate::storage::storage_utils::{
     TableUniqueFileId,
 };
 use crate::storage::{io_utils, storage_utils};
+use crate::Result;
 
 use std::collections::{HashMap, HashSet};
 use std::vec;
@@ -523,7 +524,7 @@ impl IcebergTableManager {
         &mut self,
         mut snapshot_payload: IcebergSnapshotPayload,
         file_params: PersistenceFileParams,
-    ) -> IcebergResult<PersistenceResult> {
+    ) -> Result<PersistenceResult> {
         // Initialize iceberg table on access.
         self.initialize_iceberg_table_for_once().await?;
 

--- a/src/moonlink/src/storage/iceberg/table_manager.rs
+++ b/src/moonlink/src/storage/iceberg/table_manager.rs
@@ -7,9 +7,9 @@ use crate::storage::mooncake_table::IcebergSnapshotPayload;
 use crate::storage::mooncake_table::Snapshot as MooncakeSnapshot;
 use crate::storage::storage_utils::FileId;
 use crate::storage::storage_utils::MooncakeDataFileRef;
+use crate::Result;
 
 use async_trait::async_trait;
-use iceberg::Result as IcebergResult;
 
 #[cfg(test)]
 use mockall::*;
@@ -51,16 +51,16 @@ pub trait TableManager: Send {
         &mut self,
         snapshot_payload: IcebergSnapshotPayload,
         file_params: PersistenceFileParams,
-    ) -> IcebergResult<PersistenceResult>;
+    ) -> Result<PersistenceResult>;
 
     /// Load the latest snapshot from iceberg table, and return next file id for the current mooncake table.
     /// Notice this function is supposed to call **only once**.
     #[allow(async_fn_in_trait)]
     async fn load_snapshot_from_table(
         &mut self,
-    ) -> IcebergResult<(u32 /*next file id*/, MooncakeSnapshot)>;
+    ) -> Result<(u32 /*next file id*/, MooncakeSnapshot)>;
 
     /// Drop the current iceberg table.
     #[allow(async_fn_in_trait)]
-    async fn drop_table(&mut self) -> IcebergResult<()>;
+    async fn drop_table(&mut self) -> Result<()>;
 }

--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -1424,7 +1424,7 @@ impl MooncakeTable {
         if iceberg_persistence_res.is_err() {
             table_notify
                 .send(TableEvent::IcebergSnapshotResult {
-                    iceberg_snapshot_result: Err(iceberg_persistence_res.unwrap_err().into()),
+                    iceberg_snapshot_result: Err(iceberg_persistence_res.unwrap_err()),
                 })
                 .await
                 .unwrap();

--- a/src/moonlink/src/storage/mooncake_table/tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/tests.rs
@@ -11,6 +11,7 @@ use crate::storage::snapshot_options::SnapshotOption;
 use crate::storage::wal::test_utils::WAL_TEST_TABLE_ID;
 use crate::table_handler::table_handler_state::MaintenanceProcessStatus;
 use crate::table_handler::table_handler_state::TableHandlerState;
+use crate::Error;
 use crate::FileSystemAccessor;
 use crate::WalConfig;
 use iceberg::{Error as IcebergError, ErrorKind};
@@ -545,10 +546,10 @@ async fn test_snapshot_load_failure() {
         .times(1)
         .returning(|| {
             Box::pin(async move {
-                Err(IcebergError::new(
+                Err(Error::from(IcebergError::new(
                     ErrorKind::Unexpected,
                     "Intended error for unit test",
-                ))
+                )))
             })
         });
 
@@ -601,10 +602,10 @@ async fn test_snapshot_store_failure() {
         .times(1)
         .returning(|_, _| {
             Box::pin(async move {
-                Err(IcebergError::new(
+                Err(Error::from(IcebergError::new(
                     ErrorKind::Unexpected,
                     "Intended error for unit test",
-                ))
+                )))
             })
         });
 

--- a/src/moonlink/src/table_handler/failure_tests.rs
+++ b/src/moonlink/src/table_handler/failure_tests.rs
@@ -10,6 +10,7 @@ use crate::storage::wal::WalManager;
 use crate::storage::MockTableManager;
 use crate::storage::MooncakeTable;
 use crate::storage::PersistenceResult;
+use crate::Error;
 use crate::ObjectStorageCache;
 use crate::TableEventManager;
 use crate::WalConfig;
@@ -57,10 +58,10 @@ async fn test_iceberg_snapshot_failure_mock_test() {
         .times(1)
         .returning(|_, _| {
             Box::pin(async move {
-                Err(IcebergError::new(
+                Err(Error::from(IcebergError::new(
                     ErrorKind::Unexpected,
                     "Intended error for unit test",
-                ))
+                )))
             })
         });
 
@@ -129,10 +130,10 @@ async fn test_iceberg_drop_table_failure_mock_test() {
         .times(1)
         .returning(|| {
             Box::pin(async move {
-                Err(IcebergError::new(
+                Err(Error::from(IcebergError::new(
                     ErrorKind::Unexpected,
                     "Intended error for unit test",
-                ))
+                )))
             })
         });
 
@@ -219,10 +220,10 @@ async fn test_force_index_merge_with_failed_iceberg_persistence() {
         .times(1)
         .returning(|_, _| {
             Box::pin(async move {
-                Err(IcebergError::new(
+                Err(Error::from(IcebergError::new(
                     ErrorKind::Unexpected,
                     "Intended error for unit test",
-                ))
+                )))
             })
         });
 
@@ -327,10 +328,10 @@ async fn test_force_data_compaction_with_failed_iceberg_persistence() {
         .times(1)
         .returning(|_, _| {
             Box::pin(async move {
-                Err(IcebergError::new(
+                Err(Error::from(IcebergError::new(
                     ErrorKind::Unexpected,
                     "Intended error for unit test",
-                ))
+                )))
             })
         });
 
@@ -436,10 +437,10 @@ async fn test_force_full_compaction_with_failed_iceberg_persistence() {
         .times(1)
         .returning(|_, _| {
             Box::pin(async move {
-                Err(IcebergError::new(
+                Err(Error::from(IcebergError::new(
                     ErrorKind::Unexpected,
                     "Intended error for unit test",
-                ))
+                )))
             })
         });
 


### PR DESCRIPTION
## Summary

Current implementation is bad, because `IcebergError` itself doesn't contain any source, status and location information.
After this change, we should be able to get location at iceberg table loader and syncer level;
it's hard to use `Result` further down below, since iceberg trait requires `IcebergError` for a few interfaces.

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
