### PR TITLE
add error handling for json fail condition

### DIFF
--- a/src/moonlink_service/src/rest_api.rs
+++ b/src/moonlink_service/src/rest_api.rs
@@ -210,7 +210,20 @@ async fn create_table(
     let arrow_schema = Schema::new(fields);
 
     // Serialization not expect to fail.
-    let serialized_table_config = serde_json::to_string(&payload.table_config).unwrap();
+    let serialized_table_config = match serde_json::to_string(&payload.table_config) {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            error!("serialize table_config failed: {}", e);
+            return Err((
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: "table_creation_failed".to_string(),
+                    message: format!("Failed to create table: {e}"),
+                }),
+            ));
+        }
+    };
+    // let serialized_table_config = serde_json::to_string(&table_config).unwrap();
 
     // Create table in backend
     match state

--- a/src/moonlink_service/src/rest_api.rs
+++ b/src/moonlink_service/src/rest_api.rs
@@ -223,7 +223,6 @@ async fn create_table(
             ));
         }
     };
-    // let serialized_table_config = serde_json::to_string(&table_config).unwrap();
 
     // Create table in backend
     match state

--- a/src/moonlink_service/src/rest_api.rs
+++ b/src/moonlink_service/src/rest_api.rs
@@ -213,12 +213,11 @@ async fn create_table(
     let serialized_table_config = match serde_json::to_string(&payload.table_config) {
         Ok(cfg) => cfg,
         Err(e) => {
-            error!("serialize table_config failed: {}", e);
             return Err((
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorResponse {
-                    error: "table_creation_failed".to_string(),
-                    message: format!("Failed to create table: {e}"),
+                    error: "serialization_failed".to_string(),
+                    message: format!("Serialize table config failed: {e}"),
                 }),
             ));
         }


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

Avoid crashing the REST server when JSON serialization fails by replacing `unwrap()` with proper error handling.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1624

## Checklist

- [✓] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [✓] I have reviewed my own changes
