### PR TITLE
[backend] Rename schema / table to database / table

### DIFF
--- a/src/moonlink_backend/src/lib.rs
+++ b/src/moonlink_backend/src/lib.rs
@@ -107,10 +107,18 @@ impl MoonlinkBackend {
 
     /// Create an iceberg snapshot with the given LSN, return when the a snapshot is successfully created.
     /// If the requested database or table doesn't exist, return [`TableNotFound`] error.
-    pub async fn create_snapshot(&self, schema: String, table: String, lsn: u64) -> Result<()> {
+    pub async fn create_snapshot(
+        &self,
+        mooncake_database: String,
+        mooncake_table: String,
+        lsn: u64,
+    ) -> Result<()> {
         let rx = {
             let mut manager = self.replication_manager.write().await;
-            let mooncake_table_id = MooncakeTableId { schema, table };
+            let mooncake_table_id = MooncakeTableId {
+                mooncake_database,
+                mooncake_table,
+            };
             let writer = manager.get_table_event_manager(&mooncake_table_id)?;
             writer.initiate_snapshot(lsn).await
         };
@@ -129,16 +137,16 @@ impl MoonlinkBackend {
     /// * table_config: json serialized table configuration.
     pub async fn create_table(
         &self,
-        schema: String,
-        table: String,
+        mooncake_database: String,
+        mooncake_table: String,
         src_table_name: String,
         src_uri: String,
         table_config: String,
         input_schema: Option<Schema>,
     ) -> Result<()> {
         let mooncake_table_id = MooncakeTableId {
-            schema: schema.clone(),
-            table: table.clone(),
+            mooncake_database: mooncake_database.clone(),
+            mooncake_table: mooncake_table.clone(),
         };
 
         // Add mooncake table to replication, and create corresponding mooncake table.
@@ -177,8 +185,8 @@ impl MoonlinkBackend {
         // Create metadata store entry.
         self.metadata_store_accessor
             .store_table_metadata(
-                &schema,
-                &table,
+                &mooncake_database,
+                &mooncake_table,
                 &src_table_name,
                 &src_uri,
                 moonlink_table_config,
@@ -188,8 +196,11 @@ impl MoonlinkBackend {
         Ok(())
     }
 
-    pub async fn drop_table(&self, schema: String, table: String) {
-        let mooncake_table_id = MooncakeTableId { schema, table };
+    pub async fn drop_table(&self, mooncake_database: String, mooncake_table: String) {
+        let mooncake_table_id = MooncakeTableId {
+            mooncake_database,
+            mooncake_table,
+        };
 
         let table_exists = {
             let mut manager = self.replication_manager.write().await;
@@ -200,7 +211,10 @@ impl MoonlinkBackend {
         }
 
         self.metadata_store_accessor
-            .delete_table_metadata(&mooncake_table_id.schema, &mooncake_table_id.table)
+            .delete_table_metadata(
+                &mooncake_table_id.mooncake_database,
+                &mooncake_table_id.mooncake_table,
+            )
             .await
             .unwrap()
     }
@@ -212,10 +226,17 @@ impl MoonlinkBackend {
 
     /// Get the current mooncake table schema.
     /// If the requested database or table doesn't exist, return [`TableNotFound`] error.
-    pub async fn get_table_schema(&self, schema: String, table: String) -> Result<Arc<Schema>> {
+    pub async fn get_table_schema(
+        &self,
+        mooncake_database: String,
+        mooncake_table: String,
+    ) -> Result<Arc<Schema>> {
         let table_schema = {
             let manager = self.replication_manager.read().await;
-            let mooncake_table_id = MooncakeTableId { schema, table };
+            let mooncake_table_id = MooncakeTableId {
+                mooncake_database,
+                mooncake_table,
+            };
             let table_state_reader = manager.get_table_state_reader(&mooncake_table_id)?;
             table_state_reader.get_current_table_schema().await?
         };
@@ -231,8 +252,8 @@ impl MoonlinkBackend {
             for cur_reader in cur_table_state_readers.iter() {
                 let table_snapshot_status = cur_reader.get_current_table_state().await?;
                 let table_status = TableStatus {
-                    schema: mooncake_table_id.schema.clone(),
-                    table: mooncake_table_id.table.clone(),
+                    schema: mooncake_table_id.mooncake_database.clone(),
+                    table: mooncake_table_id.mooncake_table.clone(),
                     commit_lsn: table_snapshot_status.commit_lsn,
                     flush_lsn: table_snapshot_status.flush_lsn,
                     iceberg_warehouse_location: table_snapshot_status.iceberg_warehouse_location,
@@ -250,10 +271,18 @@ impl MoonlinkBackend {
     /// - "data": perform a data compaction, only data files smaller than a threshold, or with too many deleted rows will be compacted.
     /// - "index": perform an index merge operation, only index files smaller than a threshold, or with too many deleted rows will be merged.    
     /// - "full": perform a full compaction, which merges all data files and all index files, whatever file size they are of.
-    pub async fn optimize_table(&self, schema: String, table: String, mode: &str) -> Result<()> {
+    pub async fn optimize_table(
+        &self,
+        mooncake_database: String,
+        mooncake_table: String,
+        mode: &str,
+    ) -> Result<()> {
         let mut rx = {
             let mut manager = self.replication_manager.write().await;
-            let mooncake_table_id = MooncakeTableId { schema, table };
+            let mooncake_table_id = MooncakeTableId {
+                mooncake_database,
+                mooncake_table,
+            };
             let writer = manager.get_table_event_manager(&mooncake_table_id)?;
 
             match mode {
@@ -275,13 +304,16 @@ impl MoonlinkBackend {
     /// If the requested database or table doesn't exist, return [`TableNotFound`] error.
     pub async fn scan_table(
         &self,
-        schema: String,
-        table: String,
+        mooncake_database: String,
+        mooncake_table: String,
         lsn: Option<u64>,
     ) -> Result<Arc<ReadState>> {
         let read_state = {
             let manager = self.replication_manager.read().await;
-            let mooncake_table_id = MooncakeTableId { schema, table };
+            let mooncake_table_id = MooncakeTableId {
+                mooncake_database,
+                mooncake_table,
+            };
             let table_reader = manager.get_table_reader(&mooncake_table_id)?;
             table_reader.try_read(lsn).await?
         };
@@ -292,9 +324,17 @@ impl MoonlinkBackend {
     /// Wait for the WAL flush LSN to reach the requested LSN. Note that WAL flush LSN will update
     /// up till the latest commit that has been persisted in to the WAL.
     #[cfg(feature = "test-utils")]
-    pub async fn wait_for_wal_flush(&self, schema: String, table: String, lsn: u64) -> Result<()> {
+    pub async fn wait_for_wal_flush(
+        &self,
+        mooncake_database: String,
+        mooncake_table: String,
+        lsn: u64,
+    ) -> Result<()> {
         let mut manager = self.replication_manager.write().await;
-        let mooncake_table_id = MooncakeTableId { schema, table };
+        let mooncake_table_id = MooncakeTableId {
+            mooncake_database,
+            mooncake_table,
+        };
         let writer = manager.get_table_event_manager(&mooncake_table_id)?;
 
         // Wait for WAL flush LSN to reach the requested LSN

--- a/src/moonlink_backend/src/lib.rs
+++ b/src/moonlink_backend/src/lib.rs
@@ -252,8 +252,8 @@ impl MoonlinkBackend {
             for cur_reader in cur_table_state_readers.iter() {
                 let table_snapshot_status = cur_reader.get_current_table_state().await?;
                 let table_status = TableStatus {
-                    schema: mooncake_table_id.mooncake_database.clone(),
-                    table: mooncake_table_id.mooncake_table.clone(),
+                    mooncake_database: mooncake_table_id.mooncake_database.clone(),
+                    mooncake_table: mooncake_table_id.mooncake_table.clone(),
                     commit_lsn: table_snapshot_status.commit_lsn,
                     flush_lsn: table_snapshot_status.flush_lsn,
                     iceberg_warehouse_location: table_snapshot_status.iceberg_warehouse_location,

--- a/src/moonlink_backend/src/mooncake_table_id.rs
+++ b/src/moonlink_backend/src/mooncake_table_id.rs
@@ -3,12 +3,12 @@ use std::hash::Hash;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct MooncakeTableId {
-    pub schema: String,
-    pub table: String,
+    pub mooncake_database: String,
+    pub mooncake_table: String,
 }
 
 impl Display for MooncakeTableId {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-        write!(f, "{}.{}", self.schema, self.table)
+        write!(f, "{}.{}", self.mooncake_database, self.mooncake_table)
     }
 }

--- a/src/moonlink_backend/src/recovery_utils.rs
+++ b/src/moonlink_backend/src/recovery_utils.rs
@@ -19,8 +19,8 @@ async fn recover_table(
     read_state_filepath_remap: ReadStateFilepathRemap,
 ) -> Result<()> {
     let mooncake_table_id = MooncakeTableId {
-        schema: metadata_entry.schema,
-        table: metadata_entry.table,
+        mooncake_database: metadata_entry.mooncake_database,
+        mooncake_table: metadata_entry.mooncake_table,
     };
     replication_manager
         .add_table(

--- a/src/moonlink_backend/src/table_status.rs
+++ b/src/moonlink_backend/src/table_status.rs
@@ -1,10 +1,10 @@
 /// Current table status.
 #[derive(Clone, Debug, PartialEq)]
 pub struct TableStatus {
-    /// Schema name.
-    pub schema: String,
-    /// Table name.
-    pub table: String,
+    /// Mooncake database name.
+    pub mooncake_database: String,
+    /// Mooncake table name.
+    pub mooncake_table: String,
     /// Mooncake table commit LSN.
     pub commit_lsn: u64,
     /// Iceberg flush LSN.

--- a/src/moonlink_backend/tests/test_backend.rs
+++ b/src/moonlink_backend/tests/test_backend.rs
@@ -7,7 +7,7 @@ mod tests {
     use super::common::{
         assert_scan_ids_eq, assert_scan_nonunique_ids_eq, crash_and_recover_backend,
         crash_and_recover_backend_with_guard, current_wal_lsn, smoke_create_and_insert, TestGuard,
-        TestGuardMode, SCHEMA, TABLE,
+        TestGuardMode, DATABASE, TABLE,
     };
     use moonlink_backend::table_status::TableStatus;
     use moonlink_metadata_store::{base_metadata_store::MetadataStoreTrait, SqliteMetadataStore};
@@ -30,7 +30,7 @@ mod tests {
         let backend = guard.backend();
         smoke_create_and_insert(guard.tmp().unwrap(), backend, &client, SRC_URI).await;
         backend
-            .drop_table(SCHEMA.to_string(), TABLE.to_string())
+            .drop_table(DATABASE.to_string(), TABLE.to_string())
             .await;
         smoke_create_and_insert(guard.tmp().unwrap(), backend, &client, SRC_URI).await;
     }
@@ -50,7 +50,7 @@ mod tests {
 
         let ids = ids_from_state(
             &backend
-                .scan_table(SCHEMA.to_string(), TABLE.to_string(), Some(lsn))
+                .scan_table(DATABASE.to_string(), TABLE.to_string(), Some(lsn))
                 .await
                 .unwrap(),
         );
@@ -65,7 +65,7 @@ mod tests {
 
         let ids = ids_from_state(
             &backend
-                .scan_table(SCHEMA.to_string(), TABLE.to_string(), Some(lsn))
+                .scan_table(DATABASE.to_string(), TABLE.to_string(), Some(lsn))
                 .await
                 .unwrap(),
         );
@@ -87,7 +87,7 @@ mod tests {
 
         let ids = ids_from_state(
             &backend
-                .scan_table(SCHEMA.to_string(), TABLE.to_string(), Some(lsn1))
+                .scan_table(DATABASE.to_string(), TABLE.to_string(), Some(lsn1))
                 .await
                 .unwrap(),
         );
@@ -101,7 +101,7 @@ mod tests {
 
         let ids = ids_from_state(
             &backend
-                .scan_table(SCHEMA.to_string(), TABLE.to_string(), Some(lsn2))
+                .scan_table(DATABASE.to_string(), TABLE.to_string(), Some(lsn2))
                 .await
                 .unwrap(),
         );
@@ -123,13 +123,13 @@ mod tests {
 
         // Read snapshot of the latest LSN to make sure all changes are synchronized to mooncake snapshot.
         backend
-            .scan_table(SCHEMA.to_string(), TABLE.to_string(), Some(lsn))
+            .scan_table(DATABASE.to_string(), TABLE.to_string(), Some(lsn))
             .await
             .unwrap();
 
         // After all changes reflected at mooncake snapshot, trigger an iceberg snapshot.
         backend
-            .create_snapshot(SCHEMA.to_string(), TABLE.to_string(), lsn)
+            .create_snapshot(DATABASE.to_string(), TABLE.to_string(), lsn)
             .await
             .unwrap();
 
@@ -139,7 +139,7 @@ mod tests {
             .unwrap()
             .path()
             .join("default")
-            .join(format!("{SCHEMA}.{TABLE}"))
+            .join(format!("{DATABASE}.{TABLE}"))
             .join("metadata");
         assert!(meta_dir.exists());
         assert!(meta_dir.read_dir().unwrap().next().is_some());
@@ -147,7 +147,7 @@ mod tests {
         // Check table status.
         let table_statuses = backend.list_tables().await.unwrap();
         let expected_table_status = TableStatus {
-            schema: SCHEMA.to_string(),
+            schema: DATABASE.to_string(),
             table: TABLE.to_string(),
             commit_lsn: lsn,
             flush_lsn: Some(lsn),
@@ -173,7 +173,7 @@ mod tests {
         let lsn = current_wal_lsn(&client).await;
         let ids = ids_from_state(
             &backend
-                .scan_table(SCHEMA.to_string(), TABLE.to_string(), Some(lsn))
+                .scan_table(DATABASE.to_string(), TABLE.to_string(), Some(lsn))
                 .await
                 .unwrap(),
         );
@@ -185,7 +185,7 @@ mod tests {
             .await
             .unwrap();
         backend
-            .drop_table(SCHEMA.to_string(), TABLE.to_string())
+            .drop_table(DATABASE.to_string(), TABLE.to_string())
             .await;
 
         // Second cycle: add table again, insert different data, verify it works
@@ -195,7 +195,7 @@ mod tests {
             .unwrap();
         backend
             .create_table(
-                SCHEMA.to_string(),
+                DATABASE.to_string(),
                 TABLE.to_string(),
                 /*table_name=*/ "public.repl_test".to_string(),
                 SRC_URI.to_string(),
@@ -213,7 +213,7 @@ mod tests {
         let lsn = current_wal_lsn(&client).await;
         let ids = ids_from_state(
             &backend
-                .scan_table(SCHEMA.to_string(), TABLE.to_string(), Some(lsn))
+                .scan_table(DATABASE.to_string(), TABLE.to_string(), Some(lsn))
                 .await
                 .unwrap(),
         );
@@ -242,7 +242,7 @@ mod tests {
         let ids = ids_from_state(
             &backend
                 .scan_table(
-                    SCHEMA.to_string(),
+                    DATABASE.to_string(),
                     TABLE.to_string(),
                     Some(lsn_after_insert),
                 )
@@ -274,19 +274,19 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(metadata_entries.len(), 1);
-        let table = &metadata_entries[0].table;
-        assert_eq!(table, TABLE);
+        let mooncake_table = &metadata_entries[0].mooncake_table;
+        assert_eq!(mooncake_table, TABLE);
         assert_eq!(
             metadata_entries[0]
                 .moonlink_table_config
                 .iceberg_table_config
                 .table_name,
-            format!("{SCHEMA}.{TABLE}")
+            format!("{DATABASE}.{TABLE}")
         );
 
         // Drop table and check metadata storage.
         backend
-            .drop_table(SCHEMA.to_string(), TABLE.to_string())
+            .drop_table(DATABASE.to_string(), TABLE.to_string())
             .await;
         let metadata_entries = metadata_store
             .get_all_table_metadata_entries()
@@ -305,13 +305,13 @@ mod tests {
 
         // Drop the table that setup_backend created so we can test the full cycle
         backend
-            .drop_table(SCHEMA.to_string(), TABLE.to_string())
+            .drop_table(DATABASE.to_string(), TABLE.to_string())
             .await;
 
         // First cycle: add table, insert data, verify it works
         backend
             .create_table(
-                SCHEMA.to_string(),
+                DATABASE.to_string(),
                 TABLE.to_string(),
                 "public.recovery".to_string(),
                 SRC_URI.to_string(),
@@ -329,17 +329,17 @@ mod tests {
 
         // Wait until changes reflected to mooncake snapshot, and force create iceberg snapshot to test mooncake/iceberg table recovery.
         backend
-            .scan_table(SCHEMA.to_string(), TABLE.to_string(), Some(lsn))
+            .scan_table(DATABASE.to_string(), TABLE.to_string(), Some(lsn))
             .await
             .unwrap();
         backend
-            .create_snapshot(SCHEMA.to_string(), TABLE.to_string(), lsn)
+            .create_snapshot(DATABASE.to_string(), TABLE.to_string(), lsn)
             .await
             .unwrap();
 
         let (backend, _testing_directory_before_recovery) =
             crash_and_recover_backend_with_guard(guard).await;
-        assert_scan_ids_eq(&backend, SCHEMA.to_string(), TABLE.to_string(), lsn, [1]).await;
+        assert_scan_ids_eq(&backend, DATABASE.to_string(), TABLE.to_string(), lsn, [1]).await;
 
         // Insert new rows to make sure recovered mooncake table works as usual.
         client
@@ -349,7 +349,14 @@ mod tests {
         let lsn = current_wal_lsn(&client).await;
 
         // Wait until changes reflected to mooncake snapshot, and force create iceberg snapshot to test mooncake/iceberg table recovery.
-        assert_scan_ids_eq(&backend, SCHEMA.to_string(), TABLE.to_string(), lsn, [1, 2]).await;
+        assert_scan_ids_eq(
+            &backend,
+            DATABASE.to_string(),
+            TABLE.to_string(),
+            lsn,
+            [1, 2],
+        )
+        .await;
     }
 
     /// Multiple failures and recovery from just the WAL
@@ -363,11 +370,11 @@ mod tests {
 
         // Drop the table that setup_backend created so we can test the full cycle
         backend
-            .drop_table(SCHEMA.to_string(), TABLE.to_string())
+            .drop_table(DATABASE.to_string(), TABLE.to_string())
             .await;
         backend
             .create_table(
-                SCHEMA.to_string(),
+                DATABASE.to_string(),
                 TABLE.to_string(),
                 "public.recovery".to_string(),
                 SRC_URI.to_string(),
@@ -386,13 +393,13 @@ mod tests {
         }
         let lsn = current_wal_lsn(&client).await;
         backend
-            .wait_for_wal_flush(SCHEMA.to_string(), TABLE.to_string(), lsn)
+            .wait_for_wal_flush(DATABASE.to_string(), TABLE.to_string(), lsn)
             .await
             .unwrap();
         let (backend, testing_directory) = crash_and_recover_backend_with_guard(guard).await;
         assert_scan_nonunique_ids_eq(
             &backend,
-            SCHEMA.to_string(),
+            DATABASE.to_string(),
             TABLE.to_string(),
             lsn,
             &(0..10).map(|i| (i, 1)).collect::<HashMap<_, _>>(),
@@ -407,7 +414,7 @@ mod tests {
         let lsn = current_wal_lsn(&client).await;
         assert_scan_nonunique_ids_eq(
             &backend,
-            SCHEMA.to_string(),
+            DATABASE.to_string(),
             TABLE.to_string(),
             lsn,
             &(0..11).map(|i| (i, 1)).collect::<HashMap<_, _>>(),
@@ -423,13 +430,13 @@ mod tests {
         }
         let lsn = current_wal_lsn(&client).await;
         backend
-            .wait_for_wal_flush(SCHEMA.to_string(), TABLE.to_string(), lsn)
+            .wait_for_wal_flush(DATABASE.to_string(), TABLE.to_string(), lsn)
             .await
             .unwrap();
         let backend = crash_and_recover_backend(backend, &testing_directory).await;
         assert_scan_nonunique_ids_eq(
             &backend,
-            SCHEMA.to_string(),
+            DATABASE.to_string(),
             TABLE.to_string(),
             lsn,
             &(0..20).map(|i| (i, 1)).collect::<HashMap<_, _>>(),
@@ -469,11 +476,11 @@ mod tests {
 
         // Drop the table that setup_backend created so we can test the full cycle
         backend
-            .drop_table(SCHEMA.to_string(), TABLE.to_string())
+            .drop_table(DATABASE.to_string(), TABLE.to_string())
             .await;
         backend
             .create_table(
-                SCHEMA.to_string(),
+                DATABASE.to_string(),
                 TABLE.to_string(),
                 "public.recovery".to_string(),
                 SRC_URI.to_string(),
@@ -506,18 +513,18 @@ mod tests {
                 // Take an iceberg snapshot and flush to WAL
                 let lsn = current_wal_lsn(&client1).await;
                 backend
-                    .scan_table(SCHEMA.to_string(), TABLE.to_string(), Some(lsn))
+                    .scan_table(DATABASE.to_string(), TABLE.to_string(), Some(lsn))
                     .await
                     .unwrap();
                 backend
-                    .create_snapshot(SCHEMA.to_string(), TABLE.to_string(), lsn)
+                    .create_snapshot(DATABASE.to_string(), TABLE.to_string(), lsn)
                     .await
                     .unwrap();
             }
         }
         let completed_lsn = current_wal_lsn(&client1).await;
         backend
-            .wait_for_wal_flush(SCHEMA.to_string(), TABLE.to_string(), completed_lsn)
+            .wait_for_wal_flush(DATABASE.to_string(), TABLE.to_string(), completed_lsn)
             .await
             .unwrap();
 
@@ -535,7 +542,7 @@ mod tests {
         let ids = nonunique_ids_from_state(
             &backend
                 .scan_table(
-                    SCHEMA.to_string(),
+                    DATABASE.to_string(),
                     TABLE.to_string(),
                     Some(lsn_after_commit),
                 )
@@ -577,12 +584,12 @@ mod tests {
 
         // Drop the table that setup_backend created so we can test the full cycle
         backend
-            .drop_table(SCHEMA.to_string(), TABLE.to_string())
+            .drop_table(DATABASE.to_string(), TABLE.to_string())
             .await;
 
         backend
             .create_table(
-                SCHEMA.to_string(),
+                DATABASE.to_string(),
                 TABLE.to_string(),
                 "public.recovery".to_string(),
                 SRC_URI.to_string(),
@@ -602,7 +609,7 @@ mod tests {
         }
         let wal_flush_lsn = current_wal_lsn(&client).await;
         backend
-            .wait_for_wal_flush(SCHEMA.to_string(), TABLE.to_string(), wal_flush_lsn)
+            .wait_for_wal_flush(DATABASE.to_string(), TABLE.to_string(), wal_flush_lsn)
             .await
             .unwrap();
 
@@ -610,11 +617,11 @@ mod tests {
             // Take an iceberg snapshot
             let lsn = current_wal_lsn(&client).await;
             backend
-                .scan_table(SCHEMA.to_string(), TABLE.to_string(), Some(lsn))
+                .scan_table(DATABASE.to_string(), TABLE.to_string(), Some(lsn))
                 .await
                 .unwrap();
             backend
-                .create_snapshot(SCHEMA.to_string(), TABLE.to_string(), lsn)
+                .create_snapshot(DATABASE.to_string(), TABLE.to_string(), lsn)
                 .await
                 .unwrap();
         }
@@ -641,7 +648,7 @@ mod tests {
         let expected = (0..30).map(|i| (i, 1)).collect::<HashMap<_, _>>();
         assert_scan_nonunique_ids_eq(
             &backend,
-            SCHEMA.to_string(),
+            DATABASE.to_string(),
             TABLE.to_string(),
             lsn_run_ahead,
             &expected,
@@ -662,11 +669,11 @@ mod tests {
 
         // Drop the table that setup_backend created so we can test the full cycle
         backend
-            .drop_table(SCHEMA.to_string(), TABLE.to_string())
+            .drop_table(DATABASE.to_string(), TABLE.to_string())
             .await;
         backend
             .create_table(
-                SCHEMA.to_string(),
+                DATABASE.to_string(),
                 TABLE.to_string(),
                 "public.recovery".to_string(),
                 SRC_URI.to_string(),
@@ -685,21 +692,21 @@ mod tests {
         }
         let lsn = current_wal_lsn(&client).await;
         backend
-            .wait_for_wal_flush(SCHEMA.to_string(), TABLE.to_string(), lsn)
+            .wait_for_wal_flush(DATABASE.to_string(), TABLE.to_string(), lsn)
             .await
             .unwrap();
         backend
-            .scan_table(SCHEMA.to_string(), TABLE.to_string(), Some(lsn))
+            .scan_table(DATABASE.to_string(), TABLE.to_string(), Some(lsn))
             .await
             .unwrap();
         backend
-            .create_snapshot(SCHEMA.to_string(), TABLE.to_string(), lsn)
+            .create_snapshot(DATABASE.to_string(), TABLE.to_string(), lsn)
             .await
             .unwrap();
         let (backend, testing_directory) = crash_and_recover_backend_with_guard(guard).await;
         assert_scan_nonunique_ids_eq(
             &backend,
-            SCHEMA.to_string(),
+            DATABASE.to_string(),
             TABLE.to_string(),
             lsn,
             &(0..10).map(|i| (i, 1)).collect::<HashMap<_, _>>(),
@@ -714,7 +721,7 @@ mod tests {
         let lsn = current_wal_lsn(&client).await;
         assert_scan_nonunique_ids_eq(
             &backend,
-            SCHEMA.to_string(),
+            DATABASE.to_string(),
             TABLE.to_string(),
             lsn,
             &(0..11).map(|i| (i, 1)).collect::<HashMap<_, _>>(),
@@ -724,11 +731,11 @@ mod tests {
         // Take an iceberg snapshot, but let the WAL run ahead of it, then test recovery
         let lsn = current_wal_lsn(&client).await;
         backend
-            .scan_table(SCHEMA.to_string(), TABLE.to_string(), Some(lsn))
+            .scan_table(DATABASE.to_string(), TABLE.to_string(), Some(lsn))
             .await
             .unwrap();
         backend
-            .create_snapshot(SCHEMA.to_string(), TABLE.to_string(), lsn)
+            .create_snapshot(DATABASE.to_string(), TABLE.to_string(), lsn)
             .await
             .unwrap();
         for i in 11..20 {
@@ -739,13 +746,13 @@ mod tests {
         }
         let lsn = current_wal_lsn(&client).await;
         backend
-            .wait_for_wal_flush(SCHEMA.to_string(), TABLE.to_string(), lsn)
+            .wait_for_wal_flush(DATABASE.to_string(), TABLE.to_string(), lsn)
             .await
             .unwrap();
         let backend = crash_and_recover_backend(backend, &testing_directory).await;
         assert_scan_nonunique_ids_eq(
             &backend,
-            SCHEMA.to_string(),
+            DATABASE.to_string(),
             TABLE.to_string(),
             lsn,
             &(0..20).map(|i| (i, 1)).collect::<HashMap<_, _>>(),
@@ -780,7 +787,7 @@ mod tests {
         // Scan table on non-existent table.
         let res = backend
             .scan_table(
-                SCHEMA.to_string(),
+                DATABASE.to_string(),
                 NON_EXISTENT_TABLE.to_string(),
                 Some(lsn),
             )
@@ -798,7 +805,7 @@ mod tests {
 
         // Read schema on non-existent table.
         let res = backend
-            .get_table_schema(SCHEMA.to_string(), NON_EXISTENT_TABLE.to_string())
+            .get_table_schema(DATABASE.to_string(), NON_EXISTENT_TABLE.to_string())
             .await;
         assert!(res.is_err());
     }

--- a/src/moonlink_backend/tests/test_backend.rs
+++ b/src/moonlink_backend/tests/test_backend.rs
@@ -147,8 +147,8 @@ mod tests {
         // Check table status.
         let table_statuses = backend.list_tables().await.unwrap();
         let expected_table_status = TableStatus {
-            schema: DATABASE.to_string(),
-            table: TABLE.to_string(),
+            mooncake_database: DATABASE.to_string(),
+            mooncake_table: TABLE.to_string(),
             commit_lsn: lsn,
             flush_lsn: Some(lsn),
             iceberg_warehouse_location: guard.tmp().unwrap().path().to_str().unwrap().to_string(),

--- a/src/moonlink_backend/tests/test_initial_copy.rs
+++ b/src/moonlink_backend/tests/test_initial_copy.rs
@@ -3,7 +3,7 @@ mod common;
 #[cfg(test)]
 mod tests {
     use super::common::{
-        current_wal_lsn, ids_from_state, ids_from_state_with_deletes, TestGuard, SCHEMA, SRC_URI,
+        current_wal_lsn, ids_from_state, ids_from_state_with_deletes, TestGuard, DATABASE, SRC_URI,
         TABLE,
     };
     use serial_test::serial;
@@ -49,7 +49,7 @@ mod tests {
         let create_handle = tokio::spawn(async move {
             backend_clone
                 .create_table(
-                    SCHEMA.to_string(),
+                    DATABASE.to_string(),
                     TABLE.to_string(),
                     format!("public.{table_name}"),
                     SRC_URI.to_string(),
@@ -74,7 +74,7 @@ mod tests {
         let ids = ids_from_state(
             &backend
                 .scan_table(
-                    SCHEMA.to_string(),
+                    DATABASE.to_string(),
                     TABLE.to_string(),
                     Some(lsn_after_insert),
                 )
@@ -90,7 +90,7 @@ mod tests {
             .await
             .unwrap();
         let _ = backend
-            .drop_table(SCHEMA.to_string(), TABLE.to_string())
+            .drop_table(DATABASE.to_string(), TABLE.to_string())
             .await;
     }
 
@@ -131,7 +131,7 @@ mod tests {
         // Register the table - this kicks off *initial copy* in the background
         backend
             .create_table(
-                SCHEMA.to_string(),
+                DATABASE.to_string(),
                 TABLE.to_string(),
                 format!("public.{table_name}"),
                 SRC_URI.to_string(),
@@ -149,7 +149,7 @@ mod tests {
         let ids = ids_from_state(
             &backend
                 .scan_table(
-                    SCHEMA.to_string(),
+                    DATABASE.to_string(),
                     TABLE.to_string(),
                     Some(lsn_after_insert),
                 )
@@ -166,7 +166,7 @@ mod tests {
             .await
             .unwrap();
         let _ = backend
-            .drop_table(SCHEMA.to_string(), TABLE.to_string())
+            .drop_table(DATABASE.to_string(), TABLE.to_string())
             .await;
     }
 
@@ -202,7 +202,7 @@ mod tests {
         let create_handle = tokio::spawn(async move {
             backend_clone
                 .create_table(
-                    SCHEMA.to_string(),
+                    DATABASE.to_string(),
                     TABLE.to_string(),
                     format!("public.{table_name}"),
                     SRC_URI.to_string(),
@@ -230,7 +230,7 @@ mod tests {
 
         let ids = ids_from_state(
             &backend
-                .scan_table(SCHEMA.to_string(), TABLE.to_string(), Some(lsn))
+                .scan_table(DATABASE.to_string(), TABLE.to_string(), Some(lsn))
                 .await
                 .unwrap(),
         );
@@ -246,7 +246,7 @@ mod tests {
             .await
             .unwrap();
         let _ = backend
-            .drop_table(SCHEMA.to_string(), TABLE.to_string())
+            .drop_table(DATABASE.to_string(), TABLE.to_string())
             .await;
     }
 
@@ -282,7 +282,7 @@ mod tests {
         let create_handle = tokio::spawn(async move {
             backend_clone
                 .create_table(
-                    SCHEMA.to_string(),
+                    DATABASE.to_string(),
                     TABLE.to_string(),
                     format!("public.{table_name}"),
                     SRC_URI.to_string(),
@@ -334,7 +334,7 @@ mod tests {
         let lsn = current_wal_lsn(&initial_client).await;
         let ids = ids_from_state(
             &backend
-                .scan_table(SCHEMA.to_string(), TABLE.to_string(), Some(lsn))
+                .scan_table(DATABASE.to_string(), TABLE.to_string(), Some(lsn))
                 .await
                 .unwrap(),
         );
@@ -351,7 +351,7 @@ mod tests {
             .await
             .unwrap();
         let _ = backend
-            .drop_table(SCHEMA.to_string(), TABLE.to_string())
+            .drop_table(DATABASE.to_string(), TABLE.to_string())
             .await;
     }
 
@@ -391,7 +391,7 @@ mod tests {
         let create_handle = tokio::spawn(async move {
             backend_clone
                 .create_table(
-                    SCHEMA.to_string(),
+                    DATABASE.to_string(),
                     TABLE.to_string(),
                     format!("public.{table_name}"),
                     SRC_URI.to_string(),
@@ -424,7 +424,7 @@ mod tests {
         let lsn = current_wal_lsn(&initial_client).await;
         let ids = ids_from_state_with_deletes(
             &backend
-                .scan_table(SCHEMA.to_string(), TABLE.to_string(), Some(lsn))
+                .scan_table(DATABASE.to_string(), TABLE.to_string(), Some(lsn))
                 .await
                 .unwrap(),
         )
@@ -440,7 +440,7 @@ mod tests {
             .await
             .unwrap();
         let _ = backend
-            .drop_table(SCHEMA.to_string(), TABLE.to_string())
+            .drop_table(DATABASE.to_string(), TABLE.to_string())
             .await;
     }
 
@@ -474,7 +474,7 @@ mod tests {
         let create_handle = tokio::spawn(async move {
             backend_clone
                 .create_table(
-                    SCHEMA.to_string(),
+                    DATABASE.to_string(),
                     TABLE.to_string(),
                     format!("public.{table_name}"),
                     SRC_URI.to_string(),
@@ -501,7 +501,7 @@ mod tests {
         let lsn = current_wal_lsn(&initial_client).await;
         let ids = ids_from_state_with_deletes(
             &backend
-                .scan_table(SCHEMA.to_string(), TABLE.to_string(), Some(lsn))
+                .scan_table(DATABASE.to_string(), TABLE.to_string(), Some(lsn))
                 .await
                 .unwrap(),
         )
@@ -518,7 +518,7 @@ mod tests {
             .await
             .unwrap();
         let _ = backend
-            .drop_table(SCHEMA.to_string(), TABLE.to_string())
+            .drop_table(DATABASE.to_string(), TABLE.to_string())
             .await;
     }
 
@@ -546,7 +546,7 @@ mod tests {
         let backend = guard.backend();
         backend
             .create_table(
-                SCHEMA.to_string(),
+                DATABASE.to_string(),
                 TABLE.to_string(),
                 format!("public.{table_name}"),
                 SRC_URI.to_string(),
@@ -559,7 +559,7 @@ mod tests {
         // Scan should yield empty set; also exercises the early no-copy branch
         let ids = ids_from_state(
             &backend
-                .scan_table(SCHEMA.to_string(), TABLE.to_string(), None)
+                .scan_table(DATABASE.to_string(), TABLE.to_string(), None)
                 .await
                 .unwrap(),
         );
@@ -571,7 +571,7 @@ mod tests {
             .await
             .unwrap();
         let _ = backend
-            .drop_table(SCHEMA.to_string(), TABLE.to_string())
+            .drop_table(DATABASE.to_string(), TABLE.to_string())
             .await;
     }
 
@@ -614,7 +614,7 @@ mod tests {
         let create_handle = tokio::spawn(async move {
             backend_clone
                 .create_table(
-                    SCHEMA.to_string(),
+                    DATABASE.to_string(),
                     TABLE.to_string(),
                     format!("public.{table_name}"),
                     SRC_URI.to_string(),
@@ -682,7 +682,7 @@ mod tests {
         let lsn = current_wal_lsn(&initial_client).await;
         let observed_ids = ids_from_state_with_deletes(
             &backend
-                .scan_table(SCHEMA.to_string(), TABLE.to_string(), Some(lsn))
+                .scan_table(DATABASE.to_string(), TABLE.to_string(), Some(lsn))
                 .await
                 .unwrap(),
         )
@@ -722,7 +722,7 @@ mod tests {
             .await
             .unwrap();
         let _ = backend
-            .drop_table(SCHEMA.to_string(), TABLE.to_string())
+            .drop_table(DATABASE.to_string(), TABLE.to_string())
             .await;
     }
 
@@ -755,7 +755,7 @@ mod tests {
         let handle = tokio::spawn(async move {
             backend_clone
                 .create_table(
-                    SCHEMA.to_string(),
+                    DATABASE.to_string(),
                     TABLE.to_string(),
                     format!("public.{table_name}"),
                     SRC_URI.to_string(),
@@ -781,7 +781,7 @@ mod tests {
 
         // Best-effort cleanup of mooncake table if it was partially created
         let _ = backend
-            .drop_table(SCHEMA.to_string(), TABLE.to_string())
+            .drop_table(DATABASE.to_string(), TABLE.to_string())
             .await;
     }
 
@@ -814,7 +814,7 @@ mod tests {
         let handle = tokio::spawn(async move {
             backend_clone
                 .create_table(
-                    SCHEMA.to_string(),
+                    DATABASE.to_string(),
                     TABLE.to_string(),
                     format!("public.{table_name}"),
                     SRC_URI.to_string(),
@@ -836,7 +836,7 @@ mod tests {
         let _ = handle.await; // ignore result; best-effort
 
         let _ = backend
-            .drop_table(SCHEMA.to_string(), TABLE.to_string())
+            .drop_table(DATABASE.to_string(), TABLE.to_string())
             .await;
     }
 }

--- a/src/moonlink_metadata_store/src/base_metadata_store.rs
+++ b/src/moonlink_metadata_store/src/base_metadata_store.rs
@@ -16,10 +16,10 @@ pub const MOONLINK_SECRET_TABLE: &str = "secrets";
 /// Metadata entry for each table.
 #[derive(Clone, Debug)]
 pub struct TableMetadataEntry {
-    /// Table schema.
-    pub schema: String,
-    /// Table name.
-    pub table: String,
+    /// Mooncake database name.
+    pub mooncake_database: String,
+    /// Mooncake table name.
+    pub mooncake_table: String,
     /// Src table name.
     pub src_table_name: String,
     /// Src table connection string.
@@ -56,8 +56,8 @@ pub trait MetadataStoreTrait: Send + Sync {
     #[allow(async_fn_in_trait)]
     async fn store_table_metadata(
         &self,
-        schema: &str,
-        table: &str,
+        mooncake_database: &str,
+        mooncake_table: &str,
         src_table_name: &str,
         src_uri: &str,
         moonlink_table_config: MoonlinkTableConfig,
@@ -66,5 +66,9 @@ pub trait MetadataStoreTrait: Send + Sync {
     /// Delete table config for the given table.
     /// Precondition: the requested table id has been record in the metadata storage.
     #[allow(async_fn_in_trait)]
-    async fn delete_table_metadata(&self, schema: &str, table: &str) -> Result<()>;
+    async fn delete_table_metadata(
+        &self,
+        mooncake_database: &str,
+        mooncake_table: &str,
+    ) -> Result<()>;
 }

--- a/src/moonlink_metadata_store/src/postgres/sql/create_secrets.sql
+++ b/src/moonlink_metadata_store/src/postgres/sql/create_secrets.sql
@@ -3,8 +3,8 @@ BEGIN;
 
 CREATE TABLE secrets (
     id SERIAL PRIMARY KEY,          -- Unique row identifier.
-    "schema" TEXT,                  -- Column store schema name.
-    "table" TEXT,                   -- Column store table name.
+    mooncake_database TEXT,         -- Column store database name.
+    mooncake_table TEXT,            -- Column store table name.
     secret_type TEXT,               -- One of (S3, GCS)
     key_id TEXT,
     secret TEXT,
@@ -13,5 +13,5 @@ CREATE TABLE secrets (
     region TEXT            -- (optional)
 );
 
--- Index to enable query on ("schema", "table").
-CREATE INDEX idx_secrets_uid_oid ON secrets ("schema", "table");
+-- Index to enable query on (mooncake_database, mooncake_table).
+CREATE INDEX idx_secrets_uid_oid ON secrets (mooncake_database, mooncake_table);

--- a/src/moonlink_metadata_store/src/postgres/sql/create_tables.sql
+++ b/src/moonlink_metadata_store/src/postgres/sql/create_tables.sql
@@ -1,9 +1,9 @@
 -- SQL statement(s) to store moonlink managed column store tables.
 CREATE TABLE tables (
-    "schema" TEXT,                  -- column store schema name
-    "table" TEXT,                   -- column store table name
+    mooncake_database TEXT,         -- column store database name
+    mooncake_table TEXT,            -- column store table name
     src_table_name TEXT NOT NULL,   -- source table name
     src_table_uri TEXT,             -- source URI
     config JSON,                    -- mooncake and persistence configurations
-    PRIMARY KEY ("schema", "table")
+    PRIMARY KEY (mooncake_database, mooncake_table)
 );

--- a/src/moonlink_metadata_store/src/sqlite/sql/create_secrets.sql
+++ b/src/moonlink_metadata_store/src/sqlite/sql/create_secrets.sql
@@ -1,8 +1,8 @@
 -- SQL statements to store moonlink secret related fields.
 CREATE TABLE secrets (
     id SERIAL PRIMARY KEY,      -- Unique row identifier
-    "schema" TEXT,              -- column store schema name
-    "table" TEXT,               -- column store table name
+    mooncake_database TEXT,     -- column store database name
+    mooncake_table TEXT,        -- column store table name
     secret_type TEXT,           -- One of (S3, GCS)
     key_id TEXT,
     secret TEXT,
@@ -11,5 +11,5 @@ CREATE TABLE secrets (
     region TEXT            -- (optional)
 );
 
--- Index to enable query on ("schema", "table").
-CREATE INDEX idx_secrets_uid_oid ON secrets ("schema", "table");
+-- Index to enable query on (mooncake_database, mooncake_table).
+CREATE INDEX idx_secrets_uid_oid ON secrets (mooncake_database, mooncake_table);

--- a/src/moonlink_metadata_store/src/sqlite/sql/create_tables.sql
+++ b/src/moonlink_metadata_store/src/sqlite/sql/create_tables.sql
@@ -1,9 +1,9 @@
 -- SQL statement(s) to store moonlink managed column store tables.
 CREATE TABLE tables (
-    "schema" TEXT,                  -- column store schema name
-    "table" TEXT,                   -- column store table name
+    mooncake_database TEXT,         -- column store database name
+    mooncake_table TEXT,            -- column store table name
     src_table_name TEXT NOT NULL,   -- source table name
     src_table_uri TEXT,             -- source table URI
     config TEXT,                    -- mooncake and persistence configurations
-    PRIMARY KEY ("schema", "table")
+    PRIMARY KEY (mooncake_database, mooncake_table)
 );

--- a/src/moonlink_metadata_store/src/sqlite/tests.rs
+++ b/src/moonlink_metadata_store/src/sqlite/tests.rs
@@ -8,10 +8,10 @@ use tempfile::{tempdir, TempDir};
 const SRC_TABLE_URI: &str = "postgresql://postgres:postgres@postgres:5432/postgres";
 /// Test table name.
 const SRC_TABLE_NAME: &str = "src_table";
-/// Test destination table schema.
-const SCHEMA: &str = "dst_schema";
-/// Test destination table id.
-const TABLE: &str = "dst_table";
+/// Test destination database.
+const DATABASE: &str = "dst_database";
+/// Test destination table name.
+const TABLE: &str = "dst_schema.dst_table";
 
 /// Create a filesystem config for test.
 fn get_storage_config() -> StorageConfig {
@@ -79,7 +79,7 @@ async fn check_persisted_metadata(sqlite_metadata_store: &SqliteMetadataStore) {
         .unwrap();
     assert_eq!(metadata_entries.len(), 1);
     let table_metadata_entry = &metadata_entries[0];
-    assert_eq!(table_metadata_entry.table, TABLE);
+    assert_eq!(table_metadata_entry.mooncake_table, TABLE);
     assert_eq!(table_metadata_entry.src_table_name, SRC_TABLE_NAME);
     assert_eq!(table_metadata_entry.src_table_uri, SRC_TABLE_URI);
     assert_eq!(
@@ -111,7 +111,7 @@ async fn test_metadata_table_exists() {
     // Store moonlink table config to metadata storage.
     metadata_store
         .store_table_metadata(
-            SCHEMA,
+            DATABASE,
             TABLE,
             SRC_TABLE_NAME,
             SRC_TABLE_URI,
@@ -137,7 +137,7 @@ async fn test_table_metadata_store_and_load() {
     // Store moonlink table config to metadata storage.
     metadata_store
         .store_table_metadata(
-            SCHEMA,
+            DATABASE,
             TABLE,
             SRC_TABLE_NAME,
             SRC_TABLE_URI,
@@ -162,7 +162,7 @@ async fn test_table_metadata_store_for_duplicate_tables() {
     // Store moonlink table config to metadata storage.
     metadata_store
         .store_table_metadata(
-            SCHEMA,
+            DATABASE,
             TABLE,
             SRC_TABLE_NAME,
             SRC_TABLE_URI,
@@ -174,7 +174,7 @@ async fn test_table_metadata_store_for_duplicate_tables() {
     // Load and check moonlink table config from metadata config.
     let res = metadata_store
         .store_table_metadata(
-            SCHEMA,
+            DATABASE,
             TABLE,
             SRC_TABLE_NAME,
             SRC_TABLE_URI,
@@ -208,7 +208,7 @@ async fn test_delete_table_metadata_store() {
     // Store moonlink table config to metadata storage.
     metadata_store
         .store_table_metadata(
-            SCHEMA,
+            DATABASE,
             TABLE,
             SRC_TABLE_NAME,
             SRC_TABLE_URI,
@@ -222,7 +222,7 @@ async fn test_delete_table_metadata_store() {
 
     // Delete moonlink table config to metadata storage and check.
     metadata_store
-        .delete_table_metadata(SCHEMA, TABLE)
+        .delete_table_metadata(DATABASE, TABLE)
         .await
         .unwrap();
     let metadata_entries = metadata_store
@@ -232,6 +232,6 @@ async fn test_delete_table_metadata_store() {
     assert_eq!(metadata_entries.len(), 0);
 
     // Delete for the second time also fails.
-    let res = metadata_store.delete_table_metadata(SCHEMA, TABLE).await;
+    let res = metadata_store.delete_table_metadata(DATABASE, TABLE).await;
     assert!(res.is_err());
 }

--- a/src/moonlink_metadata_store/tests/test_pg_metadata_store.rs
+++ b/src/moonlink_metadata_store/tests/test_pg_metadata_store.rs
@@ -9,10 +9,10 @@ use moonlink_metadata_store::PgMetadataStore;
 const SRC_TABLE_URI: &str = "postgresql://postgres:postgres@postgres:5432/postgres";
 /// Test table name.
 const SRC_TABLE_NAME: &str = "table";
-/// Test destination schema name.
-const SCHEMA: &str = "dst-schema";
+/// Test destination database name.
+const DATABASE: &str = "dst-database";
 /// Test destination table name.
-const TABLE: &str = "dst-table";
+const TABLE: &str = "dst-schema.dst-table";
 
 #[cfg(test)]
 mod tests {
@@ -35,7 +35,7 @@ mod tests {
             .unwrap();
         assert_eq!(metadata_entries.len(), 1);
         let table_metadata_entry = &metadata_entries[0];
-        assert_eq!(table_metadata_entry.table, TABLE);
+        assert_eq!(table_metadata_entry.mooncake_table, TABLE);
         assert_eq!(table_metadata_entry.src_table_name, SRC_TABLE_NAME);
         assert_eq!(table_metadata_entry.src_table_uri, get_table_uri());
         assert_eq!(
@@ -58,7 +58,7 @@ mod tests {
         // Store moonlink table config to metadata storage.
         metadata_store
             .store_table_metadata(
-                SCHEMA,
+                DATABASE,
                 TABLE,
                 SRC_TABLE_NAME,
                 &table_uri,
@@ -112,7 +112,7 @@ mod tests {
         // Store moonlink table config to metadata storage.
         metadata_store
             .store_table_metadata(
-                SCHEMA,
+                DATABASE,
                 TABLE,
                 SRC_TABLE_NAME,
                 &table_uri,
@@ -124,7 +124,7 @@ mod tests {
         // Store moonlink table config to metadata storage.
         let res = metadata_store
             .store_table_metadata(
-                SCHEMA,
+                DATABASE,
                 TABLE,
                 SRC_TABLE_NAME,
                 &table_uri,
@@ -146,7 +146,7 @@ mod tests {
         // Store moonlink table metadata to metadata storage.
         metadata_store
             .store_table_metadata(
-                SCHEMA,
+                DATABASE,
                 TABLE,
                 SRC_TABLE_NAME,
                 &table_uri,
@@ -160,7 +160,7 @@ mod tests {
 
         // Delete moonlink table config to metadata storage and check.
         metadata_store
-            .delete_table_metadata(SCHEMA, TABLE)
+            .delete_table_metadata(DATABASE, TABLE)
             .await
             .unwrap();
         let metadata_entries = metadata_store
@@ -170,7 +170,7 @@ mod tests {
         assert_eq!(metadata_entries.len(), 0);
 
         // Delete for the second time also fails.
-        let res = metadata_store.delete_table_metadata(SCHEMA, TABLE).await;
+        let res = metadata_store.delete_table_metadata(DATABASE, TABLE).await;
         assert!(res.is_err());
     }
 }

--- a/src/moonlink_rpc/src/lib.rs
+++ b/src/moonlink_rpc/src/lib.rs
@@ -25,14 +25,14 @@ macro_rules! rpcs {
 }
 
 rpcs! {
-    create_snapshot(schema: String, table: String, lsn: u64) -> ();
-    create_table(schema: String, table: String, src: String, src_uri: String, table_config: String) -> ();
-    drop_table(schema: String, table: String) -> ();
-    get_table_schema(schema: String, table: String) -> Vec<u8>;
+    create_snapshot(mooncake_database: String, mooncake_table: String, lsn: u64) -> ();
+    create_table(mooncake_database: String, mooncake_table: String, src: String, src_uri: String, table_config: String) -> ();
+    drop_table(mooncake_database: String, mooncake_table: String) -> ();
+    get_table_schema(mooncake_database: String, mooncake_table: String) -> Vec<u8>;
     list_tables() -> Vec<Table>;
-    optimize_table(schema: String, table: String, mode: String) -> ();
-    scan_table_begin(schema: String, table: String, lsn: u64) -> Vec<u8>;
-    scan_table_end(schema: String, table: String) -> ();
+    optimize_table(mooncake_database: String, mooncake_table: String, mode: String) -> ();
+    scan_table_begin(mooncake_database: String, mooncake_table: String, lsn: u64) -> Vec<u8>;
+    scan_table_end(mooncake_database: String, mooncake_table: String) -> ();
 }
 
 pub async fn write<W: AsyncWrite + Unpin, S: Serialize>(writer: &mut W, data: &S) -> Result<()> {
@@ -56,8 +56,8 @@ const BINCODE_CONFIG: bincode::config::Configuration = bincode::config::standard
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Table {
-    pub schema: String,
-    pub table: String,
+    pub mooncake_database: String,
+    pub mooncake_table: String,
     pub commit_lsn: u64,
     pub flush_lsn: Option<u64>,
     pub iceberg_warehouse_location: String,

--- a/src/moonlink_service/examples/rest_api_demo.rs
+++ b/src/moonlink_service/examples/rest_api_demo.rs
@@ -59,8 +59,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Test 2: Create a table
     println!("\n🏗️ Creating table 'demo_users'...");
     let create_table_payload = json!({
-        "schema_name": "schema_name",
-        "table_name": "table_name",
+        "mooncake_database": "database_name",
+        "mooncake_table": "schema_name",
         "schema": [
             {"name": "id", "data_type": "int32", "nullable": false},
             {"name": "name", "data_type": "string", "nullable": false},
@@ -270,9 +270,9 @@ async fn read_table_via_rpc() -> Result<(), Box<dyn std::error::Error>> {
     println!("   Found {} table(s):", tables.len());
     for table in &tables {
         println!(
-            "     - Schema: {}, Table: {}, Commit LSN: {}",
-            table.table.clone(),
-            table.table.clone(),
+            "     - Database: {}, Table: {}, Commit LSN: {}",
+            table.mooncake_database.clone(),
+            table.mooncake_table.clone(),
             table.commit_lsn
         );
     }
@@ -285,35 +285,43 @@ async fn read_table_via_rpc() -> Result<(), Box<dyn std::error::Error>> {
     // Find our demo table (database_id=1, table_id=100)
     let demo_table = tables
         .iter()
-        .find(|t| t.schema == "test_schema" && t.table == "test_table");
+        .find(|t| t.mooncake_database == "test_schema" && t.mooncake_table == "test_table");
 
     if let Some(table) = demo_table {
         println!(
-            "   📖 Reading from demo table (Schema: {}, Table: {})...",
-            table.table.clone(),
-            table.table.clone()
+            "   📖 Reading from demo table (Database: {}, Table: {})...",
+            table.mooncake_database.clone(),
+            table.mooncake_table.clone()
         );
 
         // Get table schema
         println!("   📐 Getting table schema...");
-        let schema_bytes =
-            moonlink_rpc::get_table_schema(&mut stream, table.table.clone(), table.table.clone())
-                .await?;
+        let schema_bytes = moonlink_rpc::get_table_schema(
+            &mut stream,
+            table.mooncake_database.clone(),
+            table.mooncake_table.clone(),
+        )
+        .await?;
         println!("   Schema size: {} bytes", schema_bytes.len());
 
         // Scan table data
         println!("   🔍 Scanning table data...");
         let data_bytes = moonlink_rpc::scan_table_begin(
             &mut stream,
-            table.table.clone(),
-            table.table.clone(),
+            table.mooncake_database.clone(),
+            table.mooncake_table.clone(),
             0,
         )
         .await?;
         println!("   Data size: {} bytes", data_bytes.len());
 
         // End scan
-        moonlink_rpc::scan_table_end(&mut stream, table.table.clone(), table.table.clone()).await?;
+        moonlink_rpc::scan_table_end(
+            &mut stream,
+            table.mooncake_database.clone(),
+            table.mooncake_table.clone(),
+        )
+        .await?;
         println!("   ✅ Table scan completed");
 
         // Try to decode the Arrow data (basic attempt)

--- a/src/moonlink_service/src/rest_api.rs
+++ b/src/moonlink_service/src/rest_api.rs
@@ -30,8 +30,8 @@ impl ApiState {
 /// Request structure for table creation
 #[derive(Debug, Deserialize)]
 pub struct CreateTableRequest {
-    pub schema_name: String,
-    pub table_name: String,
+    pub mooncake_database: String,
+    pub mooncake_table: String,
     pub schema: Vec<FieldSchema>,
 }
 
@@ -170,8 +170,8 @@ async fn create_table(
     match state
         .backend
         .create_table(
-            payload.schema_name.clone(),
-            payload.table_name.clone(),
+            payload.mooncake_database.clone(),
+            payload.mooncake_table.clone(),
             table_name.clone(),
             REST_API_URI.to_string(),
             "{}".to_string(),
@@ -182,13 +182,13 @@ async fn create_table(
         Ok(()) => {
             info!(
                 "Successfully created table '{}' with ID {}:{}",
-                table_name, payload.schema_name, payload.table_name,
+                table_name, payload.mooncake_database, payload.mooncake_table,
             );
             Ok(Json(CreateTableResponse {
                 status: "success".to_string(),
                 message: "Table created successfully".to_string(),
                 table_name,
-                schema: payload.schema_name.clone(),
+                schema: payload.mooncake_database.clone(),
             }))
         }
         Err(e) => {


### PR DESCRIPTION
## Summary

Current `<schema>.<table>` doesn't uniquely identify a table, since it could duplicate across databases;
this PR updates them to `<database>.<schema.table>`.

This PR is supposed to be a no-op change.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1528

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
