### PR TITLE
[storage] Fix compaction for append-only table

### DIFF
--- a/src/moonlink/src/storage/compaction/compactor.rs
+++ b/src/moonlink/src/storage/compaction/compactor.rs
@@ -408,13 +408,17 @@ impl CompactionBuilder {
             self.flush_arrow_writer().await?;
         }
 
-        // Perform compaction on file indices.
-        let new_file_indices = self
-            .compact_file_indices(
-                self.compaction_payload.file_indices.clone(),
-                &old_record_loc_to_new_mapping,
-            )
-            .await;
+        // Perform compaction on file indices
+        let mut new_file_indices = vec![];
+        if !old_file_indices.is_empty() {
+            let cur_new_file_indices = self
+                .compact_file_indices(
+                    self.compaction_payload.file_indices.clone(),
+                    &old_record_loc_to_new_mapping,
+                )
+                .await;
+            new_file_indices.push(cur_new_file_indices);
+        }
 
         Ok(DataCompactionResult {
             id: self.compaction_payload.id,
@@ -423,7 +427,7 @@ impl CompactionBuilder {
             old_data_files,
             old_file_indices,
             new_data_files: self.new_data_files,
-            new_file_indices: vec![new_file_indices],
+            new_file_indices,
             evicted_files_to_delete,
         })
     }

--- a/src/moonlink/src/storage/compaction/table_compaction.rs
+++ b/src/moonlink/src/storage/compaction/table_compaction.rs
@@ -123,6 +123,7 @@ pub struct DataCompactionResult {
 impl DataCompactionResult {
     /// Return whether data compaction result is empty.
     pub fn is_empty(&self) -> bool {
+        // If all rows have been deleted after compaction, there'll be no new data files, file indices and remaps.
         if self.old_data_files.is_empty() {
             assert!(self.remapped_data_files.is_empty());
             assert!(self.old_data_files.is_empty());
@@ -132,8 +133,6 @@ impl DataCompactionResult {
             return true;
         }
 
-        // If all rows have been deleted after compaction, there'll be no new data files, file indices and remaps.
-        assert!(!self.old_file_indices.is_empty());
         false
     }
 }

--- a/src/moonlink/src/storage/iceberg/iceberg_table_loader.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_loader.rs
@@ -287,6 +287,8 @@ impl IcebergTableManager {
             }
         }
 
+        println!("data file file id = {next_file_id}");
+
         // Attempt to load file indices and deletion vector.
         let mut loaded_deletion_vector = HashMap::new();
         for manifest_file in manifest_list.entries().iter() {
@@ -299,6 +301,8 @@ impl IcebergTableManager {
                 continue;
             }
 
+            println!("before index file id = {next_file_id}");
+
             for entry in manifest_entries.iter() {
                 // Load file indices.
                 let recovered_file_index = self
@@ -309,6 +313,7 @@ impl IcebergTableManager {
                     )
                     .await?;
                 if let Some(recovered_file_index) = recovered_file_index {
+                    println!("we have index???");
                     loaded_file_indices.push(recovered_file_index);
                 }
 
@@ -321,6 +326,7 @@ impl IcebergTableManager {
                     )
                     .await?
                 {
+                    println!("delete???");
                     assert!(loaded_deletion_vector
                         .insert(file_id, puffin_blob_ref)
                         .is_none());

--- a/src/moonlink/src/storage/iceberg/tests.rs
+++ b/src/moonlink/src/storage/iceberg/tests.rs
@@ -1307,6 +1307,126 @@ async fn test_data_compaction_and_create_snapshot_with_gcs() {
 }
 
 /// ================================
+/// Test data compaction with append-only table
+/// ================================
+///
+/// Testing scenario: create iceberg snapshot for data compaction.
+async fn test_data_compaction_append_only_and_create_snapshot_impl(
+    iceberg_table_config: IcebergTableConfig,
+) {
+    // Local filesystem to store write-through cache.
+    let table_temp_dir = tempdir().unwrap();
+    let data_compaction_config = DataCompactionConfig {
+        min_data_file_to_compact: 2,
+        max_data_file_to_compact: 2,
+        data_file_final_size: u64::MAX,
+        data_file_deletion_percentage: 0,
+    };
+    let mut config = MooncakeTableConfig::new(table_temp_dir.path().to_str().unwrap().to_string());
+    config.data_compaction_config = data_compaction_config;
+    config.append_only = true;
+    let mooncake_table_metadata = create_test_table_metadata_with_config(
+        table_temp_dir.path().to_str().unwrap().to_string(),
+        config,
+    );
+
+    // Local filesystem to store read-through cache.
+    let cache_temp_dir = tempdir().unwrap();
+
+    // Create mooncake table and table event notification receiver.
+    let (mut table, mut notify_rx) = create_mooncake_table_and_notify(
+        mooncake_table_metadata.clone(),
+        iceberg_table_config.clone(),
+        create_test_object_storage_cache(&cache_temp_dir), // Use separate cache for each table.
+    )
+    .await;
+    let filesystem_accessor = create_test_filesystem_accessor(&iceberg_table_config);
+
+    // Append one row and commit/flush, so we have one file indice persisted.
+    let row_1 = test_row_1();
+    table.append(row_1.clone()).unwrap();
+    table.commit(/*lsn=*/ 1);
+    flush_table_and_sync(&mut table, &mut notify_rx, /*lsn=*/ 1)
+        .await
+        .unwrap();
+
+    // Append one row and commit/flush, so we have one file indice persisted.
+    let row_2 = test_row_2();
+    table.append(row_2.clone()).unwrap();
+    table.commit(/*lsn=*/ 2);
+    flush_table_and_sync(&mut table, &mut notify_rx, /*lsn=*/ 2)
+        .await
+        .unwrap();
+
+    // Attempt data compaction and flush to iceberg table.
+    create_mooncake_and_persist_for_data_compaction_for_test(
+        &mut table,
+        &mut notify_rx,
+        /*injected_committed_deletion_rows=*/ vec![],
+        /*injected_uncommitted_deletion_rows=*/ vec![],
+    )
+    .await;
+
+    // Create a new iceberg table manager and check states.
+    let mut iceberg_table_manager_for_recovery = IcebergTableManager::new(
+        mooncake_table_metadata.clone(),
+        create_test_object_storage_cache(&cache_temp_dir), // Use separate cache for each table.
+        filesystem_accessor.clone(),
+        iceberg_table_config.clone(),
+    )
+    .unwrap();
+    let (next_file_id, snapshot) = iceberg_table_manager_for_recovery
+        .load_snapshot_from_table()
+        .await
+        .unwrap();
+    assert_eq!(next_file_id, 1); // one compacted data file
+    assert_eq!(snapshot.disk_files.len(), 1);
+    assert_eq!(snapshot.indices.file_indices.len(), 0);
+    assert_eq!(snapshot.flush_lsn.unwrap(), 2);
+    validate_recovered_snapshot(
+        &snapshot,
+        &iceberg_table_config.accessor_config.get_root_path(),
+        filesystem_accessor.as_ref(),
+    )
+    .await;
+    check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+}
+
+#[tokio::test]
+async fn test_data_compaction_append_only_and_create_snapshot() {
+    // Local filesystem for iceberg.
+    let iceberg_temp_dir = tempdir().unwrap();
+    let iceberg_table_config = get_iceberg_table_config(&iceberg_temp_dir);
+
+    // Common testing logic.
+    test_data_compaction_append_only_and_create_snapshot_impl(iceberg_table_config).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[cfg(feature = "storage-s3")]
+async fn test_data_compaction_append_only_and_create_snapshot_with_s3() {
+    // Remote object storage for iceberg.
+    let (bucket, warehouse_uri) = s3_test_utils::get_test_s3_bucket_and_warehouse();
+    let _test_guard = S3TestGuard::new(bucket.clone()).await;
+    let iceberg_table_config = create_iceberg_table_config(warehouse_uri);
+
+    // Common testing logic.
+    test_data_compaction_append_only_and_create_snapshot_impl(iceberg_table_config.clone()).await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[cfg(feature = "storage-gcs")]
+async fn test_data_compaction_append_only_and_create_snapshot_with_gcs() {
+    // Remote object storage for iceberg.
+    let (bucket, warehouse_uri) = gcs_test_utils::get_test_gcs_bucket_and_warehouse();
+    let _test_guard = GcsTestGuard::new(bucket.clone()).await;
+    let iceberg_table_config = create_iceberg_table_config(warehouse_uri);
+
+    // Common testing logic.
+    test_data_compaction_append_only_and_create_snapshot_impl(iceberg_table_config.clone()).await;
+}
+
+/// ================================
 /// Test data compaction by deletion
 /// ================================
 ///

--- a/src/moonlink/src/storage/mooncake_table/snapshot_maintenance.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot_maintenance.rs
@@ -186,14 +186,18 @@ impl SnapshotTableState {
 
         #[cfg(any(test, debug_assertions))]
         {
-            Self::validate_compaction_payload(&payload);
+            self.validate_compaction_payload(&payload);
         }
         DataCompactionMaintenanceStatus::Payload(payload)
     }
 
-    /// Util function to validate the consistency of data compaction payload.
+    /// Util function to validate the consistency of data files and file indices for data compaction payload.
     #[cfg(any(test, debug_assertions))]
-    fn validate_compaction_payload(payload: &DataCompactionPayload) {
+    fn validate_compaction_payload(&self, payload: &DataCompactionPayload) {
+        if self.mooncake_table_metadata.config.append_only {
+            return;
+        }
+
         // Data files to compact.
         let data_files = payload
             .disk_files
@@ -327,13 +331,16 @@ impl SnapshotTableState {
             .await;
         evicted_files_to_delete.extend(cur_evicted_files);
 
-        let cur_evicted_files = self
-            .update_file_indices_to_mooncake_snapshot_impl(
-                data_compaction_res.old_file_indices,
-                data_compaction_res.new_file_indices,
-            )
-            .await;
-        evicted_files_to_delete.extend(cur_evicted_files);
+        // Append only table doesn't have file indices, directly skip.
+        if !self.mooncake_table_metadata.config.append_only {
+            let cur_evicted_files = self
+                .update_file_indices_to_mooncake_snapshot_impl(
+                    data_compaction_res.old_file_indices,
+                    data_compaction_res.new_file_indices,
+                )
+                .await;
+            evicted_files_to_delete.extend(cur_evicted_files);
+        }
 
         // Apply evicted data files to delete within data compaction process.
         evicted_files_to_delete.extend(

--- a/src/moonlink/src/storage/mooncake_table/table_creation_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_creation_test_utils.rs
@@ -204,13 +204,18 @@ pub(crate) fn create_test_table_metadata_with_config(
     local_table_directory: String,
     mooncake_table_config: MooncakeTableConfig,
 ) -> Arc<MooncakeTableMetadata> {
+    let identity = if mooncake_table_config.append_only {
+        RowIdentity::None
+    } else {
+        RowIdentity::FullRow
+    };
     Arc::new(MooncakeTableMetadata {
         name: ICEBERG_TEST_TABLE.to_string(),
         table_id: 0,
         schema: create_test_arrow_schema(),
         config: mooncake_table_config,
         path: std::path::PathBuf::from(local_table_directory),
-        identity: RowIdentity::FullRow,
+        identity,
     })
 }
 

--- a/src/moonlink/src/storage/mooncake_table/validation_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/validation_test_utils.rs
@@ -79,6 +79,11 @@ pub(crate) async fn validate_recovered_snapshot(
         assert!(tokio::fs::try_exists(puffin_filepath).await.unwrap());
     }
 
+    // For append-only table, there's no file indices.
+    if snapshot.indices.file_indices.is_empty() {
+        return;
+    }
+
     // Check file indices.
     let mut index_referenced_data_filepaths: HashSet<String> = HashSet::new();
     for cur_file_index in snapshot.indices.file_indices.iter() {


### PR DESCRIPTION
## Summary

Fix a few compaction related issue for append-only table:
- A few invariant check doesn't make sense for append-only tables
- Bug: if there's no file indices, compactor should emit an empty index file

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1694

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
