### PR TITLE
[storage] Recovery replication LSN for REST

### DIFF
--- a/src/moonlink/src/lib.rs
+++ b/src/moonlink/src/lib.rs
@@ -12,10 +12,10 @@ pub use event_sync::EventSyncSender;
 pub use storage::storage_utils::create_data_file;
 pub(crate) use storage::NonEvictableHandle;
 pub use storage::{
-    AccessorConfig, BaseFileSystemAccess, BaseIcebergSchemaFetcher, CacheTrait,
+    AccessorConfig, BaseFileSystemAccess, BaseIcebergSnapshotFetcher, CacheTrait,
     DataCompactionConfig, DiskSliceWriterConfig, EventSyncReceiver, FileIndexMergeConfig,
     FileSystemAccessor, FsChaosConfig, FsRetryConfig, FsTimeoutConfig, IcebergPersistenceConfig,
-    IcebergSchemaFetcher, IcebergTableConfig, IcebergTableManager, MooncakeTable,
+    IcebergSnapshotFetcher, IcebergTableConfig, IcebergTableManager, MooncakeTable,
     MooncakeTableConfig, MoonlinkSecretType, MoonlinkTableConfig, MoonlinkTableSecret,
     ObjectStorageCache, ObjectStorageCacheConfig, PersistentWalMetadata, SnapshotReadOutput,
     StorageConfig, TableEventManager, TableManager, TableSnapshotStatus, TableStatusReader,

--- a/src/moonlink/src/storage.rs
+++ b/src/moonlink/src/storage.rs
@@ -26,8 +26,8 @@ pub use filesystem::accessor_config::{
     TimeoutConfig as FsTimeoutConfig,
 };
 pub use filesystem::storage_config::StorageConfig;
-pub use iceberg::base_iceberg_schema_fetcher::BaseIcebergSchemaFetcher;
-pub use iceberg::iceberg_schema_fetcher::IcebergSchemaFetcher;
+pub use iceberg::base_iceberg_snapshot_fetcher::BaseIcebergSnapshotFetcher;
+pub use iceberg::iceberg_snapshot_fetcher::IcebergSnapshotFetcher;
 pub use iceberg::iceberg_table_config::IcebergTableConfig;
 pub use iceberg::iceberg_table_manager::IcebergTableManager;
 pub use iceberg::table_event_manager::TableEventManager;

--- a/src/moonlink/src/storage/iceberg.rs
+++ b/src/moonlink/src/storage/iceberg.rs
@@ -1,12 +1,12 @@
-pub mod base_iceberg_schema_fetcher;
+pub mod base_iceberg_snapshot_fetcher;
 pub(super) mod catalog_utils;
 mod data_file_manifest_manager;
 pub(super) mod deletion_vector;
 mod deletion_vector_manifest_manager;
 pub(super) mod file_catalog;
 mod file_index_manifest_manager;
-pub mod iceberg_schema_fetcher;
 mod iceberg_schema_manager;
+pub mod iceberg_snapshot_fetcher;
 pub(super) mod iceberg_table_config;
 mod iceberg_table_loader;
 pub(super) mod iceberg_table_manager;
@@ -62,4 +62,4 @@ mod file_catalog_test;
 mod mock_filesystem_test;
 
 #[cfg(test)]
-mod schema_fetcher_test;
+mod snapshot_fetcher_test;

--- a/src/moonlink/src/storage/iceberg/base_iceberg_snapshot_fetcher.rs
+++ b/src/moonlink/src/storage/iceberg/base_iceberg_snapshot_fetcher.rs
@@ -9,7 +9,9 @@ use mockall::*;
 
 #[async_trait]
 #[cfg_attr(test, automock)]
-pub trait BaseIcebergSchemaFetcher {
+pub trait BaseIcebergSnapshotFetcher {
     /// Get the latest iceberg table schema.
     async fn fetch_table_schema(&self) -> Result<Option<ArrowSchema>>;
+    /// Get the latest flush LSN for the latest snapshot.
+    async fn get_flush_lsn(&self) -> Result<Option<u64>>;
 }

--- a/src/moonlink/src/storage/iceberg/iceberg_snapshot_fetcher.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_snapshot_fetcher.rs
@@ -1,6 +1,7 @@
-use crate::storage::iceberg::base_iceberg_schema_fetcher::BaseIcebergSchemaFetcher;
+use crate::storage::iceberg::base_iceberg_snapshot_fetcher::BaseIcebergSnapshotFetcher;
 use crate::storage::iceberg::catalog_utils;
 use crate::storage::iceberg::iceberg_table_config::IcebergTableConfig;
+use crate::storage::iceberg::iceberg_table_manager::MOONCAKE_TABLE_FLUSH_LSN;
 use crate::storage::iceberg::moonlink_catalog::MoonlinkCatalog;
 use crate::storage::iceberg::utils;
 use crate::Result;
@@ -10,14 +11,14 @@ use async_trait::async_trait;
 use iceberg::arrow as IcebergArrow;
 
 #[allow(dead_code)]
-pub struct IcebergSchemaFetcher {
+pub struct IcebergSnapshotFetcher {
     /// Iceberg table configuration.
     config: IcebergTableConfig,
     /// Iceberg catalog, which interacts with the iceberg table.
     catalog: Box<dyn MoonlinkCatalog>,
 }
 
-impl IcebergSchemaFetcher {
+impl IcebergSnapshotFetcher {
     pub fn new(config: IcebergTableConfig) -> Result<Self> {
         let catalog = catalog_utils::create_catalog_without_schema(config.accessor_config.clone())?;
         Ok(Self { config, catalog })
@@ -25,7 +26,7 @@ impl IcebergSchemaFetcher {
 }
 
 #[async_trait]
-impl BaseIcebergSchemaFetcher for IcebergSchemaFetcher {
+impl BaseIcebergSnapshotFetcher for IcebergSnapshotFetcher {
     async fn fetch_table_schema(&self) -> Result<Option<ArrowSchema>> {
         let table = utils::get_table_if_exists(
             &*self.catalog,
@@ -37,6 +38,28 @@ impl BaseIcebergSchemaFetcher for IcebergSchemaFetcher {
             let iceberg_schema = table.metadata().current_schema();
             let arrow_schema = IcebergArrow::schema_to_arrow_schema(iceberg_schema)?;
             return Ok(Some(arrow_schema));
+        }
+        Ok(None)
+    }
+
+    async fn get_flush_lsn(&self) -> Result<Option<u64>> {
+        let table = utils::get_table_if_exists(
+            &*self.catalog,
+            &self.config.namespace,
+            &self.config.table_name,
+        )
+        .await?;
+        if let Some(table) = table {
+            if let Some(iceberg_snapshot) = table.metadata().current_snapshot() {
+                let flush_lsn = iceberg_snapshot
+                    .summary()
+                    .additional_properties
+                    .get(MOONCAKE_TABLE_FLUSH_LSN)
+                    .map(|s| s.parse::<u64>())
+                    .unwrap_or_else(|| Ok(0))
+                    .unwrap();
+                return Ok(Some(flush_lsn));
+            }
         }
         Ok(None)
     }

--- a/src/moonlink/src/storage/iceberg/snapshot_fetcher_test.rs
+++ b/src/moonlink/src/storage/iceberg/snapshot_fetcher_test.rs
@@ -2,8 +2,8 @@ use tempfile::tempdir;
 
 use crate::row::MoonlinkRow;
 use crate::row::RowValue;
-use crate::storage::iceberg::base_iceberg_schema_fetcher::BaseIcebergSchemaFetcher;
-use crate::storage::iceberg::iceberg_schema_fetcher::IcebergSchemaFetcher;
+use crate::storage::iceberg::base_iceberg_snapshot_fetcher::BaseIcebergSnapshotFetcher;
+use crate::storage::iceberg::iceberg_snapshot_fetcher::IcebergSnapshotFetcher;
 use crate::storage::mooncake_table::table_creation_test_utils::*;
 use crate::storage::mooncake_table::table_operation_test_utils::*;
 
@@ -16,26 +16,30 @@ fn get_test_row() -> MoonlinkRow {
 }
 
 #[tokio::test]
-async fn test_schema_for_empty_table() {
+async fn test_snapshot_for_empty_table() {
     let iceberg_temp_dir = tempdir().unwrap();
     let config = get_iceberg_table_config(&iceberg_temp_dir);
-    let schema_fetcher = IcebergSchemaFetcher::new(config).unwrap();
-    let arrow_schema = schema_fetcher.fetch_table_schema().await.unwrap();
+    let snapshot_fetcher = IcebergSnapshotFetcher::new(config).unwrap();
+    let arrow_schema = snapshot_fetcher.fetch_table_schema().await.unwrap();
     assert!(arrow_schema.is_none());
+    let flush_lsn = snapshot_fetcher.get_flush_lsn().await.unwrap();
+    assert!(flush_lsn.is_none());
 }
 
 #[tokio::test]
-async fn test_schema_fetch() {
+async fn test_snapshot_fetch() {
     let temp_dir = tempfile::tempdir().unwrap();
     let (mut table, _, mut notify_rx) = create_table_and_iceberg_manager(&temp_dir).await;
     table.append(get_test_row()).unwrap();
-    flush_table_and_sync(&mut table, &mut notify_rx, /*lsn=*/ 1)
+    flush_table_and_sync(&mut table, &mut notify_rx, /*lsn=*/ 10)
         .await
         .unwrap();
     create_mooncake_and_persist_for_test(&mut table, &mut notify_rx).await;
 
     let config = get_iceberg_table_config(&temp_dir);
-    let schema_fetcher = IcebergSchemaFetcher::new(config).unwrap();
-    let arrow_schema = schema_fetcher.fetch_table_schema().await.unwrap();
+    let snapshot_fetcher = IcebergSnapshotFetcher::new(config).unwrap();
+    let arrow_schema = snapshot_fetcher.fetch_table_schema().await.unwrap();
     assert_eq!(arrow_schema.unwrap(), *create_test_arrow_schema());
+    let flush_lsn = snapshot_fetcher.get_flush_lsn().await.unwrap();
+    assert_eq!(flush_lsn.unwrap(), 10);
 }

--- a/src/moonlink_backend/src/lib.rs
+++ b/src/moonlink_backend/src/lib.rs
@@ -157,7 +157,7 @@ impl MoonlinkBackend {
                         input_schema.expect("arrow_schema is required for REST API"),
                         moonlink_table_config.clone(),
                         self.read_state_filepath_remap.clone(),
-                        /*is_recovery=*/ false,
+                        /*flush_lsn=*/ None,
                     )
                     .await?;
             } else {

--- a/src/moonlink_connectors/src/replication_manager.rs
+++ b/src/moonlink_connectors/src/replication_manager.rs
@@ -119,6 +119,7 @@ impl<T: Clone + Eq + Hash + std::fmt::Display> ReplicationManager<T> {
     ///
     /// * src_uri: should be a REST API URL
     /// * arrow_schema: Arrow schema for the table
+    /// * flush_lsn: only assigned when recovery, which indicates the iceberg persistence LSN; otherwise it's a fresh table.
     #[allow(clippy::too_many_arguments)]
     pub async fn add_rest_table(
         &mut self,
@@ -128,7 +129,7 @@ impl<T: Clone + Eq + Hash + std::fmt::Display> ReplicationManager<T> {
         arrow_schema: arrow_schema::Schema,
         moonlink_table_config: MoonlinkTableConfig,
         read_state_filepath_remap: ReadStateFilepathRemap,
-        is_recovery: bool,
+        flush_lsn: Option<u64>,
     ) -> Result<()> {
         debug!(%src_uri, src_table_name, "adding REST API table through manager");
 
@@ -148,7 +149,7 @@ impl<T: Clone + Eq + Hash + std::fmt::Display> ReplicationManager<T> {
                 arrow_schema,
                 moonlink_table_config,
                 read_state_filepath_remap,
-                is_recovery,
+                flush_lsn,
             )
             .await?;
         self.table_info

--- a/src/moonlink_connectors/src/replication_state.rs
+++ b/src/moonlink_connectors/src/replication_state.rs
@@ -32,8 +32,8 @@ impl ReplicationState {
     /// Mark the replication position as `lsn` if it is newer than the current
     /// value.
     pub fn mark(&self, lsn: u64) {
-        if lsn > self.current.load(Ordering::Relaxed) {
-            self.current.store(lsn, Ordering::Release);
+        if lsn > self.current.load(Ordering::SeqCst) {
+            self.current.store(lsn, Ordering::SeqCst);
             self.tx.send(lsn).unwrap();
         }
     }
@@ -45,6 +45,6 @@ impl ReplicationState {
 
     /// Get the current replicated LSN value.
     pub fn now(&self) -> u64 {
-        self.current.load(Ordering::Acquire)
+        self.current.load(Ordering::SeqCst)
     }
 }


### PR DESCRIPTION
## Summary

Followup PR for https://github.com/Mooncake-Labs/moonlink/pull/1643.
Previous one only handles schema recovery, this PR makes the same decision for replication LSN recovery to use iceberg as persistence layer.

After this PR, we're able to get consistent LSN across moonlink backend crash and recovery, and able to implement LSN-related features for REST API.

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
