### PR TITLE
[chaos] Fix replay table config

### DIFF
--- a/src/moonlink/src/storage/mooncake_table/table_creation_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_creation_test_utils.rs
@@ -264,23 +264,6 @@ pub(crate) fn create_disk_slice_write_option(
     }
 }
 
-/// Test util function to create mooncake table metadata with the provided full config, and disabled flush at commit.
-#[cfg(feature = "chaos-test")]
-pub(crate) fn create_test_table_metadata_disable_flush_with_full_config(
-    local_table_directory: String,
-    disk_slice_write_config: DiskSliceWriterConfig,
-    index_merge_config: FileIndexMergeConfig,
-    data_compaction_config: DataCompactionConfig,
-    identity: RowIdentity,
-) -> Arc<MooncakeTableMetadata> {
-    let mut config = MooncakeTableConfig::new(local_table_directory.clone());
-    config.mem_slice_size = usize::MAX; // Disable flush at commit if not force flush.
-    config.disk_slice_writer_config = disk_slice_write_config;
-    config.file_index_config = index_merge_config;
-    config.data_compaction_config = data_compaction_config;
-    create_test_table_metadata_with_config_and_identity(local_table_directory, config, identity)
-}
-
 /// Test util function to create mooncake table metadata, which disables flush at commit.
 #[cfg(feature = "chaos-test")]
 pub(crate) fn create_test_table_metadata_disable_flush(

--- a/src/moonlink/src/table_handler/chaos_test.rs
+++ b/src/moonlink/src/table_handler/chaos_test.rs
@@ -1479,30 +1479,7 @@ async fn test_append_only_chaos_on_local_fs_with_no_background_maintenance() {
         append_only: true,
         maintenance_option: TableMaintenanceOption::NoTableMaintenance,
         error_injection_enabled: false,
-        event_count: 1000,
-        storage_config: StorageConfig::FileSystem {
-            root_directory,
-            atomic_write_dir: None,
-        },
-    };
-    let env = TestEnvironment::new(test_env_config).await;
-    chaos_test_impl(env).await;
-}
-
-/// Chaos test with index merge enabled by default.
-#[named]
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn test_append_only_chaos_on_local_fs_with_index_merge() {
-    let iceberg_temp_dir = tempdir().unwrap();
-    let root_directory = iceberg_temp_dir.path().to_str().unwrap().to_string();
-    let test_env_config = TestEnvConfig {
-        test_name: function_name!(),
-        local_filesystem_optimization_enabled: false,
-        disk_slice_write_chaos_enabled: false,
-        append_only: true,
-        maintenance_option: TableMaintenanceOption::IndexMerge,
-        error_injection_enabled: false,
-        event_count: 1000,
+        event_count: 3500,
         storage_config: StorageConfig::FileSystem {
             root_directory,
             atomic_write_dir: None,
@@ -1525,7 +1502,7 @@ async fn test_append_only_chaos_on_local_fs_with_data_compaction() {
         append_only: true,
         maintenance_option: TableMaintenanceOption::DataCompaction,
         error_injection_enabled: false,
-        event_count: 1000,
+        event_count: 3500,
         storage_config: StorageConfig::FileSystem {
             root_directory,
             atomic_write_dir: None,


### PR DESCRIPTION
## Summary

Current implementation doesn't considers append-only config, which breaks invariant assertion.
This PR also remove index merge for append-only table, which doesn't make any sense.

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
