### PR TITLE
[chaos] Fix replay config

### DIFF
--- a/src/moonlink/src/storage/mooncake_table/table_creation_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_creation_test_utils.rs
@@ -254,6 +254,23 @@ pub(crate) fn create_disk_slice_write_option(
     }
 }
 
+/// Test util function to create mooncake table metadata with the provided full config, and disabled flush at commit.
+#[cfg(feature = "chaos-test")]
+pub(crate) fn create_test_table_metadata_disable_flush_with_full_config(
+    local_table_directory: String,
+    disk_slice_write_config: DiskSliceWriterConfig,
+    index_merge_config: FileIndexMergeConfig,
+    data_compaction_config: DataCompactionConfig,
+    identity: RowIdentity,
+) -> Arc<MooncakeTableMetadata> {
+    let mut config = MooncakeTableConfig::new(local_table_directory.clone());
+    config.mem_slice_size = usize::MAX; // Disable flush at commit if not force flush.
+    config.disk_slice_writer_config = disk_slice_write_config;
+    config.file_index_config = index_merge_config;
+    config.data_compaction_config = data_compaction_config;
+    create_test_table_metadata_with_config_and_identity(local_table_directory, config, identity)
+}
+
 /// Test util function to create mooncake table metadata, which disables flush at commit.
 #[cfg(feature = "chaos-test")]
 pub(crate) fn create_test_table_metadata_disable_flush(

--- a/src/moonlink/src/table_handler/chaos_test.rs
+++ b/src/moonlink/src/table_handler/chaos_test.rs
@@ -1166,7 +1166,7 @@ async fn test_chaos_on_local_fs_with_data_compaction() {
         deletion_enabled: true,
         maintenance_option: TableMaintenanceOption::DataCompaction,
         error_injection_enabled: false,
-        event_count: 20,
+        event_count: 3500,
         storage_config: StorageConfig::FileSystem {
             root_directory,
             atomic_write_dir: None,


### PR DESCRIPTION
## Summary

Replay system should use the same config (i.e., index merge and data compaction config) as source, otherwise cannot get the same event stream.

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
