### PR TITLE
[REST] Fix eventloop listening to channel

### DIFF
--- a/src/moonlink_connectors/src/rest_ingest.rs
+++ b/src/moonlink_connectors/src/rest_ingest.rs
@@ -243,6 +243,8 @@ pub async fn run_rest_event_loop(
                     }
                 }
             }
+            // All channels are closed.
+            else => break,
         }
     }
 


### PR DESCRIPTION
## Summary

... otherwise binary emits warning message, see linked issue for details

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1712

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
