### PR TITLE
[chaos] Record puffin blob deleted rows

### DIFF
--- a/src/moonlink/src/storage/compaction/test_utils.rs
+++ b/src/moonlink/src/storage/compaction/test_utils.rs
@@ -220,6 +220,7 @@ pub(crate) async fn dump_deletion_vector_puffin(
         puffin_file_cache_handle: cache_handle.unwrap(),
         start_offset: 4_u32, // Puffin file starts with 4 magic bytes.
         blob_size: blob_size as u32,
+        num_rows: deleted_rows_num,
     }
 }
 

--- a/src/moonlink/src/storage/iceberg/iceberg_table_loader.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_loader.rs
@@ -120,6 +120,8 @@ impl IcebergTableManager {
 
         IcebergValidation::validate_puffin_manifest_entry(entry)?;
         let deletion_vector = DeletionVector::load_from_dv_blob(file_io.clone(), data_file).await?;
+        let num_rows = data_file.record_count();
+
         let batch_deletion_vector = deletion_vector.take_as_batch_delete_vector();
         data_file_entry.deletion_vector = batch_deletion_vector;
 
@@ -162,6 +164,7 @@ impl IcebergTableManager {
             puffin_file_cache_handle: cache_handle.unwrap(),
             start_offset: data_file.content_offset().unwrap() as u32,
             blob_size: data_file.content_size_in_bytes().unwrap() as u32,
+            num_rows: num_rows as usize,
         };
 
         Ok(Some((*data_file_id, persisted_deletion_vector)))

--- a/src/moonlink/src/storage/iceberg/iceberg_table_syncer.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_syncer.rs
@@ -163,6 +163,7 @@ impl IcebergTableManager {
             puffin_file_cache_handle: cache_handle.unwrap(),
             start_offset: 4_u32, // Puffin file starts with 4 magic bytes.
             blob_size: blob_size as u32,
+            num_rows: deleted_row_count,
         };
         Ok(puffin_blob_ref)
     }

--- a/src/moonlink/src/storage/iceberg/puffin_utils.rs
+++ b/src/moonlink/src/storage/iceberg/puffin_utils.rs
@@ -19,6 +19,8 @@ pub struct PuffinBlobRef {
     pub(crate) start_offset: u32,
     /// Blob size.
     pub(crate) blob_size: u32,
+    /// Number of rows deleted in the puffin blob.
+    pub(crate) num_rows: usize,
 }
 
 /// Get puffin writer with the given file io.

--- a/src/moonlink/src/storage/mooncake_table/replay/replay_events.rs
+++ b/src/moonlink/src/storage/mooncake_table/replay/replay_events.rs
@@ -196,8 +196,8 @@ pub struct CacheHandleEvent {
 pub struct SingleCompactionPayloadEvent {
     /// File id.
     pub file_id: TableUniqueFileId,
-    /// Deletion vector.
-    pub puffin_blob_ref: Option<CacheHandleEvent>,
+    /// Number of rows deleted.
+    pub num_rows_deleted: usize,
 }
 
 /// For the ease of serde, replay event only stores necessary part of [`DataCompactionPayload`].
@@ -446,20 +446,15 @@ pub fn create_index_merge_event_completion(uuid: uuid::Uuid) -> IndexMergeEventC
     IndexMergeEventCompletion { uuid }
 }
 /// Create data compaction events.
-pub fn get_cache_handle_event(cache_handle: &Option<PuffinBlobRef>) -> Option<CacheHandleEvent> {
-    if let Some(cache_handle) = cache_handle {
-        return Some(CacheHandleEvent {
-            file_id: cache_handle.puffin_file_cache_handle.file_id,
-        });
-    }
-    None
-}
 pub fn get_file_compaction_payload(
     single_file_compaction: &SingleFileToCompact,
 ) -> SingleCompactionPayloadEvent {
     SingleCompactionPayloadEvent {
         file_id: single_file_compaction.file_id,
-        puffin_blob_ref: get_cache_handle_event(&single_file_compaction.deletion_vector),
+        num_rows_deleted: single_file_compaction
+            .deletion_vector
+            .as_ref()
+            .map_or(0, |puffin_blob_ref| puffin_blob_ref.num_rows),
     }
 }
 pub fn create_data_compaction_event_initiation(


### PR DESCRIPTION
## Summary

Current replay event json file only records puffin blob file id, which is useless for inspect deleted rows or row number.
When debugging chaos test, number of rows is important to check whether compaction outcome is correct or not.
This PR adds number of rows to puffin blob data structure, and update replay events accordingly.

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
