### PR TITLE
feat: Handle negative scales in Decimal type

### DIFF
--- a/src/moonlink_datafusion/Cargo.toml
+++ b/src/moonlink_datafusion/Cargo.toml
@@ -12,8 +12,8 @@ bincode = { workspace = true }
 clap = { workspace = true }
 datafusion = { workspace = true }
 datafusion-cli = { workspace = true }
-moonlink_rpc = { path = "../moonlink_rpc" }
 moonlink_error = { path = "../moonlink_error" }
+moonlink_rpc = { path = "../moonlink_rpc" }
 object_store = { workspace = true }
 parquet = { workspace = true }
 roaring = { workspace = true }


### PR DESCRIPTION


<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

In a previous PR, support for Decimal did not account for cases where the scale is negative. This PR extend coverage to handle negative scales as well, in line with PostgreSQL’s numeric type specification.

Reference: [PostgreSQL 17 – Numeric Types](https://www.postgresql.org/docs/17/datatype-numeric.html)

## Related Issues

Closes #<issue-number> or links to related issues.

## Changes

- refactor the decimal utils for better readiability
- support NUMERIC(2, -3), NUMERIC(3, 5)
- Currently, Ignore Infinity / NaN for now, unless we see a strong use case

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
