### PR TITLE
[storage] Fix iceberg error propagation

### DIFF
--- a/src/moonlink/src/error.rs
+++ b/src/moonlink/src/error.rs
@@ -27,10 +27,6 @@ pub enum Error {
     #[error("{0}")]
     IcebergError(ErrorStruct),
 
-    // TODO(hjiang): Improve error propagation.
-    #[error("Iceberg error: {0}")]
-    IcebergMessage(String),
-
     #[error("{0}")]
     OpenDal(ErrorStruct),
 
@@ -233,7 +229,7 @@ mod tests {
         if let Error::Io(ref inner) = io_error {
             let loc = inner.location.unwrap();
             assert_eq!(loc.file(), "src/moonlink/src/error.rs");
-            assert_eq!(loc.line(), 217);
+            assert_eq!(loc.line(), 213);
             assert_eq!(loc.column(), 9);
         }
     }

--- a/src/moonlink/src/storage/iceberg/mock_filesystem_test.rs
+++ b/src/moonlink/src/storage/iceberg/mock_filesystem_test.rs
@@ -7,6 +7,8 @@ use crate::storage::mooncake_table::table_creation_test_utils::*;
 use crate::Error;
 use crate::{ObjectStorageCache, TableManager};
 
+use iceberg::Error as IcebergError;
+
 use std::sync::Arc;
 
 /// Mock-based unit tests for iceberg table manager.
@@ -36,8 +38,9 @@ async fn test_failed_iceberg_table_manager_drop_table() {
         .times(1)
         .returning(|_| {
             Box::pin(async move {
-                Err(Error::IcebergMessage(String::from(
-                    "Failed to delete object",
+                Err(Error::from(IcebergError::new(
+                    iceberg::ErrorKind::Unexpected,
+                    "Intended error for unit test",
                 )))
             })
         });
@@ -55,8 +58,9 @@ async fn test_failed_recover_from_iceberg_table() {
         .times(1)
         .returning(|_| {
             Box::pin(async move {
-                Err(Error::IcebergMessage(String::from(
-                    "Failed to check object existence",
+                Err(Error::from(IcebergError::new(
+                    iceberg::ErrorKind::Unexpected,
+                    "Intended error for unit test",
                 )))
             })
         });

--- a/src/moonlink/src/table_handler.rs
+++ b/src/moonlink/src/table_handler.rs
@@ -17,7 +17,6 @@ use crate::storage::snapshot_options::SnapshotOption;
 use crate::storage::{io_utils, MooncakeTable};
 use crate::table_handler_timer::TableHandlerTimer;
 use crate::table_notify::TableEvent;
-use crate::Error;
 use tokio::sync::mpsc::{self, Receiver, Sender};
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
@@ -580,13 +579,10 @@ impl TableHandler {
                                 .update_iceberg_persisted_lsn(iceberg_flush_lsn, replication_lsn);
                         }
                         Err(e) => {
-                            let err = Err(Error::IcebergMessage(format!(
-                                "Failed to create iceberg snapshot: {e:?}"
-                            )));
                             if table_handler_state.has_pending_force_snapshot_request() {
                                 if let Err(send_err) = table_handler_state
                                     .force_snapshot_completion_tx
-                                    .send(Some(err.clone()))
+                                    .send(Some(Err(e.clone())))
                                 {
                                     error!(error = ?send_err, "failed to notify force snapshot, because receive end has closed channel");
                                 }


### PR DESCRIPTION
## Summary

This PR fixes error propagation from iceberg errors.
Before:
```sh
called `Result::unwrap()` on an `Err` value, location: Some(Location { file: "src/moonlink/src/storage/mooncake_table.rs", line: 1425, col: 87 }) })
```
After:
```sh
alled `Result::unwrap()` on an `Err` value: IcebergError(ErrorStruct { message: "Iceberg error: DataInvalid => helloworld", status: Permanent, source: Some(DataInvalid => helloworld), location: Some(Location { file: "src/moonlink/src/storage/iceberg/iceberg_table_syncer.rs", line: 529, col: 9 }) })
```
As you could tell, error source location is actually from iceberg syncer.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1487

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
