### PR TITLE
[storage] Set storage bloom filter for compacted files

### DIFF
--- a/src/moonlink/src/storage/compaction/compactor.rs
+++ b/src/moonlink/src/storage/compaction/compactor.rs
@@ -133,7 +133,7 @@ impl CompactionBuilder {
         self.cur_new_data_file = Some(self.create_new_data_file());
         let write_file =
             tokio::fs::File::create(self.cur_new_data_file.as_ref().unwrap().file_path()).await?;
-        let properties = parquet_utils::get_default_parquet_properties();
+        let properties = parquet_utils::get_parquet_properties_for_compaction();
         let writer: AsyncArrowWriter<tokio::fs::File> =
             AsyncArrowWriter::try_new(write_file, self.schema.clone(), Some(properties))?;
         self.cur_arrow_writer = Some(writer);

--- a/src/moonlink/src/storage/iceberg/compaction_tests.rs
+++ b/src/moonlink/src/storage/iceberg/compaction_tests.rs
@@ -93,7 +93,7 @@ fn get_data_compaction_config() -> DataCompactionConfig {
     DataCompactionConfig {
         min_data_file_to_compact: 2,
         max_data_file_to_compact: u32::MAX,
-        data_file_final_size: 1000000,
+        data_file_final_size: u64::MAX,
         data_file_deletion_percentage: 0,
     }
 }

--- a/src/moonlink/src/storage/mooncake_table/disk_slice.rs
+++ b/src/moonlink/src/storage/mooncake_table/disk_slice.rs
@@ -221,7 +221,7 @@ impl DiskSliceWriter {
             writer.as_mut().unwrap().write(batch).await?;
             let estimated_total_size = {
                 let cur_writer = writer.as_ref().unwrap();
-                cur_writer.in_progress_size() + cur_writer.bytes_written()
+                cur_writer.memory_size()
             };
             if estimated_total_size > self.disk_slice_writer_config.parquet_file_size {
                 // Finalize the writer

--- a/src/moonlink/src/storage/parquet_utils.rs
+++ b/src/moonlink/src/storage/parquet_utils.rs
@@ -24,7 +24,5 @@ pub(crate) fn get_default_parquet_properties() -> WriterProperties {
 /// Parquet option for already compacted files.
 pub(crate) fn get_parquet_properties_for_compaction() -> WriterProperties {
     let builder = get_default_parquet_properties_builder();
-    builder
-        .set_bloom_filter_enabled(true)
-        .build()
+    builder.set_bloom_filter_enabled(true).build()
 }

--- a/src/moonlink/src/storage/parquet_utils.rs
+++ b/src/moonlink/src/storage/parquet_utils.rs
@@ -8,9 +8,6 @@ const DEFAULT_COMPRESSION: Compression = parquet::basic::Compression::SNAPPY;
 /// Default row group size from duckdb.
 const DEFAULT_ROW_GROUP_SIZE: usize = 122880;
 
-/// Default false positive probability.
-const DEFAULT_BLOOM_FILTER_FPP: f64 = 0.01;
-
 fn get_default_parquet_properties_builder() -> WriterPropertiesBuilder {
     WriterProperties::builder()
         .set_compression(DEFAULT_COMPRESSION)
@@ -29,6 +26,5 @@ pub(crate) fn get_parquet_properties_for_compaction() -> WriterProperties {
     let builder = get_default_parquet_properties_builder();
     builder
         .set_bloom_filter_enabled(true)
-        .set_bloom_filter_fpp(DEFAULT_BLOOM_FILTER_FPP)
         .build()
 }

--- a/src/moonlink/src/storage/parquet_utils.rs
+++ b/src/moonlink/src/storage/parquet_utils.rs
@@ -1,17 +1,34 @@
 /// This module contains parquet related constants and utils.
-use parquet::{basic::Compression, file::properties::WriterProperties};
+use parquet::basic::Compression;
+use parquet::file::properties::{WriterProperties, WriterPropertiesBuilder};
 
 /// Default compression.
 const DEFAULT_COMPRESSION: Compression = parquet::basic::Compression::SNAPPY;
 
-// Default row group size from duckdb.
+/// Default row group size from duckdb.
 const DEFAULT_ROW_GROUP_SIZE: usize = 122880;
 
-pub(crate) fn get_default_parquet_properties() -> WriterProperties {
+/// Default false positive probability.
+const DEFAULT_BLOOM_FILTER_FPP: f64 = 0.01;
+
+fn get_default_parquet_properties_builder() -> WriterPropertiesBuilder {
     WriterProperties::builder()
         .set_compression(DEFAULT_COMPRESSION)
         .set_dictionary_enabled(true)
         .set_dictionary_page_size_limit(DEFAULT_ROW_GROUP_SIZE / 100)
         .set_writer_version(parquet::file::properties::WriterVersion::PARQUET_1_0)
+}
+
+pub(crate) fn get_default_parquet_properties() -> WriterProperties {
+    let builder = get_default_parquet_properties_builder();
+    builder.build()
+}
+
+/// Parquet option for already compacted files.
+pub(crate) fn get_parquet_properties_for_compaction() -> WriterProperties {
+    let builder = get_default_parquet_properties_builder();
+    builder
+        .set_bloom_filter_enabled(true)
+        .set_bloom_filter_fpp(DEFAULT_BLOOM_FILTER_FPP)
         .build()
 }


### PR DESCRIPTION
## Summary

This PR does two things:
- I found bloom filter affect file size A LOT; for example, for file row count <100, file size could increase from 100 byte to 6MB
- Fix estimated size into memory size, I found prev calculation doesn't account for bloom filter size

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1435
Closes https://github.com/Mooncake-Labs/moonlink/issues/525

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
