### PR TITLE
[REST] Fix replication state for rest connector

### DIFF
--- a/src/moonlink_connectors/src/lib.rs
+++ b/src/moonlink_connectors/src/lib.rs
@@ -2,6 +2,7 @@ pub mod error;
 mod pg_replicate;
 mod replication_connection;
 mod replication_manager;
+pub mod replication_state;
 pub mod rest_ingest;
 
 pub use error::*;

--- a/src/moonlink_connectors/src/pg_replicate.rs
+++ b/src/moonlink_connectors/src/pg_replicate.rs
@@ -5,7 +5,6 @@ pub mod conversions;
 pub mod initial_copy;
 pub mod moonlink_sink;
 pub mod postgres_source;
-pub mod replication_state;
 pub mod table;
 pub mod table_init;
 pub mod util;
@@ -17,9 +16,9 @@ use crate::pg_replicate::moonlink_sink::{SchemaChangeRequest, Sink};
 use crate::pg_replicate::postgres_source::{
     CdcStreamConfig, CdcStreamError, PostgresSource, PostgresSourceError,
 };
-use crate::pg_replicate::replication_state::ReplicationState;
 use crate::pg_replicate::table::{SrcTableId, TableSchema};
 use crate::pg_replicate::table_init::{build_table_components, TableComponents};
+use crate::replication_state::ReplicationState;
 use crate::Result;
 use futures::StreamExt;
 use moonlink::{

--- a/src/moonlink_connectors/src/pg_replicate/table_init.rs
+++ b/src/moonlink_connectors/src/pg_replicate/table_init.rs
@@ -1,5 +1,5 @@
-use crate::pg_replicate::replication_state::ReplicationState;
 use crate::pg_replicate::table::SrcTableId;
+use crate::replication_state::ReplicationState;
 use crate::{Error, Result};
 use arrow_schema::Schema as ArrowSchema;
 use moonlink::event_sync::create_table_event_syncer;

--- a/src/moonlink_connectors/src/replication_connection.rs
+++ b/src/moonlink_connectors/src/replication_connection.rs
@@ -1,6 +1,7 @@
 use crate::pg_replicate::table_init::build_table_components;
 use crate::pg_replicate::PostgresConnection;
 use crate::pg_replicate::{table::SrcTableId, table_init::TableComponents};
+use crate::replication_state::ReplicationState;
 use crate::rest_ingest::rest_source::EventRequest;
 use crate::rest_ingest::RestApiConnection;
 use crate::Result;
@@ -224,7 +225,7 @@ impl ReplicationConnection {
                     src_table_id,
                     &self.table_base_path,
                     // REST API doesn't have replication state, create a dummy one
-                    &crate::pg_replicate::replication_state::ReplicationState::new(),
+                    &ReplicationState::new(),
                     table_components,
                     is_recovery,
                 )

--- a/src/moonlink_connectors/src/replication_connection.rs
+++ b/src/moonlink_connectors/src/replication_connection.rs
@@ -217,6 +217,7 @@ impl ReplicationConnection {
                 };
 
                 // Create MooncakeTable resources using the table init function
+                let replication_state = ReplicationState::new();
                 let mut table_resources = build_table_components(
                     mooncake_table_id.to_string(),
                     arrow_schema.clone(),
@@ -224,8 +225,7 @@ impl ReplicationConnection {
                     src_table_name.to_string(),
                     src_table_id,
                     &self.table_base_path,
-                    // REST API doesn't have replication state, create a dummy one
-                    &ReplicationState::new(),
+                    &replication_state,
                     table_components,
                     is_recovery,
                 )
@@ -249,6 +249,7 @@ impl ReplicationConnection {
                         .wal_flush_lsn_rx
                         .take()
                         .expect("wal_flush_lsn_rx not set"),
+                    replication_state,
                 )
                 .await?;
 

--- a/src/moonlink_connectors/src/replication_state.rs
+++ b/src/moonlink_connectors/src/replication_state.rs
@@ -11,6 +11,14 @@ pub struct ReplicationState {
     tx: watch::Sender<u64>,
 }
 
+impl std::fmt::Debug for ReplicationState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ReplicationState")
+            .field("current", &self.current.load(Ordering::SeqCst))
+            .finish()
+    }
+}
+
 impl ReplicationState {
     /// Create a new state initialised to LSN 0.
     pub fn new() -> Arc<Self> {

--- a/src/moonlink_connectors/src/rest_ingest.rs
+++ b/src/moonlink_connectors/src/rest_ingest.rs
@@ -4,6 +4,7 @@ pub mod json_converter;
 pub mod moonlink_rest_sink;
 pub mod rest_source;
 
+use crate::replication_state::ReplicationState;
 use crate::rest_ingest::moonlink_rest_sink::RestSink;
 use crate::rest_ingest::rest_source::{EventRequest, RestSource};
 use crate::{Error, Result};
@@ -30,6 +31,7 @@ pub enum RestCommand {
         commit_lsn_tx: watch::Sender<u64>,
         flush_lsn_rx: watch::Receiver<u64>,
         wal_flush_lsn_rx: watch::Receiver<u64>,
+        replication_state: Arc<ReplicationState>,
     },
     DropTable {
         src_table_name: String,
@@ -81,6 +83,7 @@ impl RestApiConnection {
         commit_lsn_tx: watch::Sender<u64>,
         flush_lsn_rx: watch::Receiver<u64>,
         wal_flush_lsn_rx: watch::Receiver<u64>,
+        replication_state: Arc<ReplicationState>,
     ) -> Result<()> {
         let command = RestCommand::AddTable {
             src_table_name,
@@ -90,6 +93,7 @@ impl RestApiConnection {
             commit_lsn_tx,
             flush_lsn_rx,
             wal_flush_lsn_rx,
+            replication_state,
         };
 
         self.cmd_tx
@@ -156,11 +160,12 @@ pub async fn run_rest_event_loop(
     // UNDON, send status back for REST API if wait=true
     let mut flush_lsn_rxs: HashMap<SrcTableId, watch::Receiver<u64>> = HashMap::new();
     let mut wal_flush_lsn_rxs: HashMap<SrcTableId, watch::Receiver<u64>> = HashMap::new();
+    let mut replication_states: HashMap<SrcTableId, Arc<ReplicationState>> = HashMap::new();
 
     loop {
         tokio::select! {
             Some(cmd) = cmd_rx.recv() => match cmd {
-                RestCommand::AddTable { src_table_name, src_table_id, schema, event_sender, commit_lsn_tx, flush_lsn_rx, wal_flush_lsn_rx } => {
+                RestCommand::AddTable { src_table_name, src_table_id, schema, event_sender, commit_lsn_tx, flush_lsn_rx, wal_flush_lsn_rx, replication_state } => {
                     debug!("Adding REST table '{}' with src_table_id {}", src_table_name, src_table_id);
 
                     // Add to sink (handles table events)
@@ -174,7 +179,7 @@ pub async fn run_rest_event_loop(
                     }
                     // Invariant sanity check.
                     assert!(wal_flush_lsn_rxs.insert(src_table_id, wal_flush_lsn_rx).is_none());
-
+                    assert!(replication_states.insert(src_table_id, replication_state).is_none());
                 }
                 RestCommand::DropTable { src_table_name, src_table_id } => {
                     debug!("Dropping REST table '{}' with src_table_id {}", src_table_name, src_table_id);
@@ -190,6 +195,7 @@ pub async fn run_rest_event_loop(
                     }
                     // Invariant sanity check.
                     assert!(wal_flush_lsn_rxs.remove(&src_table_id).is_some());
+                    assert!(replication_states.remove(&src_table_id).is_some());
                 }
                 RestCommand::Shutdown => {
                     debug!("received shutdown command");
@@ -203,9 +209,16 @@ pub async fn run_rest_event_loop(
                     Ok(rest_events) => {
                         // Send all events to be processed by the sink
                         for rest_event in rest_events {
-                            if let Err(e) = sink.process_rest_event(rest_event).await {
+                            let rest_event_proc_result = sink.process_rest_event(rest_event).await;
+                            if let Err(e) = &rest_event_proc_result {
                                 warn!(error = ?e, "failed to process REST event");
                                 break; // Stop processing further events on error
+                            }
+
+                            // Update replication LSN if applicable.
+                            let rest_event_proc_result = rest_event_proc_result.unwrap();
+                            if let Some(commit_lsn) = rest_event_proc_result.commit_lsn {
+                                replication_states.get(&rest_event_proc_result.src_table_id).as_ref().unwrap().mark(commit_lsn);
                             }
                         }
                     }

--- a/src/moonlink_connectors/src/rest_ingest/rest_source.rs
+++ b/src/moonlink_connectors/src/rest_ingest/rest_source.rs
@@ -102,6 +102,8 @@ pub enum RestEvent {
         timestamp: SystemTime,
     },
     FileInsertEvent {
+        /// Source table id.
+        src_table_id: SrcTableId,
         /// Used for file row insertion operation.
         table_events: Arc<Mutex<tokio::sync::mpsc::UnboundedReceiver<Result<RestEvent>>>>,
     },
@@ -269,6 +271,7 @@ impl RestSource {
 
                 let file_upload_row_rx = Arc::new(Mutex::new(file_upload_row_rx));
                 let file_rest_event = RestEvent::FileInsertEvent {
+                    src_table_id,
                     table_events: file_upload_row_rx,
                 };
                 Ok(vec![file_rest_event])
@@ -489,7 +492,7 @@ mod tests {
 
         // Check file events.
         match &events[0] {
-            RestEvent::FileInsertEvent { table_events } => {
+            RestEvent::FileInsertEvent { table_events, .. } => {
                 let rest_events = get_all_rest_events(table_events.clone()).await.unwrap();
                 // There're 3 append events and 1 commit event.
                 assert_eq!(rest_events.len(), 4);
@@ -591,7 +594,7 @@ mod tests {
 
         // Check file events.
         match &events[0] {
-            RestEvent::FileInsertEvent { table_events } => {
+            RestEvent::FileInsertEvent { table_events, .. } => {
                 let rest_events = get_all_rest_events(table_events.clone()).await;
                 assert!(rest_events.is_err());
             }

--- a/src/moonlink_service/src/test.rs
+++ b/src/moonlink_service/src/test.rs
@@ -172,7 +172,7 @@ async fn test_moonlink_standalone() {
         &mut moonlink_stream,
         DATABASE.to_string(),
         TABLE.to_string(),
-        0,
+        /*lsn=*/ 1,
     )
     .await
     .unwrap();


### PR DESCRIPTION
## Summary

Problem statement:
- REST connector creates temporary replication state variable, which means the replication LSN receiver at read state manager listens to a broken (closed) replication sender;
- It leads to a problem, whenever we scan table (block wait) for a non-zero LSN, it crashes

This PR fixes by 
- Extracting replication state out of pg connector
- Send out commit LSN via replication LSN channel

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1605

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
