### PR TITLE
[REST] Fix config recovery for rest table

### DIFF
--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -136,6 +136,9 @@ impl TableMetadata {
         if self.identity == IdentityProp::None {
             assert!(self.config.append_only);
         }
+        if self.config.append_only {
+            assert_eq!(self.identity, IdentityProp::None);
+        }
         // Validate table config.
         self.config.validate();
     }

--- a/src/moonlink_connectors/src/replication_connection.rs
+++ b/src/moonlink_connectors/src/replication_connection.rs
@@ -261,6 +261,7 @@ impl<T: Clone + Eq + Hash + std::fmt::Display> ReplicationConnection<T> {
                 debug!(src_table_name, "adding REST API table");
 
                 let src_table_id = conn.next_src_table_id();
+                let append_only = moonlink_table_config.mooncake_table_config.append_only;
                 let table_components = TableComponents {
                     read_state_filepath_remap,
                     object_storage_cache: self.object_storage_cache.clone(),
@@ -269,10 +270,16 @@ impl<T: Clone + Eq + Hash + std::fmt::Display> ReplicationConnection<T> {
 
                 // Create MooncakeTable resources using the table init function.
                 let replication_state = conn.get_replication_state();
+                // REST API doesn't need identity.
+                let identity = if append_only {
+                    moonlink::row::IdentityProp::None
+                } else {
+                    moonlink::row::IdentityProp::FullRow
+                };
                 let mut table_resources = build_table_components(
                     mooncake_table_id.to_string(),
                     arrow_schema.clone(),
-                    moonlink::row::IdentityProp::FullRow, // REST API doesn't need identity
+                    identity,
                     src_table_name.to_string(),
                     src_table_id,
                     &self.table_base_path,

--- a/src/moonlink_metadata_store/src/config_utils.rs
+++ b/src/moonlink_metadata_store/src/config_utils.rs
@@ -83,7 +83,7 @@ impl MoonlinkTableConfigForPersistence {
     /// Get mooncake table config from persisted moonlink config.
     fn get_mooncake_table_config(&self) -> MooncakeTableConfig {
         MooncakeTableConfig {
-            append_only: false,
+            append_only: self.mooncake_table_config.append_only,
             mem_slice_size: self.mooncake_table_config.mem_slice_size,
             snapshot_deletion_record_count: self
                 .mooncake_table_config


### PR DESCRIPTION
## Summary

On table recovery, we hard-code `append_only` to be false, without considering the persisted value.
The newly added assertion is able to catch the bug partially.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1704

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
