### PR TITLE
Add Rest and Glue iceberg catalog configuration to support multiple catalog

### DIFF
--- a/src/moonlink/Cargo.toml
+++ b/src/moonlink/Cargo.toml
@@ -31,6 +31,9 @@ storage-gcs = [
     "reqwest",
 ]
 
+catalog-rest = []
+catalog-glue = []
+
 bench = []
 
 chaos-test = ["function_name"]

--- a/src/moonlink/benches/bench_write.rs
+++ b/src/moonlink/benches/bench_write.rs
@@ -55,7 +55,13 @@ fn bench_write(c: &mut Criterion) {
                 let temp_warehouse_dir = tempdir().unwrap();
                 let temp_warehouse_uri = temp_warehouse_dir.path().to_str().unwrap().to_string();
                 let iceberg_table_config = IcebergTableConfig {
-                    catalog: moonlink::IcebergCatalogConfig::File {
+                    data_accessor_config: AccessorConfig::new_with_storage_config(
+                        StorageConfig::FileSystem {
+                            root_directory: temp_warehouse_uri.clone(),
+                            atomic_write_dir: None,
+                        },
+                    ),
+                    metadata_accessor_config: moonlink::IcebergCatalogConfig::File {
                         accessor_config: AccessorConfig::new_with_storage_config(
                             StorageConfig::FileSystem {
                                 root_directory: temp_warehouse_uri.clone(),
@@ -106,7 +112,13 @@ fn bench_write(c: &mut Criterion) {
                 let temp_warehouse_dir = tempdir().unwrap();
                 let temp_warehouse_uri = temp_warehouse_dir.path().to_str().unwrap().to_string();
                 let iceberg_table_config = IcebergTableConfig {
-                    catalog: moonlink::IcebergCatalogConfig::File {
+                    data_accessor_config: AccessorConfig::new_with_storage_config(
+                        StorageConfig::FileSystem {
+                            root_directory: temp_warehouse_uri.clone(),
+                            atomic_write_dir: None,
+                        },
+                    ),
+                    metadata_accessor_config: moonlink::IcebergCatalogConfig::File {
                         accessor_config: AccessorConfig::new_with_storage_config(
                             StorageConfig::FileSystem {
                                 root_directory: temp_warehouse_uri.clone(),
@@ -160,7 +172,13 @@ fn bench_write(c: &mut Criterion) {
                 let temp_warehouse_dir = tempdir().unwrap();
                 let temp_warehouse_uri = temp_warehouse_dir.path().to_str().unwrap().to_string();
                 let iceberg_table_config = IcebergTableConfig {
-                    catalog: moonlink::IcebergCatalogConfig::File {
+                    data_accessor_config: AccessorConfig::new_with_storage_config(
+                        StorageConfig::FileSystem {
+                            root_directory: temp_warehouse_uri.clone(),
+                            atomic_write_dir: None,
+                        },
+                    ),
+                    metadata_accessor_config: moonlink::IcebergCatalogConfig::File {
                         accessor_config: AccessorConfig::new_with_storage_config(
                             StorageConfig::FileSystem {
                                 root_directory: temp_warehouse_uri.clone(),

--- a/src/moonlink/benches/bench_write.rs
+++ b/src/moonlink/benches/bench_write.rs
@@ -55,12 +55,14 @@ fn bench_write(c: &mut Criterion) {
                 let temp_warehouse_dir = tempdir().unwrap();
                 let temp_warehouse_uri = temp_warehouse_dir.path().to_str().unwrap().to_string();
                 let iceberg_table_config = IcebergTableConfig {
-                    accessor_config: AccessorConfig::new_with_storage_config(
-                        StorageConfig::FileSystem {
-                            root_directory: temp_warehouse_uri.clone(),
-                            atomic_write_dir: None,
-                        },
-                    ),
+                    catalog: moonlink::IcebergCatalogConfig::File {
+                        accessor_config: AccessorConfig::new_with_storage_config(
+                            StorageConfig::FileSystem {
+                                root_directory: temp_warehouse_uri.clone(),
+                                atomic_write_dir: None,
+                            },
+                        ),
+                    },
                     ..Default::default()
                 };
                 let table_config =
@@ -104,12 +106,14 @@ fn bench_write(c: &mut Criterion) {
                 let temp_warehouse_dir = tempdir().unwrap();
                 let temp_warehouse_uri = temp_warehouse_dir.path().to_str().unwrap().to_string();
                 let iceberg_table_config = IcebergTableConfig {
-                    accessor_config: AccessorConfig::new_with_storage_config(
-                        StorageConfig::FileSystem {
-                            root_directory: temp_warehouse_uri.clone(),
-                            atomic_write_dir: None,
-                        },
-                    ),
+                    catalog: moonlink::IcebergCatalogConfig::File {
+                        accessor_config: AccessorConfig::new_with_storage_config(
+                            StorageConfig::FileSystem {
+                                root_directory: temp_warehouse_uri.clone(),
+                                atomic_write_dir: None,
+                            },
+                        ),
+                    },
                     ..Default::default()
                 };
                 let table_config =
@@ -156,12 +160,14 @@ fn bench_write(c: &mut Criterion) {
                 let temp_warehouse_dir = tempdir().unwrap();
                 let temp_warehouse_uri = temp_warehouse_dir.path().to_str().unwrap().to_string();
                 let iceberg_table_config = IcebergTableConfig {
-                    accessor_config: AccessorConfig::new_with_storage_config(
-                        StorageConfig::FileSystem {
-                            root_directory: temp_warehouse_uri.clone(),
-                            atomic_write_dir: None,
-                        },
-                    ),
+                    catalog: moonlink::IcebergCatalogConfig::File {
+                        accessor_config: AccessorConfig::new_with_storage_config(
+                            StorageConfig::FileSystem {
+                                root_directory: temp_warehouse_uri.clone(),
+                                atomic_write_dir: None,
+                            },
+                        ),
+                    },
                     ..Default::default()
                 };
                 let table_config =

--- a/src/moonlink/benches/microbench_write_mooncake_table.rs
+++ b/src/moonlink/benches/microbench_write_mooncake_table.rs
@@ -54,12 +54,14 @@ fn bench_write_mooncake_table(c: &mut Criterion) {
     let iceberg_table_config = IcebergTableConfig {
         namespace: vec!["default".to_string()],
         table_name: table_name.to_string(),
-        accessor_config: AccessorConfig::new_with_storage_config(
-            moonlink::StorageConfig::FileSystem {
-                root_directory: warehouse_location.clone(),
-                atomic_write_dir: None,
-            },
-        ),
+        catalog: moonlink::IcebergCatalogConfig::File {
+            accessor_config: AccessorConfig::new_with_storage_config(
+                moonlink::StorageConfig::FileSystem {
+                    root_directory: warehouse_location.clone(),
+                    atomic_write_dir: None,
+                },
+            ),
+        },
     };
     let rt = Runtime::new().unwrap();
     let table_config = MooncakeTableConfig::new(temp_dir.path().to_str().unwrap().to_string());

--- a/src/moonlink/benches/microbench_write_mooncake_table.rs
+++ b/src/moonlink/benches/microbench_write_mooncake_table.rs
@@ -54,7 +54,13 @@ fn bench_write_mooncake_table(c: &mut Criterion) {
     let iceberg_table_config = IcebergTableConfig {
         namespace: vec!["default".to_string()],
         table_name: table_name.to_string(),
-        catalog: moonlink::IcebergCatalogConfig::File {
+        data_accessor_config: AccessorConfig::new_with_storage_config(
+            moonlink::StorageConfig::FileSystem {
+                root_directory: warehouse_location.clone(),
+                atomic_write_dir: None,
+            },
+        ),
+        metadata_accessor_config: moonlink::IcebergCatalogConfig::File {
             accessor_config: AccessorConfig::new_with_storage_config(
                 moonlink::StorageConfig::FileSystem {
                     root_directory: warehouse_location.clone(),

--- a/src/moonlink/src/lib.rs
+++ b/src/moonlink/src/lib.rs
@@ -16,12 +16,12 @@ pub(crate) use storage::NonEvictableHandle;
 pub use storage::{
     AccessorConfig, BaseFileSystemAccess, BaseIcebergSnapshotFetcher, CacheTrait,
     DataCompactionConfig, DiskSliceWriterConfig, EventSyncReceiver, FileIndexMergeConfig,
-    FileSystemAccessor, FsChaosConfig, FsRetryConfig, FsTimeoutConfig, IcebergPersistenceConfig,
-    IcebergSnapshotFetcher, IcebergTableConfig, IcebergTableManager, MooncakeTable,
-    MooncakeTableConfig, MoonlinkSecretType, MoonlinkTableConfig, MoonlinkTableSecret,
-    ObjectStorageCache, ObjectStorageCacheConfig, PersistentWalMetadata, SnapshotReadOutput,
-    StorageConfig, TableEventManager, TableManager, TableSnapshotStatus, TableStatusReader,
-    WalConfig, WalManager, WalTransactionState,
+    FileSystemAccessor, FsChaosConfig, FsRetryConfig, FsTimeoutConfig, IcebergCatalogConfig,
+    IcebergPersistenceConfig, IcebergSnapshotFetcher, IcebergTableConfig, IcebergTableManager,
+    MooncakeTable, MooncakeTableConfig, MoonlinkSecretType, MoonlinkTableConfig,
+    MoonlinkTableSecret, ObjectStorageCache, ObjectStorageCacheConfig, PersistentWalMetadata,
+    SnapshotReadOutput, StorageConfig, TableEventManager, TableManager, TableSnapshotStatus,
+    TableStatusReader, WalConfig, WalManager, WalTransactionState,
 };
 pub use table_handler::TableHandler;
 pub use table_handler_timer::TableHandlerTimer;

--- a/src/moonlink/src/storage.rs
+++ b/src/moonlink/src/storage.rs
@@ -28,7 +28,7 @@ pub use filesystem::accessor_config::{
 pub use filesystem::storage_config::StorageConfig;
 pub use iceberg::base_iceberg_snapshot_fetcher::BaseIcebergSnapshotFetcher;
 pub use iceberg::iceberg_snapshot_fetcher::IcebergSnapshotFetcher;
-pub use iceberg::iceberg_table_config::IcebergTableConfig;
+pub use iceberg::iceberg_table_config::{IcebergCatalogConfig, IcebergTableConfig};
 pub use iceberg::iceberg_table_manager::IcebergTableManager;
 pub use iceberg::table_event_manager::TableEventManager;
 pub use iceberg::table_manager::TableManager;

--- a/src/moonlink/src/storage/iceberg/catalog_utils.rs
+++ b/src/moonlink/src/storage/iceberg/catalog_utils.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 use crate::storage::filesystem::accessor::base_filesystem_accessor::BaseFileSystemAccess;
-use crate::storage::filesystem::accessor_config::AccessorConfig;
 use crate::storage::iceberg::file_catalog::FileCatalog;
+use crate::storage::iceberg::iceberg_table_config::IcebergCatalogConfig;
 use crate::storage::iceberg::moonlink_catalog::MoonlinkCatalog;
 
 use iceberg::spec::Schema as IcebergSchema;
@@ -12,17 +12,37 @@ use iceberg::Result as IcebergResult;
 /// It's worth noting catalog and warehouse uri are not 1-1 mapping; for example, rest catalog could handle warehouse.
 /// Here we simply deduce catalog type from warehouse because both filesystem and object storage catalog are only able to handle certain scheme.
 pub fn create_catalog(
-    accessor_config: AccessorConfig,
+    catalog: IcebergCatalogConfig,
     iceberg_schema: IcebergSchema,
 ) -> IcebergResult<Box<dyn MoonlinkCatalog>> {
-    Ok(Box::new(FileCatalog::new(accessor_config, iceberg_schema)?))
+    match catalog {
+        IcebergCatalogConfig::File { accessor_config } => {
+            Ok(Box::new(FileCatalog::new(accessor_config, iceberg_schema)?))
+        }
+        IcebergCatalogConfig::Rest { .. } | IcebergCatalogConfig::Glue { .. } => {
+            Err(iceberg::Error::new(
+                iceberg::ErrorKind::Unexpected,
+                "Only File catalog is supported currently",
+            ))
+        }
+    }
 }
 
 /// Create a catalog with no schema provided.
 pub fn create_catalog_without_schema(
-    accessor_config: AccessorConfig,
+    catalog: IcebergCatalogConfig,
 ) -> IcebergResult<Box<dyn MoonlinkCatalog>> {
-    Ok(Box::new(FileCatalog::new_without_schema(accessor_config)?))
+    match catalog {
+        IcebergCatalogConfig::File { accessor_config } => {
+            Ok(Box::new(FileCatalog::new_without_schema(accessor_config)?))
+        }
+        IcebergCatalogConfig::Rest { .. } | IcebergCatalogConfig::Glue { .. } => {
+            Err(iceberg::Error::new(
+                iceberg::ErrorKind::Unexpected,
+                "Only File catalog is supported currently",
+            ))
+        }
+    }
 }
 
 /// Test util function to create catalog with provided filesystem accessor.

--- a/src/moonlink/src/storage/iceberg/catalog_utils.rs
+++ b/src/moonlink/src/storage/iceberg/catalog_utils.rs
@@ -19,12 +19,16 @@ pub fn create_catalog(
         IcebergCatalogConfig::File { accessor_config } => {
             Ok(Box::new(FileCatalog::new(accessor_config, iceberg_schema)?))
         }
-        IcebergCatalogConfig::Rest { .. } | IcebergCatalogConfig::Glue { .. } => {
-            Err(iceberg::Error::new(
-                iceberg::ErrorKind::FeatureUnsupported,
-                "Only File catalog is supported currently",
-            ))
-        }
+        #[cfg(feature = "catalog-rest")]
+        IcebergCatalogConfig::Rest { .. } => Err(iceberg::Error::new(
+            iceberg::ErrorKind::FeatureUnsupported,
+            "Only File catalog is supported currently",
+        )),
+        #[cfg(feature = "catalog-glue")]
+        IcebergCatalogConfig::Glue { .. } => Err(iceberg::Error::new(
+            iceberg::ErrorKind::FeatureUnsupported,
+            "Only File catalog is supported currently",
+        )),
     }
 }
 
@@ -36,12 +40,16 @@ pub fn create_catalog_without_schema(
         IcebergCatalogConfig::File { accessor_config } => {
             Ok(Box::new(FileCatalog::new_without_schema(accessor_config)?))
         }
-        IcebergCatalogConfig::Rest { .. } | IcebergCatalogConfig::Glue { .. } => {
-            Err(iceberg::Error::new(
-                iceberg::ErrorKind::FeatureUnsupported,
-                "Only File catalog is supported currently",
-            ))
-        }
+        #[cfg(feature = "catalog-rest")]
+        IcebergCatalogConfig::Rest { .. } => Err(iceberg::Error::new(
+            iceberg::ErrorKind::FeatureUnsupported,
+            "Only File catalog is supported currently",
+        )),
+        #[cfg(feature = "catalog-glue")]
+        IcebergCatalogConfig::Glue { .. } => Err(iceberg::Error::new(
+            iceberg::ErrorKind::FeatureUnsupported,
+            "Only File catalog is supported currently",
+        )),
     }
 }
 

--- a/src/moonlink/src/storage/iceberg/catalog_utils.rs
+++ b/src/moonlink/src/storage/iceberg/catalog_utils.rs
@@ -21,7 +21,7 @@ pub fn create_catalog(
         }
         IcebergCatalogConfig::Rest { .. } | IcebergCatalogConfig::Glue { .. } => {
             Err(iceberg::Error::new(
-                iceberg::ErrorKind::Unexpected,
+                iceberg::ErrorKind::FeatureUnsupported,
                 "Only File catalog is supported currently",
             ))
         }
@@ -38,7 +38,7 @@ pub fn create_catalog_without_schema(
         }
         IcebergCatalogConfig::Rest { .. } | IcebergCatalogConfig::Glue { .. } => {
             Err(iceberg::Error::new(
-                iceberg::ErrorKind::Unexpected,
+                iceberg::ErrorKind::FeatureUnsupported,
                 "Only File catalog is supported currently",
             ))
         }

--- a/src/moonlink/src/storage/iceberg/compaction_tests.rs
+++ b/src/moonlink/src/storage/iceberg/compaction_tests.rs
@@ -351,8 +351,7 @@ async fn test_compaction_1_1_1() {
         &iceberg_table_manager_to_load
             .config
             .metadata_accessor_config
-            .get_warehouse_uri()
-            .unwrap(),
+            .get_warehouse_uri(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -418,8 +417,7 @@ async fn test_compaction_1_1_2() {
         &iceberg_table_manager_to_load
             .config
             .metadata_accessor_config
-            .get_warehouse_uri()
-            .unwrap(),
+            .get_warehouse_uri(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -508,8 +506,7 @@ async fn test_compaction_1_2_1() {
         &iceberg_table_manager_to_load
             .config
             .metadata_accessor_config
-            .get_warehouse_uri()
-            .unwrap(),
+            .get_warehouse_uri(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -598,8 +595,7 @@ async fn test_compaction_1_2_2() {
         &iceberg_table_manager_to_load
             .config
             .metadata_accessor_config
-            .get_warehouse_uri()
-            .unwrap(),
+            .get_warehouse_uri(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -702,8 +698,7 @@ async fn test_compaction_2_2_1() {
         &iceberg_table_manager_to_load
             .config
             .metadata_accessor_config
-            .get_warehouse_uri()
-            .unwrap(),
+            .get_warehouse_uri(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -795,8 +790,7 @@ async fn test_compaction_2_2_2() {
         &iceberg_table_manager_to_load
             .config
             .metadata_accessor_config
-            .get_warehouse_uri()
-            .unwrap(),
+            .get_warehouse_uri(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -903,8 +897,7 @@ async fn test_compaction_2_3_1() {
         &iceberg_table_manager_to_load
             .config
             .metadata_accessor_config
-            .get_warehouse_uri()
-            .unwrap(),
+            .get_warehouse_uri(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -983,8 +976,7 @@ async fn test_compaction_2_3_2() {
         &iceberg_table_manager_to_load
             .config
             .metadata_accessor_config
-            .get_warehouse_uri()
-            .unwrap(),
+            .get_warehouse_uri(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -1091,8 +1083,7 @@ async fn test_compaction_3_2_1() {
         &iceberg_table_manager_to_load
             .config
             .metadata_accessor_config
-            .get_warehouse_uri()
-            .unwrap(),
+            .get_warehouse_uri(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -1190,8 +1181,7 @@ async fn test_compaction_3_3_1() {
         &iceberg_table_manager_to_load
             .config
             .metadata_accessor_config
-            .get_warehouse_uri()
-            .unwrap(),
+            .get_warehouse_uri(),
         filesystem_accessor.as_ref(),
     )
     .await;

--- a/src/moonlink/src/storage/iceberg/compaction_tests.rs
+++ b/src/moonlink/src/storage/iceberg/compaction_tests.rs
@@ -350,10 +350,9 @@ async fn test_compaction_1_1_1() {
         &snapshot,
         &iceberg_table_manager_to_load
             .config
-            .catalog
-            .get_file_catalog_accessor_config()
-            .unwrap()
-            .get_root_path(),
+            .metadata_accessor_config
+            .get_warehouse_uri()
+            .unwrap(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -418,10 +417,9 @@ async fn test_compaction_1_1_2() {
         &snapshot,
         &iceberg_table_manager_to_load
             .config
-            .catalog
-            .get_file_catalog_accessor_config()
-            .unwrap()
-            .get_root_path(),
+            .metadata_accessor_config
+            .get_warehouse_uri()
+            .unwrap(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -509,10 +507,9 @@ async fn test_compaction_1_2_1() {
         &snapshot,
         &iceberg_table_manager_to_load
             .config
-            .catalog
-            .get_file_catalog_accessor_config()
-            .unwrap()
-            .get_root_path(),
+            .metadata_accessor_config
+            .get_warehouse_uri()
+            .unwrap(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -600,10 +597,9 @@ async fn test_compaction_1_2_2() {
         &snapshot,
         &iceberg_table_manager_to_load
             .config
-            .catalog
-            .get_file_catalog_accessor_config()
-            .unwrap()
-            .get_root_path(),
+            .metadata_accessor_config
+            .get_warehouse_uri()
+            .unwrap(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -705,10 +701,9 @@ async fn test_compaction_2_2_1() {
         &snapshot,
         &iceberg_table_manager_to_load
             .config
-            .catalog
-            .get_file_catalog_accessor_config()
-            .unwrap()
-            .get_root_path(),
+            .metadata_accessor_config
+            .get_warehouse_uri()
+            .unwrap(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -799,10 +794,9 @@ async fn test_compaction_2_2_2() {
         &snapshot,
         &iceberg_table_manager_to_load
             .config
-            .catalog
-            .get_file_catalog_accessor_config()
-            .unwrap()
-            .get_root_path(),
+            .metadata_accessor_config
+            .get_warehouse_uri()
+            .unwrap(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -908,10 +902,9 @@ async fn test_compaction_2_3_1() {
         &snapshot,
         &iceberg_table_manager_to_load
             .config
-            .catalog
-            .get_file_catalog_accessor_config()
-            .unwrap()
-            .get_root_path(),
+            .metadata_accessor_config
+            .get_warehouse_uri()
+            .unwrap(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -989,10 +982,9 @@ async fn test_compaction_2_3_2() {
         &snapshot,
         &iceberg_table_manager_to_load
             .config
-            .catalog
-            .get_file_catalog_accessor_config()
-            .unwrap()
-            .get_root_path(),
+            .metadata_accessor_config
+            .get_warehouse_uri()
+            .unwrap(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -1098,10 +1090,9 @@ async fn test_compaction_3_2_1() {
         &snapshot,
         &iceberg_table_manager_to_load
             .config
-            .catalog
-            .get_file_catalog_accessor_config()
-            .unwrap()
-            .get_root_path(),
+            .metadata_accessor_config
+            .get_warehouse_uri()
+            .unwrap(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -1198,10 +1189,9 @@ async fn test_compaction_3_3_1() {
         &snapshot,
         &iceberg_table_manager_to_load
             .config
-            .catalog
-            .get_file_catalog_accessor_config()
-            .unwrap()
-            .get_root_path(),
+            .metadata_accessor_config
+            .get_warehouse_uri()
+            .unwrap(),
         filesystem_accessor.as_ref(),
     )
     .await;

--- a/src/moonlink/src/storage/iceberg/compaction_tests.rs
+++ b/src/moonlink/src/storage/iceberg/compaction_tests.rs
@@ -345,11 +345,14 @@ async fn test_compaction_1_1_1() {
     check_loaded_snapshot(&snapshot, /*row_indices=*/ vec![0, 1, 2, 3]).await;
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
+
     validate_recovered_snapshot(
         &snapshot,
         &iceberg_table_manager_to_load
             .config
-            .accessor_config
+            .catalog
+            .get_file_catalog_accessor_config()
+            .unwrap()
             .get_root_path(),
         filesystem_accessor.as_ref(),
     )
@@ -415,7 +418,9 @@ async fn test_compaction_1_1_2() {
         &snapshot,
         &iceberg_table_manager_to_load
             .config
-            .accessor_config
+            .catalog
+            .get_file_catalog_accessor_config()
+            .unwrap()
             .get_root_path(),
         filesystem_accessor.as_ref(),
     )
@@ -504,7 +509,9 @@ async fn test_compaction_1_2_1() {
         &snapshot,
         &iceberg_table_manager_to_load
             .config
-            .accessor_config
+            .catalog
+            .get_file_catalog_accessor_config()
+            .unwrap()
             .get_root_path(),
         filesystem_accessor.as_ref(),
     )
@@ -593,7 +600,9 @@ async fn test_compaction_1_2_2() {
         &snapshot,
         &iceberg_table_manager_to_load
             .config
-            .accessor_config
+            .catalog
+            .get_file_catalog_accessor_config()
+            .unwrap()
             .get_root_path(),
         filesystem_accessor.as_ref(),
     )
@@ -696,7 +705,9 @@ async fn test_compaction_2_2_1() {
         &snapshot,
         &iceberg_table_manager_to_load
             .config
-            .accessor_config
+            .catalog
+            .get_file_catalog_accessor_config()
+            .unwrap()
             .get_root_path(),
         filesystem_accessor.as_ref(),
     )
@@ -788,7 +799,9 @@ async fn test_compaction_2_2_2() {
         &snapshot,
         &iceberg_table_manager_to_load
             .config
-            .accessor_config
+            .catalog
+            .get_file_catalog_accessor_config()
+            .unwrap()
             .get_root_path(),
         filesystem_accessor.as_ref(),
     )
@@ -895,7 +908,9 @@ async fn test_compaction_2_3_1() {
         &snapshot,
         &iceberg_table_manager_to_load
             .config
-            .accessor_config
+            .catalog
+            .get_file_catalog_accessor_config()
+            .unwrap()
             .get_root_path(),
         filesystem_accessor.as_ref(),
     )
@@ -974,7 +989,9 @@ async fn test_compaction_2_3_2() {
         &snapshot,
         &iceberg_table_manager_to_load
             .config
-            .accessor_config
+            .catalog
+            .get_file_catalog_accessor_config()
+            .unwrap()
             .get_root_path(),
         filesystem_accessor.as_ref(),
     )
@@ -1081,7 +1098,9 @@ async fn test_compaction_3_2_1() {
         &snapshot,
         &iceberg_table_manager_to_load
             .config
-            .accessor_config
+            .catalog
+            .get_file_catalog_accessor_config()
+            .unwrap()
             .get_root_path(),
         filesystem_accessor.as_ref(),
     )
@@ -1179,7 +1198,9 @@ async fn test_compaction_3_3_1() {
         &snapshot,
         &iceberg_table_manager_to_load
             .config
-            .accessor_config
+            .catalog
+            .get_file_catalog_accessor_config()
+            .unwrap()
             .get_root_path(),
         filesystem_accessor.as_ref(),
     )

--- a/src/moonlink/src/storage/iceberg/iceberg_snapshot_fetcher.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_snapshot_fetcher.rs
@@ -20,7 +20,7 @@ pub struct IcebergSnapshotFetcher {
 
 impl IcebergSnapshotFetcher {
     pub fn new(config: IcebergTableConfig) -> Result<Self> {
-        let catalog = catalog_utils::create_catalog_without_schema(config.accessor_config.clone())?;
+        let catalog = catalog_utils::create_catalog_without_schema(config.catalog.clone())?;
         Ok(Self { config, catalog })
     }
 }

--- a/src/moonlink/src/storage/iceberg/iceberg_snapshot_fetcher.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_snapshot_fetcher.rs
@@ -20,7 +20,8 @@ pub struct IcebergSnapshotFetcher {
 
 impl IcebergSnapshotFetcher {
     pub fn new(config: IcebergTableConfig) -> Result<Self> {
-        let catalog = catalog_utils::create_catalog_without_schema(config.catalog.clone())?;
+        let catalog =
+            catalog_utils::create_catalog_without_schema(config.metadata_accessor_config.clone())?;
         Ok(Self { config, catalog })
     }
 }

--- a/src/moonlink/src/storage/iceberg/iceberg_table_config.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_config.rs
@@ -31,6 +31,18 @@ pub enum IcebergCatalogConfig {
 }
 
 impl IcebergCatalogConfig {
+    pub fn get_warehouse_uri(&self) -> Option<String> {
+        match self {
+            IcebergCatalogConfig::File { accessor_config } => Some(accessor_config.get_root_path()),
+            IcebergCatalogConfig::Rest {
+                rest_catalog_config,
+            } => rest_catalog_config.warehouse.clone(),
+            IcebergCatalogConfig::Glue {
+                glue_catalog_config,
+            } => Some(glue_catalog_config.warehouse.clone()),
+        }
+    }
+
     pub fn get_file_catalog_accessor_config(&self) -> Option<AccessorConfig> {
         match self {
             IcebergCatalogConfig::File { accessor_config } => Some(accessor_config.clone()),
@@ -61,8 +73,10 @@ pub struct IcebergTableConfig {
     pub namespace: Vec<String>,
     /// Iceberg table name.
     pub table_name: String,
+    /// Accessor config for writing data files.
+    pub data_accessor_config: AccessorConfig,
     /// Catalog configuration (defaults to File).
-    pub catalog: IcebergCatalogConfig,
+    pub metadata_accessor_config: IcebergCatalogConfig,
 }
 
 impl IcebergTableConfig {
@@ -81,7 +95,8 @@ impl Default for IcebergTableConfig {
         Self {
             namespace: vec![Self::DEFAULT_NAMESPACE.to_string()],
             table_name: Self::DEFAULT_TABLE.to_string(),
-            catalog: IcebergCatalogConfig::File {
+            data_accessor_config: AccessorConfig::new_with_storage_config(storage_config.clone()),
+            metadata_accessor_config: IcebergCatalogConfig::File {
                 accessor_config: AccessorConfig::new_with_storage_config(storage_config),
             },
         }

--- a/src/moonlink/src/storage/iceberg/iceberg_table_config.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_config.rs
@@ -1,4 +1,59 @@
 use crate::{storage::filesystem::accessor_config::AccessorConfig, StorageConfig};
+use std::collections::HashMap;
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct RestCatalogConfig {
+    uri: String,
+    warehouse: Option<String>,
+    props: HashMap<String, String>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub struct GlueCatalogConfig {
+    name: Option<String>,
+    uri: Option<String>,
+    catalog_id: Option<String>,
+    warehouse: String,
+    props: HashMap<String, String>,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum IcebergCatalogConfig {
+    File {
+        accessor_config: AccessorConfig,
+    },
+    Rest {
+        rest_catalog_config: RestCatalogConfig,
+    },
+    Glue {
+        glue_catalog_config: GlueCatalogConfig,
+    },
+}
+
+impl IcebergCatalogConfig {
+    pub fn get_file_catalog_accessor_config(&self) -> Option<AccessorConfig> {
+        match self {
+            IcebergCatalogConfig::File { accessor_config } => Some(accessor_config.clone()),
+            _ => None,
+        }
+    }
+    pub fn get_rest_catalog_config(&self) -> Option<RestCatalogConfig> {
+        match self {
+            IcebergCatalogConfig::Rest {
+                rest_catalog_config,
+            } => Some(rest_catalog_config.clone()),
+            _ => None,
+        }
+    }
+    pub fn get_glue_catalog_config(&self) -> Option<GlueCatalogConfig> {
+        match self {
+            IcebergCatalogConfig::Glue {
+                glue_catalog_config,
+            } => Some(glue_catalog_config.clone()),
+            _ => None,
+        }
+    }
+}
 
 #[derive(Clone, Debug, PartialEq)]
 pub struct IcebergTableConfig {
@@ -6,8 +61,8 @@ pub struct IcebergTableConfig {
     pub namespace: Vec<String>,
     /// Iceberg table name.
     pub table_name: String,
-    // Accessor config.
-    pub accessor_config: AccessorConfig,
+    /// Catalog configuration (defaults to File).
+    pub catalog: IcebergCatalogConfig,
 }
 
 impl IcebergTableConfig {
@@ -26,7 +81,9 @@ impl Default for IcebergTableConfig {
         Self {
             namespace: vec![Self::DEFAULT_NAMESPACE.to_string()],
             table_name: Self::DEFAULT_TABLE.to_string(),
-            accessor_config: AccessorConfig::new_with_storage_config(storage_config),
+            catalog: IcebergCatalogConfig::File {
+                accessor_config: AccessorConfig::new_with_storage_config(storage_config),
+            },
         }
     }
 }

--- a/src/moonlink/src/storage/iceberg/iceberg_table_config.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_config.rs
@@ -75,6 +75,7 @@ impl IcebergCatalogConfig {
     pub fn get_file_catalog_accessor_config(&self) -> Option<AccessorConfig> {
         match self {
             IcebergCatalogConfig::File { accessor_config } => Some(accessor_config.clone()),
+            #[cfg(any(feature = "catalog-rest", feature = "catalog-glue"))]
             _ => None,
         }
     }

--- a/src/moonlink/src/storage/iceberg/iceberg_table_config.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_config.rs
@@ -1,14 +1,15 @@
 use crate::{storage::filesystem::accessor_config::AccessorConfig, StorageConfig};
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct RestCatalogConfig {
     uri: String,
     warehouse: Option<String>,
     props: HashMap<String, String>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GlueCatalogConfig {
     name: Option<String>,
     uri: Option<String>,
@@ -17,7 +18,7 @@ pub struct GlueCatalogConfig {
     props: HashMap<String, String>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum IcebergCatalogConfig {
     File {
         accessor_config: AccessorConfig,
@@ -67,13 +68,13 @@ impl IcebergCatalogConfig {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct IcebergTableConfig {
     /// Namespace for the iceberg table.
     pub namespace: Vec<String>,
     /// Iceberg table name.
     pub table_name: String,
-    /// Accessor config for writing data files.
+    /// Accessor config for accessing data files.
     pub data_accessor_config: AccessorConfig,
     /// Catalog configuration (defaults to File).
     pub metadata_accessor_config: IcebergCatalogConfig,

--- a/src/moonlink/src/storage/iceberg/iceberg_table_config.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_config.rs
@@ -26,6 +26,7 @@ pub struct GlueCatalogConfig {
     #[serde(rename = "uri")]
     #[serde(default)]
     uri: Option<String>,
+
     #[serde(rename = "catalog_id")]
     #[serde(default)]
     catalog_id: Option<String>,
@@ -39,10 +40,12 @@ pub struct GlueCatalogConfig {
     props: HashMap<String, String>,
 }
 
+pub type FileCatalogConfig = AccessorConfig;
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum IcebergCatalogConfig {
     #[serde(rename = "file")]
-    File { accessor_config: AccessorConfig },
+    File { accessor_config: FileCatalogConfig },
 
     #[cfg(feature = "catalog-rest")]
     #[serde(rename = "rest")]
@@ -72,7 +75,7 @@ impl IcebergCatalogConfig {
         }
     }
 
-    pub fn get_file_catalog_accessor_config(&self) -> Option<AccessorConfig> {
+    pub fn get_file_catalog_accessor_config(&self) -> Option<FileCatalogConfig> {
         match self {
             IcebergCatalogConfig::File { accessor_config } => Some(accessor_config.clone()),
             #[cfg(any(feature = "catalog-rest", feature = "catalog-glue"))]

--- a/src/moonlink/src/storage/iceberg/iceberg_table_config.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_config.rs
@@ -31,15 +31,15 @@ pub enum IcebergCatalogConfig {
 }
 
 impl IcebergCatalogConfig {
-    pub fn get_warehouse_uri(&self) -> Option<String> {
+    pub fn get_warehouse_uri(&self) -> String {
         match self {
-            IcebergCatalogConfig::File { accessor_config } => Some(accessor_config.get_root_path()),
+            IcebergCatalogConfig::File { accessor_config } => accessor_config.get_root_path(),
             IcebergCatalogConfig::Rest {
                 rest_catalog_config,
-            } => rest_catalog_config.warehouse.clone(),
+            } => rest_catalog_config.warehouse.clone().unwrap_or_default(),
             IcebergCatalogConfig::Glue {
                 glue_catalog_config,
-            } => Some(glue_catalog_config.warehouse.clone()),
+            } => glue_catalog_config.warehouse.clone(),
         }
     }
 

--- a/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
@@ -84,7 +84,8 @@ impl IcebergTableManager {
     ) -> IcebergResult<IcebergTableManager> {
         let iceberg_schema =
             iceberg::arrow::arrow_schema_to_schema(mooncake_table_metadata.schema.as_ref())?;
-        let catalog = catalog_utils::create_catalog(config.catalog.clone(), iceberg_schema)?;
+        let catalog =
+            catalog_utils::create_catalog(config.metadata_accessor_config.clone(), iceberg_schema)?;
         Ok(Self {
             snapshot_loaded: false,
             config,
@@ -161,10 +162,9 @@ impl IcebergTableManager {
                 &*self.catalog,
                 &self
                     .config
-                    .catalog
-                    .get_file_catalog_accessor_config()
-                    .unwrap()
-                    .get_root_path(),
+                    .metadata_accessor_config
+                    .get_warehouse_uri()
+                    .unwrap(),
                 &self.config.namespace,
                 &self.config.table_name,
                 self.mooncake_table_metadata.schema.as_ref(),
@@ -193,10 +193,9 @@ impl IcebergTableManager {
 impl TableManager for IcebergTableManager {
     fn get_warehouse_location(&self) -> String {
         self.config
-            .catalog
-            .get_file_catalog_accessor_config()
+            .metadata_accessor_config
+            .get_warehouse_uri()
             .unwrap()
-            .get_root_path()
     }
 
     async fn sync_snapshot(

--- a/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
@@ -84,8 +84,7 @@ impl IcebergTableManager {
     ) -> IcebergResult<IcebergTableManager> {
         let iceberg_schema =
             iceberg::arrow::arrow_schema_to_schema(mooncake_table_metadata.schema.as_ref())?;
-        let catalog =
-            catalog_utils::create_catalog(config.accessor_config.clone(), iceberg_schema)?;
+        let catalog = catalog_utils::create_catalog(config.catalog.clone(), iceberg_schema)?;
         Ok(Self {
             snapshot_loaded: false,
             config,
@@ -160,7 +159,12 @@ impl IcebergTableManager {
         if self.iceberg_table.is_none() {
             let table = utils::get_or_create_iceberg_table(
                 &*self.catalog,
-                &self.config.accessor_config.get_root_path(),
+                &self
+                    .config
+                    .catalog
+                    .get_file_catalog_accessor_config()
+                    .unwrap()
+                    .get_root_path(),
                 &self.config.namespace,
                 &self.config.table_name,
                 self.mooncake_table_metadata.schema.as_ref(),
@@ -188,7 +192,11 @@ impl IcebergTableManager {
 #[async_trait]
 impl TableManager for IcebergTableManager {
     fn get_warehouse_location(&self) -> String {
-        self.config.accessor_config.get_root_path()
+        self.config
+            .catalog
+            .get_file_catalog_accessor_config()
+            .unwrap()
+            .get_root_path()
     }
 
     async fn sync_snapshot(

--- a/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
@@ -160,11 +160,7 @@ impl IcebergTableManager {
         if self.iceberg_table.is_none() {
             let table = utils::get_or_create_iceberg_table(
                 &*self.catalog,
-                &self
-                    .config
-                    .metadata_accessor_config
-                    .get_warehouse_uri()
-                    .unwrap(),
+                &self.config.metadata_accessor_config.get_warehouse_uri(),
                 &self.config.namespace,
                 &self.config.table_name,
                 self.mooncake_table_metadata.schema.as_ref(),
@@ -192,10 +188,7 @@ impl IcebergTableManager {
 #[async_trait]
 impl TableManager for IcebergTableManager {
     fn get_warehouse_location(&self) -> String {
-        self.config
-            .metadata_accessor_config
-            .get_warehouse_uri()
-            .unwrap()
+        self.config.metadata_accessor_config.get_warehouse_uri()
     }
 
     async fn sync_snapshot(

--- a/src/moonlink/src/storage/iceberg/state_tests.rs
+++ b/src/moonlink/src/storage/iceberg/state_tests.rs
@@ -299,7 +299,12 @@ async fn validate_no_snapshot(
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
     validate_recovered_snapshot(
         &snapshot,
-        &iceberg_table_manager.config.accessor_config.get_root_path(),
+        &iceberg_table_manager
+            .config
+            .catalog
+            .get_file_catalog_accessor_config()
+            .unwrap()
+            .get_root_path(),
         filesystem_accessor,
     )
     .await;
@@ -321,7 +326,12 @@ async fn validate_only_initial_snapshot(
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
     validate_recovered_snapshot(
         &snapshot,
-        &iceberg_table_manager.config.accessor_config.get_root_path(),
+        &iceberg_table_manager
+            .config
+            .catalog
+            .get_file_catalog_accessor_config()
+            .unwrap()
+            .get_root_path(),
         filesystem_accessor,
     )
     .await;
@@ -343,7 +353,12 @@ async fn validate_only_new_data_files_in_snapshot(
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
     validate_recovered_snapshot(
         &snapshot,
-        &iceberg_table_manager.config.accessor_config.get_root_path(),
+        &iceberg_table_manager
+            .config
+            .catalog
+            .get_file_catalog_accessor_config()
+            .unwrap()
+            .get_root_path(),
         filesystem_accessor,
     )
     .await;
@@ -365,7 +380,12 @@ async fn validate_only_new_deletion_vectors_in_snapshot(
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
     validate_recovered_snapshot(
         &snapshot,
-        &iceberg_table_manager.config.accessor_config.get_root_path(),
+        &iceberg_table_manager
+            .config
+            .catalog
+            .get_file_catalog_accessor_config()
+            .unwrap()
+            .get_root_path(),
         filesystem_accessor,
     )
     .await;
@@ -395,7 +415,12 @@ async fn validate_new_data_files_and_deletion_vectors_in_snapshot(
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
     validate_recovered_snapshot(
         &snapshot,
-        &iceberg_table_manager.config.accessor_config.get_root_path(),
+        &iceberg_table_manager
+            .config
+            .catalog
+            .get_file_catalog_accessor_config()
+            .unwrap()
+            .get_root_path(),
         filesystem_accessor,
     )
     .await;

--- a/src/moonlink/src/storage/iceberg/state_tests.rs
+++ b/src/moonlink/src/storage/iceberg/state_tests.rs
@@ -302,8 +302,7 @@ async fn validate_no_snapshot(
         &iceberg_table_manager
             .config
             .metadata_accessor_config
-            .get_warehouse_uri()
-            .unwrap(),
+            .get_warehouse_uri(),
         filesystem_accessor,
     )
     .await;
@@ -328,8 +327,7 @@ async fn validate_only_initial_snapshot(
         &iceberg_table_manager
             .config
             .metadata_accessor_config
-            .get_warehouse_uri()
-            .unwrap(),
+            .get_warehouse_uri(),
         filesystem_accessor,
     )
     .await;
@@ -354,8 +352,7 @@ async fn validate_only_new_data_files_in_snapshot(
         &iceberg_table_manager
             .config
             .metadata_accessor_config
-            .get_warehouse_uri()
-            .unwrap(),
+            .get_warehouse_uri(),
         filesystem_accessor,
     )
     .await;
@@ -380,8 +377,7 @@ async fn validate_only_new_deletion_vectors_in_snapshot(
         &iceberg_table_manager
             .config
             .metadata_accessor_config
-            .get_warehouse_uri()
-            .unwrap(),
+            .get_warehouse_uri(),
         filesystem_accessor,
     )
     .await;
@@ -414,8 +410,7 @@ async fn validate_new_data_files_and_deletion_vectors_in_snapshot(
         &iceberg_table_manager
             .config
             .metadata_accessor_config
-            .get_warehouse_uri()
-            .unwrap(),
+            .get_warehouse_uri(),
         filesystem_accessor,
     )
     .await;

--- a/src/moonlink/src/storage/iceberg/state_tests.rs
+++ b/src/moonlink/src/storage/iceberg/state_tests.rs
@@ -301,10 +301,9 @@ async fn validate_no_snapshot(
         &snapshot,
         &iceberg_table_manager
             .config
-            .catalog
-            .get_file_catalog_accessor_config()
-            .unwrap()
-            .get_root_path(),
+            .metadata_accessor_config
+            .get_warehouse_uri()
+            .unwrap(),
         filesystem_accessor,
     )
     .await;
@@ -328,10 +327,9 @@ async fn validate_only_initial_snapshot(
         &snapshot,
         &iceberg_table_manager
             .config
-            .catalog
-            .get_file_catalog_accessor_config()
-            .unwrap()
-            .get_root_path(),
+            .metadata_accessor_config
+            .get_warehouse_uri()
+            .unwrap(),
         filesystem_accessor,
     )
     .await;
@@ -355,10 +353,9 @@ async fn validate_only_new_data_files_in_snapshot(
         &snapshot,
         &iceberg_table_manager
             .config
-            .catalog
-            .get_file_catalog_accessor_config()
-            .unwrap()
-            .get_root_path(),
+            .metadata_accessor_config
+            .get_warehouse_uri()
+            .unwrap(),
         filesystem_accessor,
     )
     .await;
@@ -382,10 +379,9 @@ async fn validate_only_new_deletion_vectors_in_snapshot(
         &snapshot,
         &iceberg_table_manager
             .config
-            .catalog
-            .get_file_catalog_accessor_config()
-            .unwrap()
-            .get_root_path(),
+            .metadata_accessor_config
+            .get_warehouse_uri()
+            .unwrap(),
         filesystem_accessor,
     )
     .await;
@@ -417,10 +413,9 @@ async fn validate_new_data_files_and_deletion_vectors_in_snapshot(
         &snapshot,
         &iceberg_table_manager
             .config
-            .catalog
-            .get_file_catalog_accessor_config()
-            .unwrap()
-            .get_root_path(),
+            .metadata_accessor_config
+            .get_warehouse_uri()
+            .unwrap(),
         filesystem_accessor,
     )
     .await;

--- a/src/moonlink/src/storage/iceberg/tests.rs
+++ b/src/moonlink/src/storage/iceberg/tests.rs
@@ -542,7 +542,11 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     validate_recovered_snapshot(
         &snapshot,
-        &iceberg_table_config.accessor_config.get_root_path(),
+        &iceberg_table_config
+            .catalog
+            .get_file_catalog_accessor_config()
+            .unwrap()
+            .get_root_path(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -636,7 +640,11 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
     assert_eq!(snapshot.indices.file_indices.len(), 1);
     validate_recovered_snapshot(
         &snapshot,
-        &iceberg_table_config.accessor_config.get_root_path(),
+        &iceberg_table_config
+            .catalog
+            .get_file_catalog_accessor_config()
+            .unwrap()
+            .get_root_path(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -693,7 +701,11 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
     assert!(snapshot.indices.file_indices.is_empty());
     validate_recovered_snapshot(
         &snapshot,
-        &iceberg_table_config.accessor_config.get_root_path(),
+        &iceberg_table_config
+            .catalog
+            .get_file_catalog_accessor_config()
+            .unwrap()
+            .get_root_path(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -852,7 +864,11 @@ async fn test_empty_snapshot_load_impl(iceberg_table_config: IcebergTableConfig)
     assert!(snapshot.flush_lsn.is_none());
     validate_recovered_snapshot(
         &snapshot,
-        &iceberg_table_config.accessor_config.get_root_path(),
+        &iceberg_table_config
+            .catalog
+            .get_file_catalog_accessor_config()
+            .unwrap()
+            .get_root_path(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -954,7 +970,11 @@ async fn test_recover_from_failed_snapshot_impl(iceberg_table_config: IcebergTab
     // Craft such situation: there's only initial metadata file (with version 0).
     let version_hint = format!(
         "{}/{}/{}/metadata/{}",
-        iceberg_table_config.accessor_config.get_root_path(),
+        iceberg_table_config
+            .catalog
+            .get_file_catalog_accessor_config()
+            .unwrap()
+            .get_root_path(),
         ICEBERG_TEST_NAMESPACE,
         ICEBERG_TEST_TABLE,
         VERSION_HINT_FILENAME
@@ -1071,7 +1091,11 @@ async fn test_index_merge_and_create_snapshot_impl(iceberg_table_config: Iceberg
     assert_eq!(snapshot.flush_lsn.unwrap(), 3);
     validate_recovered_snapshot(
         &snapshot,
-        &iceberg_table_config.accessor_config.get_root_path(),
+        &iceberg_table_config
+            .catalog
+            .get_file_catalog_accessor_config()
+            .unwrap()
+            .get_root_path(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -1106,7 +1130,11 @@ async fn test_index_merge_and_create_snapshot_impl(iceberg_table_config: Iceberg
     assert_eq!(snapshot.flush_lsn.unwrap(), 5);
     validate_recovered_snapshot(
         &snapshot,
-        &iceberg_table_config.accessor_config.get_root_path(),
+        &iceberg_table_config
+            .catalog
+            .get_file_catalog_accessor_config()
+            .unwrap()
+            .get_root_path(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -1231,7 +1259,11 @@ async fn test_data_compaction_and_create_snapshot_impl(iceberg_table_config: Ice
     assert_eq!(snapshot.flush_lsn.unwrap(), 3);
     validate_recovered_snapshot(
         &snapshot,
-        &iceberg_table_config.accessor_config.get_root_path(),
+        &iceberg_table_config
+            .catalog
+            .get_file_catalog_accessor_config()
+            .unwrap()
+            .get_root_path(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -1272,7 +1304,11 @@ async fn test_data_compaction_and_create_snapshot_impl(iceberg_table_config: Ice
     assert_eq!(snapshot.flush_lsn.unwrap(), 5);
     validate_recovered_snapshot(
         &snapshot,
-        &iceberg_table_config.accessor_config.get_root_path(),
+        &iceberg_table_config
+            .catalog
+            .get_file_catalog_accessor_config()
+            .unwrap()
+            .get_root_path(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -1392,7 +1428,11 @@ async fn test_data_compaction_append_only_and_create_snapshot_impl(
     assert_eq!(snapshot.flush_lsn.unwrap(), 2);
     validate_recovered_snapshot(
         &snapshot,
-        &iceberg_table_config.accessor_config.get_root_path(),
+        &iceberg_table_config
+            .catalog
+            .get_file_catalog_accessor_config()
+            .unwrap()
+            .get_root_path(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -1527,7 +1567,11 @@ async fn test_data_compaction_by_deletion_and_create_snapshot_impl(
     assert_eq!(snapshot.flush_lsn.unwrap(), 8);
     validate_recovered_snapshot(
         &snapshot,
-        &iceberg_table_config.accessor_config.get_root_path(),
+        &iceberg_table_config
+            .catalog
+            .get_file_catalog_accessor_config()
+            .unwrap()
+            .get_root_path(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -2093,7 +2137,11 @@ async fn test_async_iceberg_snapshot_impl(iceberg_table_config: IcebergTableConf
     assert!(deletion_vector_1.puffin_deletion_blob.is_none());
     validate_recovered_snapshot(
         &snapshot,
-        &iceberg_table_config.accessor_config.get_root_path(),
+        &iceberg_table_config
+            .catalog
+            .get_file_catalog_accessor_config()
+            .unwrap()
+            .get_root_path(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -2133,7 +2181,11 @@ async fn test_async_iceberg_snapshot_impl(iceberg_table_config: IcebergTableConf
 
     validate_recovered_snapshot(
         &snapshot,
-        &iceberg_table_config.accessor_config.get_root_path(),
+        &iceberg_table_config
+            .catalog
+            .get_file_catalog_accessor_config()
+            .unwrap()
+            .get_root_path(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -2300,7 +2352,11 @@ async fn mooncake_table_snapshot_persist_impl(iceberg_table_config: IcebergTable
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
     validate_recovered_snapshot(
         &snapshot,
-        &iceberg_table_config.accessor_config.get_root_path(),
+        &iceberg_table_config
+            .catalog
+            .get_file_catalog_accessor_config()
+            .unwrap()
+            .get_root_path(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -2374,7 +2430,11 @@ async fn mooncake_table_snapshot_persist_impl(iceberg_table_config: IcebergTable
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
     validate_recovered_snapshot(
         &snapshot,
-        &iceberg_table_config.accessor_config.get_root_path(),
+        &iceberg_table_config
+            .catalog
+            .get_file_catalog_accessor_config()
+            .unwrap()
+            .get_root_path(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -2436,7 +2496,11 @@ async fn mooncake_table_snapshot_persist_impl(iceberg_table_config: IcebergTable
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
     validate_recovered_snapshot(
         &snapshot,
-        &iceberg_table_config.accessor_config.get_root_path(),
+        &iceberg_table_config
+            .catalog
+            .get_file_catalog_accessor_config()
+            .unwrap()
+            .get_root_path(),
         filesystem_accessor.as_ref(),
     )
     .await;

--- a/src/moonlink/src/storage/iceberg/tests.rs
+++ b/src/moonlink/src/storage/iceberg/tests.rs
@@ -544,8 +544,7 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
         &snapshot,
         &iceberg_table_config
             .metadata_accessor_config
-            .get_warehouse_uri()
-            .unwrap(),
+            .get_warehouse_uri(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -641,8 +640,7 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
         &snapshot,
         &iceberg_table_config
             .metadata_accessor_config
-            .get_warehouse_uri()
-            .unwrap(),
+            .get_warehouse_uri(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -701,8 +699,7 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
         &snapshot,
         &iceberg_table_config
             .metadata_accessor_config
-            .get_warehouse_uri()
-            .unwrap(),
+            .get_warehouse_uri(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -863,8 +860,7 @@ async fn test_empty_snapshot_load_impl(iceberg_table_config: IcebergTableConfig)
         &snapshot,
         &iceberg_table_config
             .metadata_accessor_config
-            .get_warehouse_uri()
-            .unwrap(),
+            .get_warehouse_uri(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -968,8 +964,7 @@ async fn test_recover_from_failed_snapshot_impl(iceberg_table_config: IcebergTab
         "{}/{}/{}/metadata/{}",
         iceberg_table_config
             .metadata_accessor_config
-            .get_warehouse_uri()
-            .unwrap(),
+            .get_warehouse_uri(),
         ICEBERG_TEST_NAMESPACE,
         ICEBERG_TEST_TABLE,
         VERSION_HINT_FILENAME
@@ -1088,8 +1083,7 @@ async fn test_index_merge_and_create_snapshot_impl(iceberg_table_config: Iceberg
         &snapshot,
         &iceberg_table_config
             .metadata_accessor_config
-            .get_warehouse_uri()
-            .unwrap(),
+            .get_warehouse_uri(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -1126,8 +1120,7 @@ async fn test_index_merge_and_create_snapshot_impl(iceberg_table_config: Iceberg
         &snapshot,
         &iceberg_table_config
             .metadata_accessor_config
-            .get_warehouse_uri()
-            .unwrap(),
+            .get_warehouse_uri(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -1254,8 +1247,7 @@ async fn test_data_compaction_and_create_snapshot_impl(iceberg_table_config: Ice
         &snapshot,
         &iceberg_table_config
             .metadata_accessor_config
-            .get_warehouse_uri()
-            .unwrap(),
+            .get_warehouse_uri(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -1298,8 +1290,7 @@ async fn test_data_compaction_and_create_snapshot_impl(iceberg_table_config: Ice
         &snapshot,
         &iceberg_table_config
             .metadata_accessor_config
-            .get_warehouse_uri()
-            .unwrap(),
+            .get_warehouse_uri(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -1421,8 +1412,7 @@ async fn test_data_compaction_append_only_and_create_snapshot_impl(
         &snapshot,
         &iceberg_table_config
             .metadata_accessor_config
-            .get_warehouse_uri()
-            .unwrap(),
+            .get_warehouse_uri(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -1559,8 +1549,7 @@ async fn test_data_compaction_by_deletion_and_create_snapshot_impl(
         &snapshot,
         &iceberg_table_config
             .metadata_accessor_config
-            .get_warehouse_uri()
-            .unwrap(),
+            .get_warehouse_uri(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -2128,8 +2117,7 @@ async fn test_async_iceberg_snapshot_impl(iceberg_table_config: IcebergTableConf
         &snapshot,
         &iceberg_table_config
             .metadata_accessor_config
-            .get_warehouse_uri()
-            .unwrap(),
+            .get_warehouse_uri(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -2171,8 +2159,7 @@ async fn test_async_iceberg_snapshot_impl(iceberg_table_config: IcebergTableConf
         &snapshot,
         &iceberg_table_config
             .metadata_accessor_config
-            .get_warehouse_uri()
-            .unwrap(),
+            .get_warehouse_uri(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -2341,8 +2328,7 @@ async fn mooncake_table_snapshot_persist_impl(iceberg_table_config: IcebergTable
         &snapshot,
         &iceberg_table_config
             .metadata_accessor_config
-            .get_warehouse_uri()
-            .unwrap(),
+            .get_warehouse_uri(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -2418,8 +2404,7 @@ async fn mooncake_table_snapshot_persist_impl(iceberg_table_config: IcebergTable
         &snapshot,
         &iceberg_table_config
             .metadata_accessor_config
-            .get_warehouse_uri()
-            .unwrap(),
+            .get_warehouse_uri(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -2483,8 +2468,7 @@ async fn mooncake_table_snapshot_persist_impl(iceberg_table_config: IcebergTable
         &snapshot,
         &iceberg_table_config
             .metadata_accessor_config
-            .get_warehouse_uri()
-            .unwrap(),
+            .get_warehouse_uri(),
         filesystem_accessor.as_ref(),
     )
     .await;

--- a/src/moonlink/src/storage/iceberg/tests.rs
+++ b/src/moonlink/src/storage/iceberg/tests.rs
@@ -543,10 +543,9 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
     validate_recovered_snapshot(
         &snapshot,
         &iceberg_table_config
-            .catalog
-            .get_file_catalog_accessor_config()
-            .unwrap()
-            .get_root_path(),
+            .metadata_accessor_config
+            .get_warehouse_uri()
+            .unwrap(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -641,10 +640,9 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
     validate_recovered_snapshot(
         &snapshot,
         &iceberg_table_config
-            .catalog
-            .get_file_catalog_accessor_config()
-            .unwrap()
-            .get_root_path(),
+            .metadata_accessor_config
+            .get_warehouse_uri()
+            .unwrap(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -702,10 +700,9 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
     validate_recovered_snapshot(
         &snapshot,
         &iceberg_table_config
-            .catalog
-            .get_file_catalog_accessor_config()
-            .unwrap()
-            .get_root_path(),
+            .metadata_accessor_config
+            .get_warehouse_uri()
+            .unwrap(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -865,10 +862,9 @@ async fn test_empty_snapshot_load_impl(iceberg_table_config: IcebergTableConfig)
     validate_recovered_snapshot(
         &snapshot,
         &iceberg_table_config
-            .catalog
-            .get_file_catalog_accessor_config()
-            .unwrap()
-            .get_root_path(),
+            .metadata_accessor_config
+            .get_warehouse_uri()
+            .unwrap(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -971,10 +967,9 @@ async fn test_recover_from_failed_snapshot_impl(iceberg_table_config: IcebergTab
     let version_hint = format!(
         "{}/{}/{}/metadata/{}",
         iceberg_table_config
-            .catalog
-            .get_file_catalog_accessor_config()
-            .unwrap()
-            .get_root_path(),
+            .metadata_accessor_config
+            .get_warehouse_uri()
+            .unwrap(),
         ICEBERG_TEST_NAMESPACE,
         ICEBERG_TEST_TABLE,
         VERSION_HINT_FILENAME
@@ -1092,10 +1087,9 @@ async fn test_index_merge_and_create_snapshot_impl(iceberg_table_config: Iceberg
     validate_recovered_snapshot(
         &snapshot,
         &iceberg_table_config
-            .catalog
-            .get_file_catalog_accessor_config()
-            .unwrap()
-            .get_root_path(),
+            .metadata_accessor_config
+            .get_warehouse_uri()
+            .unwrap(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -1131,10 +1125,9 @@ async fn test_index_merge_and_create_snapshot_impl(iceberg_table_config: Iceberg
     validate_recovered_snapshot(
         &snapshot,
         &iceberg_table_config
-            .catalog
-            .get_file_catalog_accessor_config()
-            .unwrap()
-            .get_root_path(),
+            .metadata_accessor_config
+            .get_warehouse_uri()
+            .unwrap(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -1260,10 +1253,9 @@ async fn test_data_compaction_and_create_snapshot_impl(iceberg_table_config: Ice
     validate_recovered_snapshot(
         &snapshot,
         &iceberg_table_config
-            .catalog
-            .get_file_catalog_accessor_config()
-            .unwrap()
-            .get_root_path(),
+            .metadata_accessor_config
+            .get_warehouse_uri()
+            .unwrap(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -1305,10 +1297,9 @@ async fn test_data_compaction_and_create_snapshot_impl(iceberg_table_config: Ice
     validate_recovered_snapshot(
         &snapshot,
         &iceberg_table_config
-            .catalog
-            .get_file_catalog_accessor_config()
-            .unwrap()
-            .get_root_path(),
+            .metadata_accessor_config
+            .get_warehouse_uri()
+            .unwrap(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -1429,10 +1420,9 @@ async fn test_data_compaction_append_only_and_create_snapshot_impl(
     validate_recovered_snapshot(
         &snapshot,
         &iceberg_table_config
-            .catalog
-            .get_file_catalog_accessor_config()
-            .unwrap()
-            .get_root_path(),
+            .metadata_accessor_config
+            .get_warehouse_uri()
+            .unwrap(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -1568,10 +1558,9 @@ async fn test_data_compaction_by_deletion_and_create_snapshot_impl(
     validate_recovered_snapshot(
         &snapshot,
         &iceberg_table_config
-            .catalog
-            .get_file_catalog_accessor_config()
-            .unwrap()
-            .get_root_path(),
+            .metadata_accessor_config
+            .get_warehouse_uri()
+            .unwrap(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -2138,10 +2127,9 @@ async fn test_async_iceberg_snapshot_impl(iceberg_table_config: IcebergTableConf
     validate_recovered_snapshot(
         &snapshot,
         &iceberg_table_config
-            .catalog
-            .get_file_catalog_accessor_config()
-            .unwrap()
-            .get_root_path(),
+            .metadata_accessor_config
+            .get_warehouse_uri()
+            .unwrap(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -2182,10 +2170,9 @@ async fn test_async_iceberg_snapshot_impl(iceberg_table_config: IcebergTableConf
     validate_recovered_snapshot(
         &snapshot,
         &iceberg_table_config
-            .catalog
-            .get_file_catalog_accessor_config()
-            .unwrap()
-            .get_root_path(),
+            .metadata_accessor_config
+            .get_warehouse_uri()
+            .unwrap(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -2353,10 +2340,9 @@ async fn mooncake_table_snapshot_persist_impl(iceberg_table_config: IcebergTable
     validate_recovered_snapshot(
         &snapshot,
         &iceberg_table_config
-            .catalog
-            .get_file_catalog_accessor_config()
-            .unwrap()
-            .get_root_path(),
+            .metadata_accessor_config
+            .get_warehouse_uri()
+            .unwrap(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -2431,10 +2417,9 @@ async fn mooncake_table_snapshot_persist_impl(iceberg_table_config: IcebergTable
     validate_recovered_snapshot(
         &snapshot,
         &iceberg_table_config
-            .catalog
-            .get_file_catalog_accessor_config()
-            .unwrap()
-            .get_root_path(),
+            .metadata_accessor_config
+            .get_warehouse_uri()
+            .unwrap(),
         filesystem_accessor.as_ref(),
     )
     .await;
@@ -2497,10 +2482,9 @@ async fn mooncake_table_snapshot_persist_impl(iceberg_table_config: IcebergTable
     validate_recovered_snapshot(
         &snapshot,
         &iceberg_table_config
-            .catalog
-            .get_file_catalog_accessor_config()
-            .unwrap()
-            .get_root_path(),
+            .metadata_accessor_config
+            .get_warehouse_uri()
+            .unwrap(),
         filesystem_accessor.as_ref(),
     )
     .await;

--- a/src/moonlink/src/storage/mooncake_table/file_index_state_tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/file_index_state_tests.rs
@@ -193,8 +193,9 @@ pub(super) async fn create_mooncake_table_and_notify_for_index_merge(
         atomic_write_dir: None,
     };
     let iceberg_table_config = IcebergTableConfig {
-        catalog: crate::IcebergCatalogConfig::File {
-            accessor_config: AccessorConfig::new_with_storage_config(storage_config),
+        data_accessor_config: AccessorConfig::new_with_storage_config(storage_config.clone()),
+        metadata_accessor_config: crate::IcebergCatalogConfig::File {
+            accessor_config: AccessorConfig::new_with_storage_config(storage_config.clone()),
         },
         ..Default::default()
     };

--- a/src/moonlink/src/storage/mooncake_table/file_index_state_tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/file_index_state_tests.rs
@@ -193,7 +193,9 @@ pub(super) async fn create_mooncake_table_and_notify_for_index_merge(
         atomic_write_dir: None,
     };
     let iceberg_table_config = IcebergTableConfig {
-        accessor_config: AccessorConfig::new_with_storage_config(storage_config),
+        catalog: crate::IcebergCatalogConfig::File {
+            accessor_config: AccessorConfig::new_with_storage_config(storage_config),
+        },
         ..Default::default()
     };
     let schema = create_test_arrow_schema();

--- a/src/moonlink/src/storage/mooncake_table/table_creation_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_creation_test_utils.rs
@@ -52,7 +52,8 @@ pub(crate) fn get_iceberg_table_config(temp_dir: &TempDir) -> IcebergTableConfig
     IcebergTableConfig {
         namespace: vec![ICEBERG_TEST_NAMESPACE.to_string()],
         table_name: ICEBERG_TEST_TABLE.to_string(),
-        catalog: crate::IcebergCatalogConfig::File { accessor_config },
+        data_accessor_config: accessor_config.clone(),
+        metadata_accessor_config: crate::IcebergCatalogConfig::File { accessor_config },
     }
 }
 
@@ -65,7 +66,8 @@ pub(crate) fn get_iceberg_table_config_with_storage_config(
     IcebergTableConfig {
         namespace: vec![ICEBERG_TEST_NAMESPACE.to_string()],
         table_name: ICEBERG_TEST_TABLE.to_string(),
-        catalog: crate::IcebergCatalogConfig::File { accessor_config },
+        data_accessor_config: accessor_config.clone(),
+        metadata_accessor_config: crate::IcebergCatalogConfig::File { accessor_config },
     }
 }
 
@@ -92,7 +94,8 @@ pub(crate) fn get_iceberg_table_config_with_chaos_injection(
     IcebergTableConfig {
         namespace: vec![ICEBERG_TEST_NAMESPACE.to_string()],
         table_name: ICEBERG_TEST_TABLE.to_string(),
-        catalog: crate::IcebergCatalogConfig::File { accessor_config },
+        data_accessor_config: accessor_config.clone(),
+        metadata_accessor_config: crate::IcebergCatalogConfig::File { accessor_config },
     }
 }
 
@@ -125,7 +128,8 @@ pub(crate) fn create_iceberg_table_config(warehouse_uri: String) -> IcebergTable
     };
 
     IcebergTableConfig {
-        catalog: crate::IcebergCatalogConfig::File { accessor_config },
+        data_accessor_config: accessor_config.clone(),
+        metadata_accessor_config: crate::IcebergCatalogConfig::File { accessor_config },
         ..Default::default()
     }
 }
@@ -166,13 +170,7 @@ pub(crate) fn create_test_updated_arrow_schema_remove_age() -> Arc<ArrowSchema> 
 pub(crate) fn create_test_filesystem_accessor(
     iceberg_table_config: &IcebergTableConfig,
 ) -> Arc<dyn BaseFileSystemAccess> {
-    create_filesystem_accessor(
-        iceberg_table_config
-            .catalog
-            .get_file_catalog_accessor_config()
-            .unwrap()
-            .clone(),
-    )
+    create_filesystem_accessor(iceberg_table_config.data_accessor_config.clone())
 }
 
 /// Test util function to create mooncake table metadata.

--- a/src/moonlink/src/storage/mooncake_table/table_creation_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_creation_test_utils.rs
@@ -52,7 +52,7 @@ pub(crate) fn get_iceberg_table_config(temp_dir: &TempDir) -> IcebergTableConfig
     IcebergTableConfig {
         namespace: vec![ICEBERG_TEST_NAMESPACE.to_string()],
         table_name: ICEBERG_TEST_TABLE.to_string(),
-        accessor_config,
+        catalog: crate::IcebergCatalogConfig::File { accessor_config },
     }
 }
 
@@ -65,7 +65,7 @@ pub(crate) fn get_iceberg_table_config_with_storage_config(
     IcebergTableConfig {
         namespace: vec![ICEBERG_TEST_NAMESPACE.to_string()],
         table_name: ICEBERG_TEST_TABLE.to_string(),
-        accessor_config,
+        catalog: crate::IcebergCatalogConfig::File { accessor_config },
     }
 }
 
@@ -92,7 +92,7 @@ pub(crate) fn get_iceberg_table_config_with_chaos_injection(
     IcebergTableConfig {
         namespace: vec![ICEBERG_TEST_NAMESPACE.to_string()],
         table_name: ICEBERG_TEST_TABLE.to_string(),
-        accessor_config,
+        catalog: crate::IcebergCatalogConfig::File { accessor_config },
     }
 }
 
@@ -125,7 +125,7 @@ pub(crate) fn create_iceberg_table_config(warehouse_uri: String) -> IcebergTable
     };
 
     IcebergTableConfig {
-        accessor_config,
+        catalog: crate::IcebergCatalogConfig::File { accessor_config },
         ..Default::default()
     }
 }
@@ -166,7 +166,13 @@ pub(crate) fn create_test_updated_arrow_schema_remove_age() -> Arc<ArrowSchema> 
 pub(crate) fn create_test_filesystem_accessor(
     iceberg_table_config: &IcebergTableConfig,
 ) -> Arc<dyn BaseFileSystemAccess> {
-    create_filesystem_accessor(iceberg_table_config.accessor_config.clone())
+    create_filesystem_accessor(
+        iceberg_table_config
+            .catalog
+            .get_file_catalog_accessor_config()
+            .unwrap()
+            .clone(),
+    )
 }
 
 /// Test util function to create mooncake table metadata.

--- a/src/moonlink/src/storage/mooncake_table/table_status_reader.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_status_reader.rs
@@ -22,10 +22,9 @@ impl TableStatusReader {
         let (table_snapshot, _) = table.get_state_for_reader();
         Self {
             iceberg_warehouse_location: iceberg_table_config
-                .catalog
-                .get_file_catalog_accessor_config()
-                .unwrap()
-                .get_root_path(),
+                .metadata_accessor_config
+                .get_warehouse_uri()
+                .unwrap(),
             table_snapshot,
         }
     }

--- a/src/moonlink/src/storage/mooncake_table/table_status_reader.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_status_reader.rs
@@ -23,8 +23,7 @@ impl TableStatusReader {
         Self {
             iceberg_warehouse_location: iceberg_table_config
                 .metadata_accessor_config
-                .get_warehouse_uri()
-                .unwrap(),
+                .get_warehouse_uri(),
             table_snapshot,
         }
     }
@@ -89,8 +88,7 @@ mod tests {
         let expected_table_state = TableSnapshotStatus {
             iceberg_warehouse_location: iceberg_table_config
                 .metadata_accessor_config
-                .get_warehouse_uri()
-                .unwrap(),
+                .get_warehouse_uri(),
             commit_lsn: 0,
             cardinality: 0,
             flush_lsn: None,
@@ -115,8 +113,7 @@ mod tests {
         let expected_table_state = TableSnapshotStatus {
             iceberg_warehouse_location: iceberg_table_config
                 .metadata_accessor_config
-                .get_warehouse_uri()
-                .unwrap(),
+                .get_warehouse_uri(),
             commit_lsn: 0,
             cardinality: 0,
             flush_lsn: None,
@@ -145,8 +142,7 @@ mod tests {
         let expected_table_state = TableSnapshotStatus {
             iceberg_warehouse_location: iceberg_table_config
                 .metadata_accessor_config
-                .get_warehouse_uri()
-                .unwrap(),
+                .get_warehouse_uri(),
             commit_lsn: 10,
             cardinality: 1,
             flush_lsn: None,
@@ -176,8 +172,7 @@ mod tests {
         let expected_table_state = TableSnapshotStatus {
             iceberg_warehouse_location: iceberg_table_config
                 .metadata_accessor_config
-                .get_warehouse_uri()
-                .unwrap(),
+                .get_warehouse_uri(),
             commit_lsn: 10,
             flush_lsn: Some(10),
             cardinality: 1,

--- a/src/moonlink/src/storage/mooncake_table/table_status_reader.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_status_reader.rs
@@ -88,10 +88,9 @@ mod tests {
         let actual_table_state = table_state_reader.get_current_table_state().await.unwrap();
         let expected_table_state = TableSnapshotStatus {
             iceberg_warehouse_location: iceberg_table_config
-                .catalog
-                .get_file_catalog_accessor_config()
-                .unwrap()
-                .get_root_path(),
+                .metadata_accessor_config
+                .get_warehouse_uri()
+                .unwrap(),
             commit_lsn: 0,
             cardinality: 0,
             flush_lsn: None,
@@ -115,10 +114,9 @@ mod tests {
         let actual_table_state = table_state_reader.get_current_table_state().await.unwrap();
         let expected_table_state = TableSnapshotStatus {
             iceberg_warehouse_location: iceberg_table_config
-                .catalog
-                .get_file_catalog_accessor_config()
-                .unwrap()
-                .get_root_path(),
+                .metadata_accessor_config
+                .get_warehouse_uri()
+                .unwrap(),
             commit_lsn: 0,
             cardinality: 0,
             flush_lsn: None,
@@ -146,10 +144,9 @@ mod tests {
         let actual_table_state = table_state_reader.get_current_table_state().await.unwrap();
         let expected_table_state = TableSnapshotStatus {
             iceberg_warehouse_location: iceberg_table_config
-                .catalog
-                .get_file_catalog_accessor_config()
-                .unwrap()
-                .get_root_path(),
+                .metadata_accessor_config
+                .get_warehouse_uri()
+                .unwrap(),
             commit_lsn: 10,
             cardinality: 1,
             flush_lsn: None,
@@ -178,10 +175,9 @@ mod tests {
         let actual_table_state = table_state_reader.get_current_table_state().await.unwrap();
         let expected_table_state = TableSnapshotStatus {
             iceberg_warehouse_location: iceberg_table_config
-                .catalog
-                .get_file_catalog_accessor_config()
-                .unwrap()
-                .get_root_path(),
+                .metadata_accessor_config
+                .get_warehouse_uri()
+                .unwrap(),
             commit_lsn: 10,
             flush_lsn: Some(10),
             cardinality: 1,

--- a/src/moonlink/src/storage/mooncake_table/table_status_reader.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_status_reader.rs
@@ -21,7 +21,11 @@ impl TableStatusReader {
     pub fn new(iceberg_table_config: &IcebergTableConfig, table: &MooncakeTable) -> Self {
         let (table_snapshot, _) = table.get_state_for_reader();
         Self {
-            iceberg_warehouse_location: iceberg_table_config.accessor_config.get_root_path(),
+            iceberg_warehouse_location: iceberg_table_config
+                .catalog
+                .get_file_catalog_accessor_config()
+                .unwrap()
+                .get_root_path(),
             table_snapshot,
         }
     }
@@ -84,7 +88,11 @@ mod tests {
         // Get table state and check.
         let actual_table_state = table_state_reader.get_current_table_state().await.unwrap();
         let expected_table_state = TableSnapshotStatus {
-            iceberg_warehouse_location: iceberg_table_config.accessor_config.get_root_path(),
+            iceberg_warehouse_location: iceberg_table_config
+                .catalog
+                .get_file_catalog_accessor_config()
+                .unwrap()
+                .get_root_path(),
             commit_lsn: 0,
             cardinality: 0,
             flush_lsn: None,
@@ -107,7 +115,11 @@ mod tests {
         // Get table state and check.
         let actual_table_state = table_state_reader.get_current_table_state().await.unwrap();
         let expected_table_state = TableSnapshotStatus {
-            iceberg_warehouse_location: iceberg_table_config.accessor_config.get_root_path(),
+            iceberg_warehouse_location: iceberg_table_config
+                .catalog
+                .get_file_catalog_accessor_config()
+                .unwrap()
+                .get_root_path(),
             commit_lsn: 0,
             cardinality: 0,
             flush_lsn: None,
@@ -134,7 +146,11 @@ mod tests {
         // Get table state and check.
         let actual_table_state = table_state_reader.get_current_table_state().await.unwrap();
         let expected_table_state = TableSnapshotStatus {
-            iceberg_warehouse_location: iceberg_table_config.accessor_config.get_root_path(),
+            iceberg_warehouse_location: iceberg_table_config
+                .catalog
+                .get_file_catalog_accessor_config()
+                .unwrap()
+                .get_root_path(),
             commit_lsn: 10,
             cardinality: 1,
             flush_lsn: None,
@@ -162,7 +178,11 @@ mod tests {
         // Get table state and check.
         let actual_table_state = table_state_reader.get_current_table_state().await.unwrap();
         let expected_table_state = TableSnapshotStatus {
-            iceberg_warehouse_location: iceberg_table_config.accessor_config.get_root_path(),
+            iceberg_warehouse_location: iceberg_table_config
+                .catalog
+                .get_file_catalog_accessor_config()
+                .unwrap()
+                .get_root_path(),
             commit_lsn: 10,
             flush_lsn: Some(10),
             cardinality: 1,

--- a/src/moonlink/src/storage/mooncake_table/test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/test_utils.rs
@@ -56,7 +56,8 @@ pub fn test_iceberg_table_config(context: &TestContext, table_name: &str) -> Ice
     IcebergTableConfig {
         namespace: vec!["default".to_string()],
         table_name: table_name.to_string(),
-        catalog: crate::IcebergCatalogConfig::File {
+        data_accessor_config: AccessorConfig::new_with_storage_config(storage_config.clone()),
+        metadata_accessor_config: crate::IcebergCatalogConfig::File {
             accessor_config: AccessorConfig::new_with_storage_config(storage_config),
         },
     }

--- a/src/moonlink/src/storage/mooncake_table/test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/test_utils.rs
@@ -56,7 +56,9 @@ pub fn test_iceberg_table_config(context: &TestContext, table_name: &str) -> Ice
     IcebergTableConfig {
         namespace: vec!["default".to_string()],
         table_name: table_name.to_string(),
-        accessor_config: AccessorConfig::new_with_storage_config(storage_config),
+        catalog: crate::IcebergCatalogConfig::File {
+            accessor_config: AccessorConfig::new_with_storage_config(storage_config),
+        },
     }
 }
 

--- a/src/moonlink/src/table_handler/test_utils.rs
+++ b/src/moonlink/src/table_handler/test_utils.rs
@@ -16,6 +16,7 @@ use crate::storage::{verify_files_and_deletions, MooncakeTable};
 use crate::table_handler::{TableEvent, TableHandler};
 use crate::table_handler_timer::create_table_handler_timers;
 use crate::union_read::{decode_read_state_for_testing, ReadStateManager};
+use crate::IcebergCatalogConfig;
 use crate::Result;
 use crate::{
     FileSystemAccessor, IcebergTableManager, MooncakeTableConfig, StorageConfig, TableEventManager,
@@ -52,7 +53,9 @@ pub fn get_iceberg_manager_config(table_name: String, warehouse_uri: String) -> 
     IcebergTableConfig {
         namespace: vec!["default".to_string()],
         table_name,
-        accessor_config: AccessorConfig::new_with_storage_config(storage_config),
+        catalog: IcebergCatalogConfig::File {
+            accessor_config: AccessorConfig::new_with_storage_config(storage_config),
+        },
     }
 }
 

--- a/src/moonlink/src/table_handler/test_utils.rs
+++ b/src/moonlink/src/table_handler/test_utils.rs
@@ -53,7 +53,8 @@ pub fn get_iceberg_manager_config(table_name: String, warehouse_uri: String) -> 
     IcebergTableConfig {
         namespace: vec!["default".to_string()],
         table_name,
-        catalog: IcebergCatalogConfig::File {
+        data_accessor_config: AccessorConfig::new_with_storage_config(storage_config.clone()),
+        metadata_accessor_config: IcebergCatalogConfig::File {
             accessor_config: AccessorConfig::new_with_storage_config(storage_config),
         },
     }

--- a/src/moonlink_backend/src/table_config.rs
+++ b/src/moonlink_backend/src/table_config.rs
@@ -99,8 +99,9 @@ impl TableConfig {
             iceberg_table_config: IcebergTableConfig {
                 namespace: vec![mooncake_table_id.database.clone()],
                 table_name: mooncake_table_id.table.clone(),
-                catalog: moonlink::IcebergCatalogConfig::File {
-                    accessor_config: self.iceberg_config.unwrap(),
+                data_accessor_config: self.iceberg_config.clone().unwrap(),
+                metadata_accessor_config: moonlink::IcebergCatalogConfig::File {
+                    accessor_config: self.iceberg_config.clone().unwrap(),
                 },
             },
             wal_table_config: WalConfig::new(

--- a/src/moonlink_backend/src/table_config.rs
+++ b/src/moonlink_backend/src/table_config.rs
@@ -99,7 +99,9 @@ impl TableConfig {
             iceberg_table_config: IcebergTableConfig {
                 namespace: vec![mooncake_table_id.database.clone()],
                 table_name: mooncake_table_id.table.clone(),
-                accessor_config: self.iceberg_config.unwrap(),
+                catalog: moonlink::IcebergCatalogConfig::File {
+                    accessor_config: self.iceberg_config.unwrap(),
+                },
             },
             wal_table_config: WalConfig::new(
                 self.wal_config.unwrap(),

--- a/src/moonlink_connectors/src/pg_replicate/table_init.rs
+++ b/src/moonlink_connectors/src/pg_replicate/table_init.rs
@@ -151,9 +151,8 @@ pub async fn build_table_components(
             table_components
                 .moonlink_table_config
                 .iceberg_table_config
-                .catalog
-                .get_file_catalog_accessor_config()
-                .unwrap(),
+                .data_accessor_config
+                .clone(),
         )),
     )
     .await?;
@@ -168,7 +167,10 @@ pub async fn build_table_components(
         table_components.read_state_filepath_remap,
     );
     let table_status_reader = TableStatusReader::new(
-        &table_components.moonlink_table_config.iceberg_table_config,
+        &table_components
+            .moonlink_table_config
+            .iceberg_table_config
+            .clone(),
         &table,
     );
     let (event_sync_sender, event_sync_receiver) = create_table_event_syncer();

--- a/src/moonlink_connectors/src/pg_replicate/table_init.rs
+++ b/src/moonlink_connectors/src/pg_replicate/table_init.rs
@@ -167,10 +167,7 @@ pub async fn build_table_components(
         table_components.read_state_filepath_remap,
     );
     let table_status_reader = TableStatusReader::new(
-        &table_components
-            .moonlink_table_config
-            .iceberg_table_config
-            .clone(),
+        &table_components.moonlink_table_config.iceberg_table_config,
         &table,
     );
     let (event_sync_sender, event_sync_receiver) = create_table_event_syncer();

--- a/src/moonlink_connectors/src/pg_replicate/table_init.rs
+++ b/src/moonlink_connectors/src/pg_replicate/table_init.rs
@@ -151,8 +151,9 @@ pub async fn build_table_components(
             table_components
                 .moonlink_table_config
                 .iceberg_table_config
-                .accessor_config
-                .clone(),
+                .catalog
+                .get_file_catalog_accessor_config()
+                .unwrap(),
         )),
     )
     .await?;

--- a/src/moonlink_metadata_store/src/config_utils.rs
+++ b/src/moonlink_metadata_store/src/config_utils.rs
@@ -119,7 +119,11 @@ pub(crate) fn parse_moonlink_table_config(
     let mooncake_config = moonlink_table_config.mooncake_table_config;
     let persisted = MoonlinkTableConfigForPersistence {
         iceberg_table_config: IcebergTableConfigForPersistence {
-            warehouse_uri: iceberg_config.accessor_config.get_root_path(),
+            warehouse_uri: iceberg_config
+                .catalog
+                .get_file_catalog_accessor_config()
+                .unwrap()
+                .get_root_path(),
             namespace: iceberg_config.namespace[0].to_string(),
             table_name: iceberg_config.table_name,
         },
@@ -141,7 +145,9 @@ pub(crate) fn parse_moonlink_table_config(
 
     // Extract table secret entry.
     let iceberg_secret_entry = iceberg_config
-        .accessor_config
+        .catalog
+        .get_file_catalog_accessor_config()
+        .unwrap()
         .extract_security_metadata_entry();
     let wal_secret_entry = wal_config
         .get_accessor_config()
@@ -223,7 +229,9 @@ pub(crate) fn deserialize_moonlink_table_config(
         iceberg_table_config: IcebergTableConfig {
             namespace: vec![parsed.iceberg_table_config.namespace],
             table_name: parsed.iceberg_table_config.table_name,
-            accessor_config: AccessorConfig::new_with_storage_config(storage_config),
+            catalog: moonlink::IcebergCatalogConfig::File {
+                accessor_config: AccessorConfig::new_with_storage_config(storage_config),
+            },
         },
         mooncake_table_config,
         wal_table_config: WalConfig::new(

--- a/src/moonlink_metadata_store/src/config_utils.rs
+++ b/src/moonlink_metadata_store/src/config_utils.rs
@@ -119,10 +119,7 @@ pub(crate) fn parse_moonlink_table_config(
     let mooncake_config = moonlink_table_config.mooncake_table_config;
     let persisted = MoonlinkTableConfigForPersistence {
         iceberg_table_config: IcebergTableConfigForPersistence {
-            warehouse_uri: iceberg_config
-                .metadata_accessor_config
-                .get_warehouse_uri()
-                .unwrap(),
+            warehouse_uri: iceberg_config.metadata_accessor_config.get_warehouse_uri(),
             namespace: iceberg_config.namespace[0].to_string(),
             table_name: iceberg_config.table_name,
         },

--- a/src/moonlink_metadata_store/src/config_utils.rs
+++ b/src/moonlink_metadata_store/src/config_utils.rs
@@ -120,10 +120,9 @@ pub(crate) fn parse_moonlink_table_config(
     let persisted = MoonlinkTableConfigForPersistence {
         iceberg_table_config: IcebergTableConfigForPersistence {
             warehouse_uri: iceberg_config
-                .catalog
-                .get_file_catalog_accessor_config()
-                .unwrap()
-                .get_root_path(),
+                .metadata_accessor_config
+                .get_warehouse_uri()
+                .unwrap(),
             namespace: iceberg_config.namespace[0].to_string(),
             table_name: iceberg_config.table_name,
         },
@@ -145,7 +144,7 @@ pub(crate) fn parse_moonlink_table_config(
 
     // Extract table secret entry.
     let iceberg_secret_entry = iceberg_config
-        .catalog
+        .metadata_accessor_config
         .get_file_catalog_accessor_config()
         .unwrap()
         .extract_security_metadata_entry();
@@ -229,8 +228,9 @@ pub(crate) fn deserialize_moonlink_table_config(
         iceberg_table_config: IcebergTableConfig {
             namespace: vec![parsed.iceberg_table_config.namespace],
             table_name: parsed.iceberg_table_config.table_name,
-            catalog: moonlink::IcebergCatalogConfig::File {
-                accessor_config: AccessorConfig::new_with_storage_config(storage_config),
+            data_accessor_config: AccessorConfig::new_with_storage_config(storage_config.clone()),
+            metadata_accessor_config: moonlink::IcebergCatalogConfig::File {
+                accessor_config: AccessorConfig::new_with_storage_config(storage_config.clone()),
             },
         },
         mooncake_table_config,

--- a/src/moonlink_metadata_store/src/sqlite/tests.rs
+++ b/src/moonlink_metadata_store/src/sqlite/tests.rs
@@ -1,6 +1,8 @@
 use crate::base_metadata_store::MetadataStoreTrait;
 use crate::sqlite::sqlite_metadata_store::SqliteMetadataStore;
-use moonlink::{AccessorConfig, IcebergTableConfig, MoonlinkTableConfig, StorageConfig, WalConfig};
+use moonlink::{
+    IcebergCatalogConfig, IcebergTableConfig, MoonlinkTableConfig, StorageConfig, WalConfig,
+};
 
 use tempfile::{tempdir, TempDir};
 
@@ -76,7 +78,9 @@ pub(crate) fn get_moonlink_table_config() -> MoonlinkTableConfig {
         iceberg_table_config: IcebergTableConfig {
             namespace: vec!["namespace".to_string()],
             table_name: "table".to_string(),
-            accessor_config: get_accessor_config(),
+            catalog: IcebergCatalogConfig::File {
+                accessor_config: get_accessor_config(),
+            },
         },
         wal_table_config: WalConfig::new(wal_accessor, &format!("{DATABASE}.{TABLE}")),
         ..Default::default()

--- a/src/moonlink_metadata_store/src/sqlite/tests.rs
+++ b/src/moonlink_metadata_store/src/sqlite/tests.rs
@@ -1,7 +1,8 @@
 use crate::base_metadata_store::MetadataStoreTrait;
 use crate::sqlite::sqlite_metadata_store::SqliteMetadataStore;
 use moonlink::{
-    IcebergCatalogConfig, IcebergTableConfig, MoonlinkTableConfig, StorageConfig, WalConfig,
+    AccessorConfig, IcebergCatalogConfig, IcebergTableConfig, MoonlinkTableConfig, StorageConfig,
+    WalConfig,
 };
 
 use tempfile::{tempdir, TempDir};

--- a/src/moonlink_metadata_store/src/sqlite/tests.rs
+++ b/src/moonlink_metadata_store/src/sqlite/tests.rs
@@ -79,7 +79,8 @@ pub(crate) fn get_moonlink_table_config() -> MoonlinkTableConfig {
         iceberg_table_config: IcebergTableConfig {
             namespace: vec!["namespace".to_string()],
             table_name: "table".to_string(),
-            catalog: IcebergCatalogConfig::File {
+            data_accessor_config: get_accessor_config(),
+            metadata_accessor_config: IcebergCatalogConfig::File {
                 accessor_config: get_accessor_config(),
             },
         },

--- a/src/moonlink_metadata_store/src/test_utils.rs
+++ b/src/moonlink_metadata_store/src/test_utils.rs
@@ -1,5 +1,8 @@
 #[cfg(any(feature = "storage-s3", feature = "storage-gcs"))]
-use moonlink::{AccessorConfig, IcebergTableConfig, MoonlinkTableConfig, StorageConfig, WalConfig};
+use moonlink::{
+    AccessorConfig, IcebergCatalogConfig, IcebergTableConfig, MoonlinkTableConfig, StorageConfig,
+    WalConfig,
+};
 
 #[cfg(feature = "storage-s3")]
 pub fn get_s3_moonlink_table_config(database: &str, table: &str) -> MoonlinkTableConfig {
@@ -22,7 +25,9 @@ pub fn get_s3_moonlink_table_config(database: &str, table: &str) -> MoonlinkTabl
         iceberg_table_config: IcebergTableConfig {
             namespace: vec!["namespace".to_string()],
             table_name: "table".to_string(),
-            accessor_config: AccessorConfig::new_with_storage_config(iceberg_storage),
+            catalog: IcebergCatalogConfig::File {
+                accessor_config: AccessorConfig::new_with_storage_config(iceberg_storage),
+            },
         },
         wal_table_config: WalConfig::new(wal_accessor, &format!("{database}.{table}")),
         ..Default::default()
@@ -56,7 +61,9 @@ pub fn get_gcs_moonlink_table_config(database: &str, table: &str) -> MoonlinkTab
         iceberg_table_config: IcebergTableConfig {
             namespace: vec!["namespace".to_string()],
             table_name: "table".to_string(),
-            accessor_config: AccessorConfig::new_with_storage_config(iceberg_storage),
+            catalog: IcebergCatalogConfig::File {
+                accessor_config: AccessorConfig::new_with_storage_config(iceberg_storage),
+            },
         },
         wal_table_config: WalConfig::new(wal_accessor, &format!("{database}.{table}")),
         ..Default::default()

--- a/src/moonlink_metadata_store/src/test_utils.rs
+++ b/src/moonlink_metadata_store/src/test_utils.rs
@@ -25,8 +25,9 @@ pub fn get_s3_moonlink_table_config(database: &str, table: &str) -> MoonlinkTabl
         iceberg_table_config: IcebergTableConfig {
             namespace: vec!["namespace".to_string()],
             table_name: "table".to_string(),
-            catalog: IcebergCatalogConfig::File {
-                accessor_config: AccessorConfig::new_with_storage_config(iceberg_storage),
+            data_accessor_config: AccessorConfig::new_with_storage_config(iceberg_storage.clone()),
+            metadata_accessor_config: IcebergCatalogConfig::File {
+                accessor_config: AccessorConfig::new_with_storage_config(iceberg_storage.clone()),
             },
         },
         wal_table_config: WalConfig::new(wal_accessor, &format!("{database}.{table}")),
@@ -61,8 +62,9 @@ pub fn get_gcs_moonlink_table_config(database: &str, table: &str) -> MoonlinkTab
         iceberg_table_config: IcebergTableConfig {
             namespace: vec!["namespace".to_string()],
             table_name: "table".to_string(),
-            catalog: IcebergCatalogConfig::File {
-                accessor_config: AccessorConfig::new_with_storage_config(iceberg_storage),
+            data_accessor_config: AccessorConfig::new_with_storage_config(iceberg_storage.clone()),
+            metadata_accessor_config: IcebergCatalogConfig::File {
+                accessor_config: AccessorConfig::new_with_storage_config(iceberg_storage.clone()),
             },
         },
         wal_table_config: WalConfig::new(wal_accessor, &format!("{database}.{table}")),

--- a/src/moonlink_metadata_store/tests/common/test_utils.rs
+++ b/src/moonlink_metadata_store/tests/common/test_utils.rs
@@ -18,7 +18,9 @@ pub(crate) fn get_moonlink_table_config() -> MoonlinkTableConfig {
         iceberg_table_config: IcebergTableConfig {
             namespace: vec!["namespace".to_string()],
             table_name: "table".to_string(),
-            accessor_config: iceberg_accessor_config,
+            catalog: moonlink::IcebergCatalogConfig::File {
+                accessor_config: iceberg_accessor_config,
+            },
         },
         wal_table_config: WalConfig::new(wal_accessor_config, "dst-database.dst-schema.dst-table"),
         ..Default::default()

--- a/src/moonlink_metadata_store/tests/common/test_utils.rs
+++ b/src/moonlink_metadata_store/tests/common/test_utils.rs
@@ -18,7 +18,8 @@ pub(crate) fn get_moonlink_table_config() -> MoonlinkTableConfig {
         iceberg_table_config: IcebergTableConfig {
             namespace: vec!["namespace".to_string()],
             table_name: "table".to_string(),
-            catalog: moonlink::IcebergCatalogConfig::File {
+            data_accessor_config: iceberg_accessor_config.clone(),
+            metadata_accessor_config: moonlink::IcebergCatalogConfig::File {
                 accessor_config: iceberg_accessor_config,
             },
         },


### PR DESCRIPTION
## Summary

Current iceberg table config only supports file catalog: [main/src/moonlink/src/storage/iceberg/iceberg_table_config.rs](https://github.com/Mooncake-Labs/moonlink/blob/main/src/moonlink/src/storage/iceberg/iceberg_table_config.rs?rgh-link-date=2025-08-24T08%3A46%3A19.000Z)

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1691

## Changes

- Add RestCatalogConfig and GlueCatalogConfig for iceberg-rust CatalogConfig Builders
  - [GlueCatalogBuilder](https://github.com/apache/iceberg-rust/blob/4aacad756250a5a1bbc44842ea4b608e3213b641/crates/catalog/rest/src/catalog.rs#L73-L119)
  - [RestCatalogBuilder](https://github.com/apache/iceberg-rust/blob/4aacad756250a5a1bbc44842ea4b608e3213b641/crates/catalog/glue/src/catalog.rs#L66-L119)
- 

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [x] Documentation updated if necessary
- [x] I have reviewed my own changes
