### PR TITLE
Reestablish pg connection

### DIFF
--- a/src/moonlink_connectors/src/pg_replicate/moonlink_sink.rs
+++ b/src/moonlink_connectors/src/pg_replicate/moonlink_sink.rs
@@ -105,8 +105,8 @@ impl Sink {
         self.relation_cache.insert(src_table_id, columns);
     }
     pub fn drop_table(&mut self, src_table_id: SrcTableId) {
-        self.event_senders.remove(&src_table_id).unwrap();
-        self.commit_lsn_txs.remove(&src_table_id).unwrap();
+        self.event_senders.remove(&src_table_id);
+        self.commit_lsn_txs.remove(&src_table_id);
         if let Some((cached_id, _)) = &self.cached_event_sender {
             if *cached_id == src_table_id {
                 self.cached_event_sender = None;

--- a/src/moonlink_connectors/src/replication_connection.rs
+++ b/src/moonlink_connectors/src/replication_connection.rs
@@ -110,6 +110,18 @@ impl<T: Clone + Eq + Hash + std::fmt::Display> ReplicationConnection<T> {
         self.replication_started
     }
 
+    /// Refresh internal replication status by checking if the background task has finished.
+    /// If finished, clear the handle and mark replication as not started so callers can restart it.
+    pub fn refresh_replication_status(&mut self) {
+        if let Some(handle) = &self.handle {
+            if handle.is_finished() {
+                self.handle = None;
+                self.replication_started = false;
+                debug!("replication task finished; marking as not started");
+            }
+        }
+    }
+
     /// Get the REST request sender for submitting REST API requests
     pub fn get_rest_request_sender(&self) -> mpsc::Sender<EventRequest> {
         match &self.source {

--- a/src/moonlink_connectors/src/replication_manager.rs
+++ b/src/moonlink_connectors/src/replication_manager.rs
@@ -205,6 +205,8 @@ impl<T: Clone + Eq + Hash + std::fmt::Display> ReplicationManager<T> {
         assert!(self.connections.contains_key(src_uri));
 
         let connection = self.connections.get_mut(src_uri).unwrap();
+        // If the background task has exited (e.g., due to PG connection drop), allow restart.
+        connection.refresh_replication_status();
         if !connection.replication_started() {
             connection.start_replication().await?;
         }


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

We don't currently implement any reconnection logic in the event that we lose our connection to Postgres. This is true for the replication task as well as any control commands we send (ALTER TABLE/PUB, etc.)

In the case of control commands to PG, instead of holding a client across commands that may at some point disconnect, we should just create and drop ephemeral PG clients as we need. The command events are rare enough that this shouldn't be a performance concern and ensures the PG client remains fresh. It also prevents any lingering unused connections to PG. 

In the case the replication task goes down, for each control command we check the status of the replication task and reestablish if not currently active. 

## Related Issues

Closes #<issue-number> or links to related issues.

## Changes

- 
- 
- 

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
