### PR TITLE
[storage] Fix iceberg recovery

### DIFF
--- a/src/moonlink/src/storage/iceberg/iceberg_table_loader.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_loader.rs
@@ -240,18 +240,17 @@ impl IcebergTableManager {
 
         // Load moonlink related metadata.
         let table_metadata = self.iceberg_table.as_ref().unwrap().metadata();
-        let snapshot_property = snapshot_utils::get_snapshot_properties(table_metadata)?;
 
         // There's nothing stored in iceberg table.
         if table_metadata.current_snapshot().is_none() {
-            let mut empty_mooncake_snapshot =
+            let empty_mooncake_snapshot =
                 MooncakeSnapshot::new(self.mooncake_table_metadata.clone());
-            empty_mooncake_snapshot.flush_lsn = snapshot_property.flush_lsn;
             return Ok((next_file_id as u32, empty_mooncake_snapshot));
         }
 
         // Load table state into iceberg table manager.
         let snapshot_meta = table_metadata.current_snapshot().unwrap();
+        let snapshot_property = snapshot_utils::get_snapshot_properties(table_metadata)?;
         let manifest_list = snapshot_meta
             .load_manifest_list(
                 self.iceberg_table.as_ref().unwrap().file_io(),


### PR DESCRIPTION
## Summary

When create iceberg table, version hint with version 0 is written;
when a successful snapshot is made, version hint is updated.
For recovery, we should be able to recover from any possible states; this PR fixes cases when there's only version 0.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1690

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
