### PR TITLE
fix: moonlink_service panics when client closes connection

### DIFF
--- a/src/moonlink_service/src/rpc_server.rs
+++ b/src/moonlink_service/src/rpc_server.rs
@@ -3,7 +3,7 @@ use arrow_ipc::writer::StreamWriter;
 use moonlink_backend::MoonlinkBackend;
 use moonlink_rpc::{read, write, Request, Table};
 use std::collections::HashMap;
-use std::error::Error as StdError;
+use std::error::Error as _;
 use std::io::ErrorKind::{BrokenPipe, ConnectionReset, UnexpectedEof};
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -12,6 +12,10 @@ use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::net::{TcpListener, UnixListener};
 use tracing::info;
 
+fn is_disconnect(io: &std::io::Error) -> bool {
+    matches!(io.kind(), BrokenPipe | ConnectionReset | UnexpectedEof)
+}
+
 fn is_closed_connection(err: &Error) -> bool {
     // Direct IO error path
     if let Error::Io(error_struct) = err {
@@ -19,7 +23,7 @@ fn is_closed_connection(err: &Error) -> bool {
             .source()
             .and_then(|e| e.downcast_ref::<std::io::Error>())
         {
-            return matches!(io_err.kind(), BrokenPipe | ConnectionReset | UnexpectedEof);
+            return is_disconnect(io_err);
         }
     }
 
@@ -34,7 +38,7 @@ fn is_closed_connection(err: &Error) -> bool {
                     .source()
                     .and_then(|e| e.downcast_ref::<std::io::Error>())
                 {
-                    return matches!(io_err.kind(), BrokenPipe | ConnectionReset | UnexpectedEof);
+                    return is_disconnect(io_err);
                 }
             }
         }
@@ -180,5 +184,75 @@ where
                 write(&mut stream, &()).await?;
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::rpc_server::start_unix_server;
+    use moonlink_backend::MoonlinkBackend;
+    use moonlink_metadata_store::SqliteMetadataStore;
+    use serial_test::serial;
+    use std::sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc as StdArc,
+    };
+    use tempfile::TempDir;
+    use tokio::net::UnixStream;
+
+    #[tokio::test]
+    #[serial]
+    async fn unix_server_ignores_client_disconnect() {
+        // Capture panics from background tasks
+        let panic_count = StdArc::new(AtomicUsize::new(0));
+        let prev_hook = std::panic::take_hook();
+        {
+            let panic_count = StdArc::clone(&panic_count);
+            std::panic::set_hook(Box::new(move |_| {
+                panic_count.fetch_add(1, Ordering::SeqCst);
+            }));
+        }
+
+        let tempdir = TempDir::new().unwrap();
+        let base_path = tempdir.path().to_str().unwrap().to_string();
+        let sqlite_store = SqliteMetadataStore::new_with_directory(&base_path)
+            .await
+            .unwrap();
+        let backend = MoonlinkBackend::new(base_path.clone(), None, Box::new(sqlite_store))
+            .await
+            .unwrap();
+
+        let socket_path = tempdir.path().join("moonlink_test.sock");
+        let server_handle = tokio::spawn({
+            let backend = std::sync::Arc::new(backend);
+            let socket_path = socket_path.clone();
+            async move {
+                // Ignore the result since we abort the task at the end of the test
+                let _ = start_unix_server(backend, socket_path).await;
+            }
+        });
+
+        // Wait for the socket file to appear
+        for _ in 0..50 {
+            if tokio::fs::metadata(&socket_path).await.is_ok() {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+
+        // Connect and immediately drop to simulate client closing connection
+        let stream = UnixStream::connect(&socket_path).await.unwrap();
+        drop(stream);
+
+        // Give the server a brief moment to process the disconnect
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+        // Ensure no panic occurred
+        assert_eq!(panic_count.load(Ordering::SeqCst), 0);
+
+        // Cleanup
+        server_handle.abort();
+        let _ = server_handle.await;
+        std::panic::set_hook(prev_hook);
     }
 }

--- a/src/moonlink_service/src/rpc_server.rs
+++ b/src/moonlink_service/src/rpc_server.rs
@@ -29,17 +29,15 @@ fn is_closed_connection(err: &Error) -> bool {
 
     // RPC wraps an RPC error which can wrap an IO error
     if let Error::Rpc(error_struct) = err {
-        if let Some(rpc_err) = error_struct
+        if let Some(moonlink_rpc::Error::Io(inner)) = error_struct
             .source()
             .and_then(|e| e.downcast_ref::<moonlink_rpc::Error>())
         {
-            if let moonlink_rpc::Error::Io(inner) = rpc_err {
-                if let Some(io_err) = inner
-                    .source()
-                    .and_then(|e| e.downcast_ref::<std::io::Error>())
-                {
-                    return is_disconnect(io_err);
-                }
+            if let Some(io_err) = inner
+                .source()
+                .and_then(|e| e.downcast_ref::<std::io::Error>())
+            {
+                return is_disconnect(io_err);
             }
         }
     }


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

Run anything on pg_mooncake that will connect to moonlink, e.g.

```sql
CREATE EXTENSION pg_mooncake;
CREATE TABLE r (a int primary key, b text);
CALL mooncake.create_table('c', 'r');
INSERT INTO r VALUES (1, 'a'), (2, 'b'), (3, 'c');
SELECT * FROM c;
```

Now Ctrl-C to close client. In pg log (/home/vscode/.pgrx/17.log), we have

```
thread 'tokio-runtime-worker' panicked at /workspaces/pg_mooncake/moonlink/src/moonlink_service/src/rpc_server.rs:42:27:
Unexpected Unix RPC server error: RPC error (permanent) at /workspaces/pg_mooncake/moonlink/src/moonlink_service/src/rpc_server.rs:80:23, source: IO error (permanent) at /workspaces/pg_mooncake/moonlink/src/moonlink_rpc/src/lib.rs:49:5, source: early eof
stack backtrace:
   0: __rustc::rust_begin_unwind
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/std/src/panicking.rs:697:5
   1: core::panicking::panic_fmt
             at /rustc/6b00bc3880198600130e1cf62b8f8a93494488cc/library/core/src/panicking.rs:75:14
   2: moonlink_service::rpc_server::start_unix_server::{{closure}}::{{closure}}
             at /workspaces/pg_mooncake/moonlink/src/moonlink_service/src/rpc_server.rs:42:27
   3: <core::pin::Pin<P> as core::future::future::Future>::poll
             at /usr/local/rustup/toolchains/1.88.0-aarch64-unknown-linux-
....
```

**The root cause is the error is actually a two level depth error - `Error::Rpc(moonlink_rpc::Error(std::io::Error))`. 
The original error handling path can only handle the `moonlink_rpc::Error(std::io::Error)` or `Error::Rpc(std::io::Error)`
So that's why the panic happend.**

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1597

## Changes

- If source is IO directly, means it's the tokio error or service-level IO like `accept/bind/fs`
- All error return from inside of the `handle_stream` are basically PRC error
- Add a test that start a unix server and then close its client to check no panic

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [x] Documentation updated if necessary
- [x] I have reviewed my own changes
