### PR TITLE
[storage] Fix missing flush LSN

### DIFF
--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -66,7 +66,7 @@ pub(crate) use disk_slice::DiskSliceWriter;
 use mem_slice::MemSlice;
 use more_asserts as ma;
 pub(crate) use snapshot::SnapshotTableState;
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
 use table_snapshot::{IcebergSnapshotImportResult, IcebergSnapshotIndexMergeResult};
@@ -463,6 +463,12 @@ pub struct MooncakeTable {
     /// Maps from LSN to its count.
     pub ongoing_flush_lsns: BTreeMap<u64, u32>,
 
+    /// Unrecorded completed flush LSNs.
+    ///
+    /// All flush operations are async, which means it's possible that flushes with larger LSN finish before those with smaller LSNs, so they cannot be reflected to snapshot flush LSN immediately.
+    /// To avoid losing LSNs, we need to keep track of early completed unrecorded LSNs as well.
+    pub completed_unrecorded_flush_lsns: BTreeSet<u64>,
+
     /// Table replay sender.
     event_replay_tx: Option<mpsc::UnboundedSender<MooncakeTableEvent>>,
 }
@@ -563,6 +569,7 @@ impl MooncakeTable {
             table_notify: None,
             wal_manager,
             ongoing_flush_lsns: BTreeMap::new(),
+            completed_unrecorded_flush_lsns: BTreeSet::new(),
             event_replay_tx: None,
         })
     }
@@ -916,11 +923,28 @@ impl MooncakeTable {
     // Attempts to set the flush LSN for the next iceberg snapshot. Note that we can only set the flush LSN if it's less than the current min pending flush LSN. Otherwise, LSNs will be persisted to iceberg in the wrong order.
     fn try_set_next_flush_lsn(&mut self, lsn: u64) {
         let min_pending_lsn = self.get_min_ongoing_flush_lsn();
+
         if lsn < min_pending_lsn {
             if let Some(old_flush_lsn) = self.next_snapshot_task.new_flush_lsn {
                 ma::assert_le!(old_flush_lsn, lsn);
             }
             self.next_snapshot_task.new_flush_lsn = Some(lsn);
+        } else {
+            // It's possible to have multiple flushes with the same LSN.
+            self.completed_unrecorded_flush_lsns.insert(lsn);
+        }
+
+        // Check whether we need to add completed unrecorded flush LSNs into next snapshot.
+        if self.ongoing_flush_lsns.is_empty() {
+            if let Some(smallest_lsn) = self.completed_unrecorded_flush_lsns.first() {
+                if let Some(cur_flush_lsn) = self.next_snapshot_task.new_flush_lsn {
+                    ma::assert_le!(cur_flush_lsn, smallest_lsn);
+                }
+            }
+            if let Some(largest_lsn) = self.completed_unrecorded_flush_lsns.last() {
+                self.next_snapshot_task.new_flush_lsn = Some(*largest_lsn);
+            }
+            self.completed_unrecorded_flush_lsns.clear();
         }
     }
 

--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -936,13 +936,11 @@ impl MooncakeTable {
 
         // Check whether we need to add completed unrecorded flush LSNs into next snapshot.
         if self.ongoing_flush_lsns.is_empty() {
-            if let Some(smallest_lsn) = self.completed_unrecorded_flush_lsns.first() {
-                if let Some(cur_flush_lsn) = self.next_snapshot_task.new_flush_lsn {
-                    ma::assert_le!(cur_flush_lsn, smallest_lsn);
-                }
-            }
             if let Some(largest_lsn) = self.completed_unrecorded_flush_lsns.last() {
-                self.next_snapshot_task.new_flush_lsn = Some(*largest_lsn);
+                // Till this point, flush LSN is already set.
+                if *largest_lsn > self.next_snapshot_task.new_flush_lsn.unwrap() {
+                    self.next_snapshot_task.new_flush_lsn = Some(*largest_lsn);
+                }
             }
             self.completed_unrecorded_flush_lsns.clear();
         }

--- a/src/moonlink/src/storage/mooncake_table/table_operation_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_operation_test_utils.rs
@@ -1,10 +1,8 @@
-#[cfg(test)]
 use std::collections::HashMap;
 use std::sync::Arc;
 
 use tokio::sync::mpsc::Receiver;
 
-#[cfg(test)]
 use crate::row::MoonlinkRow;
 use crate::storage::io_utils;
 use crate::storage::mooncake_table::disk_slice::DiskSliceWriter;
@@ -27,7 +25,6 @@ use tracing::{debug, error};
 /// ===============================
 ///
 /// Synchronize on ongoing flushes and return a map of <event id, disk slice>.
-#[cfg(test)]
 pub(crate) async fn get_flush_results(
     receiver: &mut Receiver<TableEvent>,
     expected_flushes: usize,
@@ -159,7 +156,6 @@ pub(crate) async fn flush_stream_and_sync_no_apply(
 }
 
 /// Commit transaction stream, block wait its completion and reflect result to mooncake table.
-#[cfg(test)]
 pub(crate) async fn commit_transaction_stream_and_sync(
     table: &mut MooncakeTable,
     receiver: &mut Receiver<TableEvent>,
@@ -198,7 +194,6 @@ pub(crate) async fn commit_transaction_stream_and_sync(
 /// ===============================
 ///
 /// Test util function to block wait delete request, and check whether matches expected data files.
-#[cfg(test)]
 pub(crate) async fn sync_delete_evicted_files(
     receiver: &mut Receiver<TableEvent>,
     mut expected_files_to_delete: Vec<String>,
@@ -385,11 +380,6 @@ pub(crate) async fn create_mooncake_and_persist_for_test(
     io_utils::delete_local_files(&evicted_data_files_to_delete)
         .await
         .unwrap();
-
-    println!(
-        "after creating mooncake snapshot, iceberg snapdhot ? {}",
-        iceberg_snapshot_payload.is_some()
-    );
 
     // Create iceberg snapshot if possible.
     if let Some(iceberg_snapshot_payload) = iceberg_snapshot_payload {

--- a/src/moonlink/src/storage/mooncake_table/tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/tests.rs
@@ -2988,7 +2988,7 @@ async fn test_late_arriving_high_flush_lsn() {
     let lsn_1 = 13;
     let lsn_2 = 16;
 
-    let flush_event_ids = vec![
+    let flush_event_ids = [
         uuid::Uuid::new_v4(),
         uuid::Uuid::new_v4(),
         uuid::Uuid::new_v4(),
@@ -2999,12 +2999,12 @@ async fn test_late_arriving_high_flush_lsn() {
         .append_in_stream_batch(test_row(1, "A", 10), xact_id_1)
         .unwrap();
     table
-        .flush_stream(xact_id_1, /*lsn=*/ None, flush_event_ids[0].clone())
+        .flush_stream(xact_id_1, /*lsn=*/ None, flush_event_ids[0])
         .unwrap();
 
     // Second flush operation.
     table
-        .commit_transaction_stream(xact_id_1, lsn_1, flush_event_ids[1].clone())
+        .commit_transaction_stream(xact_id_1, lsn_1, flush_event_ids[1])
         .unwrap();
 
     // Third flush operation.
@@ -3012,7 +3012,7 @@ async fn test_late_arriving_high_flush_lsn() {
         .append_in_stream_batch(test_row(2, "B", 20), xact_id_2)
         .unwrap();
     table
-        .commit_transaction_stream(xact_id_2, lsn_2, flush_event_ids[2].clone())
+        .commit_transaction_stream(xact_id_2, lsn_2, flush_event_ids[2])
         .unwrap();
 
     // Validate all streaming LSN are tracked.


### PR DESCRIPTION
## Summary

Suppose we have three ongoing flush operations, two with flush LSN 13, one with flush LSN 16.
If they finish in the order of 13, 16, 13; in the current implementation we will miss LSN 16, see linked issue for example.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1770

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [x] Documentation updated if necessary
- [x] I have reviewed my own changes
