### PR TITLE
set ndv value for compacted parquet files

### DIFF
--- a/src/moonlink/src/storage/compaction/compactor.rs
+++ b/src/moonlink/src/storage/compaction/compactor.rs
@@ -133,7 +133,7 @@ impl CompactionBuilder {
         self.cur_new_data_file = Some(self.create_new_data_file());
         let write_file =
             tokio::fs::File::create(self.cur_new_data_file.as_ref().unwrap().file_path()).await?;
-        let properties = parquet_utils::get_parquet_properties_for_compaction();
+        let properties = parquet_utils::get_parquet_properties_for_compaction(self.cur_row_num);
         let writer: AsyncArrowWriter<tokio::fs::File> =
             AsyncArrowWriter::try_new(write_file, self.schema.clone(), Some(properties))?;
         self.cur_arrow_writer = Some(writer);

--- a/src/moonlink/src/storage/parquet_utils.rs
+++ b/src/moonlink/src/storage/parquet_utils.rs
@@ -22,7 +22,7 @@ pub(crate) fn get_default_parquet_properties() -> WriterProperties {
 }
 
 /// Parquet option for already compacted files.
-pub(crate) fn get_parquet_properties_for_compaction() -> WriterProperties {
+pub(crate) fn get_parquet_properties_for_compaction(row_num: usize) -> WriterProperties {
     let builder = get_default_parquet_properties_builder();
-    builder.set_bloom_filter_enabled(true).build()
+    builder.set_bloom_filter_ndv(row_num as u64).build()
 }


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

set ndv value for compacted parquet files

https://github.com/duckdb/duckdb/blob/0b83e5d2f68bc02dfefde74b846bd039f078affa/extension/parquet/parquet_statistics.cpp#L570-L571

> double n = LossyNumericCast<double>(num_entries);
> double m = -k * n / std::log(1 - std::pow(f, 1 / k));

n is the NDV, which basically is the row count in DuckDB’s implementation.
m is the recommended bitmap size required to achieve the target ffp, but there is no corresponding property in `WriterPropertiesBuilder` options.

Closes [Related Issues](https://github.com/Mooncake-Labs/moonlink/issues/1571)

## Changes
- set ndv to row number

## Checklist

- [✓] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [✓] I have reviewed my own changes
