### PR TITLE
perf: parallelize remote filepath download / pin

### DIFF
--- a/src/moonlink/src/storage/mooncake_table/snapshot_read_output.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot_read_output.rs
@@ -85,7 +85,7 @@ impl ReadOutput {
 
     /// File ordering should be preserved because the index determines the position
     /// in the final [`resolved_data_files`] array, which delete or other operations rely on.
-    async fn process_remote_files(
+    async fn resolve_remote_files(
         &mut self,
         object_storage_cache: Arc<dyn CacheTrait>,
         filesystem_accessor: Arc<dyn BaseFileSystemAccess>,

--- a/src/moonlink/src/storage/mooncake_table/snapshot_read_output.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot_read_output.rs
@@ -74,7 +74,7 @@ impl ReadOutput {
             .unwrap();
     }
 
-    fn process_temporary_files(
+    fn resolve_temporary_files(
         temp_files_with_index: Vec<(usize, String)>,
         resolved_data_files: &mut [String],
     ) {

--- a/src/moonlink/src/storage/mooncake_table/snapshot_read_output.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot_read_output.rs
@@ -113,7 +113,7 @@ impl ReadOutput {
                     )
                 }
             })
-            .buffered(MAX_PARALLEL_OPERATIONS);
+            .buffer_unordered(MAX_PARALLEL_OPERATIONS);
 
         while let Some((index, remote_filepath, result)) = results.next().await {
             match result {

--- a/src/moonlink/src/storage/mooncake_table/snapshot_read_output.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot_read_output.rs
@@ -206,7 +206,7 @@ impl ReadOutput {
     /// Handle cleanup and notifications when resolving remote filepaths fails.
     async fn handle_resolution_error(&mut self, mut cache_handles: Vec<NonEvictableHandle>) {
         // Pre-allocate based on known sizes: cache_handles + puffin_cache_handles + associated_files
-        let total_capacity =
+        let total_size =
             cache_handles.len() + self.puffin_cache_handles.len() + self.associated_files.len();
         let mut evicted_files_to_delete_on_error: Vec<String> = Vec::with_capacity(total_capacity);
         // Unpin all previously pinned cache handles before propagating error.

--- a/src/moonlink/src/storage/mooncake_table/snapshot_read_output.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot_read_output.rs
@@ -84,7 +84,7 @@ impl ReadOutput {
     }
 
     /// File ordering should be preserved because the index determines the position
-    /// in the final resolved_data_files array, which delete or other operations rely on.
+    /// in the final [`resolved_data_files`] array, which delete or other operations rely on.
     async fn process_remote_files(
         &mut self,
         object_storage_cache: Arc<dyn CacheTrait>,

--- a/src/moonlink/src/storage/mooncake_table/snapshot_read_output.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot_read_output.rs
@@ -439,7 +439,7 @@ mod tests {
                         _ => 0,
                     };
                     tokio::time::sleep(Duration::from_millis(delay)).await;
-                    Ok((None, SmallVec::new()))
+                    Ok((/*cache_handle=*/None, /*evicted_files=*/SmallVec::new()))
                 })
             }
         });

--- a/src/moonlink/src/storage/mooncake_table/snapshot_read_output.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot_read_output.rs
@@ -490,7 +490,7 @@ mod tests {
             .returning(|_, _, _| {
                 Box::pin(async move {
                     tokio::time::sleep(Duration::from_millis(20)).await;
-                    Ok((None, SmallVec::new()))
+                    Ok((/*cache_handle=*/None, /*evicted_files=*/SmallVec::new()))
                 })
             });
 


### PR DESCRIPTION


<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary
The current snapshot reading implementation processes files sequentially, one by one. This can cause performance issues when a file is particularly large, leading to unnecessary delays.

### Improvement
Introduce parallel file reading to reduce total wait time. By downloading and pinning multiple files concurrently, the overall snapshot read process becomes faster and more efficient.

## Related Issues

Closes #1310 

## Changes

- parallelize the download / pin, seq the others
- init the evicted_files_to_delete_on_error size

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [x] Documentation updated if necessary
- [x] I have reviewed my own changes
