### PR TITLE
Initial load direct-to-disk optimization

### DIFF
--- a/src/moonlink/src/lib.rs
+++ b/src/moonlink/src/lib.rs
@@ -11,6 +11,9 @@ mod union_read;
 pub use error::*;
 pub use event_sync::EventSyncSender;
 pub use mooncake_table_id::MooncakeTableId;
+pub use storage::mooncake_table::batch_id_counter::BatchIdCounter;
+pub use storage::mooncake_table::data_batches::ColumnStoreBuffer;
+pub use storage::parquet_utils::get_default_parquet_properties;
 pub use storage::storage_utils::create_data_file;
 pub(crate) use storage::NonEvictableHandle;
 pub use storage::{

--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -1,6 +1,6 @@
-mod batch_id_counter;
+pub mod batch_id_counter;
 mod batch_ingestion;
-mod data_batches;
+pub mod data_batches;
 pub(crate) mod delete_vector;
 mod disk_slice;
 mod iceberg_persisted_records;
@@ -77,11 +77,6 @@ use tokio::sync::{watch, RwLock};
 use tracing::info_span;
 use tracing::Instrument;
 use transaction_stream::{TransactionStreamOutput, TransactionStreamState};
-
-/// Special transaction id used for initial copy append operation.
-/// `0` is designated as `InvalidTransactionId` in the postgres implementation, so we can be sure this will never collide with a valid transaction id.
-/// [https://github.com/postgres/postgres/blob/d5b9b2d40262f57f58322ad49f8928fd4a492adb/src/include/access/transam.h#L31]
-pub(crate) const INITIAL_COPY_XACT_ID: u32 = 0;
 
 #[derive(Debug)]
 pub struct TableMetadata {

--- a/src/moonlink/src/storage/mooncake_table/batch_id_counter.rs
+++ b/src/moonlink/src/storage/mooncake_table/batch_id_counter.rs
@@ -12,7 +12,7 @@ pub const STREAMING_BATCH_ID_MAX: u64 = 1u64 << 63;
 ///
 /// We give streaming batches the smaller range so that they are always behind the commit point, which points to the most recently added batch of the non-streaming batches.
 /// This ensures batch IDs are always monotonically increasing and unique across all transactions.
-pub(super) struct BatchIdCounter {
+pub struct BatchIdCounter {
     counter: Arc<AtomicU64>,
     is_streaming: bool,
 }

--- a/src/moonlink/src/storage/mooncake_table/batch_ingestion.rs
+++ b/src/moonlink/src/storage/mooncake_table/batch_ingestion.rs
@@ -290,7 +290,7 @@ mod tests {
             )
             .await;
 
-        let (files, mut indices) = match &table.next_snapshot_task.new_streaming_xact[0] {
+        let (mut files, mut indices) = match &table.next_snapshot_task.new_streaming_xact[0] {
             TransactionStreamOutput::Commit(commit) => {
                 (commit.get_flushed_data_files(), commit.get_file_indices())
             }
@@ -307,6 +307,8 @@ mod tests {
             vec![k1, k2].into_iter(),
         );
         let results = index.search_values(&lookups).await;
+        // Ensure deterministic order for seg_idx mapping in assertions
+        files.sort_by_key(|f| f.file_path().clone());
         let file_ids: Vec<_> = files.iter().map(|f| f.file_id()).collect();
         assert!(results.contains(&(k1, RecordLocation::DiskFile(file_ids[0], 0))));
         assert!(results.contains(&(k2, RecordLocation::DiskFile(file_ids[1], 1))));

--- a/src/moonlink/src/storage/mooncake_table/batch_ingestion.rs
+++ b/src/moonlink/src/storage/mooncake_table/batch_ingestion.rs
@@ -128,3 +128,340 @@ impl MooncakeTable {
         Ok(index)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::mooncake_table::table_creation_test_utils::create_test_arrow_schema;
+    use crate::storage::mooncake_table::test_utils::TestContext;
+    use crate::storage::storage_utils::RecordLocation;
+    use arrow_array::RecordBatch;
+    use parquet::arrow::AsyncArrowWriter;
+    use std::sync::Arc;
+    use tempfile::tempdir;
+
+    async fn write_parquet_file(path: &std::path::Path, batches: &[RecordBatch]) {
+        let file = tokio::fs::File::create(path).await.unwrap();
+        let mut writer =
+            AsyncArrowWriter::try_new(file, create_test_arrow_schema(), /*props=*/ None).unwrap();
+        for batch in batches.iter() {
+            writer.write(batch).await.unwrap();
+        }
+        writer.close().await.unwrap();
+    }
+
+    fn batch_with_rows(ids: &[i32]) -> RecordBatch {
+        use arrow_array::{Int32Array, RecordBatch, StringArray};
+        let schema = create_test_arrow_schema();
+        let names: Vec<String> = ids.iter().map(|i| format!("name-{i}")).collect();
+        let ages: Vec<i32> = ids.iter().map(|i| 20 + *i).collect();
+        RecordBatch::try_new(
+            schema.clone(),
+            vec![
+                Arc::new(Int32Array::from(ids.to_vec())),
+                Arc::new(StringArray::from(names)),
+                Arc::new(Int32Array::from(ages)),
+            ],
+        )
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_batch_ingest_append_only_skips_index() {
+        let context = TestContext::new("batch_ingest_append_only");
+        let temp_dir = tempdir().unwrap();
+        let data_dir = temp_dir.path();
+
+        let mut table = crate::storage::mooncake_table::test_utils::test_append_only_table(
+            &context,
+            "t_append_only",
+        )
+        .await;
+
+        // Prepare one parquet file
+        let file1 = data_dir.join("file1.parquet");
+        let batch1 = batch_with_rows(&[1, 2, 3]);
+        write_parquet_file(&file1, &[batch1]).await;
+
+        let lsn = 100u64;
+        table
+            .batch_ingest(vec![file1.to_string_lossy().to_string()], lsn)
+            .await;
+
+        // Verify next_snapshot_task updated
+        assert_eq!(table.next_snapshot_task.new_streaming_xact.len(), 1);
+        assert_eq!(table.next_snapshot_task.new_flush_lsn, Some(lsn));
+        assert_eq!(table.next_snapshot_task.commit_lsn_baseline, lsn);
+
+        // Verify commit has files and NO index for append-only
+        match &table.next_snapshot_task.new_streaming_xact[0] {
+            TransactionStreamOutput::Abort(_) => panic!("unexpected abort"),
+            TransactionStreamOutput::Commit(commit) => {
+                assert_eq!(commit.get_flushed_data_files().len(), 1);
+                assert!(commit.get_file_indices().is_empty());
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_batch_ingest_builds_index_for_single_primitive_key() {
+        let context = TestContext::new("batch_ingest_single_key");
+        let temp_dir = tempdir().unwrap();
+        let data_dir = temp_dir.path();
+        let mut table = crate::storage::mooncake_table::test_utils::test_table(
+            &context,
+            "t_single_key",
+            IdentityProp::SinglePrimitiveKey(0),
+        )
+        .await;
+
+        // Prepare two parquet files with known rows
+        let file1 = data_dir.join("file1.parquet");
+        let file2 = data_dir.join("file2.parquet");
+        let b1 = batch_with_rows(&[10, 11, 12]);
+        let b2 = batch_with_rows(&[20, 21, 22]);
+        write_parquet_file(&file1, &[b1.clone()]).await;
+        write_parquet_file(&file2, &[b2.clone()]).await;
+
+        let lsn = 200u64;
+        table
+            .batch_ingest(
+                vec![
+                    file1.to_string_lossy().to_string(),
+                    file2.to_string_lossy().to_string(),
+                ],
+                lsn,
+            )
+            .await;
+
+        // Commit enqueued and index attached
+        let (mut flushed_files, mut indices) = match &table.next_snapshot_task.new_streaming_xact[0]
+        {
+            TransactionStreamOutput::Abort(_) => panic!("unexpected abort"),
+            TransactionStreamOutput::Commit(commit) => {
+                (commit.get_flushed_data_files(), commit.get_file_indices())
+            }
+        };
+        flushed_files.sort_by_key(|f| f.file_path().clone());
+        assert_eq!(flushed_files.len(), 2);
+        assert_eq!(indices.len(), 1);
+
+        // Validate index can look up a couple of keys across files
+        let index = indices.remove(0);
+        let rows_file1 = MoonlinkRow::from_record_batch(&b1);
+        let rows_file2 = MoonlinkRow::from_record_batch(&b2);
+        let key1 = IdentityProp::SinglePrimitiveKey(0).get_lookup_key(&rows_file1[0]);
+        let key2 = IdentityProp::SinglePrimitiveKey(0).get_lookup_key(&rows_file2[2]);
+        let lookups = crate::storage::index::persisted_bucket_hash_map::GlobalIndex::prepare_hashes_for_lookup(
+            vec![key1, key2].into_iter(),
+        );
+        let results = index.search_values(&lookups).await;
+        let file_ids: Vec<_> = flushed_files.iter().map(|f| f.file_id()).collect();
+        assert!(results.contains(&(key1, RecordLocation::DiskFile(file_ids[0], 0))));
+        assert!(results.contains(&(key2, RecordLocation::DiskFile(file_ids[1], 2))));
+    }
+
+    #[tokio::test]
+    async fn test_batch_ingest_builds_index_for_keys_identity() {
+        let context = TestContext::new("batch_ingest_keys");
+        let temp_dir = tempdir().unwrap();
+        let data_dir = temp_dir.path();
+        let mut table = crate::storage::mooncake_table::test_utils::test_table(
+            &context,
+            "t_keys",
+            IdentityProp::Keys(vec![0]),
+        )
+        .await;
+
+        let file1 = data_dir.join("file1.parquet");
+        let file2 = data_dir.join("file2.parquet");
+        let b1 = batch_with_rows(&[101, 102]);
+        let b2 = batch_with_rows(&[201, 202]);
+        write_parquet_file(&file1, &[b1.clone()]).await;
+        write_parquet_file(&file2, &[b2.clone()]).await;
+
+        table
+            .batch_ingest(
+                vec![
+                    file1.to_string_lossy().to_string(),
+                    file2.to_string_lossy().to_string(),
+                ],
+                500,
+            )
+            .await;
+
+        let (files, mut indices) = match &table.next_snapshot_task.new_streaming_xact[0] {
+            TransactionStreamOutput::Commit(commit) => {
+                (commit.get_flushed_data_files(), commit.get_file_indices())
+            }
+            _ => panic!("unexpected"),
+        };
+        assert_eq!(files.len(), 2);
+        assert_eq!(indices.len(), 1);
+        let index = indices.remove(0);
+        let r1 = MoonlinkRow::from_record_batch(&b1);
+        let r2 = MoonlinkRow::from_record_batch(&b2);
+        let k1 = IdentityProp::Keys(vec![0]).get_lookup_key(&r1[0]);
+        let k2 = IdentityProp::Keys(vec![0]).get_lookup_key(&r2[1]);
+        let lookups = crate::storage::index::persisted_bucket_hash_map::GlobalIndex::prepare_hashes_for_lookup(
+            vec![k1, k2].into_iter(),
+        );
+        let results = index.search_values(&lookups).await;
+        let file_ids: Vec<_> = files.iter().map(|f| f.file_id()).collect();
+        assert!(results.contains(&(k1, RecordLocation::DiskFile(file_ids[0], 0))));
+        assert!(results.contains(&(k2, RecordLocation::DiskFile(file_ids[1], 1))));
+    }
+
+    #[tokio::test]
+    async fn test_batch_ingest_builds_index_for_fullrow_identity() {
+        let context = TestContext::new("batch_ingest_fullrow");
+        let temp_dir = tempdir().unwrap();
+        let data_dir = temp_dir.path();
+        let mut table = crate::storage::mooncake_table::test_utils::test_table(
+            &context,
+            "t_fullrow",
+            IdentityProp::FullRow,
+        )
+        .await;
+
+        let file1 = data_dir.join("file1.parquet");
+        let b1 = batch_with_rows(&[301, 302, 303]);
+        write_parquet_file(&file1, &[b1.clone()]).await;
+
+        table
+            .batch_ingest(vec![file1.to_string_lossy().to_string()], 600)
+            .await;
+
+        let (files, mut indices) = match &table.next_snapshot_task.new_streaming_xact[0] {
+            TransactionStreamOutput::Commit(commit) => {
+                (commit.get_flushed_data_files(), commit.get_file_indices())
+            }
+            _ => panic!("unexpected"),
+        };
+        assert_eq!(files.len(), 1);
+        assert_eq!(indices.len(), 1);
+        let index = indices.remove(0);
+        let rows = MoonlinkRow::from_record_batch(&b1);
+        let k = IdentityProp::FullRow.get_lookup_key(&rows[2]);
+        let lookups = crate::storage::index::persisted_bucket_hash_map::GlobalIndex::prepare_hashes_for_lookup(
+            vec![k].into_iter(),
+        );
+        let results = index.search_values(&lookups).await;
+        let file_id = files[0].file_id();
+        assert!(results.contains(&(k, RecordLocation::DiskFile(file_id, 2))));
+    }
+
+    #[tokio::test]
+    async fn test_batch_ingest_index_build_failure_proceeds_without_index() {
+        let context = TestContext::new("batch_ingest_index_fail");
+        let temp_dir = tempdir().unwrap();
+        let data_dir = temp_dir.path();
+        let mut table = crate::storage::mooncake_table::test_utils::test_table(
+            &context,
+            "t_keys",
+            IdentityProp::Keys(vec![0]),
+        )
+        .await;
+
+        // Prepare one parquet file
+        let file1 = data_dir.join("file1.parquet");
+        let b1 = batch_with_rows(&[1, 2, 3]);
+        write_parquet_file(&file1, &[b1]).await;
+
+        // Remove the table directory so index block file creation fails
+        let table_dir = context.path();
+        tokio::fs::remove_dir_all(&table_dir).await.unwrap();
+
+        table
+            .batch_ingest(vec![file1.to_string_lossy().to_string()], 300)
+            .await;
+
+        match &table.next_snapshot_task.new_streaming_xact[0] {
+            TransactionStreamOutput::Abort(_) => panic!("unexpected abort"),
+            TransactionStreamOutput::Commit(commit) => {
+                assert_eq!(commit.get_flushed_data_files().len(), 1);
+                // Index build should have failed and been skipped
+                assert!(commit.get_file_indices().is_empty());
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_batch_ingest_empty_input() {
+        let context = TestContext::new("batch_ingest_empty");
+        let mut table = crate::storage::mooncake_table::test_utils::test_table(
+            &context,
+            "t_empty",
+            IdentityProp::Keys(vec![0]),
+        )
+        .await;
+
+        table.batch_ingest(vec![], 400).await;
+
+        match &table.next_snapshot_task.new_streaming_xact[0] {
+            TransactionStreamOutput::Abort(_) => panic!("unexpected abort"),
+            TransactionStreamOutput::Commit(commit) => {
+                assert_eq!(commit.get_flushed_data_files().len(), 0);
+                let indices = commit.get_file_indices();
+                if indices.is_empty() {
+                    // ok: no index attached
+                } else {
+                    // ok: identity set; empty index may be attached
+                    assert_eq!(indices.len(), 1);
+                    let idx = &indices[0];
+                    assert_eq!(idx.files.len(), 0);
+                    assert_eq!(idx.num_rows, 0);
+                }
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_batch_ingest_empty_input_append_only() {
+        let context = TestContext::new("batch_ingest_empty_append_only");
+        let mut table = crate::storage::mooncake_table::test_utils::test_append_only_table(
+            &context,
+            "t_empty_append_only",
+        )
+        .await;
+
+        table.batch_ingest(vec![], 700).await;
+
+        match &table.next_snapshot_task.new_streaming_xact[0] {
+            TransactionStreamOutput::Commit(commit) => {
+                assert_eq!(commit.get_flushed_data_files().len(), 0);
+                assert!(commit.get_file_indices().is_empty());
+            }
+            _ => panic!("unexpected"),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_batch_ingest_empty_input_with_identity() {
+        let context = TestContext::new("batch_ingest_empty_identity");
+        let mut table = crate::storage::mooncake_table::test_utils::test_table(
+            &context,
+            "t_empty_identity",
+            IdentityProp::Keys(vec![0]),
+        )
+        .await;
+
+        table.batch_ingest(vec![], 800).await;
+
+        match &table.next_snapshot_task.new_streaming_xact[0] {
+            TransactionStreamOutput::Commit(commit) => {
+                assert_eq!(commit.get_flushed_data_files().len(), 0);
+                let indices = commit.get_file_indices();
+                if indices.is_empty() {
+                    // ok
+                } else {
+                    assert_eq!(indices.len(), 1);
+                    let idx = &indices[0];
+                    assert_eq!(idx.files.len(), 0);
+                    assert_eq!(idx.num_rows, 0);
+                }
+            }
+            _ => panic!("unexpected"),
+        }
+    }
+}

--- a/src/moonlink/src/storage/mooncake_table/batch_ingestion.rs
+++ b/src/moonlink/src/storage/mooncake_table/batch_ingestion.rs
@@ -5,8 +5,12 @@ use crate::{
 use super::*;
 
 use futures::{stream, StreamExt};
-use parquet::arrow::ParquetRecordBatchStreamBuilder;
+use parquet::arrow::async_reader::ParquetRecordBatchStreamBuilder;
+use parquet::arrow::ProjectionMask;
+use std::path::PathBuf;
 use tokio::fs::File;
+
+use crate::storage::index::persisted_bucket_hash_map::GlobalIndexBuilder;
 
 impl MooncakeTable {
     /// Batch ingestion the given [`parquet_files`] into mooncake table.
@@ -55,11 +59,72 @@ impl MooncakeTable {
         .await;
 
         // Commit the current crafted streaming transaction.
-        let commit = TransactionStreamCommit::from_disk_files(disk_files, lsn);
+        let mut commit = TransactionStreamCommit::from_disk_files(disk_files, lsn);
+
+        // Build file index if needed (skip for append-only tables)
+        if !matches!(self.metadata.identity, IdentityProp::None) {
+            // Clone owned inputs needed for async build without capturing &self.
+            let files = commit.get_flushed_data_files();
+            let identity = self.metadata.identity.clone();
+            let table_dir: PathBuf = self.metadata.path.clone();
+            let index_file_id = self.next_file_id as u64;
+
+            if let Ok(file_index) =
+                Self::build_index_for_files(files, identity, table_dir, index_file_id).await
+            {
+                commit.add_file_index(file_index);
+            } else {
+                tracing::error!(
+                    "failed to build file index for batch_ingest; proceeding without index"
+                );
+            }
+        }
+
         self.next_snapshot_task
             .new_streaming_xact
             .push(TransactionStreamOutput::Commit(commit));
         self.next_snapshot_task.new_flush_lsn = Some(lsn);
         self.next_snapshot_task.commit_lsn_baseline = lsn;
+    }
+
+    /// Build a single GlobalIndex spanning `files` by scanning Parquet with identity projection.
+    async fn build_index_for_files(
+        files: Vec<MooncakeDataFileRef>,
+        identity: IdentityProp,
+        table_dir: PathBuf,
+        index_file_id: u64,
+    ) -> Result<FileIndex> {
+        // Accumulate (hash, seg_idx, row_idx)
+        let mut entries: Vec<(u64, usize, usize)> = Vec::new();
+
+        for (seg_idx, data_file) in files.iter().enumerate() {
+            let file = tokio::fs::File::open(data_file.file_path()).await?;
+            let mut stream_builder = ParquetRecordBatchStreamBuilder::new(file).await?;
+            let schema_descr = stream_builder.metadata().file_metadata().schema_descr();
+            let indices = identity.get_key_indices(schema_descr.num_columns());
+            let mask = ProjectionMask::roots(schema_descr, indices);
+            stream_builder = stream_builder.with_projection(mask);
+
+            let mut reader = stream_builder.build()?;
+            let mut row_idx_within_file: usize = 0;
+            while let Some(row_group_reader) = reader.next_row_group().await? {
+                let mut batch_stream = row_group_reader;
+                while let Some(batch) = batch_stream.next().transpose()? {
+                    let rows = MoonlinkRow::from_record_batch(&batch);
+                    for row in rows {
+                        let hash = identity.get_lookup_key(&row);
+                        entries.push((hash, seg_idx, row_idx_within_file));
+                        row_idx_within_file += 1;
+                    }
+                }
+            }
+        }
+
+        // Build index blocks and attach data files
+        let mut builder = GlobalIndexBuilder::new();
+        builder.set_directory(table_dir);
+        builder.set_files(files);
+        let index = builder.build_from_flush(entries, index_file_id).await?;
+        Ok(index)
     }
 }

--- a/src/moonlink/src/storage/mooncake_table/batch_ingestion.rs
+++ b/src/moonlink/src/storage/mooncake_table/batch_ingestion.rs
@@ -62,10 +62,10 @@ impl MooncakeTable {
         let mut commit = TransactionStreamCommit::from_disk_files(disk_files, lsn);
 
         // Build file index if needed (skip for append-only tables)
-        if !matches!(self.metadata.identity, IdentityProp::None) {
+        if !matches!(self.metadata.config.row_identity, IdentityProp::None) {
             // Clone owned inputs needed for async build without capturing &self.
             let files = commit.get_flushed_data_files();
-            let identity = self.metadata.identity.clone();
+            let identity = self.metadata.config.row_identity.clone();
             let table_dir: PathBuf = self.metadata.path.clone();
             let index_file_id = self.next_file_id as u64;
 

--- a/src/moonlink/src/storage/mooncake_table/data_batches.rs
+++ b/src/moonlink/src/storage/mooncake_table/data_batches.rs
@@ -143,7 +143,7 @@ impl ColumnStoreBuffer {
     /// finalize it and start a new one.
     ///
     #[allow(clippy::type_complexity)]
-    pub fn append_row(
+    pub(super) fn append_row(
         &mut self,
         row: MoonlinkRow,
     ) -> Result<(u64, usize, Option<(u64, Arc<RecordBatch>)>)> {

--- a/src/moonlink/src/storage/mooncake_table/data_batches.rs
+++ b/src/moonlink/src/storage/mooncake_table/data_batches.rs
@@ -2,6 +2,7 @@ use crate::error::Result;
 use crate::row::ColumnArrayBuilder;
 use crate::row::IdentityProp;
 use crate::row::MoonlinkRow;
+use crate::row::RowValue;
 use crate::storage::mooncake_table::batch_id_counter::BatchIdCounter;
 use crate::storage::mooncake_table::delete_vector::BatchDeletionVector;
 use crate::storage::mooncake_table::shared_array::SharedRowBuffer;
@@ -12,7 +13,7 @@ use arrow_schema::Schema;
 use std::sync::Arc;
 
 #[derive(Clone, Debug)]
-pub(super) struct InMemoryBatch {
+pub struct InMemoryBatch {
     pub(super) data: Option<Arc<RecordBatch>>,
     pub(super) deletions: BatchDeletionVector,
 }
@@ -61,7 +62,7 @@ pub(super) struct BatchEntry {
 
 /// A streaming buffered writer for column-oriented data.
 /// Creates new buffers when the current one is full and links them together.
-pub(super) struct ColumnStoreBuffer {
+pub struct ColumnStoreBuffer {
     /// The Arrow schema defining the structure of the data
     schema: Arc<Schema>,
     /// Maximum number of rows per buffer before creating a new one
@@ -80,7 +81,7 @@ pub(super) struct ColumnStoreBuffer {
 impl ColumnStoreBuffer {
     /// Initialize a new column store buffer with the given schema and buffer size.
     ///
-    pub(super) fn new(
+    pub fn new(
         schema: Arc<Schema>,
         max_rows_per_buffer: usize,
         batch_id_counter: Arc<BatchIdCounter>,
@@ -110,11 +111,39 @@ impl ColumnStoreBuffer {
         }
     }
 
+    /// Append a row for initial copy (append-only, no deletions).
+    /// Skips MoonlinkRow creation and SharedRowBuffer since no deletions occur.
+    /// Returns (batch_id, row_offset, optional_finished_batch).
+    #[allow(clippy::type_complexity)]
+    pub fn append_initial_copy_row(
+        &mut self,
+        values: Vec<RowValue>,
+    ) -> Result<(u64, usize, Option<(u64, Arc<RecordBatch>)>)> {
+        let mut new_batch: Option<(u64, Arc<RecordBatch>)> = None;
+        // Check if we need to finalize the current batch
+        if self.current_row_count >= self.max_rows_per_buffer {
+            new_batch = self.finalize_current_batch()?;
+        }
+
+        // Append values directly to builders - no MoonlinkRow needed
+        values.iter().enumerate().for_each(|(i, cell)| {
+            let _res = self.current_batch_builder[i].append_value(cell);
+            assert!(_res.is_ok());
+        });
+        self.current_row_count += 1;
+
+        Ok((
+            self.in_memory_batches.last().unwrap().id,
+            self.current_row_count - 1,
+            new_batch,
+        ))
+    }
+
     /// Append a row of data to the buffer. If the current buffer is full,
     /// finalize it and start a new one.
     ///
     #[allow(clippy::type_complexity)]
-    pub(super) fn append_row(
+    pub fn append_row(
         &mut self,
         row: MoonlinkRow,
     ) -> Result<(u64, usize, Option<(u64, Arc<RecordBatch>)>)> {
@@ -140,7 +169,7 @@ impl ColumnStoreBuffer {
 
     /// Finalize the current batch, adding it to filled_batches and preparing for a new batch
     ///
-    pub(super) fn finalize_current_batch(&mut self) -> Result<Option<(u64, Arc<RecordBatch>)>> {
+    pub fn finalize_current_batch(&mut self) -> Result<Option<(u64, Arc<RecordBatch>)>> {
         if self.current_row_count == 0 {
             return Ok(None);
         }

--- a/src/moonlink/src/storage/mooncake_table/test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/test_utils.rs
@@ -96,6 +96,30 @@ pub async fn test_table(
     .unwrap()
 }
 
+pub async fn test_append_only_table(context: &TestContext, table_name: &str) -> MooncakeTable {
+    // Append-only table requires IdentityProp::None and append_only=true
+    let iceberg_table_config = test_iceberg_table_config(context, table_name);
+    let mut table_config = test_mooncake_table_config(context);
+    table_config.batch_size = 2;
+    table_config.append_only = true;
+    let wal_config = WalConfig::default_wal_config_local(WAL_TEST_TABLE_ID, &context.path());
+    let wal_manager = WalManager::new(&wal_config);
+    MooncakeTable::new(
+        (*create_test_arrow_schema()).clone(),
+        table_name.to_string(),
+        1,
+        context.path(),
+        IdentityProp::None,
+        iceberg_table_config.clone(),
+        table_config,
+        wal_manager,
+        create_test_object_storage_cache(&context.temp_dir),
+        create_test_filesystem_accessor(&iceberg_table_config),
+    )
+    .await
+    .unwrap()
+}
+
 pub fn read_ids_from_parquet(file_path: &String) -> Vec<Option<i32>> {
     let file = File::open(file_path).unwrap();
     let reader = ParquetRecordBatchReaderBuilder::try_new(file)

--- a/src/moonlink/src/storage/mooncake_table/test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/test_utils.rs
@@ -102,6 +102,7 @@ pub async fn test_append_only_table(context: &TestContext, table_name: &str) -> 
     let mut table_config = test_mooncake_table_config(context);
     table_config.batch_size = 2;
     table_config.append_only = true;
+    table_config.row_identity = IdentityProp::None;
     let wal_config = WalConfig::default_wal_config_local(WAL_TEST_TABLE_ID, &context.path());
     let wal_manager = WalManager::new(&wal_config);
     MooncakeTable::new(
@@ -109,7 +110,6 @@ pub async fn test_append_only_table(context: &TestContext, table_name: &str) -> 
         table_name.to_string(),
         1,
         context.path(),
-        IdentityProp::None,
         iceberg_table_config.clone(),
         table_config,
         wal_manager,

--- a/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
+++ b/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
@@ -91,6 +91,10 @@ impl TransactionStreamCommit {
     pub(crate) fn get_file_indices(&self) -> Vec<FileIndex> {
         self.flushed_file_index.file_indices.clone()
     }
+    /// Attach a file index so snapshot can integrate it immediately.
+    pub(crate) fn add_file_index(&mut self, index: FileIndex) {
+        self.flushed_file_index.file_indices.push(index);
+    }
     /// Import file index into cache.
     /// Return evicted files to delete.
     pub(crate) async fn import_file_index_into_cache(

--- a/src/moonlink/src/storage/parquet_utils.rs
+++ b/src/moonlink/src/storage/parquet_utils.rs
@@ -19,7 +19,7 @@ fn get_default_parquet_properties_builder() -> WriterPropertiesBuilder {
         .set_writer_version(parquet::file::properties::WriterVersion::PARQUET_1_0)
 }
 
-pub(crate) fn get_default_parquet_properties() -> WriterProperties {
+pub fn get_default_parquet_properties() -> WriterProperties {
     let builder = get_default_parquet_properties_builder();
     builder.build()
 }

--- a/src/moonlink/src/storage/wal.rs
+++ b/src/moonlink/src/storage/wal.rs
@@ -80,7 +80,6 @@ pub enum WalEvent {
         row: MoonlinkRow,
         xact_id: Option<u32>,
         lsn: u64,
-        is_copied: bool,
     },
     Delete {
         row: MoonlinkRow,
@@ -130,16 +129,11 @@ impl WalEvent {
     pub fn new(table_event: &TableEvent) -> Self {
         match table_event {
             TableEvent::Append {
-                row,
-                xact_id,
-                lsn,
-                is_copied,
-                ..
+                row, xact_id, lsn, ..
             } => WalEvent::Append {
                 row: row.clone(),
                 xact_id: *xact_id,
                 lsn: *lsn,
-                is_copied: *is_copied,
             },
             TableEvent::Delete {
                 row,
@@ -172,16 +166,10 @@ impl WalEvent {
 
     pub fn into_table_event(self) -> TableEvent {
         match self {
-            WalEvent::Append {
+            WalEvent::Append { row, xact_id, lsn } => TableEvent::Append {
                 row,
                 xact_id,
                 lsn,
-                is_copied,
-            } => TableEvent::Append {
-                row,
-                xact_id,
-                lsn,
-                is_copied,
                 is_recovery: false,
             },
             WalEvent::Delete {

--- a/src/moonlink/src/storage/wal/test_utils.rs
+++ b/src/moonlink/src/storage/wal/test_utils.rs
@@ -175,17 +175,15 @@ pub fn ingestion_events_equal(actual: &TableEvent, expected: &TableEvent) -> boo
                 row: row1,
                 lsn: lsn1,
                 xact_id: xact1,
-                is_copied: copied1,
                 ..
             },
             TableEvent::Append {
                 row: row2,
                 lsn: lsn2,
                 xact_id: xact2,
-                is_copied: copied2,
                 ..
             },
-        ) => row1 == row2 && lsn1 == lsn2 && xact1 == xact2 && copied1 == copied2,
+        ) => row1 == row2 && lsn1 == lsn2 && xact1 == xact2,
         (
             TableEvent::Delete {
                 row: row1,
@@ -306,7 +304,6 @@ pub async fn create_test_wal(wal_config: WalConfig) -> (WalManager, Vec<TableEve
             row: row.clone(),
             xact_id: None,
             lsn: 100 + i,
-            is_copied: false,
             is_recovery: false,
         };
 
@@ -349,7 +346,6 @@ pub fn add_new_example_append_event(
         row: test_row(1, "Alice", 30),
         lsn,
         xact_id,
-        is_copied: false,
         is_recovery: false,
     };
     wal.push(&event);

--- a/src/moonlink/src/table_handler.rs
+++ b/src/moonlink/src/table_handler.rs
@@ -783,7 +783,7 @@ impl TableHandler {
             return;
         }
 
-        if !event.is_recovery() && !is_initial_copy_event {
+        if !event.is_recovery() {
             table.push_wal_event(&event);
         }
 

--- a/src/moonlink/src/table_handler.rs
+++ b/src/moonlink/src/table_handler.rs
@@ -11,7 +11,6 @@
 use crate::event_sync::EventSyncSender;
 use crate::storage::mooncake_table::replay::replay_events::MooncakeTableEvent;
 use crate::storage::mooncake_table::AlterTableRequest;
-use crate::storage::mooncake_table::INITIAL_COPY_XACT_ID;
 use crate::storage::snapshot_options::IcebergSnapshotOption;
 use crate::storage::snapshot_options::MaintenanceOption;
 use crate::storage::snapshot_options::SnapshotOption;
@@ -349,14 +348,6 @@ impl TableHandler {
                     }
                     TableEvent::FinishInitialCopy { start_lsn } => {
                         debug!("finishing initial copy");
-                        let event_id = uuid::Uuid::new_v4();
-                        if let Err(e) = table.commit_transaction_stream(
-                            INITIAL_COPY_XACT_ID,
-                            start_lsn,
-                            event_id,
-                        ) {
-                            error!(error = %e, "failed to finish initial copy");
-                        }
                         // Force create the snapshot with LSN `start_lsn`
                         assert!(table.create_snapshot(SnapshotOption {
                             uuid: uuid::Uuid::new_v4(),
@@ -778,51 +769,24 @@ impl TableHandler {
         // Replication events
         // ==============================
         //
-        let is_initial_copy_event = matches!(
-            event,
-            TableEvent::Append {
-                is_copied: true,
-                ..
-            }
-        );
-
-        if table_handler_state.is_in_blocking_state() && !is_initial_copy_event {
+        if table_handler_state.special_table_state == SpecialTableState::InitialCopy {
             table_handler_state.initial_copy_buffered_events.push(event);
             return;
         }
         // Don't update the lsn if the event is not processed yet.
         table_handler_state.update_table_lsns(&event);
 
-        // In the case that this is an initial copy event we actually expect the LSN to be less than the initial persistence LSN, hence we don't discard it.
-        if table_handler_state.should_discard_event(&event)
-            && !is_initial_copy_event
-            && !event.is_recovery()
-        {
+        // Discard events that we have already processed.
+        if table_handler_state.should_discard_event(&event) && !event.is_recovery() {
             return;
         }
-        assert_eq!(
-            is_initial_copy_event,
-            table_handler_state.special_table_state == SpecialTableState::InitialCopy
-        );
 
         if !event.is_recovery() && !is_initial_copy_event {
             table.push_wal_event(&event);
         }
 
         match event {
-            TableEvent::Append {
-                is_copied,
-                row,
-                xact_id,
-                ..
-            } => {
-                if is_copied {
-                    if let Err(e) = table.append_in_stream_batch(row, INITIAL_COPY_XACT_ID) {
-                        error!(error = %e, "failed to append row");
-                    }
-                    return;
-                }
-
+            TableEvent::Append { row, xact_id, .. } => {
                 let result = match xact_id {
                     Some(xact_id) => {
                         let res = table.append_in_stream_batch(row, xact_id);

--- a/src/moonlink/src/table_handler.rs
+++ b/src/moonlink/src/table_handler.rs
@@ -769,7 +769,9 @@ impl TableHandler {
         // Replication events
         // ==============================
         //
-        if table_handler_state.special_table_state == SpecialTableState::InitialCopy {
+
+        // If the table is in a blocking state, buffer the event.
+        if table_handler_state.is_in_blocking_state() {
             table_handler_state.initial_copy_buffered_events.push(event);
             return;
         }

--- a/src/moonlink/src/table_handler/chaos_test.rs
+++ b/src/moonlink/src/table_handler/chaos_test.rs
@@ -645,7 +645,6 @@ impl ChaosState {
                     row,
                     xact_id: self.get_cur_xact_id(),
                     lsn: self.get_and_update_cur_lsn(),
-                    is_copied: false,
                     is_recovery: false,
                 }])
             }
@@ -656,7 +655,6 @@ impl ChaosState {
                     row,
                     xact_id: self.get_cur_xact_id(),
                     lsn: self.get_and_update_cur_lsn(),
-                    is_copied: false,
                     is_recovery: false,
                 }])
             }
@@ -664,7 +662,6 @@ impl ChaosState {
                 row: self.get_next_row_to_append(),
                 xact_id: self.get_cur_xact_id(),
                 lsn: self.get_and_update_cur_lsn(),
-                is_copied: false,
                 is_recovery: false,
             }]),
             EventKind::Delete => ChaosEvent::create_table_events(vec![TableEvent::Delete {
@@ -688,7 +685,6 @@ impl ChaosState {
                         row: row.clone(),
                         xact_id: self.get_cur_xact_id(),
                         lsn: self.get_and_update_cur_lsn(),
-                        is_copied: false,
                         is_recovery: false,
                     },
                 ])

--- a/src/moonlink/src/table_handler/table_handler_state.rs
+++ b/src/moonlink/src/table_handler/table_handler_state.rs
@@ -241,6 +241,10 @@ impl TableHandlerState {
         }
     }
 
+    pub(crate) fn is_in_blocking_state(&self) -> bool {
+        self.special_table_state != SpecialTableState::Normal
+    }
+
     /// Get the largest LSN where all updates have been persisted into iceberg.
     /// The difference between "persisted table LSN" and "iceberg snapshot LSN" is, suppose we have two tables, table A has persisted all changes to iceberg with flush LSN-1;
     /// if there're no further updates to the table A, meanwhile there're updates to table B with LSN-2, flush LSN-1 actually represents a consistent view of LSN-2.

--- a/src/moonlink/src/table_handler/table_handler_state.rs
+++ b/src/moonlink/src/table_handler/table_handler_state.rs
@@ -241,10 +241,6 @@ impl TableHandlerState {
         }
     }
 
-    pub(crate) fn is_in_blocking_state(&self) -> bool {
-        self.special_table_state != SpecialTableState::Normal
-    }
-
     /// Get the largest LSN where all updates have been persisted into iceberg.
     /// The difference between "persisted table LSN" and "iceberg snapshot LSN" is, suppose we have two tables, table A has persisted all changes to iceberg with flush LSN-1;
     /// if there're no further updates to the table A, meanwhile there're updates to table B with LSN-2, flush LSN-1 actually represents a consistent view of LSN-2.

--- a/src/moonlink/src/table_handler/test_utils.rs
+++ b/src/moonlink/src/table_handler/test_utils.rs
@@ -233,7 +233,6 @@ impl TestEnvironment {
         );
         let row = create_row(id, name, age);
         let event = TableEvent::Append {
-            is_copied: false,
             row,
             lsn,
             xact_id,

--- a/src/moonlink/src/table_handler/tests.rs
+++ b/src/moonlink/src/table_handler/tests.rs
@@ -2420,25 +2420,24 @@ async fn test_initial_copy_iceberg_ack_without_wal() {
     assert_eq!(*flush_lsn_rx.borrow(), 0);
     assert_eq!(*env.wal_flush_lsn_rx.borrow(), 0);
 
-    // Start initial copy and emit a copied row (should not go to WAL)
+    // Start initial copy (enter blocking state for CDC events)
     sender
         .send(TableEvent::StartInitialCopy)
         .await
         .expect("send start initial copy");
 
+    // Simulate initial copy by generating a parquet file and sending LoadFiles
+    let start_lsn = 42u64;
+    let file_path = generate_parquet_file(&env.temp_dir, "init_copy.parquet").await;
     sender
-        .send(TableEvent::Append {
-            row: create_row(10, "InitCopy", 1),
-            xact_id: None,
-            lsn: 0,
-            is_copied: true,
-            is_recovery: false,
+        .send(TableEvent::LoadFiles {
+            files: vec![file_path],
+            lsn: start_lsn,
         })
         .await
-        .expect("send copied row");
+        .expect("send LoadFiles");
 
-    // Finish initial copy with a start LSN and ensure iceberg snapshot completes
-    let start_lsn = 42u64;
+    // Finish initial copy; this triggers an iceberg snapshot (BestEffort) at start_lsn
     sender
         .send(TableEvent::FinishInitialCopy { start_lsn })
         .await
@@ -2453,8 +2452,11 @@ async fn test_initial_copy_iceberg_ack_without_wal() {
         flush_lsn_rx.changed().await.unwrap();
     }
 
-    // WAL flush LSN should still be zero since initial copy events bypass WAL
+    // WAL flush LSN should still be zero since initial copy bypasses WAL
     assert_eq!(*env.wal_flush_lsn_rx.borrow(), 0);
+
+    // Verify the snapshot contains the rows from the parquet (ids 1,2,3)
+    env.verify_snapshot(start_lsn, &[1, 2, 3]).await;
 
     env.shutdown().await;
 }

--- a/src/moonlink/src/table_handler/tests.rs
+++ b/src/moonlink/src/table_handler/tests.rs
@@ -1286,7 +1286,6 @@ async fn test_initial_copy_basic() {
             row: create_row(1, "Alice", 30),
             xact_id: None,
             lsn: 5,
-            is_copied: true,
             is_recovery: false,
         })
         .await

--- a/src/moonlink/src/table_handler/tests.rs
+++ b/src/moonlink/src/table_handler/tests.rs
@@ -2396,7 +2396,6 @@ async fn test_alter_table() {
     .await;
 
     env.send_event(TableEvent::Append {
-        is_copied: false,
         row: MoonlinkRow::new(vec![RowValue::Int32(2), RowValue::Int32(30)]),
         lsn: 1,
         xact_id: None,

--- a/src/moonlink/src/table_notify.rs
+++ b/src/moonlink/src/table_notify.rs
@@ -69,7 +69,6 @@ pub enum TableEvent {
         row: MoonlinkRow,
         xact_id: Option<u32>,
         lsn: u64,
-        is_copied: bool,
         is_recovery: bool,
     },
     /// Delete a row from the table

--- a/src/moonlink_connectors/src/pg_replicate.rs
+++ b/src/moonlink_connectors/src/pg_replicate.rs
@@ -3,6 +3,7 @@
 pub mod clients;
 pub mod conversions;
 pub mod initial_copy;
+pub mod initial_copy_writer;
 pub mod moonlink_sink;
 pub mod postgres_source;
 pub mod table;
@@ -11,7 +12,7 @@ pub mod util;
 
 use crate::pg_replicate::clients::postgres::{build_tls_connector, ReplicationClient};
 use crate::pg_replicate::conversions::cdc_event::{CdcEvent, CdcEventConversionError};
-use crate::pg_replicate::initial_copy::copy_table_stream_impl;
+use crate::pg_replicate::initial_copy::copy_table_stream;
 use crate::pg_replicate::moonlink_sink::{SchemaChangeRequest, Sink};
 use crate::pg_replicate::postgres_source::{
     CdcStreamConfig, CdcStreamError, PostgresSource, PostgresSourceError,
@@ -253,7 +254,8 @@ impl PostgresConnection {
                 .get_table_copy_stream(&schema.table_name, &schema.column_schemas)
                 .await
                 .expect("failed to get table copy stream");
-            let res = copy_table_stream_impl(schema.clone(), stream, &event_sender).await;
+            let res =
+                copy_table_stream(schema.clone(), stream, &event_sender, start_lsn.into()).await;
 
             if let Err(e) = res {
                 error!(error = ?e, table_id = src_table_id, "failed to copy table");

--- a/src/moonlink_connectors/src/pg_replicate.rs
+++ b/src/moonlink_connectors/src/pg_replicate.rs
@@ -254,8 +254,14 @@ impl PostgresConnection {
                 .get_table_copy_stream(&schema.table_name, &schema.column_schemas)
                 .await
                 .expect("failed to get table copy stream");
-            let res =
-                copy_table_stream(schema.clone(), stream, &event_sender, start_lsn.into()).await;
+            let res = copy_table_stream(
+                schema.clone(),
+                stream,
+                &event_sender,
+                start_lsn.into(),
+                None,
+            )
+            .await;
 
             if let Err(e) = res {
                 error!(error = ?e, table_id = src_table_id, "failed to copy table");

--- a/src/moonlink_connectors/src/pg_replicate/initial_copy.rs
+++ b/src/moonlink_connectors/src/pg_replicate/initial_copy.rs
@@ -1,9 +1,15 @@
+use crate::pg_replicate::initial_copy_writer::{
+    create_batch_channel, ArrowBatchBuilder, InitialCopyWriterConfig, ParquetFileWriter,
+};
 use crate::pg_replicate::postgres_source::{PostgresSource, TableCopyStream};
 use crate::pg_replicate::table::{ColumnSchema, LookupKey, SrcTableId, TableName, TableSchema};
-use crate::pg_replicate::util::PostgresTableRow;
+use crate::pg_replicate::util::postgres_schema_to_moonlink_schema;
 use crate::Result;
 use futures::{pin_mut, Stream, StreamExt};
 use moonlink::TableEvent;
+use moonlink_error::ErrorStatus;
+use moonlink_error::ErrorStruct;
+use std::path::Path;
 use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
 use tokio::task::JoinHandle;
@@ -20,74 +26,94 @@ pub struct CopyProgress {
 }
 
 /// Reads rows from `stream` and sends them to the provided `event_sender`.
-pub async fn copy_table_stream_impl(
-    table_schema: TableSchema,
-    mut stream: TableCopyStream,
-    event_sender: &Sender<TableEvent>,
-) -> Result<CopyProgress> {
-    // `TableEvent::Append` events. These events must be written to the
-    // Mooncake table via `event_sender`.
-    // TODO: periodically report progress and
-    // support cancellation / restart.
-    pin_mut!(stream);
-    let mut rows_copied = 0u64;
-    while let Some(row) = stream.next().await {
-        let row = row?;
-        if let Err(e) = event_sender
-            .send(TableEvent::Append {
-                row: PostgresTableRow(row).into(),
-                xact_id: None,
-                lsn: 0,
-                is_copied: true,
-                is_recovery: false,
-            })
-            .await
-        {
-            tracing::warn!(error = ?e, "failed to send copied row event");
-        }
-        rows_copied += 1;
-    }
-
-    Ok(CopyProgress {
-        last_lsn: PgLsn::from(0),
-        rows_copied,
-    })
-}
-
-/// Generic version for testing
-#[cfg(test)]
 pub async fn copy_table_stream<S>(
     table_schema: TableSchema,
     mut stream: S,
-    event_sender: Sender<TableEvent>,
+    event_sender: &Sender<TableEvent>,
+    start_lsn: u64,
 ) -> Result<CopyProgress>
 where
-    S: Stream<Item = Result<crate::pg_replicate::conversions::table_row::TableRow>> + Unpin,
+    S: Stream<
+        Item = std::result::Result<
+            crate::pg_replicate::conversions::table_row::TableRow,
+            crate::pg_replicate::postgres_source::TableCopyStreamError,
+        >,
+    >,
 {
-    // `TableEvent::Append` events. These events must be written to the
-    // Mooncake table via `event_sender`.
-    // TODO: periodically report progress and
-    // support cancellation / restart.
+    // Convert PostgreSQL schema to Arrow schema
+    let (arrow_schema, _identity_prop) = postgres_schema_to_moonlink_schema(&table_schema);
+    let arrow_schema = Arc::new(arrow_schema);
+
+    // Create output directory for initial copy files
+    let output_dir = std::env::temp_dir()
+        .join("moonlink_initial_copy")
+        .join(format!("table_{}", table_schema.src_table_id));
+
+    // Create batch channel for RecordBatches
+    let (batch_tx, batch_rx) = create_batch_channel(16); // Channel capacity of 16
+
+    let config = InitialCopyWriterConfig::default();
+
+    // Create Arrow batch builder
+    let mut batch_builder = ArrowBatchBuilder::new(arrow_schema.clone(), config.max_rows_per_batch);
+
+    // Create and spawn Parquet file writer
+    let parquet_writer = ParquetFileWriter {
+        output_dir,
+        schema: arrow_schema,
+        config,
+    };
+    let writer_handle =
+        tokio::spawn(async move { parquet_writer.write_from_channel(batch_rx).await });
+
+    // Stream rows into batches
+    pin_mut!(stream);
     let mut rows_copied = 0u64;
     while let Some(row) = stream.next().await {
-        let row = row?;
-        if let Err(e) = event_sender
-            .send(TableEvent::Append {
-                row: PostgresTableRow(row).into(),
-                xact_id: None,
-                lsn: 0,
-                is_copied: true,
-                is_recovery: false,
-            })
-            .await
-        {
-            tracing::warn!(error = ?e, "failed to send copied row event");
+        let row = row.map_err(|e| crate::Error::from(e))?;
+
+        // Append row to batch builder and check if a batch is ready
+        if let Some(finished_batch) = batch_builder.append_table_row(row)? {
+            if let Err(e) = batch_tx.send(finished_batch).await {
+                tracing::error!(error = ?e, "failed to send batch to Parquet writer");
+                break;
+            }
         }
         rows_copied += 1;
     }
 
+    // Finalize any remaining batch
+    if let Some(final_batch) = batch_builder.finish()? {
+        if let Err(e) = batch_tx.send(final_batch).await {
+            tracing::error!(error = ?e, "failed to send final batch to Parquet writer");
+        }
+    }
+
+    // Close channel to signal writer completion
+    drop(batch_tx);
+
+    // Wait for writer to finish and get list of files written
+    let files_written = writer_handle.await??;
+
+    tracing::info!(
+        "Initial copy completed: {} rows, {} files written",
+        rows_copied,
+        files_written.len()
+    );
+
+    // Send LoadFiles event to batch ingest the Parquet files
+    if let Err(e) = event_sender
+        .send(TableEvent::LoadFiles {
+            files: files_written,
+            lsn: start_lsn,
+        })
+        .await
+    {
+        tracing::warn!(error = ?e, "failed to send LoadFiles event");
+    }
+
     Ok(CopyProgress {
-        last_lsn: PgLsn::from(0),
+        last_lsn: PgLsn::from(start_lsn),
         rows_copied,
     })
 }
@@ -95,12 +121,15 @@ where
 /// Tests for the initial copy functionality
 #[cfg(test)]
 mod tests {
+    use std::fs;
     use std::panic::Location;
+    use std::path::Path;
 
     use super::*;
     use crate::pg_replicate::table::{ColumnSchema, LookupKey, TableName};
     use futures::stream;
     use moonlink_error::ErrorStruct;
+    use tempfile;
     use tokio::sync::mpsc;
     use tokio::time::{timeout, Duration};
     use tokio_postgres::types::Type;
@@ -141,7 +170,7 @@ mod tests {
     }
 
     //----------------------------------------------------------------------
-    // 1. Happy-path – rows are forwarded and counted
+    // 1. Happy-path – emits LoadFiles
     //----------------------------------------------------------------------
 
     #[tokio::test]
@@ -162,69 +191,164 @@ mod tests {
 
         let (tx, mut rx) = mpsc::channel::<TableEvent>(8);
         let schema = make_test_schema("test");
+        let start_lsn = 1000u64;
 
-        let progress = copy_table_stream(schema, Box::pin(stream), tx)
+        let progress = copy_table_stream(schema, Box::pin(stream), &tx, start_lsn)
             .await
             .expect("copy failed");
 
         assert_eq!(progress.rows_copied, 3);
+        assert_eq!(progress.last_lsn, PgLsn::from(start_lsn));
 
-        for expected in 1..=3 {
-            let evt = timeout(Duration::from_millis(50), rx.recv())
-                .await
-                .expect("channel lag")
-                .expect("sender closed");
-            match evt {
-                TableEvent::Append { row, is_copied, .. } => {
-                    assert!(is_copied, "flag should be true");
-                    // Check that the row has the expected value
-                    // Since we can't easily test the internals of MoonlinkRow,
-                    // we just verify the event was received correctly
-                    assert!(
-                        matches!(row.values[0], moonlink::row::RowValue::Int32(v) if v == expected)
-                    );
-                }
-                _ => panic!("unexpected event {evt:?}"),
+        // Should receive LoadFiles event
+        let evt = timeout(Duration::from_millis(500), rx.recv())
+            .await
+            .expect("channel lag")
+            .expect("sender closed");
+        let files: Vec<String> = match evt {
+            TableEvent::LoadFiles { files, lsn } => {
+                assert_eq!(lsn, start_lsn);
+                assert!(!files.is_empty(), "should have written at least one file");
+                files
             }
+            _ => panic!("expected LoadFiles event, got {evt:?}"),
+        };
+        // Files exist
+        for f in &files {
+            assert!(std::path::Path::new(f).exists(), "file not found: {}", f);
         }
-        assert!(rx.recv().await.is_none(), "no extra events");
+
+        // Explicitly drop sender to close channel and avoid hanging
+        drop(tx);
+
+        // No more events
+        assert!(rx.recv().await.is_none(), "no extra events expected");
     }
 
     //----------------------------------------------------------------------
-    // 2. Empty snapshot – returns zero rows, sends nothing
+    // 2. Empty snapshot – emits LoadFiles(empty)
     //----------------------------------------------------------------------
 
     #[tokio::test]
     async fn test_handles_empty_stream() {
-        let stream = stream::iter(
-            vec![] as Vec<Result<crate::pg_replicate::conversions::table_row::TableRow>>
-        );
-        let (tx, mut rx) = mpsc::channel::<TableEvent>(1);
+        let stream = stream::iter(vec![]
+            as Vec<
+                std::result::Result<
+                    crate::pg_replicate::conversions::table_row::TableRow,
+                    crate::pg_replicate::postgres_source::TableCopyStreamError,
+                >,
+            >);
+        let (tx, mut rx) = mpsc::channel::<TableEvent>(8);
         let schema = make_test_schema("empty");
 
-        let progress = copy_table_stream(schema, Box::pin(stream), tx)
+        let progress = copy_table_stream(schema, Box::pin(stream), &tx, 0u64)
             .await
             .expect("copy failed");
         assert_eq!(progress.rows_copied, 0);
+
+        // LoadFiles(empty)
+        let evt = timeout(Duration::from_millis(500), rx.recv())
+            .await
+            .expect("channel lag")
+            .expect("sender closed");
+        match evt {
+            TableEvent::LoadFiles { files, lsn } => {
+                assert!(files.is_empty());
+                assert_eq!(lsn, 0);
+            }
+            _ => panic!("expected LoadFiles event"),
+        }
+
+        drop(tx);
         assert!(rx.recv().await.is_none(), "no events expected");
     }
 
     //----------------------------------------------------------------------
-    // 3. Stream error – bubbles up to the caller
+    // 3. Rotation – force multiple files via tiny config
+    //----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_writes_multiple_files_with_rotation() {
+        // Force tiny file size and small batches
+        let config = InitialCopyWriterConfig {
+            target_file_size_bytes: 1024, // ~1KB
+            max_rows_per_batch: 10,
+        };
+
+        // Build many rows
+        let mut rows_vec = Vec::new();
+        for i in 0..200 {
+            let tr = crate::pg_replicate::conversions::table_row::TableRow {
+                values: vec![crate::pg_replicate::conversions::Cell::I32(i)],
+            };
+            rows_vec.push(Ok(tr));
+        }
+        let stream = stream::iter(rows_vec);
+        let (tx, mut rx) = mpsc::channel::<TableEvent>(8);
+        let schema = make_test_schema("rotate");
+        let start_lsn = 42u64;
+
+        let _ = copy_table_stream(schema, Box::pin(stream), &tx, start_lsn)
+            .await
+            .expect("copy failed");
+
+        // LoadFiles with multiple files
+        let evt = timeout(Duration::from_millis(500), rx.recv())
+            .await
+            .expect("channel lag")
+            .expect("sender closed");
+        let files = match evt {
+            TableEvent::LoadFiles { files, lsn } => {
+                assert_eq!(lsn, start_lsn);
+                assert!(
+                    files.len() >= 2,
+                    "expected at least 2 files, got {}",
+                    files.len()
+                );
+                files
+            }
+            _ => panic!("expected LoadFiles"),
+        };
+        for f in &files {
+            assert!(std::path::Path::new(f).exists(), "file not found: {}", f);
+        }
+
+        drop(tx);
+
+        // No explicit no-more-events assertion here
+    }
+
+    //----------------------------------------------------------------------
+    // 4. Stream error – bubbles up to the caller
     //----------------------------------------------------------------------
 
     #[tokio::test]
     async fn test_propagates_stream_error() {
-        let boom = make_test_error();
-        let stream = stream::iter(vec![Err(boom)]);
+        // Use a conversion error that maps to our Error type
+        let stream = stream::iter(
+            vec![Err(crate::pg_replicate::postgres_source::TableCopyStreamError::ConversionError(
+                crate::pg_replicate::conversions::table_row::TableRowConversionError::UnterminatedRow,
+            ))]
+                as Vec<
+                    std::result::Result<
+                        crate::pg_replicate::conversions::table_row::TableRow,
+                        crate::pg_replicate::postgres_source::TableCopyStreamError,
+                    >,
+                >,
+        );
         let (tx, _) = mpsc::channel::<TableEvent>(1);
         let schema = make_test_schema("broken");
 
-        let err = copy_table_stream(schema, Box::pin(stream), tx)
+        let err = copy_table_stream(schema, Box::pin(stream), &tx, 0u64)
             .await
             .expect_err("expected failure");
 
         // Just verify we got an error - the exact format may vary
-        assert!(err.to_string().contains("Postgres source error"));
+        let err_str = err.to_string().to_lowercase();
+        assert!(
+            err_str.contains("unterminated row") || err_str.contains("conversion error"),
+            "unexpected error string: {}",
+            err.to_string()
+        );
     }
 }

--- a/src/moonlink_connectors/src/pg_replicate/initial_copy_writer.rs
+++ b/src/moonlink_connectors/src/pg_replicate/initial_copy_writer.rs
@@ -1,0 +1,182 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use arrow::datatypes::Schema;
+use arrow_array::RecordBatch;
+use moonlink_error::{ErrorStatus, ErrorStruct};
+use tokio::sync::mpsc;
+
+use crate::pg_replicate::conversions::table_row::TableRow;
+use crate::Result;
+use moonlink::row::RowValue;
+use moonlink::{BatchIdCounter, ColumnStoreBuffer, DiskSliceWriterConfig, MooncakeTableConfig};
+
+/// Configuration for initial-copy Parquet writing.
+#[derive(Clone, Debug)]
+pub struct InitialCopyWriterConfig {
+    /// Target max file size in bytes before rotating to a new Parquet file.
+    pub target_file_size_bytes: usize,
+    /// Max number of rows per Arrow RecordBatch before flushing to the writer.
+    pub max_rows_per_batch: usize,
+}
+
+impl Default for InitialCopyWriterConfig {
+    fn default() -> Self {
+        Self {
+            // Align with disk slice writer default parquet file size
+            target_file_size_bytes: DiskSliceWriterConfig::default_disk_slice_parquet_file_size(),
+            // Align batch size with mooncake table default batch size
+            max_rows_per_batch: MooncakeTableConfig::default_batch_size(),
+        }
+    }
+}
+
+/// Create a bounded channel for passing Arrow RecordBatches from table copy to writer.
+pub fn create_batch_channel(capacity: usize) -> (BatchSender, BatchReceiver) {
+    let (tx, rx) = mpsc::channel(capacity);
+    (BatchSender(tx), BatchReceiver(rx))
+}
+
+/// Sending end of the batch channel.
+pub struct BatchSender(mpsc::Sender<RecordBatch>);
+
+impl BatchSender {
+    /// Send a RecordBatch to the writer. Returns Err if the receiver is closed.
+    pub async fn send(&self, batch: RecordBatch) -> Result<()> {
+        self.0.send(batch).await.map_err(|_| {
+            crate::Error::MpscChannelSendError(ErrorStruct::new(
+                "batch sender closed".to_string(),
+                ErrorStatus::Permanent,
+            ))
+        })?;
+        Ok(())
+    }
+}
+
+/// Receiving end of the batch channel.
+pub struct BatchReceiver(mpsc::Receiver<RecordBatch>);
+
+impl BatchReceiver {
+    /// Receive the next RecordBatch from the channel. Returns None if closed.
+    pub async fn recv(&mut self) -> Option<RecordBatch> {
+        self.0.recv().await
+    }
+}
+
+/// A batch builder that accumulates TableRow values from PG copy and produces RecordBatches.
+///
+/// Reuses moonlink::ColumnStoreBuffer to avoid duplicating Arrow builder logic.
+/// Converts PG TableRow cells to RowValue and delegates to the internal buffer.
+pub struct ArrowBatchBuilder {
+    buffer: ColumnStoreBuffer,
+}
+
+impl ArrowBatchBuilder {
+    pub fn new(schema: Arc<Schema>, max_rows: usize) -> Self {
+        let batch_id_counter = Arc::new(BatchIdCounter::new(false)); // Temporary instance of batch id counter
+        let buffer = ColumnStoreBuffer::new(schema, max_rows, batch_id_counter);
+        Self { buffer }
+    }
+
+    /// Append a TableRow from PG copy. Returns an immediately-finished
+    /// RecordBatch if the buffer is full, otherwise None.
+    pub fn append_table_row(&mut self, table_row: TableRow) -> Result<Option<RecordBatch>> {
+        // Convert TableRow cells to RowValue
+        let row_values: Vec<RowValue> = table_row
+            .values
+            .into_iter()
+            .map(|cell| cell.into())
+            .collect();
+
+        let (_batch_id, _row_offset, finished_batch) =
+            self.buffer.append_initial_copy_row(row_values)?;
+
+        Ok(finished_batch.map(|(_, batch)| batch.as_ref().clone()))
+    }
+
+    /// Finish the current batch and return a RecordBatch.
+    pub fn finish(&mut self) -> Result<Option<RecordBatch>> {
+        Ok(self
+            .buffer
+            .finalize_current_batch()?
+            .map(|(_, batch)| (*batch).clone()))
+    }
+}
+
+/// Writes RecordBatches into Parquet files with rotation.
+///
+/// Implemented with parquet::arrow::AsyncArrowWriter and file rotation based on writer.memory_size().
+pub struct ParquetFileWriter {
+    pub output_dir: PathBuf,
+    pub schema: Arc<Schema>,
+    pub config: InitialCopyWriterConfig,
+}
+
+impl ParquetFileWriter {
+    pub fn new(output_dir: PathBuf, schema: Arc<Schema>, config: InitialCopyWriterConfig) -> Self {
+        Self {
+            output_dir,
+            schema,
+            config,
+        }
+    }
+
+    fn next_file_path(&self) -> PathBuf {
+        let filename = format!("ic-{}.parquet", uuid::Uuid::now_v7());
+        self.output_dir.join(filename)
+    }
+
+    /// Consume RecordBatches and write Parquet files.
+    /// Returns the list of file paths written.
+    pub async fn write_from_channel(mut self, mut rx: BatchReceiver) -> Result<Vec<String>> {
+        use moonlink::get_default_parquet_properties;
+        use parquet::arrow::AsyncArrowWriter;
+
+        let mut files_written: Vec<String> = Vec::new();
+        let mut writer: Option<AsyncArrowWriter<tokio::fs::File>> = None;
+        let mut current_file_path: Option<PathBuf> = None;
+
+        while let Some(batch) = rx.recv().await {
+            if batch.num_columns() == 0 || batch.num_rows() == 0 {
+                continue;
+            }
+
+            if writer.is_none() {
+                let path = self.next_file_path();
+                // Ensure directory exists
+                if let Some(parent) = path.parent() {
+                    tokio::fs::create_dir_all(parent).await.ok();
+                }
+                let file = tokio::fs::File::create(&path).await?;
+                let props = get_default_parquet_properties();
+                let w = AsyncArrowWriter::try_new(file, self.schema.clone(), Some(props))?;
+                writer = Some(w);
+                current_file_path = Some(path.clone());
+            }
+
+            let w = writer.as_mut().unwrap();
+            w.write(&batch).await?;
+
+            // Rotate when current writer exceeds target size.
+            if w.memory_size() >= self.config.target_file_size_bytes {
+                w.finish().await?;
+                if let Some(p) = current_file_path.take() {
+                    files_written.push(p.to_string_lossy().to_string());
+                }
+                writer = None;
+            }
+        }
+
+        // Finalize any open writer.
+        if let Some(mut w) = writer.take() {
+            w.finish().await?;
+            if let Some(p) = current_file_path.take() {
+                files_written.push(p.to_string_lossy().to_string());
+            }
+        }
+
+        Ok(files_written)
+    }
+}
+
+// TODO: Add unit tests

--- a/src/moonlink_connectors/src/pg_replicate/moonlink_sink.rs
+++ b/src/moonlink_connectors/src/pg_replicate/moonlink_sink.rs
@@ -274,7 +274,6 @@ impl Sink {
                             row: PostgresTableRow(table_row).into(),
                             lsn: final_lsn,
                             xact_id,
-                            is_copied: false,
                             is_recovery: false,
                         },
                     )
@@ -307,7 +306,6 @@ impl Sink {
                             row: PostgresTableRow(new_table_row).into(),
                             lsn: final_lsn,
                             xact_id,
-                            is_copied: false,
                             is_recovery: false,
                         },
                     )

--- a/src/moonlink_connectors/src/rest_ingest/moonlink_rest_sink.rs
+++ b/src/moonlink_connectors/src/rest_ingest/moonlink_rest_sink.rs
@@ -189,7 +189,6 @@ impl RestSink {
                     row,
                     lsn,
                     xact_id: None,
-                    is_copied: false,
                     is_recovery: false,
                 };
 
@@ -216,7 +215,6 @@ impl RestSink {
                     row,
                     lsn,
                     xact_id: None,
-                    is_copied: false,
                     is_recovery: false,
                 };
 
@@ -318,7 +316,6 @@ mod tests {
             row: test_row.clone(),
             lsn: 1,
             xact_id: None,
-            is_copied: false,
             is_recovery: false,
         };
 
@@ -334,13 +331,11 @@ mod tests {
                 row,
                 lsn,
                 xact_id,
-                is_copied,
                 is_recovery,
             } => {
                 assert_eq!(row.values, test_row.values);
                 assert_eq!(lsn, 1);
                 assert_eq!(xact_id, None);
-                assert!(!is_copied);
                 assert!(!is_recovery);
             }
             _ => panic!("Expected Append event"),
@@ -354,7 +349,6 @@ mod tests {
                     row: test_row,
                     lsn: 2,
                     xact_id: None,
-                    is_copied: false,
                     is_recovery: false,
                 },
             )
@@ -377,7 +371,6 @@ mod tests {
                     row: MoonlinkRow::new(vec![RowValue::Int32(99)]),
                     lsn: 3,
                     xact_id: None,
-                    is_copied: false,
                     is_recovery: false,
                 },
             )
@@ -506,7 +499,6 @@ mod tests {
             row: test_row.clone(),
             lsn: 10,
             xact_id: None,
-            is_copied: false,
             is_recovery: false,
         };
         sink.send_table_event(1, insert_event).await.unwrap();


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

Instead of sending each row from the initial load through the table handler we can write these directly to parquet and use the batch_ingest API to integrate the files with moonlink.

We consume rows from the initial copy stream and add them to an arrow batch builder. When a new batch is ready, it's sent over an `mpsc` channel to a parquet writer. 

The reason for the `mpsc` channel is two-fold: 
First, it gives us natural backpressure for free. In the event that our copy stream is producing batches much faster than our writer(s) can consume them, the channel will apply back pressure on the copy stream and prevent memory bloat. 
Second, it decouples the producers from the consumers making parallelization easier. We can have a collection of producers appending to the queue, and a pool of writers grabbing batches off the channel and writing them (to be implemented as part of https://github.com/Mooncake-Labs/moonlink/issues/1240

When the initial load stream completes, we send a `TableEvent::LoadFiles` with the newly written parquets. We then reuse the `batch_ingest` API to integrate the files. During the ingest we check if the table is not append only, and if not we rescan the parquet files and build the index, attaching this to the commit for integration with moonlink.

## Related Issues

Closes [#1239](https://github.com/Mooncake-Labs/moonlink/issues/1239)
## Changes

- 
- 
- 

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [x] Documentation updated if necessary
- [x] I have reviewed my own changes
