### PR TITLE
[storage] Fix batch id assignment

### DIFF
--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -589,18 +589,20 @@ impl MooncakeTable {
             alter_table_request,
         ));
 
-        let mut guard = self.snapshot.try_write().unwrap();
-        guard.reset_for_alter(new_metadata.clone());
-        assert!(
-            self.metadata.schema.fields.len() != new_metadata.schema.fields.len(),
-            "Only support alter table with add/drop fields"
-        );
+        // Follow the same initialization order as mooncake table, which is used to decide batch id assignment.
         self.mem_slice = MemSlice::new(
             new_metadata.schema.clone(),
             new_metadata.config.batch_size,
             new_metadata.identity.clone(),
             Arc::clone(&self.non_streaming_batch_id_counter),
         );
+        let mut guard = self.snapshot.try_write().unwrap();
+        guard.reset_for_alter(new_metadata.clone());
+        assert!(
+            self.metadata.schema.fields.len() != new_metadata.schema.fields.len(),
+            "Only support alter table with add/drop fields"
+        );
+
         self.metadata = new_metadata.clone();
         new_metadata
     }

--- a/src/moonlink/src/storage/mooncake_table/batch_id_counter.rs
+++ b/src/moonlink/src/storage/mooncake_table/batch_id_counter.rs
@@ -34,6 +34,8 @@ impl BatchIdCounter {
         self.counter.load(Ordering::Relaxed)
     }
 
+    // Increment the id by 1, and return the id before change.
+    //
     // Relaxed ordering is used here because the counter is only used for internal state tracking, not for synchronization.
     pub fn next(&self) -> u64 {
         let current = self.counter.load(Ordering::Relaxed);

--- a/src/moonlink/src/storage/mooncake_table/data_batches.rs
+++ b/src/moonlink/src/storage/mooncake_table/data_batches.rs
@@ -92,7 +92,9 @@ impl ColumnStoreBuffer {
             .collect();
 
         // Get the initial batch ID from the counter
-        let initial_id = batch_id_counter.load();
+        // To avoid initial id conflict we need to acquire a unique id.
+        // Notice, `next` returns the value before change
+        let initial_id = batch_id_counter.next() + 1;
 
         Self {
             schema,
@@ -362,7 +364,7 @@ mod tests {
         ]);
 
         let counter = BatchIdCounter::new(false);
-        let start = counter.load();
+        let start = counter.load() + 1;
         let mut buffer = ColumnStoreBuffer::new(Arc::new(schema.clone()), 2, Arc::new(counter));
 
         let row1 = MoonlinkRow::new(vec![

--- a/src/moonlink/src/storage/mooncake_table/mem_slice.rs
+++ b/src/moonlink/src/storage/mooncake_table/mem_slice.rs
@@ -167,7 +167,7 @@ mod tests {
             )])),
         ]);
         let counter = BatchIdCounter::new(false);
-        let start = counter.load();
+        let start = counter.load() + 1;
         let mut mem_table = MemSlice::new(Arc::new(schema), 4, identity, Arc::new(counter));
 
         // Create arrays properly

--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -149,7 +149,7 @@ impl SnapshotTableState {
     ) -> Result<Self> {
         let mut batches = BTreeMap::new();
         // Properly load a batch ID from the counter to ensure correspondence with MemSlice.
-        let initial_batch_id = non_streaming_batch_id_counter.next();
+        let initial_batch_id = non_streaming_batch_id_counter.load();
         batches.insert(
             initial_batch_id,
             InMemoryBatch::new(metadata.config.batch_size),


### PR DESCRIPTION
## Summary

We could have multiple streaming transaction ongoing, current implementation doesn't guarantee each batch gets their unique id. See linked issue for details.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1748

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [x] Documentation updated if necessary
- [x] I have reviewed my own changes
