### PR TITLE
Increase LSN update frequency

### DIFF
--- a/src/moonlink_connectors/src/pg_replicate.rs
+++ b/src/moonlink_connectors/src/pg_replicate.rs
@@ -543,7 +543,7 @@ pub async fn run_event_loop(
 
     debug!("replication event loop started");
 
-    let mut status_interval = tokio::time::interval(Duration::from_secs(10));
+    let mut status_interval = tokio::time::interval(Duration::from_secs(1));
     let mut flush_lsn_rxs: HashMap<SrcTableId, watch::Receiver<u64>> = HashMap::new();
     let mut wal_flush_lsn_rxs: HashMap<SrcTableId, watch::Receiver<u64>> = HashMap::new();
 


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

We currently send the updated LSN to Postgres every 10 seconds. This duration was originally chosen in order to prevent the replication from timing out. We have since implemented functionality that returns the actual persisted iceberg/wal LSN. PG won't recycle any WAL that is newer than confirmed flush lsn. The sooner we update the sooner it can drop these records and reduce checkpoint overhead/WAL disk pressure.

Note: We could get smart about this and, for example, report ASAP after LSN moves by some amount or refrain from reporting if LSN hasn't moved, however in the interest of keeping things simple I think 1s interval allows fresh updates without being overly chatty, and keeps things very simple. 

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1645

## Changes

- 
- 
- 

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
