### PR TITLE
setup iceberg-rest service in dockercompose

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,7 @@
 {
     "dockerComposeFile": "docker-compose.yml",
     "service": "devcontainer",
-    "runServices": ["nginx", "postgres", "minio", "fake-gcs"],
+    "runServices": ["nginx", "postgres", "minio", "fake-gcs", "iceberg-rest"],
     "workspaceFolder": "/workspaces/moonlink",
     "initializeCommand": "bash ./.devcontainer/prebuild.sh",
     "features": {

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -42,6 +42,11 @@ services:
       - "9000:9000"  # S3 API
       - "9001:9001"  # Web UI
 
+  iceberg-rest:
+    image: tabulario/iceberg-rest:latest
+    ports:
+      - 8181:8181
+
   fake-gcs:
     image: fsouza/fake-gcs-server:latest
     hostname: gcs
@@ -74,6 +79,7 @@ volumes:
   fake-gcs-data:
   shared-nginx:
     name: moonlink-shared-nginx
+  
 
 networks:
   shared_network:

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -43,9 +43,9 @@ services:
       - "9001:9001"  # Web UI
 
   iceberg-rest:
-    image: tabulario/iceberg-rest:latest
+    image: apache/iceberg-rest-fixture:latest
     ports:
-      - 8181:8181
+      - "8181:8181"
 
   fake-gcs:
     image: fsouza/fake-gcs-server:latest
@@ -79,7 +79,6 @@ volumes:
   fake-gcs-data:
   shared-nginx:
     name: moonlink-shared-nginx
-  
 
 networks:
   shared_network:


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

Add iceberg-rest setup code in docker compose.yaml file.
Already tested using `test_create_table` [here](https://github.com/Mooncake-Labs/moonlink/pull/1725).

## Related Issues

Related https://github.com/Mooncake-Labs/moonlink/issues/1617
Closes https://github.com/Mooncake-Labs/moonlink/issues/1615

## Checklist

- [✓] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [✓] I have reviewed my own changes
