### PR TITLE
No crash on drop non-existent table

### DIFF
--- a/src/moonlink_backend/tests/test_backend.rs
+++ b/src/moonlink_backend/tests/test_backend.rs
@@ -37,6 +37,22 @@ mod tests {
         smoke_create_and_insert(guard.tmp().unwrap(), backend, &client, SRC_URI).await;
     }
 
+    /// Testing scenario: drop a non-existent table shouldn't crash.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[serial]
+    async fn test_drop_non_existent_table() {
+        let (guard, _client) = TestGuard::new(Some("test"), true).await;
+        let backend = guard.backend();
+
+        // We're good as long as backend doesn't crash.
+        backend
+            .drop_table(
+                "non_existent_database".to_string(),
+                "non_existent_table".to_string(),
+            )
+            .await;
+    }
+
     /// End-to-end: inserts should appear in `scan_table`.
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     #[serial]

--- a/src/moonlink_connectors/src/replication_connection.rs
+++ b/src/moonlink_connectors/src/replication_connection.rs
@@ -3,7 +3,7 @@ use crate::pg_replicate::PostgresConnection;
 use crate::pg_replicate::{table::SrcTableId, table_init::TableComponents};
 use crate::rest_ingest::rest_source::EventRequest;
 use crate::rest_ingest::RestApiConnection;
-use crate::Result;
+use crate::{Error, Result};
 use moonlink::{
     MoonlinkTableConfig, ObjectStorageCache, ReadStateFilepathRemap, ReadStateManager,
     TableEventManager, TableStatusReader,
@@ -336,7 +336,7 @@ impl<T: Clone + Eq + Hash + std::fmt::Display> ReplicationConnection<T> {
         let table_state = self
             .table_states
             .remove(&unique_table_id)
-            .expect("table not found");
+            .ok_or(Error::TableNotFound(mooncake_table_id.to_string()))?;
 
         let table_name = &table_state.src_table_name;
 


### PR DESCRIPTION
## Summary

As titled, crash on non-existent table is not ideal.

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
