### PR TITLE
Handle duplicate table creation

### DIFF
--- a/src/moonlink_backend/tests/test_backend.rs
+++ b/src/moonlink_backend/tests/test_backend.rs
@@ -116,6 +116,26 @@ mod tests {
         assert_eq!(ids, HashSet::new());
     }
 
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[serial]
+    async fn test_create_duplicate_table() {
+        let (guard, _client) = TestGuard::new(Some("duplicate_table"), true).await;
+        let backend = guard.backend();
+        // Till now, the table has been created in mooncake backend.
+
+        let res = backend
+            .create_table(
+                DATABASE.to_string(),
+                TABLE.to_string(),
+                "public.duplicate_table".to_string(),
+                SRC_URI.to_string(),
+                /*table_config=*/ "{}".to_string(),
+                /*input_schema=*/ None,
+            )
+            .await;
+        assert!(res.is_err());
+    }
+
     /// Validates that `create_iceberg_snapshot` writes Iceberg metadata.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     #[serial]

--- a/src/moonlink_backend/tests/test_backend.rs
+++ b/src/moonlink_backend/tests/test_backend.rs
@@ -22,7 +22,15 @@ mod tests {
     async fn test_moonlink_service() {
         let (guard, client) = TestGuard::new(Some("test"), true).await;
         let backend = guard.backend();
+        // Till now, table already created at backend.
+
+        // First round of table operations.
+        backend
+            .drop_table(DATABASE.to_string(), TABLE.to_string())
+            .await;
         smoke_create_and_insert(guard.tmp().unwrap(), backend, &client, SRC_URI).await;
+
+        // Second round of table operations.
         backend
             .drop_table(DATABASE.to_string(), TABLE.to_string())
             .await;
@@ -114,26 +122,6 @@ mod tests {
                 .unwrap(),
         );
         assert_eq!(ids, HashSet::new());
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    #[serial]
-    async fn test_create_duplicate_table() {
-        let (guard, _client) = TestGuard::new(Some("duplicate_table"), true).await;
-        let backend = guard.backend();
-        // Till now, the table has been created in mooncake backend.
-
-        let res = backend
-            .create_table(
-                DATABASE.to_string(),
-                TABLE.to_string(),
-                "public.duplicate_table".to_string(),
-                SRC_URI.to_string(),
-                /*table_config=*/ "{}".to_string(),
-                /*input_schema=*/ None,
-            )
-            .await;
-        assert!(res.is_err());
     }
 
     /// Validates that `create_iceberg_snapshot` writes Iceberg metadata.

--- a/src/moonlink_connectors/src/error.rs
+++ b/src/moonlink_connectors/src/error.rs
@@ -42,6 +42,10 @@ pub enum Error {
     #[error("Invalid source type: {0}")]
     InvalidSourceType(String),
 
+    // Table replication error: duplicate table.
+    #[error("Duplicate table added to replication: {0}")]
+    ReplDuplicateTable(String),
+
     // REST API error.
     #[error("REST API error: {0}")]
     RestApi(String),

--- a/src/moonlink_connectors/src/replication_manager.rs
+++ b/src/moonlink_connectors/src/replication_manager.rs
@@ -3,6 +3,7 @@ use crate::ReplicationConnection;
 use crate::{Error, Result};
 use moonlink::{MoonlinkTableConfig, ObjectStorageCache, ReadStateManager, TableEventManager};
 use moonlink::{ReadStateFilepathRemap, TableStatusReader};
+use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::hash::Hash;
 use tokio::task::JoinHandle;
@@ -59,22 +60,23 @@ impl<T: Clone + Eq + Hash + std::fmt::Display> ReplicationManager<T> {
         is_recovery: bool,
     ) -> Result<()> {
         debug!(%src_uri, table_name, "adding table through manager");
-        if !self.connections.contains_key(src_uri) {
-            debug!(%src_uri, "creating replication connection");
-            // Lazily create the directory that will hold all tables.
-            // This will not overwrite any existing directory.
-            tokio::fs::create_dir_all(&self.table_base_path).await?;
-            let base_path = tokio::fs::canonicalize(&self.table_base_path).await?;
-            let replication_connection = ReplicationConnection::new(
-                src_uri.to_string(),
-                base_path.to_str().unwrap().to_string(),
-                self.object_storage_cache.clone(),
-            )
-            .await?;
-            self.connections
-                .insert(src_uri.to_string(), replication_connection);
-        }
-        let replication_connection = self.connections.get_mut(src_uri).unwrap();
+        let (replication_connection, is_new_repl_conn): (&mut ReplicationConnection, bool) =
+            match self.connections.entry(src_uri.to_string()) {
+                Entry::Occupied(entry) => (entry.into_mut(), false),
+                Entry::Vacant(entry) => {
+                    debug!(%src_uri, "creating replication connection");
+
+                    tokio::fs::create_dir_all(&self.table_base_path).await?;
+                    let base_path = tokio::fs::canonicalize(&self.table_base_path).await?;
+                    let replication_connection = ReplicationConnection::new(
+                        src_uri.to_string(),
+                        base_path.to_str().unwrap().to_string(),
+                        self.object_storage_cache.clone(),
+                    )
+                    .await?;
+                    (entry.insert(replication_connection), true)
+                }
+            };
 
         let src_table_id = replication_connection
             .add_table_replication(
@@ -85,8 +87,14 @@ impl<T: Clone + Eq + Hash + std::fmt::Display> ReplicationManager<T> {
                 is_recovery,
             )
             .await?;
-        self.table_info
-            .insert(mooncake_table_id, (src_uri.to_string(), src_table_id));
+
+        // Error handling: don't allow duplicate mooncake table id be registered.
+        if self.table_info.contains_key(&mooncake_table_id) {
+            replication_connection.drop_table(src_table_id).await?;
+            if is_new_repl_conn {
+                assert!(self.connections.remove(src_uri).is_some());
+            }
+        }
 
         debug!(src_table_id, "table added through manager");
 

--- a/src/moonlink_connectors/src/replication_manager.rs
+++ b/src/moonlink_connectors/src/replication_manager.rs
@@ -94,7 +94,15 @@ impl<T: Clone + Eq + Hash + std::fmt::Display> ReplicationManager<T> {
             if is_new_repl_conn {
                 assert!(self.connections.remove(src_uri).is_some());
             }
+            return Err(Error::ReplDuplicateTable(mooncake_table_id.to_string()));
         }
+        assert!(self
+            .table_info
+            .insert(
+                mooncake_table_id.clone(),
+                (src_uri.to_string(), src_table_id)
+            )
+            .is_none());
 
         debug!(src_table_id, "table added through manager");
 


### PR DESCRIPTION
## Summary

This PR attempts to fix duplicate table creation, which propagate error to caller side, instead of silently override data structures states inside of replication.

Also fixes corresponding integration test -- in some tests we're actually repeatedly creating the same table, and caught by the newly added check.

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
