### PR TITLE
[storage] Set parquet fpp after compaction

### DIFF
--- a/src/moonlink/src/storage/parquet_utils.rs
+++ b/src/moonlink/src/storage/parquet_utils.rs
@@ -8,6 +8,9 @@ const DEFAULT_COMPRESSION: Compression = parquet::basic::Compression::SNAPPY;
 /// Default row group size from duckdb.
 const DEFAULT_ROW_GROUP_SIZE: usize = 122880;
 
+/// Default false positive probability (fpp).
+const DEFAULT_FPP: f64 = 0.01;
+
 fn get_default_parquet_properties_builder() -> WriterPropertiesBuilder {
     WriterProperties::builder()
         .set_compression(DEFAULT_COMPRESSION)
@@ -24,5 +27,8 @@ pub(crate) fn get_default_parquet_properties() -> WriterProperties {
 /// Parquet option for already compacted files.
 pub(crate) fn get_parquet_properties_for_compaction() -> WriterProperties {
     let builder = get_default_parquet_properties_builder();
-    builder.set_bloom_filter_enabled(true).build()
+    builder
+        .set_bloom_filter_enabled(true)
+        .set_bloom_filter_fpp(DEFAULT_FPP)
+        .build()
 }


### PR DESCRIPTION
## Summary

Use the same config as we use in pg_mooncake v0.1 and duckdb default.
https://github.com/Mooncake-Labs/pg_mooncake/blob/d68f1e5f023ba36e0810dbcf7d8deecc275eccc8/src/columnstore/columnstore_table.cpp#L66-L71

https://github.com/duckdb/duckdb/blob/v1.3.2/extension/parquet/parquet_extension.cpp#L232

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/525

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
