### PR TITLE
[storage] Validate table creation config

### DIFF
--- a/src/moonlink_backend/src/error.rs
+++ b/src/moonlink_backend/src/error.rs
@@ -46,6 +46,9 @@ pub enum Error {
 
     #[error("{0}")]
     MpscChannelSendError(ErrorStruct),
+
+    #[error("{0}")]
+    InvalidConfig(ErrorStruct),
 }
 
 pub type Result<T> = result::Result<T, Error>;
@@ -59,6 +62,11 @@ impl Error {
     pub fn data_corruption(message: String) -> Self {
         Self::DataCorruptionError(ErrorStruct::new(message, ErrorStatus::Permanent))
     }
+    #[track_caller]
+    pub fn invalid_config(message: String) -> Self {
+        Self::InvalidConfig(ErrorStruct::new(message, ErrorStatus::Permanent))
+    }
+
     pub fn get_status(&self) -> ErrorStatus {
         match self {
             Error::ParseIntError(es) => es.status,
@@ -72,6 +80,7 @@ impl Error {
             Error::Json(es) => es.status,
             Error::MpscChannelSendError(es) => es.status,
             Error::DataCorruptionError(es) => es.status,
+            Error::InvalidConfig(es) => es.status,
         }
     }
 }


### PR DESCRIPTION
## Summary

Followup PR for https://github.com/Mooncake-Labs/moonlink/pull/1758, which adds row identity into table config for creation. There're certain invariants we need to keep, so add a validation function to check and fail if breaks.

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [x] Documentation updated if necessary
- [x] I have reviewed my own changes
