### PR TITLE
Refine error propagation for all types in moonlink_connector

### DIFF
--- a/src/moonlink_connectors/src/error.rs
+++ b/src/moonlink_connectors/src/error.rs
@@ -36,32 +36,33 @@ pub enum Error {
     MpscChannelSendError(ErrorStruct),
 
     // Requested database table not found.
-    #[error("Table {0} not found")]
-    TableNotFound(String),
+    #[error("{0}")]
+    TableNotFound(ErrorStruct),
 
     // Invalid source type for operation.
-    #[error("Invalid source type: {0}")]
-    InvalidSourceType(String),
+    #[error("{0}")]
+    InvalidSourceType(ErrorStruct),
 
     // Table replication error: duplicate table.
     #[error("Duplicate table added to replication: {0}")]
     ReplDuplicateTable(String),
 
     // REST API error.
-    #[error("REST API error: {0}")]
-    RestApi(String),
+    #[error("{0}")]
+    RestApi(ErrorStruct),
 
     // REST source error.
     #[error("{0}")]
     RestSource(ErrorStruct),
 
     // REST source error: duplicate source table to add.
-    #[error("REST source error: duplicate source table to add with table id {0}")]
-    RestDuplicateTable(SrcTableId),
+    #[error("{0}")]
+    RestDuplicateTable(ErrorStruct),
 
     // REST source error: non-existent source table to remove.
-    #[error("REST source error: non-existent source table to remove with table id {0}")]
-    RestNonExistentTable(SrcTableId),
+    #[error("{0}")]
+    RestNonExistentTable(ErrorStruct),
+    // "REST source error: non-existent source table to remove with table id "
 
     // REST source error: conversion from payload to moonlink row fails.
     #[error("{0}")]
@@ -73,6 +74,55 @@ pub enum Error {
 }
 
 pub type Result<T> = result::Result<T, Error>;
+
+impl Error {
+    pub fn rest_duplicate_table(id: SrcTableId) -> Self {
+        Error::RestDuplicateTable(ErrorStruct {
+            message: format!("REST source error: duplicate source table to add with table id {id}"),
+            status: ErrorStatus::Permanent,
+            source: None,
+            location: Some(Location::caller().to_string()),
+        })
+    }
+
+    pub fn rest_non_existent_table(id: SrcTableId) -> Self {
+        Error::RestNonExistentTable(ErrorStruct {
+            message: format!(
+                "REST source error: non-existent source table to remove with table id {id}"
+            ),
+            status: ErrorStatus::Permanent,
+            source: None,
+            location: Some(Location::caller().to_string()),
+        })
+    }
+
+    pub fn table_not_found(e: String) -> Self {
+        Error::TableNotFound(ErrorStruct {
+            message: format!("Table {e} not found"),
+            status: ErrorStatus::Permanent,
+            source: None,
+            location: Some(Location::caller().to_string()),
+        })
+    }
+
+    pub fn invalid_source_type(e: String) -> Self {
+        Error::InvalidSourceType(ErrorStruct {
+            message: format!("Invalid source type: {e}"),
+            status: ErrorStatus::Permanent,
+            source: None,
+            location: Some(Location::caller().to_string()),
+        })
+    }
+
+    pub fn rest_api(e: String) -> Self {
+        Error::RestApi(ErrorStruct {
+            message: format!("REST API error: {e}"),
+            status: ErrorStatus::Permanent,
+            source: None,
+            location: Some(Location::caller().to_string()),
+        })
+    }
+}
 
 impl From<MoonlinkError> for Error {
     #[track_caller]

--- a/src/moonlink_connectors/src/replication_manager.rs
+++ b/src/moonlink_connectors/src/replication_manager.rs
@@ -134,7 +134,7 @@ impl<T: Clone + Eq + Hash + std::fmt::Display> ReplicationManager<T> {
 
         // Fail if REST API connection doesn't exist
         if !self.connections.contains_key(src_uri) {
-            return Err(crate::Error::RestApi(format!(
+            return Err(crate::Error::rest_api(format!(
                 "REST API connection '{src_uri}' not found. Initialize REST API first."
             )));
         }
@@ -260,7 +260,7 @@ impl<T: Clone + Eq + Hash + std::fmt::Display> ReplicationManager<T> {
         let (uri, src_table_id) = self
             .table_info
             .get(mooncake_table_id)
-            .ok_or_else(|| Error::TableNotFound(mooncake_table_id.to_string()))?;
+            .ok_or_else(|| Error::table_not_found(mooncake_table_id.to_string()))?;
         let connection = self
             .connections
             .get_mut(uri)
@@ -291,7 +291,7 @@ impl<T: Clone + Eq + Hash + std::fmt::Display> ReplicationManager<T> {
         let (uri, src_table_id) = self
             .table_info
             .get(mooncake_table_id)
-            .ok_or_else(|| Error::TableNotFound(mooncake_table_id.to_string()))?;
+            .ok_or_else(|| Error::table_not_found(mooncake_table_id.to_string()))?;
         let connection = self
             .connections
             .get(uri)

--- a/src/moonlink_connectors/src/rest_ingest.rs
+++ b/src/moonlink_connectors/src/rest_ingest.rs
@@ -97,10 +97,9 @@ impl RestApiConnection {
             wal_flush_lsn_rx,
         };
 
-        self.cmd_tx
-            .send(command)
-            .await
-            .map_err(|e| crate::Error::RestApi(format!("Failed to send add table command: {e}")))?;
+        self.cmd_tx.send(command).await.map_err(|e| {
+            crate::Error::rest_api(format!("Failed to send add table command: {e}"))
+        })?;
 
         Ok(())
     }
@@ -113,7 +112,7 @@ impl RestApiConnection {
         };
 
         self.cmd_tx.send(command).await.map_err(|e| {
-            crate::Error::RestApi(format!("Failed to send drop table command: {e}"))
+            crate::Error::rest_api(format!("Failed to send drop table command: {e}"))
         })?;
 
         Ok(())
@@ -133,7 +132,7 @@ impl RestApiConnection {
         self.cmd_tx
             .send(RestCommand::Shutdown)
             .await
-            .map_err(|e| crate::Error::RestApi(format!("Failed to send shutdown command: {e}")))?;
+            .map_err(|e| crate::Error::rest_api(format!("Failed to send shutdown command: {e}")))?;
         Ok(())
     }
 

--- a/src/moonlink_connectors/src/rest_ingest/moonlink_rest_sink.rs
+++ b/src/moonlink_connectors/src/rest_ingest/moonlink_rest_sink.rs
@@ -40,7 +40,7 @@ impl RestSink {
             .insert(src_table_id, table_status)
             .is_some()
         {
-            return Err(Error::RestDuplicateTable(src_table_id));
+            return Err(Error::rest_duplicate_table(src_table_id));
         }
         Ok(())
     }
@@ -48,7 +48,7 @@ impl RestSink {
     /// Remove a table from the REST sink
     pub fn drop_table(&mut self, src_table_id: SrcTableId) -> Result<()> {
         if self.table_status.remove(&src_table_id).is_none() {
-            return Err(Error::RestNonExistentTable(src_table_id));
+            return Err(Error::rest_non_existent_table(src_table_id));
         }
         Ok(())
     }
@@ -62,7 +62,7 @@ impl RestSink {
         if let Some(table_status) = self.table_status.get(&src_table_id) {
             table_status.commit_lsn_tx.send(lsn).unwrap();
         } else {
-            return Err(crate::Error::RestApi(format!(
+            return Err(crate::Error::rest_api(format!(
                 "No table status found for src_table_id: {src_table_id}"
             )));
         }
@@ -238,11 +238,11 @@ impl RestSink {
     async fn send_table_event(&self, src_table_id: SrcTableId, event: TableEvent) -> Result<()> {
         if let Some(table_status) = self.table_status.get(&src_table_id) {
             table_status.event_sender.send(event).await.map_err(|e| {
-                crate::Error::RestApi(format!("Failed to send event to table {src_table_id}: {e}"))
+                crate::Error::rest_api(format!("Failed to send event to table {src_table_id}: {e}"))
             })?;
             Ok(())
         } else {
-            Err(crate::Error::RestApi(format!(
+            Err(crate::Error::rest_api(format!(
                 "No event sender found for src_table_id: {src_table_id}"
             )))
         }


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

Refactor error propagation in moonlink_connector by unifying all error types through function-based mapping.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1630

## Checklist

- [✓] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [✓] I have reviewed my own changes
