### PR TITLE
[storage] Add serde default for write option

### DIFF
--- a/src/moonlink/src/storage/filesystem/gcs/gcs_test_utils.rs
+++ b/src/moonlink/src/storage/filesystem/gcs/gcs_test_utils.rs
@@ -1,6 +1,7 @@
 use crate::storage::filesystem::accessor::base_filesystem_accessor::BaseFileSystemAccess;
 use crate::storage::filesystem::accessor_config::AccessorConfig;
 use crate::storage::filesystem::storage_config::StorageConfig;
+use crate::storage::filesystem::storage_config::WriteOption;
 use crate::storage::filesystem::test_utils::object_storage_test_utils::*;
 use crate::FileSystemAccessor;
 
@@ -27,7 +28,9 @@ pub(crate) fn create_gcs_storage_config(warehouse_uri: &str) -> AccessorConfig {
         region: "".to_string(),
         access_key_id: "".to_string(),
         secret_access_key: "".to_string(),
-        multipart_upload_threshold: Some(usize::MAX),
+        write_option: Some(WriteOption {
+            multipart_upload_threshold: Some(usize::MAX),
+        }),
     };
     AccessorConfig::new_with_storage_config(storage_config)
 }

--- a/src/moonlink/src/storage/filesystem/storage_config.rs
+++ b/src/moonlink/src/storage/filesystem/storage_config.rs
@@ -3,6 +3,13 @@ use crate::MoonlinkSecretType;
 use crate::MoonlinkTableSecret;
 use serde::{Deserialize, Serialize};
 
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct WriteOption {
+    /// Used to overwrite write option.
+    #[serde(default)]
+    pub multipart_upload_threshold: Option<usize>,
+}
+
 /// StorageConfig contains configuration for multiple storage backends.
 #[derive(Clone, Deserialize, PartialEq, Serialize)]
 pub enum StorageConfig {
@@ -45,8 +52,9 @@ pub enum StorageConfig {
         /// Used for fake GCS server.
         #[serde(default)]
         disable_auth: bool,
-        /// Used to overwrite write option.
-        multipart_upload_threshold: Option<usize>,
+        /// Write options, only overwrite if specified.
+        #[serde(default)]
+        write_option: Option<WriteOption>,
     },
 }
 
@@ -86,7 +94,7 @@ impl std::fmt::Debug for StorageConfig {
                 bucket,
                 endpoint,
                 disable_auth,
-                multipart_upload_threshold,
+                write_option,
                 access_key_id: _,
                 secret_access_key: _,
             } => f
@@ -96,7 +104,7 @@ impl std::fmt::Debug for StorageConfig {
                 .field("bucket", bucket)
                 .field("endpoint", endpoint)
                 .field("disable_auth", disable_auth)
-                .field("multipart_upload_threshold", multipart_upload_threshold)
+                .field("write_option", write_option)
                 .field("access key id", &"xxxxx")
                 .field("secret access key", &"xxxxx")
                 .finish(),
@@ -187,7 +195,7 @@ mod tests {
                 secret_access_key: "fake-secret-key".to_string(),
                 endpoint: None,
                 disable_auth: false,
-                multipart_upload_threshold: None,
+                write_option: None,
             }
         );
     }

--- a/src/moonlink_backend/src/table_config.rs
+++ b/src/moonlink_backend/src/table_config.rs
@@ -200,7 +200,7 @@ mod tests {
                     secret_access_key: "secret".to_string(),
                     endpoint: None,
                     disable_auth: false,
-                    multipart_upload_threshold: None,
+                    write_option: None,
                 },
             )),
         };

--- a/src/moonlink_metadata_store/src/config_utils.rs
+++ b/src/moonlink_metadata_store/src/config_utils.rs
@@ -160,7 +160,7 @@ fn recover_storage_config(
                     secret_access_key: secret_entry.secret,
                     endpoint: secret_entry.endpoint,
                     disable_auth: false,
-                    multipart_upload_threshold: None,
+                    write_option: None,
                 };
             }
             #[cfg(feature = "storage-s3")]

--- a/src/moonlink_metadata_store/src/sqlite/tests.rs
+++ b/src/moonlink_metadata_store/src/sqlite/tests.rs
@@ -26,7 +26,7 @@ fn get_storage_config() -> StorageConfig {
             secret_access_key: "secret_access_key".to_string(),
             endpoint: None,
             disable_auth: false,
-            multipart_upload_threshold: None,
+            write_option: None,
         };
     }
 


### PR DESCRIPTION
## Summary

This PR adds default value to write option serde, so we don't have compatibility issues.
Existing unit tests are enough, if options are not set properly GCS tests will fail.

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
