### PR TITLE
[CI] Add cargo-sort to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,10 @@ jobs:
         with:
           tool: cargo-deny
 
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-sort
+
       - uses: swatinem/rust-cache@v2
         with:
           shared-key: ${{ steps.toolchain.outputs.cachekey }}
@@ -51,6 +55,9 @@ jobs:
 
       - name: cargo deny check
         run: cargo deny check
+
+      - name: cargo dependency format
+        run: cargo sort --workspace
 
   # ──────────────────────── 2 · GCS test (feature, chaos) ─────────────────
   gcs_test:


### PR DESCRIPTION
## Summary

CI should be a superset for precommit hook.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1674

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
