### PR TITLE
[chaos] Validate iceberg snapshot at replay

### DIFF
--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -768,8 +768,10 @@ impl MooncakeTable {
         iceberg_snapshot_res: &IcebergSnapshotResult,
     ) {
         if let Some(event_replay_tx) = &self.event_replay_tx {
-            let table_event =
-                replay_events::create_iceberg_snapshot_event_completion(iceberg_snapshot_res.uuid);
+            let table_event = replay_events::create_iceberg_snapshot_event_completion(
+                iceberg_snapshot_res.uuid,
+                iceberg_snapshot_res.flush_lsn,
+            );
             event_replay_tx
                 .send(MooncakeTableEvent::IcebergSnapshotCompletion(table_event))
                 .unwrap();

--- a/src/moonlink/src/storage/mooncake_table/replay/replay_events.rs
+++ b/src/moonlink/src/storage/mooncake_table/replay/replay_events.rs
@@ -156,6 +156,8 @@ pub struct IcebergSnapshotEventInitiation {
 pub struct IcebergSnapshotEventCompletion {
     /// Event id.
     pub uuid: uuid::Uuid,
+    /// Flush LSN.
+    pub lsn: u64,
 }
 
 /// =====================
@@ -416,8 +418,9 @@ pub fn create_iceberg_snapshot_event_initiation(
 }
 pub fn create_iceberg_snapshot_event_completion(
     uuid: uuid::Uuid,
+    lsn: u64,
 ) -> IcebergSnapshotEventCompletion {
-    IcebergSnapshotEventCompletion { uuid }
+    IcebergSnapshotEventCompletion { uuid, lsn }
 }
 /// Create index merge events.
 pub fn create_index_merge_event_initiation(


### PR DESCRIPTION
## Summary

This PR does two things:
- Add LSN at replay event, which is super useful for debugging by reading dumped json files
- Add iceberg snapshot validation at replay, so we could detect problematic snapshot earlier

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
