### PR TITLE
[REST] Provide sync mode for write operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4306,6 +4306,7 @@ dependencies = [
  "iceberg",
  "moonlink",
  "moonlink_error",
+ "more-asserts",
  "native-tls",
  "num-traits",
  "parquet",

--- a/src/moonlink_backend/src/lib.rs
+++ b/src/moonlink_backend/src/lib.rs
@@ -11,9 +11,11 @@ pub use error::{Error, Result};
 use mooncake_table_id::MooncakeTableId;
 pub use moonlink::ReadState;
 use moonlink::{ReadStateFilepathRemap, TableEventManager};
-pub use moonlink_connectors::rest_ingest::rest_source::{
+pub use moonlink_connectors::rest_ingest::event_request::{
     EventRequest, FileEventOperation, FileEventRequest, RowEventOperation, RowEventRequest,
 };
+pub use moonlink_connectors::rest_ingest::rest_event::RestEvent;
+pub use moonlink_connectors::rest_ingest::rest_source::RestSource;
 use moonlink_connectors::ReplicationManager;
 pub use moonlink_connectors::REST_API_URI;
 use moonlink_metadata_store::base_metadata_store::MetadataStoreTrait;

--- a/src/moonlink_backend/tests/test_backend.rs
+++ b/src/moonlink_backend/tests/test_backend.rs
@@ -9,11 +9,9 @@ mod tests {
         current_wal_lsn, get_serialized_table_config, smoke_create_and_insert, TestGuard,
         TestGuardMode, DATABASE, TABLE,
     };
-    use moonlink_backend::EventRequest;
-    use moonlink_backend::MoonlinkBackend;
-    use moonlink_backend::{
-        table_status::TableStatus, RowEventOperation, RowEventRequest, REST_API_URI,
-    };
+    use moonlink_backend::RowEventOperation;
+    use moonlink_backend::{table_status::TableStatus, REST_API_URI};
+    use moonlink_backend::{EventRequest, MoonlinkBackend, RowEventRequest};
     use moonlink_metadata_store::{base_metadata_store::MetadataStoreTrait, SqliteMetadataStore};
 
     use arrow::datatypes::Schema as ArrowSchema;
@@ -464,6 +462,7 @@ mod tests {
                 "age": 30
             }),
             timestamp: SystemTime::now(),
+            tx: None,
         };
         let rest_event_request = EventRequest::RowRequest(row_event_request);
         backend

--- a/src/moonlink_connectors/Cargo.toml
+++ b/src/moonlink_connectors/Cargo.toml
@@ -24,6 +24,7 @@ chrono-tz = "0.10"
 futures = { workspace = true }
 moonlink = { path = "../moonlink" }
 moonlink_error = { path = "../moonlink_error" }
+more-asserts = { workspace = true }
 native-tls = "0.2.14"
 num-traits = { workspace = true }
 parquet = { workspace = true }

--- a/src/moonlink_connectors/src/lib.rs
+++ b/src/moonlink_connectors/src/lib.rs
@@ -10,3 +10,7 @@ pub use pg_replicate::postgres_source::PostgresSourceError;
 pub use replication_connection::{ReplicationConnection, SourceType};
 pub use replication_manager::ReplicationManager;
 pub use replication_manager::REST_API_URI;
+pub use rest_ingest::event_request::{
+    EventRequest, FileEventOperation, FileEventRequest, RowEventOperation, RowEventRequest,
+};
+pub use rest_ingest::rest_event::RestEvent;

--- a/src/moonlink_connectors/src/replication_connection.rs
+++ b/src/moonlink_connectors/src/replication_connection.rs
@@ -1,7 +1,7 @@
 use crate::pg_replicate::table_init::build_table_components;
 use crate::pg_replicate::PostgresConnection;
 use crate::pg_replicate::{table::SrcTableId, table_init::TableComponents};
-use crate::rest_ingest::rest_source::EventRequest;
+use crate::rest_ingest::event_request::EventRequest;
 use crate::rest_ingest::RestApiConnection;
 use crate::{Error, Result};
 use moonlink::{

--- a/src/moonlink_connectors/src/replication_manager.rs
+++ b/src/moonlink_connectors/src/replication_manager.rs
@@ -1,4 +1,5 @@
 use crate::pg_replicate::table::SrcTableId;
+use crate::rest_ingest::event_request::EventRequest;
 use crate::ReplicationConnection;
 use crate::{Error, Result};
 use moonlink::{MoonlinkTableConfig, ObjectStorageCache, ReadStateManager, TableEventManager};
@@ -165,7 +166,7 @@ impl<T: Clone + Eq + Hash + std::fmt::Display> ReplicationManager<T> {
     pub async fn initialize_event_api_for_once(
         &mut self,
         base_path: &str,
-    ) -> Result<tokio::sync::mpsc::Sender<crate::rest_ingest::rest_source::EventRequest>> {
+    ) -> Result<tokio::sync::mpsc::Sender<EventRequest>> {
         if self.connections.contains_key(REST_API_URI) {
             return Ok(self
                 .connections

--- a/src/moonlink_connectors/src/rest_ingest/event_request.rs
+++ b/src/moonlink_connectors/src/rest_ingest/event_request.rs
@@ -1,0 +1,73 @@
+use moonlink::StorageConfig;
+
+use std::time::SystemTime;
+use tokio::sync::mpsc;
+
+/// ======================
+/// Row event request
+/// ======================
+///
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RowEventOperation {
+    Insert,
+    Update,
+    Delete,
+}
+
+#[derive(Debug, Clone)]
+pub struct RowEventRequest {
+    pub src_table_name: String,
+    pub operation: RowEventOperation,
+    pub payload: serde_json::Value,
+    pub timestamp: SystemTime,
+    /// An optional channel for commit LSN, used to synchronize request completion.
+    /// TODO(hjiang): Handle error propagation.
+    pub tx: Option<mpsc::Sender<u64>>,
+}
+
+/// ======================
+/// File event request
+/// ======================
+///
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FileEventOperation {
+    /// Insert by rows.
+    Insert,
+    /// Upload by files.
+    Upload,
+}
+
+#[derive(Debug, Clone)]
+pub struct FileEventRequest {
+    /// Src table name.
+    pub src_table_name: String,
+    /// File event operation.
+    pub operation: FileEventOperation,
+    /// Storage config, which provides access to storage backend.
+    pub storage_config: StorageConfig,
+    /// Parquet files to upload, which will be processed in order.
+    pub files: Vec<String>,
+    /// An optional channel for commit LSN, used to synchronize request completion.
+    /// TODO(hjiang): Handle error propagation.
+    pub tx: Option<mpsc::Sender<u64>>,
+}
+
+/// ======================
+/// Event request
+/// ======================
+///
+#[derive(Debug, Clone)]
+pub enum EventRequest {
+    RowRequest(RowEventRequest),
+    FileRequest(FileEventRequest),
+}
+
+impl EventRequest {
+    /// Get event compleion receiver.
+    pub fn get_request_tx(&self) -> Option<mpsc::Sender<u64>> {
+        match &self {
+            EventRequest::RowRequest(req) => req.tx.clone(),
+            EventRequest::FileRequest(req) => req.tx.clone(),
+        }
+    }
+}

--- a/src/moonlink_connectors/src/rest_ingest/moonlink_rest_sink.rs
+++ b/src/moonlink_connectors/src/rest_ingest/moonlink_rest_sink.rs
@@ -1,6 +1,7 @@
 use crate::replication_state::ReplicationState;
+use crate::rest_ingest::event_request::RowEventOperation;
+use crate::rest_ingest::rest_event::RestEvent;
 use crate::rest_ingest::rest_source::SrcTableId;
-use crate::rest_ingest::rest_source::{RestEvent, RowEventOperation};
 use crate::{Error, Result};
 use moonlink::TableEvent;
 use std::collections::HashMap;
@@ -252,7 +253,6 @@ impl RestSink {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::rest_ingest::rest_source::{RestEvent, RowEventOperation};
     use moonlink::row::{MoonlinkRow, RowValue};
     use std::time::SystemTime;
     use tokio::sync::mpsc;

--- a/src/moonlink_connectors/src/rest_ingest/rest_event.rs
+++ b/src/moonlink_connectors/src/rest_ingest/rest_event.rs
@@ -1,0 +1,52 @@
+use crate::rest_ingest::SrcTableId;
+use crate::{rest_ingest::event_request::RowEventOperation, Result};
+use moonlink::row::MoonlinkRow;
+
+use std::sync::Arc;
+use std::time::SystemTime;
+use tokio::sync::Mutex;
+
+/// ======================
+/// Rest event
+/// ======================
+///
+#[derive(Debug, Clone)]
+pub enum RestEvent {
+    RowEvent {
+        src_table_id: SrcTableId,
+        operation: RowEventOperation,
+        row: MoonlinkRow,
+        lsn: u64,
+        timestamp: SystemTime,
+    },
+    Commit {
+        lsn: u64,
+        timestamp: SystemTime,
+    },
+    FileInsertEvent {
+        /// Source table id.
+        src_table_id: SrcTableId,
+        /// Used for file row insertion operation.
+        table_events: Arc<Mutex<tokio::sync::mpsc::UnboundedReceiver<Result<RestEvent>>>>,
+    },
+    FileUploadEvent {
+        /// Source table id.
+        src_table_id: SrcTableId,
+        /// Used to directly ingest into mooncake table.
+        files: Vec<String>,
+        /// LSN for the ingestion event.
+        lsn: u64,
+    },
+}
+
+impl RestEvent {
+    /// Get event LSN, if applicable.
+    pub fn lsn(&self) -> Option<u64> {
+        match &self {
+            RestEvent::RowEvent { lsn, .. } => Some(*lsn),
+            RestEvent::Commit { lsn, .. } => Some(*lsn),
+            RestEvent::FileInsertEvent { .. } => None,
+            RestEvent::FileUploadEvent { lsn, .. } => Some(*lsn),
+        }
+    }
+}

--- a/src/moonlink_datafusion/Cargo.toml
+++ b/src/moonlink_datafusion/Cargo.toml
@@ -12,8 +12,8 @@ bincode = { workspace = true }
 clap = { workspace = true }
 datafusion = { workspace = true }
 datafusion-cli = { workspace = true }
-moonlink_rpc = { path = "../moonlink_rpc" }
 moonlink_error = { path = "../moonlink_error" }
+moonlink_rpc = { path = "../moonlink_rpc" }
 object_store = { workspace = true }
 parquet = { workspace = true }
 roaring = { workspace = true }

--- a/src/moonlink_service/src/rest_api.rs
+++ b/src/moonlink_service/src/rest_api.rs
@@ -69,6 +69,7 @@ pub struct FieldSchema {
 pub struct CreateTableResponse {
     pub database: String,
     pub table: String,
+    pub lsn: u64,
 }
 
 /// ====================
@@ -292,6 +293,8 @@ async fn create_table(
             Ok(Json(CreateTableResponse {
                 database: payload.database.clone(),
                 table,
+                // A new table is always with LSN 1.
+                lsn: 1
             }))
         }
         Err(e) => {

--- a/src/moonlink_service/src/rest_api.rs
+++ b/src/moonlink_service/src/rest_api.rs
@@ -7,15 +7,13 @@ use axum::{
 };
 use moonlink::StorageConfig;
 use moonlink_backend::{table_config::TableConfig, table_status::TableStatus};
-use moonlink_backend::{
-    EventRequest, FileEventOperation, FileEventRequest, RowEventOperation, RowEventRequest,
-    REST_API_URI,
-};
+use moonlink_backend::{EventRequest, FileEventOperation, RowEventOperation};
+use moonlink_backend::{FileEventRequest, RowEventRequest, REST_API_URI};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::SystemTime;
-use tokio::sync::oneshot;
+use tokio::sync::{mpsc, oneshot};
 use tower_http::cors::{Any, CorsLayer};
 use tracing::{debug, error, info};
 
@@ -36,6 +34,16 @@ impl ApiState {
 /// Error message
 /// ====================
 ///
+/// Request mode.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum RequestMode {
+    /// Only issues request, but not block wait its completion.
+    Async,
+    /// Block wait request completion.
+    Sync,
+}
+
 /// Error response structure
 #[derive(Debug, Serialize)]
 pub struct ErrorResponse {
@@ -106,6 +114,8 @@ pub struct ListTablesResponse {
 pub struct IngestRequest {
     pub operation: String,
     pub data: serde_json::Value,
+    /// Whether to enable synchronous mode.
+    pub request_mode: RequestMode,
 }
 
 /// Response structure for data ingestion
@@ -113,6 +123,8 @@ pub struct IngestRequest {
 pub struct IngestResponse {
     pub table: String,
     pub operation: String,
+    /// Assigned for synchronous mode.
+    pub lsn: Option<u64>,
 }
 
 /// ====================
@@ -127,12 +139,14 @@ pub struct FileUploadRequest {
     pub files: Vec<String>,
     /// Storage configuration to access files.
     pub storage_config: StorageConfig,
+    /// Whether to enable synchronous mode.
+    pub request_mode: RequestMode,
 }
 
 #[derive(Debug, Serialize)]
 pub struct FileUploadResponse {
-    pub status: String,
-    pub message: String,
+    /// Assigned for synchronous mode.
+    pub lsn: Option<u64>,
 }
 
 /// ====================
@@ -294,7 +308,7 @@ async fn create_table(
                 database: payload.database.clone(),
                 table,
                 // A new table is always with LSN 1.
-                lsn: 1
+                lsn: 1,
             }))
         }
         Err(e) => {
@@ -371,11 +385,17 @@ async fn upload_files(
     };
 
     // Create REST request.
+    let (tx, _rx) = mpsc::channel(1);
     let file_event_request = FileEventRequest {
         src_table_name: src_table_name.clone(),
         operation,
         storage_config: payload.storage_config,
         files: payload.files,
+        tx: if payload.request_mode == RequestMode::Sync {
+            Some(tx)
+        } else {
+            None
+        },
     };
     let rest_event_request = EventRequest::FileRequest(file_event_request);
     state
@@ -392,10 +412,7 @@ async fn upload_files(
                 }),
             )
         })?;
-    Ok(Json(FileUploadResponse {
-        status: "success".to_string(),
-        message: "File queued for ingestion".to_string(),
-    }))
+    Ok(Json(FileUploadResponse { lsn: None }))
 }
 
 /// Data ingestion endpoint
@@ -429,11 +446,17 @@ async fn ingest_data(
     };
 
     // Create REST request
+    let (tx, _rx) = mpsc::channel(1);
     let row_event_request = RowEventRequest {
         src_table_name: src_table_name.clone(),
         operation,
         payload: payload.data,
         timestamp: SystemTime::now(),
+        tx: if payload.request_mode == RequestMode::Sync {
+            Some(tx)
+        } else {
+            None
+        },
     };
     let rest_event_request = EventRequest::RowRequest(row_event_request);
 
@@ -454,6 +477,7 @@ async fn ingest_data(
     Ok(Json(IngestResponse {
         table: src_table_name,
         operation: payload.operation,
+        lsn: None,
     }))
 }
 

--- a/src/moonlink_service/src/test.rs
+++ b/src/moonlink_service/src/test.rs
@@ -147,8 +147,8 @@ async fn list_tables(client: &reqwest::Client) -> Vec<TableStatus> {
         response.status().is_success(),
         "Response status is {response:?}"
     );
-    let payload: ListTablesResponse = response.json().await.unwrap();
-    payload.tables
+    let response: ListTablesResponse = response.json().await.unwrap();
+    response.tables
 }
 
 /// Util function to load all record batches inside of the given [`path`].
@@ -232,6 +232,7 @@ async fn test_moonlink_standalone_data_ingestion() {
     // Ingest some data.
     let insert_payload = json!({
         "operation": "insert",
+        "request_mode": "async",
         "data": {
             "id": 1,
             "name": "Alice Johnson",
@@ -297,7 +298,7 @@ async fn test_moonlink_standalone_data_ingestion() {
 /// Test basic table creation, file upload and query.
 #[tokio::test]
 #[serial]
-async fn test_moonlink_standalone_file_upload() {
+async fn test_moonlink_standalone_file_async_upload() {
     cleanup_directory(&get_moonlink_backend_dir()).await;
     let config = get_service_config();
     tokio::spawn(async move {
@@ -313,6 +314,7 @@ async fn test_moonlink_standalone_file_upload() {
     let parquet_file = generate_parquet_file(&get_moonlink_backend_dir()).await;
     let file_upload_payload = json!({
         "operation": "upload",
+        "request_mode": "async",
         "files": [parquet_file],
         "storage_config": {
             "fs": {
@@ -401,6 +403,7 @@ async fn test_moonlink_standalone_file_insert() {
     let file_upload_payload = json!({
         "operation": "insert",
         "files": [parquet_file],
+        "request_mode": "async",
         "storage_config": {
             "fs": {
                 "root_directory": get_moonlink_backend_dir(),
@@ -681,6 +684,7 @@ async fn test_non_existent_table() {
     // Test invalid operation to upload a file.
     let file_upload_payload = json!({
         "operation": "upload",
+        "request_mode": "async",
         "files": ["parquet_file"],
         "storage_config": {
             "fs": {


### PR DESCRIPTION
## Summary

To implement `create_snapshot`, client-side needs to have LSN concept; one possible implementation is block wait operation completion and return back LSN for the completed insertions.

Current REST API server does everything async, which means client response 200 only means request has been queued at server side, but never indicates success.
In this PR, I add a SYNC mode to block wait its completion.

We could also add timeout and retry mechanism.

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
