### PR TITLE
AWS EKS deployment

### DIFF
--- a/deploy/aws/dev/deployment/moonlink_deployment.yaml
+++ b/deploy/aws/dev/deployment/moonlink_deployment.yaml
@@ -1,0 +1,83 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: moonlink-deployment-dev
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: moonlink-deployment-dev
+  template:
+    metadata:
+      labels:
+        app: moonlink-deployment-dev
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+      containers:
+      # Moonlink deployment, which serves REST API and TCP rpc requests.
+      - name: moonlink-deployment-dev
+        image: docker.io/lohpaul9/moonlink:latest
+        command: ["/app/moonlink_service"]
+        args:
+        - "/tmp/moonlink"
+        - "--no-rest-api"
+        - "--tcp-port=3031"
+        - "--data-server-uri=$(DATA_SERVER_URI)"
+        env:
+        - name: DATA_SERVER_URI
+          value: "http://<moonlink-service-uri>:8080"
+        volumeMounts:
+        - name: shared-cache-directory
+          mountPath: /tmp/moonlink
+        ports:
+        # Port number for REST API server.
+        - containerPort: 3030
+        # Port number for TCP rpc server.
+        - containerPort: 3031
+        # Port number for readiness probe.
+        - containerPort: 5050 
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 5050
+          initialDelaySeconds: 2
+          periodSeconds: 5
+          timeoutSeconds: 1
+          failureThreshold: 3
+
+      # Data server, which serves data plane requests.
+      - name: nginx
+        image: nginx:latest
+        ports:
+        - containerPort: 80
+        volumeMounts:
+        # nginx serves local files under certain directory.
+        - name: shared-cache-directory
+          mountPath: /usr/share/nginx/html
+
+      # Act as remote postgres instance.
+      - name: postgres
+        image: mooncakelabs/pg_mooncake
+        env:
+        - name: POSTGRES_PASSWORD
+          value: password
+        ports:
+        - containerPort: 5432
+        volumeMounts:
+        - name: pgdata
+          mountPath: /var/lib/postgresql/data
+
+      volumes:
+      - name: pgdata
+        emptyDir: {}
+      # Shared cache directory between data server and moonlink.
+      - name: shared-cache-directory
+        emptyDir: {}

--- a/deploy/aws/dev/service/moonlink_service.yaml
+++ b/deploy/aws/dev/service/moonlink_service.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: moonlink-service-dev
+  annotations:
+    # aws specific annotations
+    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+    service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
+    service.beta.kubernetes.io/aws-load-balancer-healthcheck-protocol: "HTTP"
+    service.beta.kubernetes.io/aws-load-balancer-healthcheck-port: "5050"
+    service.beta.kubernetes.io/aws-load-balancer-healthcheck-path: "/ready"
+spec:
+  type: LoadBalancer
+  # IP assigned by kubernetes automatically.
+  selector:
+    app: moonlink-deployment-dev
+  ports:
+  # Exposed port for data server.
+  - name: data
+    protocol: TCP
+    port: 8080
+    targetPort: 80
+  # Exposed port for REST API server.
+  - name: rest
+    protocol: TCP
+    port: 3030
+    targetPort: 3030
+  # Exposed port for TCP rpc server.
+  - name: tcp
+    protocol: TCP
+    port: 3031
+    targetPort: 3031
+  # Exposed port for readiness check.
+  - name: readiness
+    protocol: TCP
+    port: 5050
+    targetPort: 5050

--- a/deploy/aws/dev/service/postgres_service.yaml
+++ b/deploy/aws/dev/service/postgres_service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres-service
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+    service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
+spec:
+  type: LoadBalancer
+  selector:
+    app: moonlink-deployment-dev
+  ports:
+    - name: postgres
+      protocol: TCP
+      port: 5432
+      targetPort: 5432

--- a/deploy/aws/prod/deployment/moonlink_deployment.yaml
+++ b/deploy/aws/prod/deployment/moonlink_deployment.yaml
@@ -1,0 +1,81 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: moonlink-deployment
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 20%
+  selector:
+    matchLabels:
+      app: moonlink-deployment
+  template:
+    metadata:
+      labels:
+        app: moonlink-deployment
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+      containers:
+      # Moonlink deployment, which serves REST API and TCP rpc requests.
+      - name: moonlink-deployment
+        image: docker.io/lohpaul9/moonlink:latest
+        command: ["/app/moonlink_service"]
+        args:
+        - "/tmp/moonlink"
+        - "--no-rest-api"
+        - "--tcp-port=3031"
+        - "--data-server-uri=$(DATA_SERVER_URI)"
+        # TODO(hjiang): Revisit before release and production deployment, use a dummy guaranteed QoS for now. 
+        resources:
+          requests:
+            cpu: "500m"
+            memory: "1Gi"
+          limits:
+            cpu: "500m"
+            memory: "1Gi"
+        env:
+        - name: DATA_SERVER_URI
+          value: "http://<moonlink-service-uri>:8080"
+        volumeMounts:
+        - name: shared-cache-directory
+          mountPath: /tmp/moonlink
+        ports:
+        # Port number for REST API server.
+        - containerPort: 3030
+        # Port number for TCP rpc server.
+        - containerPort: 3031
+        # Port number for readiness probe.
+        - containerPort: 5050 
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 5050
+          initialDelaySeconds: 2
+          periodSeconds: 5
+          timeoutSeconds: 1
+          failureThreshold: 3
+
+      # Data server, which serves data plane requests.
+      - name: nginx
+        image: nginx:latest
+        ports:
+        - containerPort: 80
+        volumeMounts:
+        # nginx serves local files under certain directory.
+        - name: shared-cache-directory
+          mountPath: /usr/share/nginx/html
+
+      volumes:
+      # Shared cache directory between data server and moonlink.
+      - name: shared-cache-directory
+        emptyDir: {}

--- a/deploy/aws/prod/service/moonlink_service.yaml
+++ b/deploy/aws/prod/service/moonlink_service.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: moonlink-service
+  annotations:
+    # aws specific annotations
+    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+    service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
+    service.beta.kubernetes.io/aws-load-balancer-healthcheck-protocol: "HTTP"
+    service.beta.kubernetes.io/aws-load-balancer-healthcheck-port: "5050"
+    service.beta.kubernetes.io/aws-load-balancer-healthcheck-path: "/ready"
+spec:
+  type: LoadBalancer
+  # IP assigned by kubernetes automatically.
+  selector:
+    app: moonlink-deployment
+  ports:
+  # Exposed port for data server.
+  - name: data
+    protocol: TCP
+    port: 8080
+    targetPort: 80
+  # Exposed port for REST API server.
+  - name: rest
+    protocol: TCP
+    port: 3030
+    targetPort: 3030
+  # Exposed port for TCP rpc server.
+  - name: tcp
+    protocol: TCP
+    port: 3031
+    targetPort: 3031
+  # Exposed port for readiness check.
+  - name: readiness
+    protocol: TCP
+    port: 5050
+    targetPort: 5050

--- a/deploy/aws/staging/deployment/moonlink_deployment.yaml
+++ b/deploy/aws/staging/deployment/moonlink_deployment.yaml
@@ -1,0 +1,83 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: moonlink-deployment-staging
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 20%
+  selector:
+    matchLabels:
+      app: moonlink-deployment-staging
+  template:
+    metadata:
+      labels:
+        app: moonlink-deployment-staging
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+      containers:
+      # Moonlink deployment, which serves REST API and TCP rpc requests.
+      - name: moonlink-deployment-staging
+        image: docker.io/lohpaul9/moonlink:latest
+        command: ["/app/moonlink_service"]
+        args:
+        - "/tmp/moonlink"
+        - "--no-rest-api"
+        - "--tcp-port=3031"
+        - "--data-server-uri=$(DATA_SERVER_URI)"
+        # TODO(hjiang): Revisit before release and production deployment, use a dummy guaranteed QoS for now. 
+        resources:
+          requests:
+            cpu: "200m"
+            memory: "1Gi"
+          limits:
+            cpu: "200m"
+            memory: "1Gi"
+        env:
+        - name: DATA_SERVER_URI
+          value: "http://<your-server-uri>:8080"
+        volumeMounts:
+        - name: shared-cache-directory
+          mountPath: /tmp/moonlink
+        ports:
+        # Port number for REST API server.
+        - containerPort: 3030
+        # Port number for TCP rpc server.
+        - containerPort: 3031
+        # Port number for readiness probe.
+        - containerPort: 5050 
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 5050
+          initialDelaySeconds: 2
+          periodSeconds: 5
+          timeoutSeconds: 1
+          failureThreshold: 3
+
+      # Data server, which serves data plane requests.
+      - name: nginx
+        image: nginx:latest
+        ports:
+        - containerPort: 80
+        volumeMounts:
+        # nginx serves local files under certain directory.
+        - name: shared-cache-directory
+          mountPath: /usr/share/nginx/html
+
+      volumes:
+      # Shared cache directory between data server and moonlink.
+      - name: shared-cache-directory
+        emptyDir: {}
+
+

--- a/deploy/aws/staging/service/moonlink_service.yaml
+++ b/deploy/aws/staging/service/moonlink_service.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: moonlink-service-staging
+  annotations:
+    # aws specific annotations
+    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+    service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
+    service.beta.kubernetes.io/aws-load-balancer-healthcheck-protocol: "HTTP"
+    service.beta.kubernetes.io/aws-load-balancer-healthcheck-port: "5050"
+    service.beta.kubernetes.io/aws-load-balancer-healthcheck-path: "/ready"
+spec:
+  type: LoadBalancer
+  # IP assigned by kubernetes automatically.
+  selector:
+    app: moonlink-deployment-staging
+  ports:
+  # Exposed port for data server.
+  - name: data
+    protocol: TCP
+    port: 8080
+    targetPort: 80
+  # Exposed port for REST API server.
+  - name: rest
+    protocol: TCP
+    port: 3030
+    targetPort: 3030
+  # Exposed port for TCP rpc server.
+  - name: tcp
+    protocol: TCP
+    port: 3031
+    targetPort: 3031
+  # Exposed port for readiness check.
+  - name: readiness
+    protocol: TCP
+    port: 5050
+    targetPort: 5050
+
+


### PR DESCRIPTION
## Summary
Kube config files for deployment to AWS. Has been tested and working with a local pg_mooncake connecting to moonlink service deployed on AWS EKS, which then replicates from a postgres instance in the same EKS cluster.

Steps taken to set this up:
1. Create a cluster in AWS
2. Ensure at least 2 public subnets associated with cluster in 2 different AZs (https://docs.aws.amazon.com/eks/latest/best-practices/subnets.html) 
3. Tag all subnets with `kubernetes.io/role/elb : 1` (for public subnets) or `kubernetes.io/role/internal-elb : 1` (private subnets). This is a requirement for the load balancer to work https://docs.aws.amazon.com/eks/latest/userguide/network-reqs.html
4. Ensure that cluster is available to the public

kubectl with aws kubeconfig was the easiest way to do deployments in this case. https://docs.aws.amazon.com/eks/latest/userguide/create-kubeconfig.html

To deploy:
1. Apply deployment and service files using kubectl
2. When applying deployment file, you MUST set DATA_SERVER_URI to your `moonlink_deployment` service URI in order for moonlink file serving to work correctly.

Other notes:
- AWS load balancer periodically sends health checks to its target groups. This currently causes our TLS connection threads to terminate with unexpected EOF. In order to overcome this, we use AWS specific service annotations to indicate to EKS that we want our health checks to be done on the 5050 HTTP endpoint instead of all the target groups. 
https://docs.aws.amazon.com/elasticloadbalancing/latest/application/target-group-health-checks.html
https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.1/guide/ingress/annotations/#health-check 
- As a general note, additional AWS-specific annotations were needed in order to allow the network load balancer (NLB) to be exposed to the interface. 
- EKS provides both amd64 and aarch64 nodes. For now, we arbitrarily use the amd64 nodes and build the latest image with this platform in mind. 

