### PR TITLE
[chaos] Fix replay event

### DIFF
--- a/src/moonlink/benches/bench_write.rs
+++ b/src/moonlink/benches/bench_write.rs
@@ -92,7 +92,7 @@ fn bench_write(c: &mut Criterion) {
                         values: row.values.clone(),
                     });
                 }
-                let _ = table.flush(100000);
+                let _ = table.flush(100000, /*event_id=*/ uuid::Uuid::new_v4());
             });
         });
     });
@@ -144,7 +144,7 @@ fn bench_write(c: &mut Criterion) {
                         1,
                     );
                 }
-                let _ = table.flush(100000);
+                let _ = table.flush(100000, /*event_id=*/ uuid::Uuid::new_v4());
             });
         });
     });
@@ -199,9 +199,9 @@ fn bench_write(c: &mut Criterion) {
                     }
                     table
                         .flush_stream(
-                            /*event_id=*/ uuid::Uuid::new_v4(),
                             /*xact_id=*/ 1,
                             /*lsn=*/ None,
+                            /*event_id=*/ uuid::Uuid::new_v4(),
                         )
                         .unwrap();
                 });
@@ -221,9 +221,9 @@ fn bench_write(c: &mut Criterion) {
                     }
                     table
                         .flush_stream(
-                            /*event_id=*/ uuid::Uuid::new_v4(),
                             /*xact_id=*/ 1,
                             /*lsn=*/ None,
+                            /*event_id=*/ uuid::Uuid::new_v4(),
                         )
                         .unwrap();
                 });

--- a/src/moonlink/benches/bench_write.rs
+++ b/src/moonlink/benches/bench_write.rs
@@ -197,7 +197,13 @@ fn bench_write(c: &mut Criterion) {
                             1,
                         );
                     }
-                    table.flush_stream(1, None).unwrap();
+                    table
+                        .flush_stream(
+                            /*event_uuid=*/ uuid::Uuid::new_v4(),
+                            /*xact_id=*/ 1,
+                            /*lsn=*/ None,
+                        )
+                        .unwrap();
                 });
                 table
             },
@@ -213,7 +219,13 @@ fn bench_write(c: &mut Criterion) {
                             )
                             .await;
                     }
-                    table.flush_stream(1, None).unwrap();
+                    table
+                        .flush_stream(
+                            /*event_uuid=*/ uuid::Uuid::new_v4(),
+                            /*xact_id=*/ 1,
+                            /*lsn=*/ None,
+                        )
+                        .unwrap();
                 });
             },
             BatchSize::PerIteration,

--- a/src/moonlink/benches/bench_write.rs
+++ b/src/moonlink/benches/bench_write.rs
@@ -199,7 +199,7 @@ fn bench_write(c: &mut Criterion) {
                     }
                     table
                         .flush_stream(
-                            /*event_uuid=*/ uuid::Uuid::new_v4(),
+                            /*event_id=*/ uuid::Uuid::new_v4(),
                             /*xact_id=*/ 1,
                             /*lsn=*/ None,
                         )
@@ -221,7 +221,7 @@ fn bench_write(c: &mut Criterion) {
                     }
                     table
                         .flush_stream(
-                            /*event_uuid=*/ uuid::Uuid::new_v4(),
+                            /*event_id=*/ uuid::Uuid::new_v4(),
                             /*xact_id=*/ 1,
                             /*lsn=*/ None,
                         )

--- a/src/moonlink/src/storage/iceberg/state_tests.rs
+++ b/src/moonlink/src/storage/iceberg/state_tests.rs
@@ -45,6 +45,7 @@ use crate::storage::mooncake_table::table_creation_test_utils::*;
 use crate::storage::mooncake_table::table_operation_test_utils::*;
 use crate::storage::mooncake_table::validation_test_utils::*;
 use crate::storage::mooncake_table::Snapshot;
+use crate::storage::snapshot_options::IcebergSnapshotOption;
 use crate::storage::snapshot_options::MaintenanceOption;
 use crate::storage::snapshot_options::SnapshotOption;
 use crate::storage::MooncakeTable;
@@ -421,9 +422,9 @@ async fn test_state_1_1() {
         uuid: uuid::Uuid::new_v4(),
         dump_snapshot: false,
         force_create: false,
-        skip_iceberg_snapshot: false,
-        index_merge_option: MaintenanceOption::BestEffort,
-        data_compaction_option: MaintenanceOption::BestEffort,
+        iceberg_snapshot_option: IcebergSnapshotOption::BestEffort(uuid::Uuid::new_v4()),
+        index_merge_option: MaintenanceOption::BestEffort(uuid::Uuid::new_v4()),
+        data_compaction_option: MaintenanceOption::BestEffort(uuid::Uuid::new_v4()),
     }));
 
     // Validate end state.
@@ -449,9 +450,9 @@ async fn test_state_1_2() {
         uuid: uuid::Uuid::new_v4(),
         dump_snapshot: false,
         force_create: false,
-        skip_iceberg_snapshot: false,
-        index_merge_option: MaintenanceOption::BestEffort,
-        data_compaction_option: MaintenanceOption::BestEffort,
+        iceberg_snapshot_option: IcebergSnapshotOption::BestEffort(uuid::Uuid::new_v4()),
+        index_merge_option: MaintenanceOption::BestEffort(uuid::Uuid::new_v4()),
+        data_compaction_option: MaintenanceOption::BestEffort(uuid::Uuid::new_v4()),
     }));
 
     // Validate end state.

--- a/src/moonlink/src/storage/iceberg/tests.rs
+++ b/src/moonlink/src/storage/iceberg/tests.rs
@@ -34,6 +34,7 @@ use crate::storage::mooncake_table::{
 use crate::storage::mooncake_table_config::DiskSliceWriterConfig;
 use crate::storage::mooncake_table_config::IcebergPersistenceConfig;
 use crate::storage::mooncake_table_config::MooncakeTableConfig;
+use crate::storage::snapshot_options::IcebergSnapshotOption;
 use crate::storage::snapshot_options::MaintenanceOption;
 use crate::storage::snapshot_options::SnapshotOption;
 use crate::storage::storage_utils;
@@ -303,9 +304,9 @@ async fn test_skip_iceberg_snapshot() {
         uuid: uuid::Uuid::new_v4(),
         force_create: false,
         dump_snapshot: false,
-        skip_iceberg_snapshot: true,
-        index_merge_option: MaintenanceOption::BestEffort,
-        data_compaction_option: MaintenanceOption::BestEffort,
+        iceberg_snapshot_option: IcebergSnapshotOption::Skip,
+        index_merge_option: MaintenanceOption::BestEffort(uuid::Uuid::new_v4()),
+        data_compaction_option: MaintenanceOption::BestEffort(uuid::Uuid::new_v4()),
     }));
     let (_, iceberg_snapshot_payload, _, _, _) =
         sync_mooncake_snapshot(&mut table, &mut notify_rx).await;

--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -1209,7 +1209,7 @@ impl MooncakeTable {
             tokio::task::spawn(async move {
                 table_notify_tx
                     .send(TableEvent::FlushResult {
-                        uuid: event_id.clone(),
+                        uuid: event_id,
                         xact_id: None,
                         flush_result: None,
                     })
@@ -1222,7 +1222,7 @@ impl MooncakeTable {
         // Record events for flush initialization.
         if let Some(event_replay_tx) = &self.event_replay_tx {
             let table_event = replay_events::create_flush_event_initiation(
-                event_id.clone(),
+                event_id,
                 /*xact_id=*/ None,
                 Some(lsn),
                 self.mem_slice.get_commit_check_point(),

--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -844,7 +844,7 @@ impl MooncakeTable {
         disk_slice: &mut DiskSliceWriter,
         table_notify_tx: Sender<TableEvent>,
         xact_id: Option<u32>,
-        flush_event_id: uuid::Uuid,
+        event_uuid: uuid::Uuid,
     ) {
         if let Some(lsn) = disk_slice.lsn() {
             self.insert_ongoing_flush_lsn(lsn);
@@ -862,7 +862,7 @@ impl MooncakeTable {
                 Ok(()) => {
                     table_notify_tx
                         .send(TableEvent::FlushResult {
-                            uuid: flush_event_id,
+                            uuid: event_uuid,
                             xact_id,
                             flush_result: Some(Ok(disk_slice_clone)),
                         })
@@ -872,7 +872,7 @@ impl MooncakeTable {
                 Err(e) => {
                     table_notify_tx
                         .send(TableEvent::FlushResult {
-                            uuid: flush_event_id,
+                            uuid: event_uuid,
                             xact_id,
                             flush_result: Some(Err(e)),
                         })
@@ -1193,7 +1193,7 @@ impl MooncakeTable {
     /// Drains the current mem slice and create a disk slice.
     /// Flushes the disk slice.
     /// Adds the disk slice to `next_snapshot_task`.
-    pub fn flush(&mut self, lsn: u64) -> Result<()> {
+    pub fn flush(&mut self, event_uuid: uuid::Uuid, lsn: u64) -> Result<()> {
         // Sanity check flush LSN doesn't regress.
         assert!(
             self.next_snapshot_task.new_flush_lsn.is_none()
@@ -1204,14 +1204,12 @@ impl MooncakeTable {
         );
 
         let table_notify_tx = self.table_notify.as_ref().unwrap().clone();
-        let flush_event_id = uuid::Uuid::new_v4();
-
         if self.mem_slice.is_empty() || self.ongoing_flush_lsns.contains(&lsn) {
             self.try_set_next_flush_lsn(lsn);
             tokio::task::spawn(async move {
                 table_notify_tx
                     .send(TableEvent::FlushResult {
-                        uuid: flush_event_id,
+                        uuid: event_uuid,
                         xact_id: None,
                         flush_result: None,
                     })
@@ -1224,7 +1222,7 @@ impl MooncakeTable {
         // Record events for flush initialization.
         if let Some(event_replay_tx) = &self.event_replay_tx {
             let table_event = replay_events::create_flush_event_initiation(
-                flush_event_id,
+                event_uuid.clone(),
                 /*xact_id=*/ None,
                 Some(lsn),
                 self.mem_slice.get_commit_check_point(),
@@ -1239,7 +1237,7 @@ impl MooncakeTable {
             &mut disk_slice,
             table_notify_tx,
             /*xact_id=*/ None,
-            flush_event_id,
+            event_uuid,
         );
 
         Ok(())

--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -862,7 +862,7 @@ impl MooncakeTable {
                 Ok(()) => {
                     table_notify_tx
                         .send(TableEvent::FlushResult {
-                            uuid: event_id,
+                            event_id,
                             xact_id,
                             flush_result: Some(Ok(disk_slice_clone)),
                         })
@@ -872,7 +872,7 @@ impl MooncakeTable {
                 Err(e) => {
                     table_notify_tx
                         .send(TableEvent::FlushResult {
-                            uuid: event_id,
+                            event_id,
                             xact_id,
                             flush_result: Some(Err(e)),
                         })
@@ -1209,7 +1209,7 @@ impl MooncakeTable {
             tokio::task::spawn(async move {
                 table_notify_tx
                     .send(TableEvent::FlushResult {
-                        uuid: event_id,
+                        event_id,
                         xact_id: None,
                         flush_result: None,
                     })

--- a/src/moonlink/src/storage/mooncake_table/snapshot_maintenance.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot_maintenance.rs
@@ -49,20 +49,25 @@ impl SnapshotTableState {
 
         let config = &self.mooncake_table_metadata.config.data_compaction_config;
         let (
+            event_id,
             min_data_compaction_file_num_threshold,
             max_data_compaction_file_num_threshold,
             data_file_deletion_percentage_threshold,
             data_compaction_file_size_threshold,
         ) = match data_compaction_option {
-            MaintenanceOption::Skip => (usize::MAX, usize::MAX, 100, 0),
-            MaintenanceOption::ForceRegular => (
+            MaintenanceOption::Skip => (None, usize::MAX, usize::MAX, 100, 0),
+            MaintenanceOption::ForceRegular(event_id) => (
+                Some(event_id),
                 2,
                 config.max_data_file_to_compact as usize,
                 config.data_file_deletion_percentage as usize,
                 config.data_file_final_size as usize,
             ),
-            MaintenanceOption::ForceFull => (2, usize::MAX, 1, usize::MAX),
-            MaintenanceOption::BestEffort => (
+            MaintenanceOption::ForceFull(event_id) => {
+                (Some(event_id), 2, usize::MAX, 1, usize::MAX)
+            }
+            MaintenanceOption::BestEffort(event_id) => (
+                Some(event_id),
                 config.min_data_file_to_compact as usize,
                 config.max_data_file_to_compact as usize,
                 config.data_file_deletion_percentage as usize,
@@ -174,7 +179,7 @@ impl SnapshotTableState {
         }
 
         let payload = DataCompactionPayload {
-            uuid: uuid::Uuid::new_v4(),
+            uuid: event_id.unwrap().clone(),
             object_storage_cache: self.object_storage_cache.clone(),
             filesystem_accessor: self.filesystem_accessor.clone(),
             disk_files: tentative_data_files_to_compact
@@ -228,28 +233,27 @@ impl SnapshotTableState {
             .config
             .file_index_config
             .max_file_indices_to_merge as usize;
-        let min_index_merge_file_num_threshold = match index_merge_option {
-            MaintenanceOption::Skip => usize::MAX,
-            MaintenanceOption::ForceRegular => 2,
-            MaintenanceOption::ForceFull => 2,
-            MaintenanceOption::BestEffort => {
-                self.mooncake_table_metadata
-                    .config
-                    .file_index_config
-                    .min_file_indices_to_merge as usize
-            }
-        };
         let default_final_file_size = self
             .mooncake_table_metadata
             .config
             .file_index_config
             .index_block_final_size;
-        let index_merge_file_size_threshold = match index_merge_option {
-            MaintenanceOption::Skip => u64::MAX,
-            MaintenanceOption::ForceRegular => default_final_file_size,
-            MaintenanceOption::ForceFull => 0,
-            MaintenanceOption::BestEffort => default_final_file_size,
-        };
+        let (event_id, min_index_merge_file_num_threshold, index_merge_file_size_threshold) =
+            match index_merge_option {
+                MaintenanceOption::Skip => (None, usize::MAX, u64::MAX),
+                MaintenanceOption::ForceRegular(event_id) => {
+                    (Some(event_id), 2, default_final_file_size)
+                }
+                MaintenanceOption::ForceFull(event_id) => (Some(event_id), 2, 0),
+                MaintenanceOption::BestEffort(event_id) => (
+                    Some(event_id),
+                    self.mooncake_table_metadata
+                        .config
+                        .file_index_config
+                        .min_file_indices_to_merge as usize,
+                    default_final_file_size,
+                ),
+            };
 
         // Fast-path: not enough file indices to trigger index merge.
         let mut file_indices_to_merge = HashSet::new();
@@ -280,7 +284,7 @@ impl SnapshotTableState {
         // To avoid too many small IO operations, only attempt an index merge when accumulated small indices exceeds the threshold.
         if file_indices_to_merge.len() >= min_index_merge_file_num_threshold {
             let payload = FileIndiceMergePayload {
-                uuid: uuid::Uuid::new_v4(),
+                uuid: event_id.unwrap().clone(),
                 file_indices: file_indices_to_merge
                     .into_iter()
                     .take(max_index_merge_file_num_threshold)

--- a/src/moonlink/src/storage/mooncake_table/snapshot_maintenance.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot_maintenance.rs
@@ -179,7 +179,7 @@ impl SnapshotTableState {
         }
 
         let payload = DataCompactionPayload {
-            uuid: event_id.unwrap().clone(),
+            uuid: *event_id.unwrap(),
             object_storage_cache: self.object_storage_cache.clone(),
             filesystem_accessor: self.filesystem_accessor.clone(),
             disk_files: tentative_data_files_to_compact
@@ -284,7 +284,7 @@ impl SnapshotTableState {
         // To avoid too many small IO operations, only attempt an index merge when accumulated small indices exceeds the threshold.
         if file_indices_to_merge.len() >= min_index_merge_file_num_threshold {
             let payload = FileIndiceMergePayload {
-                uuid: event_id.unwrap().clone(),
+                uuid: *event_id.unwrap(),
                 file_indices: file_indices_to_merge
                     .into_iter()
                     .take(max_index_merge_file_num_threshold)

--- a/src/moonlink/src/storage/mooncake_table/snapshot_persistence.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot_persistence.rs
@@ -35,7 +35,7 @@ impl SnapshotTableState {
         committed_deletion_to_persist: CommittedDeletionToPersist,
     ) -> IcebergSnapshotPayload {
         IcebergSnapshotPayload {
-            uuid: opt.get_event_id().unwrap().clone(),
+            uuid: opt.get_event_id().unwrap(),
             flush_lsn,
             new_table_schema: None,
             committed_deletion_logs: committed_deletion_to_persist.committed_deletion_logs,

--- a/src/moonlink/src/storage/mooncake_table/snapshot_persistence.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot_persistence.rs
@@ -8,6 +8,7 @@ use crate::storage::mooncake_table::SnapshotTask;
 use crate::storage::mooncake_table::{
     IcebergSnapshotImportPayload, IcebergSnapshotIndexMergePayload,
 };
+use crate::storage::snapshot_options::IcebergSnapshotOption;
 use crate::storage::storage_utils::FileId;
 use crate::storage::storage_utils::MooncakeDataFileRef;
 /// This file stores snapshot persistence related features.
@@ -29,11 +30,12 @@ impl SnapshotTableState {
 
     pub(super) fn get_iceberg_snapshot_payload(
         &self,
+        opt: &IcebergSnapshotOption,
         flush_lsn: u64,
         committed_deletion_to_persist: CommittedDeletionToPersist,
     ) -> IcebergSnapshotPayload {
         IcebergSnapshotPayload {
-            uuid: uuid::Uuid::new_v4(),
+            uuid: opt.get_event_id().unwrap().clone(),
             flush_lsn,
             new_table_schema: None,
             committed_deletion_logs: committed_deletion_to_persist.committed_deletion_logs,

--- a/src/moonlink/src/storage/mooncake_table/table_operation_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_operation_test_utils.rs
@@ -31,8 +31,8 @@ pub(crate) async fn flush_table_and_sync(
     receiver: &mut Receiver<TableEvent>,
     lsn: u64,
 ) -> Result<()> {
-    let event_uuid = uuid::Uuid::new_v4();
-    table.flush(event_uuid, lsn).unwrap();
+    let event_id = uuid::Uuid::new_v4();
+    table.flush(lsn, event_id).unwrap();
     let flush_result = receiver.recv().await.unwrap();
     match flush_result {
         TableEvent::FlushResult {
@@ -65,8 +65,8 @@ pub(crate) async fn flush_table_and_sync_no_apply(
     receiver: &mut Receiver<TableEvent>,
     lsn: u64,
 ) -> Option<DiskSliceWriter> {
-    let event_uuid = uuid::Uuid::new_v4();
-    table.flush(event_uuid, lsn).unwrap();
+    let event_id = uuid::Uuid::new_v4();
+    table.flush(lsn, event_id).unwrap();
     let flush_result = receiver.recv().await.unwrap();
     match flush_result {
         TableEvent::FlushResult {
@@ -98,8 +98,8 @@ pub(crate) async fn flush_stream_and_sync_no_apply(
     xact_id: u32,
     lsn: Option<u64>,
 ) -> Option<DiskSliceWriter> {
-    let event_uuid = uuid::Uuid::new_v4();
-    table.flush_stream(event_uuid, xact_id, lsn).unwrap();
+    let event_id = uuid::Uuid::new_v4();
+    table.flush_stream(xact_id, lsn, event_id).unwrap();
     let flush_result = receiver.recv().await.unwrap();
     match flush_result {
         TableEvent::FlushResult {
@@ -131,9 +131,9 @@ pub(crate) async fn commit_transaction_stream_and_sync(
     xact_id: u32,
     lsn: u64,
 ) {
-    let event_uuid = uuid::Uuid::new_v4();
+    let event_id = uuid::Uuid::new_v4();
     table
-        .commit_transaction_stream(event_uuid, xact_id, lsn)
+        .commit_transaction_stream(xact_id, lsn, event_id)
         .unwrap();
     let flush_result = receiver.recv().await.unwrap();
     match flush_result {

--- a/src/moonlink/src/storage/mooncake_table/table_operation_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_operation_test_utils.rs
@@ -36,12 +36,12 @@ pub(crate) async fn flush_table_and_sync(
     let flush_result = receiver.recv().await.unwrap();
     match flush_result {
         TableEvent::FlushResult {
-            uuid,
+            event_id,
             xact_id: _,
             flush_result,
         } => match flush_result {
             Some(Ok(disk_slice)) => {
-                table.apply_flush_result(disk_slice, uuid);
+                table.apply_flush_result(disk_slice, event_id);
             }
             Some(Err(e)) => {
                 error!(error = ?e, "failed to flush disk slice");
@@ -70,7 +70,7 @@ pub(crate) async fn flush_table_and_sync_no_apply(
     let flush_result = receiver.recv().await.unwrap();
     match flush_result {
         TableEvent::FlushResult {
-            uuid: _,
+            event_id: _,
             xact_id: _,
             flush_result,
         } => match flush_result {
@@ -103,7 +103,7 @@ pub(crate) async fn flush_stream_and_sync_no_apply(
     let flush_result = receiver.recv().await.unwrap();
     match flush_result {
         TableEvent::FlushResult {
-            uuid: _,
+            event_id: _,
             xact_id: _,
             flush_result,
         } => match flush_result {
@@ -138,12 +138,12 @@ pub(crate) async fn commit_transaction_stream_and_sync(
     let flush_result = receiver.recv().await.unwrap();
     match flush_result {
         TableEvent::FlushResult {
-            uuid,
+            event_id,
             xact_id: Some(xact_id),
             flush_result,
         } => match flush_result {
             Some(Ok(disk_slice)) => {
-                table.apply_stream_flush_result(xact_id, disk_slice, uuid);
+                table.apply_stream_flush_result(xact_id, disk_slice, event_id);
             }
             Some(Err(e)) => {
                 error!(error = ?e, "failed to flush disk slice");

--- a/src/moonlink/src/storage/mooncake_table/tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/tests.rs
@@ -5,6 +5,7 @@ use crate::storage::mooncake_table::table_creation_test_utils::*;
 use crate::storage::mooncake_table::table_operation_test_utils::*;
 use crate::storage::mooncake_table::test_utils::{append_rows, test_row, test_table, TestContext};
 use crate::storage::mooncake_table::Snapshot as MooncakeSnapshot;
+use crate::storage::snapshot_options::IcebergSnapshotOption;
 use crate::storage::snapshot_options::MaintenanceOption;
 use crate::storage::snapshot_options::SnapshotOption;
 use crate::storage::wal::test_utils::WAL_TEST_TABLE_ID;
@@ -1995,7 +1996,7 @@ async fn test_iceberg_snapshot_blocked_by_ongoing_flushes() -> Result<()> {
         uuid: uuid::Uuid::new_v4(),
         force_create: true,
         dump_snapshot: false,
-        skip_iceberg_snapshot: false,
+        iceberg_snapshot_option: IcebergSnapshotOption::BestEffort(uuid::Uuid::new_v4()),
         index_merge_option: MaintenanceOption::Skip,
         data_compaction_option: MaintenanceOption::Skip,
     });
@@ -2033,7 +2034,7 @@ async fn test_iceberg_snapshot_blocked_by_ongoing_flushes() -> Result<()> {
         uuid: uuid::Uuid::new_v4(),
         force_create: true,
         dump_snapshot: false,
-        skip_iceberg_snapshot: false,
+        iceberg_snapshot_option: IcebergSnapshotOption::BestEffort(uuid::Uuid::new_v4()),
         index_merge_option: MaintenanceOption::Skip,
         data_compaction_option: MaintenanceOption::Skip,
     });
@@ -2098,7 +2099,7 @@ async fn test_out_of_order_flush_completion_with_iceberg_snapshots() -> Result<(
         uuid: uuid::Uuid::new_v4(),
         force_create: true,
         dump_snapshot: false,
-        skip_iceberg_snapshot: false,
+        iceberg_snapshot_option: IcebergSnapshotOption::BestEffort(uuid::Uuid::new_v4()),
         index_merge_option: MaintenanceOption::Skip,
         data_compaction_option: MaintenanceOption::Skip,
     });
@@ -2252,9 +2253,9 @@ async fn test_streaming_batch_id_mismatch_with_data_compaction() -> Result<()> {
         uuid: uuid::Uuid::new_v4(),
         force_create: true,
         dump_snapshot: false,
-        skip_iceberg_snapshot: true, // Skip iceberg to focus on the mooncake issue
+        iceberg_snapshot_option: IcebergSnapshotOption::Skip, // Skip iceberg to focus on the mooncake issue
         index_merge_option: MaintenanceOption::Skip,
-        data_compaction_option: MaintenanceOption::ForceRegular, // Trigger data compaction
+        data_compaction_option: MaintenanceOption::ForceRegular(uuid::Uuid::new_v4()), // Trigger data compaction
     });
 
     assert!(created, "Mooncake snapshot should be created");
@@ -2327,9 +2328,9 @@ async fn test_streaming_empty_batch_filtering() -> Result<()> {
         uuid: uuid::Uuid::new_v4(),
         force_create: true,
         dump_snapshot: false,
-        skip_iceberg_snapshot: true,
+        iceberg_snapshot_option: IcebergSnapshotOption::Skip,
         index_merge_option: MaintenanceOption::Skip,
-        data_compaction_option: MaintenanceOption::ForceRegular,
+        data_compaction_option: MaintenanceOption::ForceRegular(uuid::Uuid::new_v4()),
     });
 
     assert!(created);
@@ -2386,7 +2387,7 @@ async fn test_batch_id_removal_assertion_direct() -> Result<()> {
         uuid: uuid::Uuid::new_v4(),
         force_create: true,
         dump_snapshot: false,
-        skip_iceberg_snapshot: true,
+        iceberg_snapshot_option: IcebergSnapshotOption::Skip,
         index_merge_option: MaintenanceOption::Skip,
         data_compaction_option: MaintenanceOption::Skip, // No compaction to avoid other issues
     });
@@ -2464,9 +2465,9 @@ async fn test_puffin_deletion_blob_inconsistency_assertion() -> Result<()> {
         uuid: uuid::Uuid::new_v4(),
         force_create: true,
         dump_snapshot: false,
-        skip_iceberg_snapshot: true,
+        iceberg_snapshot_option: IcebergSnapshotOption::Skip,
         index_merge_option: MaintenanceOption::Skip,
-        data_compaction_option: MaintenanceOption::ForceRegular, // Force data compaction
+        data_compaction_option: MaintenanceOption::ForceRegular(uuid::Uuid::new_v4()), // Force data compaction
     });
 
     assert!(created, "Mooncake snapshot should be created");
@@ -2530,7 +2531,7 @@ async fn test_stream_commit_with_ongoing_flush_deletion_remapping() -> Result<()
         uuid: uuid::Uuid::new_v4(),
         force_create: true,
         dump_snapshot: false,
-        skip_iceberg_snapshot: true,
+        iceberg_snapshot_option: IcebergSnapshotOption::Skip,
         index_merge_option: MaintenanceOption::Skip,
         data_compaction_option: MaintenanceOption::Skip,
     });
@@ -2579,7 +2580,7 @@ async fn test_deletion_align_with_batch() -> Result<()> {
         uuid: uuid::Uuid::new_v4(),
         force_create: true,
         dump_snapshot: false,
-        skip_iceberg_snapshot: true,
+        iceberg_snapshot_option: IcebergSnapshotOption::Skip,
         index_merge_option: MaintenanceOption::Skip,
         data_compaction_option: MaintenanceOption::Skip,
     });
@@ -2647,7 +2648,9 @@ async fn test_disk_slice_write_failure() -> Result<()> {
     table.commit(100);
 
     // Attempt to flush - this should fail due to invalid directory
-    table.flush(100).unwrap();
+    table
+        .flush(/*event_uuid=*/ uuid::Uuid::new_v4(), /*lsn=*/ 100)
+        .unwrap();
 
     // Wait for the flush result and verify it contains the expected error
     let flush_result = event_completion_rx.recv().await.unwrap();

--- a/src/moonlink/src/storage/mooncake_table/tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/tests.rs
@@ -2649,7 +2649,7 @@ async fn test_disk_slice_write_failure() -> Result<()> {
 
     // Attempt to flush - this should fail due to invalid directory
     table
-        .flush(/*event_uuid=*/ uuid::Uuid::new_v4(), /*lsn=*/ 100)
+        .flush(/*lsn=*/ 100, /*event_id=*/ uuid::Uuid::new_v4())
         .unwrap();
 
     // Wait for the flush result and verify it contains the expected error

--- a/src/moonlink/src/storage/mooncake_table/tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/tests.rs
@@ -2656,7 +2656,7 @@ async fn test_disk_slice_write_failure() -> Result<()> {
     let flush_result = event_completion_rx.recv().await.unwrap();
     match flush_result {
         TableEvent::FlushResult {
-            uuid: _,
+            event_id: _,
             xact_id: _,
             flush_result,
         } => {

--- a/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
+++ b/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
@@ -507,7 +507,12 @@ impl MooncakeTable {
         }
     }
 
-    pub fn flush_stream(&mut self, xact_id: u32, lsn: Option<u64>) -> Result<()> {
+    pub fn flush_stream(
+        &mut self,
+        event_uuid: uuid::Uuid,
+        xact_id: u32,
+        lsn: Option<u64>,
+    ) -> Result<()> {
         // Temporarily remove to drop reference to self
         let mut stream_state = self
             .transaction_stream_states
@@ -515,10 +520,9 @@ impl MooncakeTable {
             .expect("Stream state not found for xact_id, lsn: {xact_id, lsn}");
 
         // Record events for flush initiation.
-        let flush_event_id = uuid::Uuid::new_v4();
         if let Some(event_replay_tx) = &self.event_replay_tx {
             let table_event = replay_events::create_flush_event_initiation(
-                flush_event_id,
+                event_uuid.clone(),
                 /*xact_id=*/ Some(xact_id),
                 lsn,
                 stream_state.mem_slice.get_commit_check_point(),
@@ -534,12 +538,7 @@ impl MooncakeTable {
 
         stream_state.ongoing_flush_count += 1;
 
-        self.flush_disk_slice(
-            &mut disk_slice,
-            table_notify_tx,
-            Some(xact_id),
-            flush_event_id,
-        );
+        self.flush_disk_slice(&mut disk_slice, table_notify_tx, Some(xact_id), event_uuid);
 
         // Add back stream state
         self.transaction_stream_states.insert(xact_id, stream_state);
@@ -644,12 +643,17 @@ impl MooncakeTable {
     }
 
     /// Commit a transaction stream.
-    /// Flushes any remaining rows from stream mem slice
-    /// Adds all in mem batches and indices to next snapshot task
-    /// Updates deletion records
-    /// Enqueues `TransactionStreamOutput::Commit` for snapshot task
-    pub fn commit_transaction_stream(&mut self, xact_id: u32, lsn: u64) -> Result<()> {
-        self.flush_stream(xact_id, Some(lsn))?;
+    /// - Flushes any remaining rows from stream mem slice
+    /// - Adds all in mem batches and indices to next snapshot task
+    /// - Updates deletion records
+    /// - Enqueues `TransactionStreamOutput::Commit` for snapshot task
+    pub fn commit_transaction_stream(
+        &mut self,
+        event_uuid: uuid::Uuid,
+        xact_id: u32,
+        lsn: u64,
+    ) -> Result<()> {
+        self.flush_stream(event_uuid, xact_id, Some(lsn))?;
         self.commit_transaction_stream_impl(xact_id, lsn)
     }
 }

--- a/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
+++ b/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
@@ -522,7 +522,7 @@ impl MooncakeTable {
         // Record events for flush initiation.
         if let Some(event_replay_tx) = &self.event_replay_tx {
             let table_event = replay_events::create_flush_event_initiation(
-                event_id.clone(),
+                event_id,
                 /*xact_id=*/ Some(xact_id),
                 lsn,
                 stream_state.mem_slice.get_commit_check_point(),

--- a/src/moonlink/src/storage/snapshot_options.rs
+++ b/src/moonlink/src/storage/snapshot_options.rs
@@ -35,7 +35,7 @@ impl IcebergSnapshotOption {
     pub fn get_event_id(&self) -> Option<uuid::Uuid> {
         match &self {
             IcebergSnapshotOption::Skip => None,
-            IcebergSnapshotOption::BestEffort(event_id) => Some(event_id.clone()),
+            IcebergSnapshotOption::BestEffort(event_id) => Some(*event_id),
         }
     }
 }

--- a/src/moonlink/src/storage/snapshot_options.rs
+++ b/src/moonlink/src/storage/snapshot_options.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 /// Option for a maintenance option.
 ///
-/// Event id, which is a UUID, will be used for background events to ensure reproducibility.
+/// Event id, which is a UUID, will be used for background events to ensure deterministic reproduction.
 ///
 /// For all types of maintenance tasks, we have two basic dimensions:
 /// - Selection criteria: for full-mode maintenance task, all files will take part in, however big it is; for non-full-mode, only those meet certain threshold will be selected.

--- a/src/moonlink/src/storage/snapshot_options.rs
+++ b/src/moonlink/src/storage/snapshot_options.rs
@@ -2,6 +2,8 @@ use serde::{Deserialize, Serialize};
 
 /// Option for a maintenance option.
 ///
+/// Event id, which is a UUID, will be used for background events to ensure reproducibility.
+///
 /// For all types of maintenance tasks, we have two basic dimensions:
 /// - Selection criteria: for full-mode maintenance task, all files will take part in, however big it is; for non-full-mode, only those meet certain threshold will be selected.
 ///   For example, for non-full-mode, only small files will be compacted.
@@ -11,13 +13,31 @@ use serde::{Deserialize, Serialize};
 pub enum MaintenanceOption {
     /// Regular maintenance task, which perform a best effort attempt.
     /// This is the default option, which is used for background task.
-    BestEffort,
+    BestEffort(uuid::Uuid),
     /// Force a regular maintenance attempt.
-    ForceRegular,
+    ForceRegular(uuid::Uuid),
     /// Force a full maintenance attempt.
-    ForceFull,
+    ForceFull(uuid::Uuid),
     /// Skip maintenance attempt.
     Skip,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Deserialize, Serialize)]
+pub enum IcebergSnapshotOption {
+    /// Skip iceberg snapshot attempt.
+    Skip,
+    /// Perform a best effort attempt, this is the default option for background tasks.
+    BestEffort(uuid::Uuid),
+}
+
+impl IcebergSnapshotOption {
+    /// Get event id.
+    pub fn get_event_id(&self) -> Option<uuid::Uuid> {
+        match &self {
+            IcebergSnapshotOption::Skip => None,
+            IcebergSnapshotOption::BestEffort(event_id) => Some(event_id.clone()),
+        }
+    }
 }
 
 /// Options to create mooncake snapshot.
@@ -30,8 +50,8 @@ pub struct SnapshotOption {
     /// Whether to force create snapshot.
     /// When specified, mooncake snapshot will be created with snapshot threshold ignored.
     pub(crate) force_create: bool,
-    /// Whether to skip iceberg snapshot creation.
-    pub(crate) skip_iceberg_snapshot: bool,
+    /// Iceberg snapshot option.
+    pub(crate) iceberg_snapshot_option: IcebergSnapshotOption,
     /// Index merge operation option.
     pub(crate) index_merge_option: MaintenanceOption,
     /// Data compaction operation option.

--- a/src/moonlink/src/table_handler.rs
+++ b/src/moonlink/src/table_handler.rs
@@ -735,15 +735,15 @@ impl TableHandler {
                             .unwrap();
                     }
                     TableEvent::FlushResult {
-                        uuid,
+                        event_id,
                         xact_id,
                         flush_result,
                     } => match flush_result {
                         Some(Ok(disk_slice)) => {
                             if let Some(xact_id) = xact_id {
-                                table.apply_stream_flush_result(xact_id, disk_slice, uuid);
+                                table.apply_stream_flush_result(xact_id, disk_slice, event_id);
                             } else {
-                                table.apply_flush_result(disk_slice, uuid);
+                                table.apply_flush_result(disk_slice, event_id);
                             }
                         }
                         Some(Err(e)) => {

--- a/src/moonlink/src/table_handler.rs
+++ b/src/moonlink/src/table_handler.rs
@@ -422,11 +422,6 @@ impl TableHandler {
                     TableEvent::RegularIcebergSnapshot {
                         mut iceberg_snapshot_payload,
                     } => {
-                        println!(
-                            "in table handler iceberg uuid = {:?}",
-                            iceberg_snapshot_payload.uuid
-                        );
-
                         // Update table maintenance status.
                         if iceberg_snapshot_payload.contains_table_maintenance_payload()
                             && table_handler_state.table_maintenance_process_status
@@ -494,11 +489,6 @@ impl TableHandler {
                             if let Some(iceberg_snapshot_payload) =
                                 mooncake_snapshot_result.iceberg_snapshot_payload
                             {
-                                println!(
-                                    "after mooncake snapshot, uuid = {:?}",
-                                    iceberg_snapshot_payload.uuid
-                                );
-
                                 table_handler_event_sender
                                     .send(TableEvent::RegularIcebergSnapshot {
                                         iceberg_snapshot_payload,

--- a/src/moonlink/src/table_handler.rs
+++ b/src/moonlink/src/table_handler.rs
@@ -352,11 +352,11 @@ impl TableHandler {
                     }
                     TableEvent::FinishInitialCopy { start_lsn } => {
                         debug!("finishing initial copy");
-                        let event_uuid = uuid::Uuid::new_v4();
+                        let event_id = uuid::Uuid::new_v4();
                         if let Err(e) = table.commit_transaction_stream(
-                            event_uuid,
                             INITIAL_COPY_XACT_ID,
                             start_lsn,
+                            event_id,
                         ) {
                             error!(error = %e, "failed to finish initial copy");
                         }
@@ -393,8 +393,8 @@ impl TableHandler {
                         {
                             if let Some(commit_lsn) = table_handler_state.table_consistent_view_lsn
                             {
-                                let event_uuid = uuid::Uuid::new_v4();
-                                table.flush(event_uuid, commit_lsn).unwrap();
+                                let event_id = uuid::Uuid::new_v4();
+                                table.flush(commit_lsn, event_id).unwrap();
                                 table_handler_state.last_unflushed_commit_lsn = None;
                                 table_handler_state.reset_iceberg_state_at_mooncake_snapshot();
                                 if let SpecialTableState::AlterTable { .. } =
@@ -827,8 +827,10 @@ impl TableHandler {
                     Some(xact_id) => {
                         let res = table.append_in_stream_batch(row, xact_id);
                         if table.should_transaction_flush(xact_id) {
-                            let event_uuid = uuid::Uuid::new_v4();
-                            if let Err(e) = table.flush_stream(event_uuid, xact_id, None) {
+                            let event_id = uuid::Uuid::new_v4();
+                            if let Err(e) =
+                                table.flush_stream(xact_id, /*lsn=*/ None, event_id)
+                            {
                                 error!(error = %e, "failed to flush stream");
                             }
                         }
@@ -880,8 +882,8 @@ impl TableHandler {
                 .await;
             }
             TableEvent::StreamFlush { xact_id, .. } => {
-                let event_uuid = uuid::Uuid::new_v4();
-                if let Err(e) = table.flush_stream(event_uuid, xact_id, None) {
+                let event_id = uuid::Uuid::new_v4();
+                if let Err(e) = table.flush_stream(xact_id, /*lsn=*/ None, event_id) {
                     error!(error = %e, "failed to flush stream");
                 }
             }
@@ -932,8 +934,8 @@ impl TableHandler {
                 if let Some(last_unflushed_commit_lsn) =
                     table_handler_state.last_unflushed_commit_lsn
                 {
-                    let event_uuid = uuid::Uuid::new_v4();
-                    if let Err(e) = table.flush(event_uuid, last_unflushed_commit_lsn) {
+                    let event_id = uuid::Uuid::new_v4();
+                    if let Err(e) = table.flush(last_unflushed_commit_lsn, event_id) {
                         error!(error = %e, "flush non-streaming writes failed in LSN {lsn}");
                     }
                     table_handler_state.last_unflushed_commit_lsn = None;
@@ -947,8 +949,8 @@ impl TableHandler {
                         return;
                     }
                 }
-                let event_uuid = uuid::Uuid::new_v4();
-                if let Err(e) = table.commit_transaction_stream(event_uuid, xact_id, lsn) {
+                let event_id = uuid::Uuid::new_v4();
+                if let Err(e) = table.commit_transaction_stream(xact_id, lsn, event_id) {
                     error!(error = %e, "stream commit flush failed");
                 }
             }
@@ -956,8 +958,8 @@ impl TableHandler {
                 table.commit(lsn);
                 if table.should_flush() || should_force_snapshot || force_flush_requested {
                     table_handler_state.last_unflushed_commit_lsn = None;
-                    let event_uuid = uuid::Uuid::new_v4();
-                    if let Err(e) = table.flush(event_uuid, lsn) {
+                    let event_id = uuid::Uuid::new_v4();
+                    if let Err(e) = table.flush(lsn, event_id) {
                         error!(error = %e, "flush failed in commit");
                     }
                 }

--- a/src/moonlink/src/table_handler/chaos_replay.rs
+++ b/src/moonlink/src/table_handler/chaos_replay.rs
@@ -191,7 +191,7 @@ pub(crate) async fn replay() {
             #[allow(clippy::single_match)]
             match table_event {
                 TableEvent::FlushResult {
-                    uuid,
+                    event_id,
                     xact_id,
                     flush_result,
                 } => {
@@ -200,7 +200,7 @@ pub(crate) async fn replay() {
                         flush_result,
                     };
                     let mut guard = completed_flush_events_clone.lock().await;
-                    assert!(guard.insert(uuid, completed_flush).is_none());
+                    assert!(guard.insert(event_id, completed_flush).is_none());
                     event_notification.notify_waiters();
                 }
                 TableEvent::MooncakeTableSnapshotResult {

--- a/src/moonlink/src/table_handler/chaos_replay.rs
+++ b/src/moonlink/src/table_handler/chaos_replay.rs
@@ -441,8 +441,8 @@ pub(crate) async fn replay() {
                 assert!(ongoing_iceberg_snapshot_id.insert(snapshot_initiation_event.uuid));
                 let payload = {
                     let mut guard = pending_iceberg_snapshot_payloads_clone.lock().await;
-                    let payload = guard.remove(&snapshot_initiation_event.uuid).unwrap();
-                    payload
+
+                    guard.remove(&snapshot_initiation_event.uuid).unwrap()
                 };
                 table.persist_iceberg_snapshot(payload);
             }
@@ -470,8 +470,8 @@ pub(crate) async fn replay() {
                 assert!(ongoing_index_merge_id.insert(index_merge_initiation_event.uuid));
                 let payload = {
                     let mut guard = pending_index_merge_payloads_clone.lock().await;
-                    let payload = guard.remove(&index_merge_initiation_event.uuid).unwrap();
-                    payload
+
+                    guard.remove(&index_merge_initiation_event.uuid).unwrap()
                 };
                 table.perform_index_merge(payload);
             }
@@ -497,10 +497,10 @@ pub(crate) async fn replay() {
                 assert!(ongoing_data_compaction_id.insert(data_compaction_initiation_event.uuid));
                 let payload = {
                     let mut guard = pending_data_compaction_payloads_clone.lock().await;
-                    let payload = guard
+
+                    guard
                         .remove(&data_compaction_initiation_event.uuid)
-                        .unwrap();
-                    payload
+                        .unwrap()
                 };
                 table.perform_data_compaction(payload);
             }

--- a/src/moonlink/src/table_handler/chaos_test.rs
+++ b/src/moonlink/src/table_handler/chaos_test.rs
@@ -1479,7 +1479,7 @@ async fn test_append_only_chaos_on_local_fs_with_no_background_maintenance() {
         append_only: true,
         maintenance_option: TableMaintenanceOption::NoTableMaintenance,
         error_injection_enabled: false,
-        event_count: 3500,
+        event_count: 200,
         storage_config: StorageConfig::FileSystem {
             root_directory,
             atomic_write_dir: None,

--- a/src/moonlink/src/table_notify.rs
+++ b/src/moonlink/src/table_notify.rs
@@ -96,7 +96,7 @@ pub enum TableEvent {
     },
     FlushResult {
         /// Background event id.
-        uuid: uuid::Uuid,
+        event_id: uuid::Uuid,
         /// Transaction ID
         xact_id: Option<u32>,
         /// Result for mem slice flush.


### PR DESCRIPTION
## Summary

This PR fixes non-deterministic event id issue, which is crucial for deterministic reproduction.
So in the past, background events might have their own event id generation; for example, data compaction generates new event id inside of snapshot, which creates non-deterministic replay.
In this PR, I surface all event id into mooncake table interface layer.

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
