### PR TITLE
[REST] improve error propagation for REST API 

### DIFF
--- a/src/moonlink_backend/src/error.rs
+++ b/src/moonlink_backend/src/error.rs
@@ -52,6 +52,20 @@ impl Error {
     pub fn invalid_argument(message: String) -> Self {
         Self::InvalidArgumentError(ErrorStruct::new(message, ErrorStatus::Permanent))
     }
+    pub fn get_status(&self) -> ErrorStatus {
+        match self {
+            Error::ParseIntError(es) => es.status,
+            Error::PostgresSource(es) => es.status,
+            Error::Io(es) => es.status,
+            Error::MoonlinkConnectorError(es) => es.status,
+            Error::MoonlinkError(es) => es.status,
+            Error::MoonlinkMetadataStoreError(es) => es.status,
+            Error::InvalidArgumentError(es) => es.status,
+            Error::TokioWatchRecvError(es) => es.status,
+            Error::Json(es) => es.status,
+            Error::MpscChannelSendError(es) => es.status,
+        }
+    }
 }
 
 impl From<PostgresSourceError> for Error {

--- a/src/moonlink_service/src/rest_api.rs
+++ b/src/moonlink_service/src/rest_api.rs
@@ -9,6 +9,7 @@ use moonlink::StorageConfig;
 use moonlink_backend::{table_config::TableConfig, table_status::TableStatus};
 use moonlink_backend::{EventRequest, FileEventOperation, RowEventOperation};
 use moonlink_backend::{FileEventRequest, RowEventRequest, REST_API_URI};
+use moonlink_error::ErrorStatus;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -161,7 +162,31 @@ pub struct HealthResponse {
     pub timestamp: u64,
 }
 
-/// Create the router with all API endpoints
+/// Map backend error to appropriate HTTP status code based on error type
+fn get_backend_error_status_code(error: &moonlink_backend::Error) -> StatusCode {
+    match error {
+        moonlink_backend::Error::InvalidArgumentError(_)
+        | moonlink_backend::Error::ParseIntError(_)
+        | moonlink_backend::Error::Json(_) => StatusCode::BAD_REQUEST,
+
+        _ => match error.get_status() {
+            ErrorStatus::Temporary => StatusCode::SERVICE_UNAVAILABLE,
+            ErrorStatus::Permanent => StatusCode::INTERNAL_SERVER_ERROR,
+        },
+    }
+}
+
+/// Map specific error contexts that don't have backend errors
+fn get_context_error_status_code(error_type: &str) -> StatusCode {
+    match error_type {
+        "serialization_failed" => StatusCode::INTERNAL_SERVER_ERROR,
+        "invalid_schema" => StatusCode::BAD_REQUEST,
+        "invalid_operation" => StatusCode::BAD_REQUEST,
+        _ => StatusCode::INTERNAL_SERVER_ERROR,
+    }
+}
+
+/// Create the router with all API endpoints    
 pub fn create_router(state: ApiState) -> Router {
     Router::new()
         .route("/health", get(health_check))
@@ -261,7 +286,7 @@ async fn create_table(
         Ok(fields) => fields,
         Err(e) => {
             return Err((
-                StatusCode::BAD_REQUEST,
+                get_context_error_status_code("invalid_schema"),
                 Json(ErrorResponse {
                     error: "invalid_schema".to_string(),
                     message: e,
@@ -277,7 +302,7 @@ async fn create_table(
         Ok(cfg) => cfg,
         Err(e) => {
             return Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
+                get_context_error_status_code("serialization_failed"),
                 Json(ErrorResponse {
                     error: "serialization_failed".to_string(),
                     message: format!("Serialize table config failed: {e}"),
@@ -314,7 +339,7 @@ async fn create_table(
         Err(e) => {
             error!("Failed to create table '{}': {}", table, e);
             Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
+                get_backend_error_status_code(&e),
                 Json(ErrorResponse {
                     error: "table_creation_failed".to_string(),
                     message: format!("Failed to create table: {e}"),
@@ -347,7 +372,7 @@ async fn list_tables(
     match state.backend.list_tables().await {
         Ok(tables) => Ok(Json(ListTablesResponse { tables })),
         Err(e) => Err((
-            StatusCode::INTERNAL_SERVER_ERROR,
+            get_backend_error_status_code(&e),
             Json(ErrorResponse {
                 error: "table_list_failed".to_string(),
                 message: format!("Failed to list tables: {e}"),
@@ -372,7 +397,7 @@ async fn upload_files(
         "upload" => FileEventOperation::Upload,
         _ => {
             return Err((
-                StatusCode::BAD_REQUEST,
+                get_context_error_status_code("invalid_operation"),
                 Json(ErrorResponse {
                     error: "invalid_operation".to_string(),
                     message: format!(
@@ -405,7 +430,7 @@ async fn upload_files(
         .map_err(|e| {
             error!("Failed to send event request: {}", e);
             (
-                StatusCode::INTERNAL_SERVER_ERROR,
+                get_backend_error_status_code(&e),
                 Json(ErrorResponse {
                     error: "file_upload_failed".to_string(),
                     message: format!("Failed to process request: {e}"),
@@ -439,7 +464,7 @@ async fn ingest_data(
         "delete" => RowEventOperation::Delete,
         _ => {
             return Err((
-                StatusCode::BAD_REQUEST,
+                get_context_error_status_code("invalid_operation"),
                 Json(ErrorResponse {
                     error: "invalid_operation".to_string(),
                     message: format!(
@@ -473,7 +498,7 @@ async fn ingest_data(
         .map_err(|e| {
             error!("Failed to send event request: {}", e);
             (
-                StatusCode::INTERNAL_SERVER_ERROR,
+                get_backend_error_status_code(&e),
                 Json(ErrorResponse {
                     error: "ingestion_failed".to_string(),
                     message: format!("Failed to process request: {e}"),


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

Improve REST API error propagation by replacing hardcoded `INTERNAL_SERVER_ERROR` with appropriate HTTP status codes based on error type and context. This ensures that 500 Internal Server Error is reserved for severe invariant breaks as intended, while client errors return more appropriate 4xx status codes.

## Related Issues

Closes #1652

## Changes

- Added `get_status()` to `moonlink_backend::Error` for retrieving `ErrorStatus`
- Implemented:

  - `get_backend_error_status_code()` — maps backend errors to correct HTTP codes
  - `get_context_error_status_code()` — maps context-specific errors to correct HTTP codes
- Updated all REST API endpoints to replace hardcoded `INTERNAL_SERVER_ERROR` with proper mappings:

  - `invalid_schema` / `invalid_operation` → **400 Bad Request**
  - Temporary backend errors → **503 Service Unavailable**
  - Permanent system errors → **500 Internal Server Error**

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
