### PR TITLE
[storage] Handle multiple ongoing flushes for streaming transaction

### DIFF
--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -840,6 +840,10 @@ impl MooncakeTable {
     }
 
     /// Flushes the disk slice for the transaction.
+    ///
+    /// # Arguments
+    ///
+    /// * ongoing_flush_count: used to increment ongoing flush count for the given LSN.
     fn flush_disk_slice(
         &mut self,
         disk_slice: &mut DiskSliceWriter,

--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -65,7 +65,7 @@ use delete_vector::BatchDeletionVector;
 pub(crate) use disk_slice::DiskSliceWriter;
 use mem_slice::MemSlice;
 pub(crate) use snapshot::SnapshotTableState;
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 use table_snapshot::{IcebergSnapshotImportResult, IcebergSnapshotIndexMergeResult};
@@ -462,7 +462,8 @@ pub struct MooncakeTable {
     wal_manager: WalManager,
 
     /// LSN of ongoing flushes.
-    pub ongoing_flush_lsns: BTreeSet<u64>,
+    /// Maps from LSN to its count.
+    pub ongoing_flush_lsns: BTreeMap<u64, u32>,
 
     /// Table replay sender.
     event_replay_tx: Option<mpsc::UnboundedSender<MooncakeTableEvent>>,
@@ -565,7 +566,7 @@ impl MooncakeTable {
             last_iceberg_snapshot_lsn,
             table_notify: None,
             wal_manager,
-            ongoing_flush_lsns: BTreeSet::new(),
+            ongoing_flush_lsns: BTreeMap::new(),
             event_replay_tx: None,
         })
     }
@@ -843,10 +844,11 @@ impl MooncakeTable {
         disk_slice: &mut DiskSliceWriter,
         table_notify_tx: Sender<TableEvent>,
         xact_id: Option<u32>,
+        ongoing_flush_count: u32,
         event_id: uuid::Uuid,
     ) {
         if let Some(lsn) = disk_slice.lsn() {
-            self.insert_ongoing_flush_lsn(lsn);
+            self.insert_ongoing_flush_lsn(lsn, ongoing_flush_count);
         } else {
             assert!(
                 xact_id.is_some(),
@@ -913,31 +915,39 @@ impl MooncakeTable {
     fn try_set_next_flush_lsn(&mut self, lsn: u64) {
         let min_pending_lsn = self.get_min_ongoing_flush_lsn();
         if lsn < min_pending_lsn {
+            // TODO(hjiang): Add assertion that flush LSN never regresses, currently it's still buggy, I will fix in the followup PR.
             self.next_snapshot_task.new_flush_lsn = Some(lsn);
         }
     }
 
     // We fallback to u64::MAX if there are no pending flush LSNs so that the LSN is always greater than the flush LSN and the iceberg snapshot can proceed.
     pub fn get_min_ongoing_flush_lsn(&self) -> u64 {
-        self.ongoing_flush_lsns
-            .iter()
-            .next()
-            .copied()
-            .unwrap_or(u64::MAX)
+        if let Some((lsn, _)) = self.ongoing_flush_lsns.first_key_value() {
+            return *lsn;
+        }
+        u64::MAX
     }
 
-    pub fn insert_ongoing_flush_lsn(&mut self, lsn: u64) {
-        assert!(
-            self.ongoing_flush_lsns.insert(lsn),
-            "LSN {lsn} already in pending flush LSNs"
-        );
+    pub fn insert_ongoing_flush_lsn(&mut self, lsn: u64, count: u32) {
+        *self.ongoing_flush_lsns.entry(lsn).or_insert(0) += count;
     }
 
     pub fn remove_ongoing_flush_lsn(&mut self, lsn: u64) {
-        assert!(
-            self.ongoing_flush_lsns.remove(&lsn),
-            "LSN {lsn} not found in pending flush LSNs"
-        );
+        use std::collections::btree_map::Entry;
+
+        match self.ongoing_flush_lsns.entry(lsn) {
+            Entry::Occupied(mut entry) => {
+                let counter = entry.get_mut();
+                if *counter > 1 {
+                    *counter -= 1;
+                } else {
+                    entry.remove();
+                }
+            }
+            Entry::Vacant(_) => {
+                panic!("Tried to remove LSN {lsn}, but it is not tracked");
+            }
+        }
     }
 
     pub fn has_ongoing_flush(&self) -> bool {
@@ -1203,7 +1213,7 @@ impl MooncakeTable {
         );
 
         let table_notify_tx = self.table_notify.as_ref().unwrap().clone();
-        if self.mem_slice.is_empty() || self.ongoing_flush_lsns.contains(&lsn) {
+        if self.mem_slice.is_empty() || self.ongoing_flush_lsns.contains_key(&lsn) {
             self.try_set_next_flush_lsn(lsn);
             tokio::task::spawn(async move {
                 table_notify_tx
@@ -1236,6 +1246,7 @@ impl MooncakeTable {
             &mut disk_slice,
             table_notify_tx,
             /*xact_id=*/ None,
+            /*ongoing_flush_count=*/ 1,
             event_id,
         );
 

--- a/src/moonlink/src/storage/mooncake_table/table_operation_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_operation_test_utils.rs
@@ -90,7 +90,7 @@ pub(crate) async fn flush_table_and_sync_no_apply(
     }
 }
 
-/// Flush mooncake, block wait its completion.
+/// Flush the given streaming transaction, block wait its completion.
 #[cfg(test)]
 pub(crate) async fn flush_stream_and_sync_no_apply(
     table: &mut MooncakeTable,

--- a/src/moonlink/src/storage/mooncake_table/tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/tests.rs
@@ -2506,10 +2506,14 @@ async fn test_stream_commit_with_ongoing_flush_deletion_remapping() -> Result<()
 
     // Step 4: Flush the streaming transaction (creates disk slice)
     // The disk slice now contains the deletion remapping info
-    let disk_slice =
-        flush_stream_and_sync_no_apply(&mut table, &mut event_completion_rx, xact_id, Some(4))
-            .await
-            .expect("Disk slice should be present");
+    let disk_slice = flush_stream_and_sync_no_apply(
+        &mut table,
+        &mut event_completion_rx,
+        xact_id,
+        /*lsn=*/ Some(3),
+    )
+    .await
+    .expect("Disk slice should be present");
 
     // Step 5: Commit the streaming transaction
     // This processes deletions and adds them to committed_deletion_log

--- a/src/moonlink/src/storage/mooncake_table/tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/tests.rs
@@ -1026,10 +1026,14 @@ async fn test_streaming_begin_flush_delete_commit_end_flush() {
     table.delete_in_stream_batch(row2, xact_id2).await;
 
     // Commit the new transaction
-    let disk_slice2 =
-        flush_stream_and_sync_no_apply(&mut table, &mut event_completion_rx, xact_id2, Some(lsn2 + 1))
-            .await
-            .unwrap();
+    let disk_slice2 = flush_stream_and_sync_no_apply(
+        &mut table,
+        &mut event_completion_rx,
+        xact_id2,
+        Some(lsn2 + 1),
+    )
+    .await
+    .unwrap();
     table
         .commit_transaction_stream_impl(xact_id2, lsn2 + 1)
         .unwrap();
@@ -1355,13 +1359,17 @@ async fn test_streaming_flush_lsns_tracking() -> Result<()> {
         flush_stream_and_sync_no_apply(&mut table, &mut event_completion_rx, xact_id_1, Some(50))
             .await
             .expect("Disk slice 1 should be present");
-    table.commit_transaction_stream_impl(xact_id_1, /*lsn=*/ 50).unwrap();
+    table
+        .commit_transaction_stream_impl(xact_id_1, /*lsn=*/ 50)
+        .unwrap();
 
     let disk_slice_2 =
         flush_stream_and_sync_no_apply(&mut table, &mut event_completion_rx, xact_id_2, Some(100))
             .await
             .expect("Disk slice 2 should be present");
-    table.commit_transaction_stream_impl(xact_id_2, /*lsn=*/ 100).unwrap();
+    table
+        .commit_transaction_stream_impl(xact_id_2, /*lsn=*/ 100)
+        .unwrap();
 
     // Verify both streaming LSNs are tracked
     assert!(table.ongoing_flush_lsns.contains_key(&100));
@@ -1370,7 +1378,7 @@ async fn test_streaming_flush_lsns_tracking() -> Result<()> {
 
     // Mix with regular flush (must be higher than previous regular flush)
     append_rows(&mut table, vec![test_row(3, "C", 22)])?;
-    table.commit(3);
+    table.commit(103);
     let disk_slice_3 = flush_table_and_sync_no_apply(&mut table, &mut event_completion_rx, 75)
         .await
         .expect("Disk slice 3 should be present");
@@ -2938,8 +2946,8 @@ async fn test_streaming_batch_id_assignment() -> Result<()> {
         .unwrap();
 
     // Verify both streaming LSNs are tracked
-    assert!(table.ongoing_flush_lsns.contains(&100));
-    assert!(table.ongoing_flush_lsns.contains(&50));
+    assert!(table.ongoing_flush_lsns.contains_key(&100));
+    assert!(table.ongoing_flush_lsns.contains_key(&50));
     assert_eq!(table.get_min_ongoing_flush_lsn(), 50);
 
     // Complete streaming flushes

--- a/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
+++ b/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
@@ -537,8 +537,15 @@ impl MooncakeTable {
         let table_notify_tx = self.table_notify.as_ref().unwrap().clone();
 
         stream_state.ongoing_flush_count += 1;
+        let ongoing_flush_count = stream_state.ongoing_flush_count;
 
-        self.flush_disk_slice(&mut disk_slice, table_notify_tx, Some(xact_id), event_id);
+        self.flush_disk_slice(
+            &mut disk_slice,
+            table_notify_tx,
+            Some(xact_id),
+            ongoing_flush_count,
+            event_id,
+        );
 
         // Add back stream state
         self.transaction_stream_states.insert(xact_id, stream_state);

--- a/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
+++ b/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
@@ -585,8 +585,6 @@ impl MooncakeTable {
             );
         }
         for (id, _) in stream_state.new_record_batches.iter() {
-            println!("when ingesting lsn {} has id = {}", lsn, *id);
-
             assert!(
                 self.next_snapshot_task
                     .flushing_batch_lsn_map

--- a/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
+++ b/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
@@ -585,6 +585,8 @@ impl MooncakeTable {
             );
         }
         for (id, _) in stream_state.new_record_batches.iter() {
+            println!("when ingesting lsn {} has id = {}", lsn, *id);
+
             assert!(
                 self.next_snapshot_task
                     .flushing_batch_lsn_map

--- a/src/moonlink/src/table_handler/tests.rs
+++ b/src/moonlink/src/table_handler/tests.rs
@@ -350,8 +350,8 @@ async fn test_stream_delete_unflushed_non_streamed_row() {
 }
 
 #[tokio::test]
-async fn test_streaming_transaction_periodic_flush() {
-    let mut env = TestEnvironment::default().await;
+async fn test_hjiang_streaming_transaction_periodic_flush() {
+    let env = TestEnvironment::default().await;
     let xact_id = 201;
     let commit_lsn = 20; // LSN at which the transaction will eventually commit
     let initial_read_lsn_target = commit_lsn; // For verifying no data pre-commit
@@ -386,8 +386,6 @@ async fn test_streaming_transaction_periodic_flush() {
 
     env.verify_snapshot(final_read_lsn_target, &[10, 11, 12])
         .await;
-
-    env.shutdown().await;
 }
 
 #[tokio::test]

--- a/src/moonlink/src/table_handler/tests.rs
+++ b/src/moonlink/src/table_handler/tests.rs
@@ -351,7 +351,7 @@ async fn test_stream_delete_unflushed_non_streamed_row() {
 
 #[tokio::test]
 async fn test_streaming_transaction_periodic_flush() {
-    let env = TestEnvironment::default().await;
+    let mut env = TestEnvironment::default().await;
     let xact_id = 201;
     let commit_lsn = 20; // LSN at which the transaction will eventually commit
     let initial_read_lsn_target = commit_lsn; // For verifying no data pre-commit
@@ -386,6 +386,8 @@ async fn test_streaming_transaction_periodic_flush() {
 
     env.verify_snapshot(final_read_lsn_target, &[10, 11, 12])
         .await;
+
+    env.shutdown().await;
 }
 
 #[tokio::test]

--- a/src/moonlink/src/table_handler/tests.rs
+++ b/src/moonlink/src/table_handler/tests.rs
@@ -350,7 +350,7 @@ async fn test_stream_delete_unflushed_non_streamed_row() {
 }
 
 #[tokio::test]
-async fn test_hjiang_streaming_transaction_periodic_flush() {
+async fn test_streaming_transaction_periodic_flush() {
     let env = TestEnvironment::default().await;
     let xact_id = 201;
     let commit_lsn = 20; // LSN at which the transaction will eventually commit


### PR DESCRIPTION
## Summary

Currently we use a set data structure to manage ongoing flush operations: https://github.com/Mooncake-Labs/moonlink/blob/c178bfb7e7d80127eed7fddcb8fd1113e8512b54/src/moonlink/src/storage/mooncake_table.rs#L464-L465
but for streaming transaction we could have multiple flushes in the background.

A detailed example,
- LSN = 13, streaming txn, no commit LSN, issue flush
- LSN = 16, non-streaming txn, issue flush
- LSN = 13, streaming txn, has commit LSN, issue flush

After that we have two ongoing flush LSNs, one for 13, another for 16.
The completion order is as below:
- LSN = 13
- LSN = 16

When the first flush finish, the lowest LSN is 16, which means we set flush LSN to 16 and will dump iceberg with LSN 16.
This PR fixes the issue by use a <LSN, counter> map to record all ongoing flush operations.

Another thing confuses me a lot is the unit tests, which seems to test on cases which will never happen in production.
In production codepath, we will have only two stream flush:
- on append, when threshold reaches, we trigger a flush but no commit, with no commit LSN
- on commit, we force a flush and commit with LSN

To simplify the commit / flush / LSN, this PR rewrote some of the unit tests to conform production behavior.

On flush operation, the new behavior looks like
- we only record ongoing flush LSNs to ongoing LSN map on commit; otherwise it's completely invisible to other transactions
- on commit / flush, we record all ongoing flush count to the map, which will be decremented when each of them finishes

Notice: I didn't add any new unit tests in the PR, since a simply flush LSN progression assertion already fails a few existing ones...

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [x] Documentation updated if necessary
- [x] I have reviewed my own changes
