### PR TITLE
Skip recovery for rest created tables

### DIFF
--- a/src/moonlink_backend/src/recovery_utils.rs
+++ b/src/moonlink_backend/src/recovery_utils.rs
@@ -1,7 +1,7 @@
 use crate::error::Result;
 use crate::mooncake_table_id::MooncakeTableId;
 use moonlink::ReadStateFilepathRemap;
-use moonlink_connectors::ReplicationManager;
+use moonlink_connectors::{ReplicationManager, REST_API_URI};
 use moonlink_metadata_store::base_metadata_store::{MetadataStoreTrait, TableMetadataEntry};
 
 use std::collections::HashSet;
@@ -18,6 +18,11 @@ async fn recover_table(
     replication_manager: &mut ReplicationManager<MooncakeTableId>,
     read_state_filepath_remap: ReadStateFilepathRemap,
 ) -> Result<()> {
+    // Table created by REST API doesn't support recovery.
+    if metadata_entry.src_table_uri == REST_API_URI {
+        return Ok(());
+    }
+
     let mooncake_table_id = MooncakeTableId {
         mooncake_database: metadata_entry.mooncake_database,
         mooncake_table: metadata_entry.mooncake_table,


### PR DESCRIPTION
## Summary

When working on standalone deployment, I found recovery on rest-api-created table cannot recovered and crash the whole service.

The reason being not supporting replication
https://github.com/Mooncake-Labs/moonlink/blob/fc14ea782e9535b97590b3bf7640f16b7382a9e5/src/moonlink_connectors/src/replication_connection.rs#L190-L192
Temporarily lock it down to avoid crashing the whole service, will revisit later.

All rest sever part has separate issues to track and someone working on it.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1538

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
