### PR TITLE
Attempt to fix blocked read

### DIFF
--- a/src/moonlink/src/union_read/read_state_manager.rs
+++ b/src/moonlink/src/union_read/read_state_manager.rs
@@ -226,7 +226,7 @@ mod tests {
             // Completely no updates for the snapshot.
             Case {
                 snapshot_lsn: NO_SNAPSHOT_LSN,
-                commit_lsn: 0,
+                commit_lsn: NO_COMMIT_LSN,
                 expected: true,
             },
             // All commits are sync-ed to the snapshot.


### PR DESCRIPTION
## Summary

Blocked SQL at pg_mooncake end:
```sql
CREATE EXTENSION pg_mooncake;
CREATE SCHEMA s1;
CREATE TABLE s1.r (a int primary key, b text);
CREATE SCHEMA s2;
CALL mooncake.create_table('s2.c', 's1.r');
SELECT * FROM s2.c; -- hang
```
The reason is when commit = 0 && snapshot = MAX, we consider snapshot unclean

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1527

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
