### PR TITLE
[chaos] Fix read LSN for snapshot

### DIFF
--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -755,6 +755,7 @@ impl MooncakeTable {
         if let Some(event_replay_tx) = &self.event_replay_tx {
             let table_event = replay_events::create_mooncake_snapshot_event_completion(
                 mooncake_snapshot_res.uuid,
+                mooncake_snapshot_res.commit_lsn,
             );
             event_replay_tx
                 .send(MooncakeTableEvent::MooncakeSnapshotCompletion(table_event))

--- a/src/moonlink/src/storage/mooncake_table/replay/replay_events.rs
+++ b/src/moonlink/src/storage/mooncake_table/replay/replay_events.rs
@@ -89,6 +89,8 @@ pub struct MooncakeSnapshotEventInitiation {
 pub struct MooncakeSnapshotEventCompletion {
     /// Event id.
     pub uuid: uuid::Uuid,
+    /// Commit LSN.
+    pub lsn: u64,
 }
 
 /// =====================
@@ -299,8 +301,9 @@ pub fn create_mooncake_snapshot_event_initiation(
 }
 pub fn create_mooncake_snapshot_event_completion(
     uuid: uuid::Uuid,
+    lsn: u64,
 ) -> MooncakeSnapshotEventCompletion {
-    MooncakeSnapshotEventCompletion { uuid }
+    MooncakeSnapshotEventCompletion { uuid, lsn }
 }
 /// Create iceberg snapshot events.
 pub fn get_iceberg_snapshot_import_payload(


### PR DESCRIPTION
## Summary

The issue is, assume such event flow when replay:
- mooncake snapshot begin
- append
- commit
- mooncake snapshot end & validate snapshot

In the current implementation, since we requested for latest commit LSN and all events will be front-end events are blocked, the replay program gets blocked.

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
