### PR TITLE
fix(test): remove duplicate table creation in S3/GCS tests to avoid version-hint ETag 412

### DIFF
--- a/src/moonlink/src/storage/iceberg/file_catalog_test.rs
+++ b/src/moonlink/src/storage/iceberg/file_catalog_test.rs
@@ -484,14 +484,12 @@ async fn test_update_table_filesystem() {
 #[cfg(feature = "storage-s3")]
 async fn test_update_table_s3() -> IcebergResult<()> {
     let (catalog, _test_guard) = create_s3_catalog().await;
-    create_test_table(&catalog).await?;
     test_update_table_impl(catalog).await
 }
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[cfg(feature = "storage-gcs")]
 async fn test_update_table_gcs() -> IcebergResult<()> {
     let (catalog, _test_guard) = create_gcs_catalog().await;
-    create_test_table(&catalog).await?;
     test_update_table_impl(catalog).await
 }
 
@@ -506,13 +504,11 @@ async fn test_update_schema() {
 #[cfg(feature = "storage-s3")]
 async fn test_update_schema_s3() {
     let (catalog, _test_guard) = create_s3_catalog().await;
-    create_test_table(&catalog).await.unwrap();
     test_update_schema_impl(catalog).await;
 }
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[cfg(feature = "storage-gcs")]
 async fn test_update_schema_gcs() {
     let (catalog, _test_guard) = create_gcs_catalog().await;
-    create_test_table(&catalog).await.unwrap();
     test_update_schema_impl(catalog).await;
 }


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

create_test_table repeated creation

## Related Issues

Closes #1742.

## Changes

- remove duplicate create_test_table

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [x] Documentation updated if necessary
- [x] I have reviewed my own changes
