### PR TITLE
[REST] [1/N] Event process for file upload

### DIFF
--- a/src/moonlink_connectors/src/rest_ingest/rest_source.rs
+++ b/src/moonlink_connectors/src/rest_ingest/rest_source.rs
@@ -56,6 +56,9 @@ pub struct RowEventRequest {
 ///
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum FileEventOperation {
+    /// Insert by rows.
+    Insert,
+    /// Upload by files.
     Upload,
 }
 
@@ -63,6 +66,8 @@ pub enum FileEventOperation {
 pub struct FileEventRequest {
     /// Src table name.
     pub src_table_name: String,
+    /// File event operation.
+    pub operation: FileEventOperation,
     /// Storage config, which provides access to storage backend.
     pub storage_config: StorageConfig,
     /// Parquet files to upload, which will be processed in order.
@@ -92,13 +97,21 @@ pub enum RestEvent {
         lsn: u64,
         timestamp: SystemTime,
     },
-    FileEvent {
-        operation: FileEventOperation,
-        table_events: Arc<Mutex<tokio::sync::mpsc::UnboundedReceiver<Result<RestEvent>>>>,
-    },
     Commit {
         lsn: u64,
         timestamp: SystemTime,
+    },
+    FileInsertEvent {
+        /// Used for file row insertion operation.
+        table_events: Arc<Mutex<tokio::sync::mpsc::UnboundedReceiver<Result<RestEvent>>>>,
+    },
+    FileUploadEvent {
+        /// Source table id.
+        src_table_id: SrcTableId,
+        /// Used to directly ingest into mooncake table.
+        files: Vec<String>,
+        /// LSN for the ingestion event.
+        lsn: u64,
     },
 }
 
@@ -235,28 +248,41 @@ impl RestSource {
             .ok_or_else(|| RestSourceError::UnknownTable(request.src_table_name.clone()))?;
         let src_table_id = *src_table_id;
 
-        let (file_upload_row_tx, file_upload_row_rx) = tokio::sync::mpsc::unbounded_channel();
-        let lsn_generator = self.lsn_generator.clone();
-        let storage_config = request.storage_config.clone();
-        let parquet_files = request.files.clone();
+        match request.operation {
+            FileEventOperation::Insert => {
+                let (file_upload_row_tx, file_upload_row_rx) =
+                    tokio::sync::mpsc::unbounded_channel();
+                let lsn_generator = self.lsn_generator.clone();
+                let storage_config = request.storage_config.clone();
+                let parquet_files = request.files.clone();
 
-        tokio::task::spawn(async move {
-            Self::generate_table_events_for_file_upload(
-                src_table_id,
-                lsn_generator,
-                storage_config,
-                parquet_files,
-                file_upload_row_tx,
-            )
-            .await;
-        });
+                tokio::task::spawn(async move {
+                    Self::generate_table_events_for_file_upload(
+                        src_table_id,
+                        lsn_generator,
+                        storage_config,
+                        parquet_files,
+                        file_upload_row_tx,
+                    )
+                    .await;
+                });
 
-        let file_upload_row_rx = Arc::new(Mutex::new(file_upload_row_rx));
-        let file_rest_event = RestEvent::FileEvent {
-            operation: FileEventOperation::Upload,
-            table_events: file_upload_row_rx,
-        };
-        Ok(vec![file_rest_event])
+                let file_upload_row_rx = Arc::new(Mutex::new(file_upload_row_rx));
+                let file_rest_event = RestEvent::FileInsertEvent {
+                    table_events: file_upload_row_rx,
+                };
+                Ok(vec![file_rest_event])
+            }
+            FileEventOperation::Upload => {
+                let lsn = self.lsn_generator.fetch_add(1, Ordering::SeqCst);
+                let file_rest_event = RestEvent::FileUploadEvent {
+                    src_table_id,
+                    files: request.files.clone(),
+                    lsn,
+                };
+                Ok(vec![file_rest_event])
+            }
+        }
     }
 
     /// Process an event request, which is operated on a row.
@@ -450,6 +476,7 @@ mod tests {
 
         let request = FileEventRequest {
             src_table_name: "test_table".to_string(),
+            operation: FileEventOperation::Insert,
             storage_config: StorageConfig::FileSystem {
                 root_directory: tempdir.path().to_str().unwrap().to_string(),
                 atomic_write_dir: None,
@@ -462,11 +489,7 @@ mod tests {
 
         // Check file events.
         match &events[0] {
-            RestEvent::FileEvent {
-                operation,
-                table_events,
-            } => {
-                assert_eq!(*operation, FileEventOperation::Upload);
+            RestEvent::FileInsertEvent { table_events } => {
                 let rest_events = get_all_rest_events(table_events.clone()).await.unwrap();
                 // There're 3 append events and 1 commit event.
                 assert_eq!(rest_events.len(), 4);
@@ -514,6 +537,7 @@ mod tests {
 
         let request = FileEventRequest {
             src_table_name: "test_table".to_string(),
+            operation: FileEventOperation::Insert,
             storage_config: StorageConfig::FileSystem {
                 root_directory: "/non_existent_dir".to_string(),
                 atomic_write_dir: None,
@@ -525,11 +549,7 @@ mod tests {
 
         // Check file events.
         match &events[0] {
-            RestEvent::FileEvent {
-                operation,
-                table_events,
-            } => {
-                assert_eq!(*operation, FileEventOperation::Upload);
+            RestEvent::FileInsertEvent { table_events } => {
                 let rest_events = get_all_rest_events(table_events.clone()).await;
                 assert!(rest_events.is_err());
             }


### PR DESCRIPTION
## Summary

After this PR, we have two events supported in event processing logic, 
- one for row-based ingestion, which is more like existing pg cdc based solution
- another for file-based ingestion, which skips all indices construction and validation, but with better perf

Followup PR: expose these interfaces to rest public interfaces, so I could use HTTP to ingestion

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
