### PR TITLE
fix: make drop_table return Result

### DIFF
--- a/src/moonlink_backend/src/lib.rs
+++ b/src/moonlink_backend/src/lib.rs
@@ -215,21 +215,21 @@ impl MoonlinkBackend {
         Ok(())
     }
 
-    pub async fn drop_table(&self, database: String, table: String) {
+    pub async fn drop_table(&self, database: String, table: String) -> Result<()> {
         let mooncake_table_id = MooncakeTableId { database, table };
 
         let table_exists = {
             let mut manager = self.replication_manager.write().await;
-            manager.drop_table(&mooncake_table_id).await.unwrap()
+            manager.drop_table(&mooncake_table_id).await?
         };
         if !table_exists {
-            return;
+            return Ok(());
         }
 
         self.metadata_store_accessor
             .delete_table_metadata(&mooncake_table_id.database, &mooncake_table_id.table)
-            .await
-            .unwrap()
+            .await?;
+        Ok(())
     }
 
     /// Get the base directory for all mooncake tables.

--- a/src/moonlink_backend/tests/test_backend.rs
+++ b/src/moonlink_backend/tests/test_backend.rs
@@ -35,13 +35,15 @@ mod tests {
         // First round of table operations.
         backend
             .drop_table(DATABASE.to_string(), TABLE.to_string())
-            .await;
+            .await
+            .unwrap();
         smoke_create_and_insert(guard.tmp().unwrap(), backend, &client, SRC_URI).await;
 
         // Second round of table operations.
         backend
             .drop_table(DATABASE.to_string(), TABLE.to_string())
-            .await;
+            .await
+            .unwrap();
         smoke_create_and_insert(guard.tmp().unwrap(), backend, &client, SRC_URI).await;
     }
 
@@ -58,7 +60,8 @@ mod tests {
                 "non_existent_database".to_string(),
                 "non_existent_table".to_string(),
             )
-            .await;
+            .await
+            .unwrap();
     }
 
     /// End-to-end: inserts should appear in `scan_table`.
@@ -227,7 +230,8 @@ mod tests {
             .unwrap();
         backend
             .drop_table(DATABASE.to_string(), TABLE.to_string())
-            .await;
+            .await
+            .unwrap();
 
         // Second cycle: add table again, insert different data, verify it works
         client
@@ -335,7 +339,8 @@ mod tests {
         // Drop table and check metadata storage.
         backend
             .drop_table(DATABASE.to_string(), TABLE.to_string())
-            .await;
+            .await
+            .unwrap();
         let metadata_entries = metadata_store
             .get_all_table_metadata_entries()
             .await
@@ -354,7 +359,8 @@ mod tests {
         // Drop the table that setup_backend created so we can test the full cycle
         backend
             .drop_table(DATABASE.to_string(), TABLE.to_string())
-            .await;
+            .await
+            .unwrap();
 
         // First cycle: add table, insert data, verify it works
         backend
@@ -509,7 +515,8 @@ mod tests {
         // Drop the table that setup_backend created so we can test the full cycle
         backend
             .drop_table(DATABASE.to_string(), TABLE.to_string())
-            .await;
+            .await
+            .unwrap();
         backend
             .create_table(
                 DATABASE.to_string(),
@@ -612,7 +619,8 @@ mod tests {
         // Drop the table that setup_backend created so we can test the full cycle
         backend
             .drop_table(DATABASE.to_string(), TABLE.to_string())
-            .await;
+            .await
+            .unwrap();
         backend
             .create_table(
                 DATABASE.to_string(),
@@ -720,7 +728,8 @@ mod tests {
         // Drop the table that setup_backend created so we can test the full cycle
         backend
             .drop_table(DATABASE.to_string(), TABLE.to_string())
-            .await;
+            .await
+            .unwrap();
 
         backend
             .create_table(
@@ -805,7 +814,8 @@ mod tests {
         // Drop the table that setup_backend created so we can test the full cycle
         backend
             .drop_table(DATABASE.to_string(), TABLE.to_string())
-            .await;
+            .await
+            .unwrap();
         backend
             .create_table(
                 DATABASE.to_string(),

--- a/src/moonlink_service/src/rest_api.rs
+++ b/src/moonlink_service/src/rest_api.rs
@@ -347,11 +347,20 @@ async fn drop_table(
 ) -> Result<Json<DropTableResponse>, (StatusCode, Json<ErrorResponse>)> {
     debug!("Received table drop request for '{}': {:?}", table, payload);
 
-    // Create table in backend
+    // Drop table in backend
     state
         .backend
         .drop_table(payload.database.clone(), payload.table.clone())
-        .await;
+        .await
+        .map_err(|e| {
+            (
+                get_backend_error_status_code(&e),
+                Json(ErrorResponse {
+                    error: "table_drop_failed".to_string(),
+                    message: format!("Failed to drop table: {e}"),
+                }),
+            )
+        })?;
     Ok(Json(DropTableResponse {}))
 }
 

--- a/src/moonlink_service/src/rpc_server.rs
+++ b/src/moonlink_service/src/rpc_server.rs
@@ -127,7 +127,7 @@ where
                 write(&mut stream, &()).await?;
             }
             Request::DropTable { database, table } => {
-                backend.drop_table(database, table).await;
+                backend.drop_table(database, table).await?;
                 write(&mut stream, &()).await?;
             }
             Request::GetParquetMetadata { data_file } => {


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

Make drop_table return Result, Avoid panics in REST/RPC paths when dropping a non-existent table or on underlying errors.

## Related Issues

Closes #1686.

## Changes

- 
- 
- 

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [x] Documentation updated if necessary
- [x] I have reviewed my own changes
