### PR TITLE
Remove replication manager and connection generics

### DIFF
--- a/src/moonlink_backend/src/lib.rs
+++ b/src/moonlink_backend/src/lib.rs
@@ -41,7 +41,7 @@ pub struct MoonlinkBackend {
     // Metadata storage accessor.
     metadata_store_accessor: Box<dyn MetadataStoreTrait>,
 
-    replication_manager: RwLock<ReplicationManager<MooncakeTableId>>,
+    replication_manager: RwLock<ReplicationManager>,
 
     event_api_sender: Option<tokio::sync::mpsc::Sender<EventRequest>>,
 }

--- a/src/moonlink_backend/src/recovery_utils.rs
+++ b/src/moonlink_backend/src/recovery_utils.rs
@@ -20,7 +20,7 @@ pub(crate) struct BackendAttributes {
 async fn recover_rest_table(
     backend_attributes: BackendAttributes,
     metadata_entry: TableMetadataEntry,
-    replication_manager: &mut ReplicationManager<MooncakeTableId>,
+    replication_manager: &mut ReplicationManager,
     read_state_filepath_remap: ReadStateFilepathRemap,
 ) -> Result<()> {
     assert_eq!(metadata_entry.src_table_uri, REST_API_URI);
@@ -66,7 +66,7 @@ async fn recover_rest_table(
 /// Recovery non-REST ingestion table.
 async fn recover_non_rest_table(
     metadata_entry: TableMetadataEntry,
-    replication_manager: &mut ReplicationManager<MooncakeTableId>,
+    replication_manager: &mut ReplicationManager,
     read_state_filepath_remap: ReadStateFilepathRemap,
 ) -> Result<()> {
     assert_ne!(metadata_entry.src_table_uri, REST_API_URI);
@@ -91,7 +91,7 @@ async fn recover_non_rest_table(
 async fn recover_table(
     backend_attributes: BackendAttributes,
     metadata_entry: TableMetadataEntry,
-    replication_manager: &mut ReplicationManager<MooncakeTableId>,
+    replication_manager: &mut ReplicationManager,
     read_state_filepath_remap: ReadStateFilepathRemap,
 ) -> Result<()> {
     // Table created by REST API doesn't support recovery.
@@ -119,7 +119,7 @@ pub(super) async fn recover_all_tables(
     backend_attributes: BackendAttributes,
     metadata_store_accessor: &dyn MetadataStoreTrait,
     read_state_filepath_remap: ReadStateFilepathRemap,
-    replication_manager: &mut ReplicationManager<MooncakeTableId>,
+    replication_manager: &mut ReplicationManager,
 ) -> Result<()> {
     let mut unique_uris = HashSet::<String>::new();
 


### PR DESCRIPTION
## Summary

As we move `MooncakeTableId` from backend to moonlink crate, there's no necessity of keeping generic at replication manager and replication connection.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1707

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
