### PR TITLE
[chaos] Validate empty table

### DIFF
--- a/src/moonlink/src/table_handler/chaos_test.rs
+++ b/src/moonlink/src/table_handler/chaos_test.rs
@@ -981,6 +981,15 @@ async fn chaos_test_impl(mut env: TestEnvironment) {
             "Test {} is with random seed {}",
             test_env_config.test_name, state.random_seed
         );
+
+        // Attempt read on empty table.
+        check_read_snapshot(
+            &state.read_state_manager,
+            /*requested_read_lsn=*/ Some(0),
+            /*expected_ids=*/ &[],
+        )
+        .await;
+
         for _ in 0..test_env_config.event_count {
             let chaos_events = state.generate_random_events();
 


### PR DESCRIPTION
## Summary

Followup for https://github.com/Mooncake-Labs/moonlink/pull/1529, which validate query on empty table has no problem.

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
