### PR TITLE
[minor] Rename batch id next function

### DIFF
--- a/src/moonlink/src/storage/mooncake_table/data_batches.rs
+++ b/src/moonlink/src/storage/mooncake_table/data_batches.rs
@@ -94,7 +94,7 @@ impl ColumnStoreBuffer {
         // Get the initial batch ID from the counter
         // To avoid initial id conflict we need to acquire a unique id.
         // Notice, `next` returns the value before change
-        let initial_id = batch_id_counter.next() + 1;
+        let initial_id = batch_id_counter.get_and_next() + 1;
 
         Self {
             schema,
@@ -162,7 +162,7 @@ impl ColumnStoreBuffer {
         let batch = Arc::new(RecordBatch::try_new(Arc::clone(&self.schema), columns)?);
         let last_batch = self.in_memory_batches.last_mut();
         last_batch.unwrap().batch.data = Some(batch.clone());
-        let next_batch_id = self.batch_id_counter.next() + 1;
+        let next_batch_id = self.batch_id_counter.get_and_next() + 1;
         self.in_memory_batches.push(BatchEntry {
             id: next_batch_id,
             batch: InMemoryBatch::new(self.max_rows_per_buffer),


### PR DESCRIPTION
## Summary

A minor no-op change, even if I added documentation on function behavior, I still get confused.
This PR rename the function and clearly explains the behavior itself.

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
