### PR TITLE
[storage] Parallel batch ingest

### DIFF
--- a/src/moonlink/src/storage/mooncake_table/batch_ingestion.rs
+++ b/src/moonlink/src/storage/mooncake_table/batch_ingestion.rs
@@ -5,6 +5,7 @@ use crate::{
 use super::*;
 
 use bytes::Bytes;
+use futures::{stream, StreamExt};
 use parquet::arrow::arrow_reader::ParquetRecordBatchReaderBuilder;
 
 impl MooncakeTable {
@@ -14,34 +15,39 @@ impl MooncakeTable {
     /// 1. Record table events.
     /// 2. It involves IO operations, should be placed at background thread.s
     pub(crate) async fn batch_ingest(&mut self, parquet_files: Vec<String>, lsn: u64) {
-        let mut disk_files = hashbrown::HashMap::with_capacity(parquet_files.len());
+        const MAX_IN_FLIGHT: usize = 64;
+        let start_id = self.next_file_id;
+        self.next_file_id += parquet_files.len() as u32;
 
-        // TODO(hjiang): Parallel IO and error handling.
-        // Construct disk file from the given disk files.
-        for cur_file in parquet_files.into_iter() {
-            let content = tokio::fs::read(&cur_file)
-                .await
-                .unwrap_or_else(|_| panic!("Failed to read {cur_file}"));
-            let content = Bytes::from(content);
-            let file_size = content.len();
-            let builder = ParquetRecordBatchReaderBuilder::try_new(content).unwrap();
-            let num_rows: usize = builder.metadata().file_metadata().num_rows() as usize;
+        let disk_files = stream::iter(parquet_files.into_iter().enumerate().map(
+            |(idx, cur_file)| {
+                let cur_file_id = (start_id as u64) + idx as u64;
+                async move {
+                    // TODO(hjiang): Handle remote data file ingestion as well.
+                    let content = tokio::fs::read(&cur_file)
+                        .await
+                        .unwrap_or_else(|_| panic!("Failed to read {cur_file}"));
+                    let content = Bytes::from(content);
+                    let file_size = content.len();
+                    let builder = ParquetRecordBatchReaderBuilder::try_new(content).unwrap();
+                    let num_rows = builder.metadata().file_metadata().num_rows() as usize;
 
-            let cur_file_id = self.next_file_id;
-            self.next_file_id += 1;
-            let mooncake_data_file = create_data_file(cur_file_id as u64, cur_file);
-            let disk_file_entry = DiskFileEntry {
-                cache_handle: None,
-                num_rows,
-                file_size,
-                batch_deletion_vector: BatchDeletionVector::new(num_rows),
-                puffin_deletion_blob: None,
-            };
+                    let mooncake_data_file = create_data_file(cur_file_id, cur_file.clone());
+                    let disk_file_entry = DiskFileEntry {
+                        cache_handle: None,
+                        num_rows,
+                        file_size,
+                        batch_deletion_vector: BatchDeletionVector::new(num_rows),
+                        puffin_deletion_blob: None,
+                    };
 
-            assert!(disk_files
-                .insert(mooncake_data_file, disk_file_entry)
-                .is_none());
-        }
+                    (mooncake_data_file, disk_file_entry)
+                }
+            },
+        ))
+        .buffer_unordered(MAX_IN_FLIGHT) // run up to N at once
+        .collect::<hashbrown::HashMap<_, _>>()
+        .await;
 
         // Commit the current crafted streaming transaction.
         let commit = TransactionStreamCommit::from_disk_files(disk_files, lsn);

--- a/src/moonlink/src/table_handler/test_utils.rs
+++ b/src/moonlink/src/table_handler/test_utils.rs
@@ -636,7 +636,7 @@ pub(crate) async fn load_one_arrow_batch(filepath: &str) -> RecordBatch {
 }
 
 /// Test util function to generate a parquet under the given [`tempdir`].
-pub(crate) async fn generate_parquet_file(tempdir: &TempDir) -> String {
+pub(crate) async fn generate_parquet_file(tempdir: &TempDir, filename: &str) -> String {
     let schema = create_test_arrow_schema();
     let ids = Int32Array::from(vec![1, 2, 3]);
     let names = StringArray::from(vec!["Alice", "Bob", "Charlie"]);
@@ -646,7 +646,7 @@ pub(crate) async fn generate_parquet_file(tempdir: &TempDir) -> String {
         vec![Arc::new(ids), Arc::new(names), Arc::new(ages)],
     )
     .unwrap();
-    let file_path = tempdir.path().join("test.parquet");
+    let file_path = tempdir.path().join(filename);
     let file_path_str = file_path.to_str().unwrap().to_string();
     let file = tokio::fs::File::create(file_path).await.unwrap();
     let mut writer: AsyncArrowWriter<tokio::fs::File> =

--- a/src/moonlink/src/table_handler/tests.rs
+++ b/src/moonlink/src/table_handler/tests.rs
@@ -2363,10 +2363,12 @@ async fn test_batch_ingestion() {
     };
     let env = TestEnvironment::new(temp_dir, mooncake_table_config).await;
 
-    let disk_file = generate_parquet_file(&env.temp_dir).await;
-    env.bulk_upload_files(vec![disk_file], /*lsn=*/ 10).await;
+    let disk_file_1 = generate_parquet_file(&env.temp_dir, "1.parquet").await;
+    let disk_file_2 = generate_parquet_file(&env.temp_dir, "1.parquet").await;
+    env.bulk_upload_files(vec![disk_file_1, disk_file_2], /*lsn=*/ 10)
+        .await;
 
     // Validate bulk ingestion result.
     env.set_readable_lsn(10);
-    env.verify_snapshot(10, &[1, 2, 3]).await;
+    env.verify_snapshot(10, &[1, 1, 2, 2, 3, 3]).await;
 }


### PR DESCRIPTION
## Summary

When doing batch ingestion for large dataset, I found it took me >20 minutes to run the batch ingestion function, the reason being large number of parquet files and sequential IO.
IO operation is involved here to get row number and file size.
In this PR, these IO operations are parallelized.

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
