### PR TITLE
Implement Upsert/ Delete if exist for event API

### DIFF
--- a/src/moonlink/src/storage/iceberg/compaction_tests.rs
+++ b/src/moonlink/src/storage/iceberg/compaction_tests.rs
@@ -202,6 +202,7 @@ async fn check_loaded_file_index(file_index: FileIndex, row_indices: Vec<usize>)
             lsn: 0, // Doesn't affect.
             pos: None,
             row_identity: row_identity.extract_identity_columns(cur_row),
+            delete_if_exists: false,
         };
         let record_locations = mooncake_index.find_record(&raw_deletion_record).await;
         assert_eq!(

--- a/src/moonlink/src/storage/index/hash_index.rs
+++ b/src/moonlink/src/storage/index/hash_index.rs
@@ -110,6 +110,7 @@ mod tests {
             row_identity: None,
             pos: None,
             lsn: 1,
+            delete_if_exists: false,
         };
 
         // Test the Index trait implementation

--- a/src/moonlink/src/storage/index/mem_index.rs
+++ b/src/moonlink/src/storage/index/mem_index.rs
@@ -191,6 +191,7 @@ mod tests {
             row_identity: None,
             pos: None,
             lsn: 0,
+            delete_if_exists: false,
         });
         assert!(record_loc.is_none());
 
@@ -200,6 +201,7 @@ mod tests {
             row_identity: None,
             pos: None,
             lsn: 0,
+            delete_if_exists: false,
         };
         let record_loc = mem_index.fast_delete(&deletion_record);
         assert!(matches!(
@@ -238,6 +240,7 @@ mod tests {
             row_identity: Some(non_existent_row.clone()),
             pos: None,
             lsn: 0,
+            delete_if_exists: false,
         });
         assert!(record_loc.is_none());
 
@@ -247,6 +250,7 @@ mod tests {
             row_identity: Some(non_existent_row.clone()),
             pos: None,
             lsn: 0,
+            delete_if_exists: false,
         });
         assert!(record_loc.is_none());
 
@@ -256,6 +260,7 @@ mod tests {
             row_identity: Some(existent_row.clone()),
             pos: None,
             lsn: 0,
+            delete_if_exists: false,
         };
         let record_loc = mem_index.fast_delete(&deletion_record);
         assert!(matches!(
@@ -283,6 +288,7 @@ mod tests {
             row_identity: None,
             pos: None,
             lsn: 0,
+            delete_if_exists: false,
         });
         assert!(record_locs.is_empty());
 
@@ -292,6 +298,7 @@ mod tests {
             row_identity: None,
             pos: None,
             lsn: 0,
+            delete_if_exists: false,
         };
         let record_loc = mem_index.find_record(&deletion_record);
         assert_eq!(record_loc.len(), 1);
@@ -324,6 +331,7 @@ mod tests {
             row_identity: Some(non_existent_row.clone()),
             pos: None,
             lsn: 0,
+            delete_if_exists: false,
         });
         assert!(record_loc.is_empty());
 
@@ -333,6 +341,7 @@ mod tests {
             row_identity: Some(non_existent_row.clone()),
             pos: None,
             lsn: 0,
+            delete_if_exists: false,
         });
         assert!(record_loc.is_empty());
 
@@ -342,6 +351,7 @@ mod tests {
             row_identity: Some(existent_row.clone()),
             pos: None,
             lsn: 0,
+            delete_if_exists: false,
         };
         let record_loc = mem_index.find_record(&deletion_record);
         assert_eq!(record_loc.len(), 1);
@@ -374,6 +384,7 @@ mod tests {
             row_identity: Some(non_existent_row.clone()),
             pos: None,
             lsn: 0,
+            delete_if_exists: false,
         });
         assert!(record_loc.is_empty());
 
@@ -383,6 +394,7 @@ mod tests {
             row_identity: Some(existent_row.clone()),
             pos: None,
             lsn: 0,
+            delete_if_exists: false,
         };
         let record_loc = mem_index.find_record(&deletion_record);
         assert_eq!(record_loc.len(), 1);

--- a/src/moonlink/src/storage/mooncake_table/disk_slice.rs
+++ b/src/moonlink/src/storage/mooncake_table/disk_slice.rs
@@ -466,6 +466,7 @@ mod tests {
                     row_identity: None,
                     pos: Some((0, 1)),
                     lsn: 1,
+                    delete_if_exists: false,
                 },
                 &IdentityProp::SinglePrimitiveKey(0),
             )
@@ -477,6 +478,7 @@ mod tests {
                     row_identity: None,
                     pos: Some((0, 3)),
                     lsn: 1,
+                    delete_if_exists: false,
                 },
                 &IdentityProp::SinglePrimitiveKey(0),
             )

--- a/src/moonlink/src/storage/mooncake_table/mem_slice.rs
+++ b/src/moonlink/src/storage/mooncake_table/mem_slice.rs
@@ -214,6 +214,7 @@ mod tests {
                         lsn: 0,
                         pos: None,
                         row_identity: None,
+                        delete_if_exists: false,
                     },
                     &IdentityProp::SinglePrimitiveKey(0)
                 )
@@ -228,6 +229,7 @@ mod tests {
                         lsn: 0,
                         pos: None,
                         row_identity: None,
+                        delete_if_exists: false,
                     },
                     &IdentityProp::SinglePrimitiveKey(0)
                 )
@@ -242,6 +244,7 @@ mod tests {
                         lsn: 0,
                         pos: None,
                         row_identity: None,
+                        delete_if_exists: false,
                     },
                     &IdentityProp::SinglePrimitiveKey(0)
                 )

--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -777,6 +777,7 @@ impl SnapshotTableState {
         index_lookup_result: Vec<RecordLocation>,
         file_id_to_lsn: &HashMap<FileId, u64>,
         batch_id_to_lsn: &HashMap<u64, u64>,
+        delete_if_exists: bool,
     ) -> Vec<ProcessedDeletionRecord> {
         let mut candidates: Vec<RecordLocation> = index_lookup_result
             .into_iter()
@@ -790,6 +791,30 @@ impl SnapshotTableState {
                     )
             })
             .collect();
+
+        if delete_if_exists {
+            let mut processed_deletions = Vec::new();
+            assert!(deletions.len() == 1);
+            let deletion = deletions.first().unwrap();
+            if deletion.row_identity.is_none() {
+                let candidate = candidates.pop();
+                if let Some(candidate) = candidate {
+                    processed_deletions.push(Self::build_processed_deletion(deletion, candidate));
+                }
+            } else {
+                for loc in &candidates {
+                    if self
+                        .matches_identity(loc, deletion.row_identity.as_ref().unwrap())
+                        .await
+                    {
+                        processed_deletions
+                            .push(Self::build_processed_deletion(deletion, loc.clone()));
+                        break;
+                    }
+                }
+            }
+            return processed_deletions;
+        }
         // This optimization is important when working with table without primary key.
         // Postgres never distinguish row with same value, so they will almost always be processed together.
         // Thus we can avoid full row identity comparison if we also process them together.
@@ -988,6 +1013,17 @@ impl SnapshotTableState {
         if new_deletions.is_empty() {
             return;
         }
+        // moonlink don't support mix delete_if_exists and not delete_if_exists for now.
+        //
+        let delete_if_exists = new_deletions
+            .iter()
+            .any(|deletion| deletion.delete_if_exists);
+        assert_eq!(
+            delete_if_exists,
+            new_deletions
+                .iter()
+                .all(|deletion| deletion.delete_if_exists)
+        );
         let mut index_lookup_result = self
             .current_snapshot
             .indices
@@ -1006,7 +1042,9 @@ impl SnapshotTableState {
             }
             let deletions = &new_deletions[start_i..i];
             let mut lookup_result = Vec::new();
-            while index_lookup_result[j].0 != new_deletions[start_i].lookup_key {
+            while j < index_lookup_result.len()
+                && index_lookup_result[j].0 != new_deletions[start_i].lookup_key
+            {
                 j += 1;
             }
             let mut j_end = j;
@@ -1022,6 +1060,7 @@ impl SnapshotTableState {
                     lookup_result,
                     &task.new_disk_file_lsn_map,
                     &task.flushing_batch_lsn_map,
+                    delete_if_exists,
                 )
                 .await;
             self.add_processed_deletion(processed_deletions, task.commit_lsn_baseline);

--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -794,7 +794,7 @@ impl SnapshotTableState {
 
         if delete_if_exists {
             let mut processed_deletions = Vec::new();
-            assert!(deletions.len() == 1);
+            assert_eq!(deletions.len(), 1);
             let deletion = deletions.first().unwrap();
             if deletion.row_identity.is_none() {
                 let candidate = candidates.pop();

--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -1043,7 +1043,7 @@ impl SnapshotTableState {
             let deletions = &new_deletions[start_i..i];
             let mut lookup_result = Vec::new();
             while j < index_lookup_result.len()
-                && index_lookup_result[j].0 != new_deletions[start_i].lookup_key
+                && index_lookup_result[j].0 < new_deletions[start_i].lookup_key
             {
                 j += 1;
             }

--- a/src/moonlink/src/storage/mooncake_table/table_creation_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_creation_test_utils.rs
@@ -203,7 +203,11 @@ pub(crate) fn create_test_table_metadata_with_config(
 
 /// Test util function to get random row identity.
 #[cfg(feature = "chaos-test")]
-pub(crate) fn get_random_identity(random_seed: u64, append_only: bool) -> IdentityProp {
+pub(crate) fn get_random_identity(
+    random_seed: u64,
+    append_only: bool,
+    upsert_delete_if_exists: bool,
+) -> IdentityProp {
     // If append only, no random choice.
     if append_only {
         return IdentityProp::None;
@@ -212,11 +216,13 @@ pub(crate) fn get_random_identity(random_seed: u64, append_only: bool) -> Identi
     use rand::{seq::IndexedRandom, SeedableRng};
     let mut rng = rand::rngs::StdRng::seed_from_u64(random_seed);
 
-    let identities = [
+    let mut identities = vec![
         IdentityProp::SinglePrimitiveKey(0),
         IdentityProp::Keys(vec![0]),
-        IdentityProp::FullRow,
     ];
+    if !upsert_delete_if_exists {
+        identities.push(IdentityProp::FullRow);
+    }
     identities.choose(&mut rng).unwrap().clone()
 }
 

--- a/src/moonlink/src/storage/mooncake_table/tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/tests.rs
@@ -3129,3 +3129,66 @@ async fn test_out_of_order_flush_for_iceberg_snapshot() {
     let flush_lsn = iceberg_snapshot_fetcher.get_flush_lsn().await.unwrap();
     assert!(flush_lsn.is_none());
 }
+
+#[tokio::test]
+async fn test_delete_if_exists() -> Result<()> {
+    let context = TestContext::new("test_delete_if_exists");
+    let mut table = test_table(
+        &context,
+        "test_delete_if_exists",
+        IdentityProp::Keys(vec![0]),
+    )
+    .await;
+    let (event_completion_tx, mut event_completion_rx) = mpsc::channel(100);
+    table.register_table_notify(event_completion_tx).await;
+
+    let row1 = test_row(1, "A", 20);
+    table.append(row1.clone()).unwrap();
+    table.commit(100);
+    flush_table_and_sync(&mut table, &mut event_completion_rx, 100)
+        .await
+        .unwrap();
+
+    // delete a row that doesn't exist
+    let row2 = test_row(2, "B", 21);
+    table.delete_if_exists(row2.clone(), 101).await;
+    table.commit(102);
+    flush_table_and_sync(&mut table, &mut event_completion_rx, 102)
+        .await
+        .unwrap();
+
+    // create a snapshot and verify the row is not deleted
+    {
+        create_mooncake_snapshot_for_test(&mut table, &mut event_completion_rx).await;
+
+        let mut snapshot = table.snapshot.write().await;
+        let SnapshotReadOutput {
+            data_file_paths,
+            puffin_cache_handles,
+            position_deletes,
+            deletion_vectors,
+            ..
+        } = snapshot.request_read().await.unwrap();
+
+        verify_files_and_deletions(
+            get_data_files_for_read(&data_file_paths).as_slice(),
+            get_deletion_puffin_files_for_read(&puffin_cache_handles).as_slice(),
+            position_deletes,
+            deletion_vectors,
+            &[1],
+        )
+        .await;
+        drop(snapshot);
+    }
+
+    // upsert a row
+    let row3 = test_row(1, "C", 22);
+    table.delete_if_exists(row3.clone(), 103).await;
+    table.append(row3.clone()).unwrap();
+    table.commit(104);
+    flush_table_and_sync(&mut table, &mut event_completion_rx, 104)
+        .await
+        .unwrap();
+
+    Ok(())
+}

--- a/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
+++ b/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
@@ -213,6 +213,7 @@ impl MooncakeTable {
             lsn: get_lsn_for_pending_xact(xact_id), // at commit time we will update this with the actual lsn
             pos: None,
             row_identity: row_identity.extract_identity_columns(row),
+            delete_if_exists: false,
         };
 
         let stream_state = self.get_or_create_stream_state(xact_id);

--- a/src/moonlink/src/storage/mooncake_table/validation_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/validation_test_utils.rs
@@ -141,6 +141,7 @@ pub(crate) async fn check_row_index_nonexistent(snapshot: &Snapshot, row: &Moonl
                 .extract_identity_for_key(row),
             pos: None,
             lsn: 0, // LSN has nothing to do with deletion record search
+            delete_if_exists: false,
         })
         .await;
     assert!(
@@ -167,6 +168,7 @@ pub(crate) async fn check_row_index_on_disk(
                 .extract_identity_for_key(row),
             pos: None,
             lsn: 0, // LSN has nothing to do with deletion record search
+            delete_if_exists: false,
         })
         .await;
     assert_eq!(locs.len(), 1, "Actual location for row {row:?} is {locs:?}");

--- a/src/moonlink/src/storage/storage_utils.rs
+++ b/src/moonlink/src/storage/storage_utils.rs
@@ -130,6 +130,7 @@ pub struct RawDeletionRecord {
     pub(crate) row_identity: Option<MoonlinkRow>,
     pub(crate) pos: Option<(u64, usize)>,
     pub(crate) lsn: u64,
+    pub(crate) delete_if_exists: bool,
 }
 
 #[derive(Clone, Debug)]

--- a/src/moonlink/src/storage/wal.rs
+++ b/src/moonlink/src/storage/wal.rs
@@ -86,6 +86,7 @@ pub enum WalEvent {
         row: MoonlinkRow,
         lsn: u64,
         xact_id: Option<u32>,
+        delete_if_exists: bool,
     },
     Commit {
         lsn: u64,
@@ -141,11 +142,16 @@ impl WalEvent {
                 is_copied: *is_copied,
             },
             TableEvent::Delete {
-                row, lsn, xact_id, ..
+                row,
+                lsn,
+                xact_id,
+                delete_if_exists,
+                ..
             } => WalEvent::Delete {
                 row: row.clone(),
                 lsn: *lsn,
                 xact_id: *xact_id,
+                delete_if_exists: *delete_if_exists,
             },
             TableEvent::Commit { lsn, xact_id, .. } => WalEvent::Commit {
                 lsn: *lsn,
@@ -178,10 +184,16 @@ impl WalEvent {
                 is_copied,
                 is_recovery: false,
             },
-            WalEvent::Delete { row, lsn, xact_id } => TableEvent::Delete {
+            WalEvent::Delete {
                 row,
                 lsn,
                 xact_id,
+                delete_if_exists,
+            } => TableEvent::Delete {
+                row,
+                lsn,
+                xact_id,
+                delete_if_exists,
                 is_recovery: false,
             },
             WalEvent::Commit { lsn, xact_id } => TableEvent::Commit {

--- a/src/moonlink/src/storage/wal/test_utils.rs
+++ b/src/moonlink/src/storage/wal/test_utils.rs
@@ -366,6 +366,7 @@ pub fn add_new_example_delete_event(
         row: test_row(1, "Alice", 30),
         lsn,
         xact_id,
+        delete_if_exists: false,
         is_recovery: false,
     };
     wal.push(&event);

--- a/src/moonlink/src/table_handler/chaos_test.rs
+++ b/src/moonlink/src/table_handler/chaos_test.rs
@@ -176,6 +176,8 @@ struct ChaosState {
     rng: StdRng,
     /// Whether to enable delete operations.
     append_only: bool,
+    /// Whether to test upsert/ delete if exists.
+    is_upsert_table: bool,
     /// Non table update operation invocation status.
     non_table_update_cmd_call: NonTableUpdateCmdCall,
     /// Used to generate rows to insert.
@@ -207,12 +209,18 @@ struct ChaosState {
 }
 
 impl ChaosState {
-    fn new(read_state_manager: ReadStateManager, random_seed: u64, append_only: bool) -> Self {
+    fn new(
+        read_state_manager: ReadStateManager,
+        random_seed: u64,
+        append_only: bool,
+        upsert_delete_if_exists: bool,
+    ) -> Self {
         let rng = StdRng::seed_from_u64(random_seed);
         Self {
             random_seed,
             rng,
             append_only,
+            is_upsert_table: upsert_delete_if_exists,
             non_table_update_cmd_call: NonTableUpdateCmdCall::default(),
             txn_state: TxnState::Empty,
             next_id: 0,
@@ -342,6 +350,13 @@ impl ChaosState {
             .any(|(cur_id, _)| *cur_id == id)
     }
 
+    fn can_append(&self) -> bool {
+        if self.is_upsert_table {
+            return false;
+        }
+        true
+    }
+
     /// Return whether we could delete a row in the next event.
     ///
     /// The logic corresponds to [`get_random_row_to_delete`].
@@ -417,6 +432,13 @@ impl ChaosState {
 
     /// Get a random row to delete.
     fn get_random_row_to_delete(&mut self) -> MoonlinkRow {
+        if self.is_upsert_table && self.rng.random_range(0..100) < 50 {
+            // Delete a none existing row.
+            let row = create_row(self.next_id, /*name=*/ "user", self.next_id % 5);
+            self.next_id += 1;
+            return row;
+        }
+
         let mut candidates: Vec<(i32, MoonlinkRow, bool /*committed*/)> = self
             .committed_inserted_rows
             .iter()
@@ -471,6 +493,14 @@ impl ChaosState {
 
     /// Get a random row to update.
     fn get_random_row_to_update(&mut self) -> MoonlinkRow {
+        if self.is_upsert_table && self.rng.random_range(0..100) < 50 {
+            // upsert a new row.
+            let row = create_row(self.next_id, /*name=*/ "user", self.next_id % 5);
+            self.uncommitted_inserted_rows
+                .push_back((self.next_id, row.clone()));
+            self.next_id += 1;
+            return row;
+        }
         let mut candidates: Vec<(i32, MoonlinkRow)> = self
             .committed_inserted_rows
             .iter()
@@ -570,10 +600,14 @@ impl ChaosState {
         self.try_push_read_snapshot_cmd(&mut choices);
         self.try_push_table_maintenance_cmd(&mut choices);
         if self.txn_state == TxnState::Empty {
-            choices.push(EventKind::BeginStreamingTxn);
+            if !self.is_upsert_table {
+                choices.push(EventKind::BeginStreamingTxn);
+            }
             choices.push(EventKind::BeginNonStreamingTxn);
         } else {
-            choices.push(EventKind::Append);
+            if self.can_append() {
+                choices.push(EventKind::Append);
+            }
             if self.can_delete() {
                 choices.push(EventKind::Delete);
             }
@@ -635,7 +669,7 @@ impl ChaosState {
                 row: self.get_random_row_to_delete(),
                 xact_id: self.get_cur_xact_id(),
                 lsn: self.get_and_update_cur_lsn(),
-                delete_if_exists: false,
+                delete_if_exists: self.is_upsert_table,
                 is_recovery: false,
             }]),
             EventKind::Update => {
@@ -645,7 +679,7 @@ impl ChaosState {
                         row: row.clone(),
                         xact_id: self.get_cur_xact_id(),
                         lsn: self.get_and_update_cur_lsn(),
-                        delete_if_exists: false,
+                        delete_if_exists: self.is_upsert_table,
                         is_recovery: false,
                     },
                     TableEvent::Append {
@@ -706,6 +740,16 @@ enum TableMaintenanceOption {
     DataCompaction,
 }
 
+#[derive(Clone, Debug, PartialEq)]
+enum SpecialTableOption {
+    /// No special table option.
+    None,
+    /// Upsert/ delete if exists.
+    UpsertDeleteIfExists,
+    /// Append only.
+    AppendOnly,
+}
+
 #[derive(Clone, Debug)]
 struct TestEnvConfig {
     /// Test name.
@@ -714,8 +758,8 @@ struct TestEnvConfig {
     disk_slice_write_chaos_enabled: bool,
     /// Whether to enable local filesystem optimization for object storage cache.
     local_filesystem_optimization_enabled: bool,
-    /// Whether to disable deletion, just append operation.
-    append_only: bool,
+    /// Special table option.
+    special_table_option: SpecialTableOption,
     /// Table background maintenance option.
     maintenance_option: TableMaintenanceOption,
     /// Event count.
@@ -753,7 +797,11 @@ impl TestEnvironment {
             config.disk_slice_write_chaos_enabled,
             chaos_test_arg.seed,
         );
-        let identity = get_random_identity(chaos_test_arg.seed, config.append_only);
+        let identity = get_random_identity(
+            chaos_test_arg.seed,
+            config.special_table_option == SpecialTableOption::AppendOnly,
+            config.special_table_option == SpecialTableOption::UpsertDeleteIfExists,
+        );
         let mooncake_table_metadata = match &config.maintenance_option {
             TableMaintenanceOption::NoTableMaintenance => create_test_table_metadata_disable_flush(
                 table_temp_dir.path().to_str().unwrap().to_string(),
@@ -964,7 +1012,7 @@ async fn chaos_test_impl(mut env: TestEnvironment) {
     let event_sender = env.event_sender.clone();
     let read_state_manager = env.read_state_manager;
     let mut table_event_manager = env.table_event_manager;
-    let last_commit_lsn_tx = env.last_commit_lsn_tx.clone();
+    let last_commit_lsn_tx = env.last_commit_lsn_tx;
     let replication_lsn_tx = env.replication_lsn_tx.clone();
 
     // Fields used to recreate a new mooncake table.
@@ -976,7 +1024,8 @@ async fn chaos_test_impl(mut env: TestEnvironment) {
         let mut state = ChaosState::new(
             read_state_manager,
             cloned_args.seed,
-            test_env_config.append_only,
+            test_env_config.special_table_option == SpecialTableOption::AppendOnly,
+            test_env_config.special_table_option == SpecialTableOption::UpsertDeleteIfExists,
         );
         println!(
             "Test {} is with random seed {}",
@@ -1091,7 +1140,7 @@ async fn test_disk_slice_chaos_on_local_fs() {
         test_name: function_name!(),
         local_filesystem_optimization_enabled: false,
         disk_slice_write_chaos_enabled: true,
-        append_only: false,
+        special_table_option: SpecialTableOption::None,
         maintenance_option: TableMaintenanceOption::NoTableMaintenance,
         error_injection_enabled: false,
         event_count: 2000,
@@ -1118,7 +1167,7 @@ async fn test_chaos_on_local_fs_with_no_background_maintenance() {
         test_name: function_name!(),
         local_filesystem_optimization_enabled: false,
         disk_slice_write_chaos_enabled: false,
-        append_only: false,
+        special_table_option: SpecialTableOption::None,
         maintenance_option: TableMaintenanceOption::NoTableMaintenance,
         error_injection_enabled: false,
         event_count: 3500,
@@ -1141,7 +1190,7 @@ async fn test_chaos_on_local_fs_with_index_merge() {
         test_name: function_name!(),
         local_filesystem_optimization_enabled: false,
         disk_slice_write_chaos_enabled: false,
-        append_only: false,
+        special_table_option: SpecialTableOption::None,
         maintenance_option: TableMaintenanceOption::IndexMerge,
         error_injection_enabled: false,
         event_count: 3500,
@@ -1164,7 +1213,7 @@ async fn test_chaos_on_local_fs_with_data_compaction() {
         test_name: function_name!(),
         local_filesystem_optimization_enabled: false,
         disk_slice_write_chaos_enabled: false,
-        append_only: false,
+        special_table_option: SpecialTableOption::None,
         maintenance_option: TableMaintenanceOption::DataCompaction,
         error_injection_enabled: false,
         event_count: 3500,
@@ -1191,7 +1240,7 @@ async fn test_local_system_optimization_chaos_with_no_background_maintenance() {
         test_name: function_name!(),
         local_filesystem_optimization_enabled: true,
         disk_slice_write_chaos_enabled: false,
-        append_only: false,
+        special_table_option: SpecialTableOption::None,
         maintenance_option: TableMaintenanceOption::NoTableMaintenance,
         error_injection_enabled: false,
         event_count: 3500,
@@ -1214,7 +1263,7 @@ async fn test_local_system_optimization_chaos_with_index_merge() {
         test_name: function_name!(),
         local_filesystem_optimization_enabled: true,
         disk_slice_write_chaos_enabled: false,
-        append_only: false,
+        special_table_option: SpecialTableOption::None,
         maintenance_option: TableMaintenanceOption::IndexMerge,
         error_injection_enabled: false,
         event_count: 3500,
@@ -1237,7 +1286,7 @@ async fn test_local_system_optimization_chaos_with_data_compaction() {
         test_name: function_name!(),
         local_filesystem_optimization_enabled: true,
         disk_slice_write_chaos_enabled: false,
-        append_only: false,
+        special_table_option: SpecialTableOption::None,
         maintenance_option: TableMaintenanceOption::DataCompaction,
         error_injection_enabled: false,
         event_count: 3500,
@@ -1266,7 +1315,7 @@ async fn test_s3_chaos_with_no_background_maintenance() {
         test_name: function_name!(),
         local_filesystem_optimization_enabled: false,
         disk_slice_write_chaos_enabled: false,
-        append_only: false,
+        special_table_option: SpecialTableOption::None,
         maintenance_option: TableMaintenanceOption::NoTableMaintenance,
         error_injection_enabled: false,
         event_count: 3500,
@@ -1288,7 +1337,7 @@ async fn test_s3_chaos_with_index_merge() {
         test_name: function_name!(),
         local_filesystem_optimization_enabled: false,
         disk_slice_write_chaos_enabled: false,
-        append_only: false,
+        special_table_option: SpecialTableOption::None,
         maintenance_option: TableMaintenanceOption::IndexMerge,
         error_injection_enabled: false,
         event_count: 3500,
@@ -1310,7 +1359,7 @@ async fn test_s3_chaos_with_data_compaction() {
         test_name: function_name!(),
         local_filesystem_optimization_enabled: false,
         disk_slice_write_chaos_enabled: false,
-        append_only: false,
+        special_table_option: SpecialTableOption::None,
         maintenance_option: TableMaintenanceOption::DataCompaction,
         error_injection_enabled: false,
         event_count: 3500,
@@ -1336,7 +1385,7 @@ async fn test_gcs_chaos_with_no_background_maintenance() {
         test_name: function_name!(),
         local_filesystem_optimization_enabled: false,
         disk_slice_write_chaos_enabled: false,
-        append_only: false,
+        special_table_option: SpecialTableOption::None,
         maintenance_option: TableMaintenanceOption::NoTableMaintenance,
         error_injection_enabled: false,
         event_count: 3500,
@@ -1358,7 +1407,7 @@ async fn test_gcs_chaos_with_index_merge() {
         test_name: function_name!(),
         local_filesystem_optimization_enabled: false,
         disk_slice_write_chaos_enabled: false,
-        append_only: false,
+        special_table_option: SpecialTableOption::None,
         maintenance_option: TableMaintenanceOption::IndexMerge,
         error_injection_enabled: false,
         event_count: 3500,
@@ -1380,7 +1429,7 @@ async fn test_gcs_chaos_with_data_compaction() {
         test_name: function_name!(),
         local_filesystem_optimization_enabled: false,
         disk_slice_write_chaos_enabled: false,
-        append_only: false,
+        special_table_option: SpecialTableOption::None,
         maintenance_option: TableMaintenanceOption::DataCompaction,
         error_injection_enabled: false,
         event_count: 3500,
@@ -1404,7 +1453,7 @@ async fn test_chaos_injection_with_no_background_maintenance() {
         test_name: function_name!(),
         local_filesystem_optimization_enabled: false,
         disk_slice_write_chaos_enabled: false,
-        append_only: false,
+        special_table_option: SpecialTableOption::None,
         maintenance_option: TableMaintenanceOption::NoTableMaintenance,
         error_injection_enabled: true,
         event_count: 100,
@@ -1427,7 +1476,7 @@ async fn test_chaos_injection_with_index_merge() {
         test_name: function_name!(),
         local_filesystem_optimization_enabled: false,
         disk_slice_write_chaos_enabled: false,
-        append_only: false,
+        special_table_option: SpecialTableOption::None,
         maintenance_option: TableMaintenanceOption::IndexMerge,
         error_injection_enabled: true,
         event_count: 100,
@@ -1450,7 +1499,7 @@ async fn test_chaos_injection_with_data_compaction() {
         test_name: function_name!(),
         local_filesystem_optimization_enabled: false,
         disk_slice_write_chaos_enabled: false,
-        append_only: false,
+        special_table_option: SpecialTableOption::None,
         maintenance_option: TableMaintenanceOption::DataCompaction,
         error_injection_enabled: true,
         event_count: 100,
@@ -1477,7 +1526,7 @@ async fn test_append_only_chaos_on_local_fs_with_no_background_maintenance() {
         test_name: function_name!(),
         local_filesystem_optimization_enabled: false,
         disk_slice_write_chaos_enabled: false,
-        append_only: true,
+        special_table_option: SpecialTableOption::AppendOnly,
         maintenance_option: TableMaintenanceOption::NoTableMaintenance,
         error_injection_enabled: false,
         event_count: 3500,
@@ -1500,7 +1549,29 @@ async fn test_append_only_chaos_on_local_fs_with_data_compaction() {
         test_name: function_name!(),
         local_filesystem_optimization_enabled: false,
         disk_slice_write_chaos_enabled: false,
-        append_only: true,
+        special_table_option: SpecialTableOption::AppendOnly,
+        maintenance_option: TableMaintenanceOption::DataCompaction,
+        error_injection_enabled: false,
+        event_count: 3500,
+        storage_config: StorageConfig::FileSystem {
+            root_directory,
+            atomic_write_dir: None,
+        },
+    };
+    let env = TestEnvironment::new(test_env_config).await;
+    chaos_test_impl(env).await;
+}
+
+#[named]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_upsert_chaos_on_local_fs_with_data_compaction() {
+    let iceberg_temp_dir = tempdir().unwrap();
+    let root_directory = iceberg_temp_dir.path().to_str().unwrap().to_string();
+    let test_env_config = TestEnvConfig {
+        test_name: function_name!(),
+        local_filesystem_optimization_enabled: false,
+        disk_slice_write_chaos_enabled: false,
+        special_table_option: SpecialTableOption::UpsertDeleteIfExists,
         maintenance_option: TableMaintenanceOption::DataCompaction,
         error_injection_enabled: false,
         event_count: 3500,

--- a/src/moonlink/src/table_handler/chaos_test.rs
+++ b/src/moonlink/src/table_handler/chaos_test.rs
@@ -635,6 +635,7 @@ impl ChaosState {
                 row: self.get_random_row_to_delete(),
                 xact_id: self.get_cur_xact_id(),
                 lsn: self.get_and_update_cur_lsn(),
+                delete_if_exists: false,
                 is_recovery: false,
             }]),
             EventKind::Update => {
@@ -644,6 +645,7 @@ impl ChaosState {
                         row: row.clone(),
                         xact_id: self.get_cur_xact_id(),
                         lsn: self.get_and_update_cur_lsn(),
+                        delete_if_exists: false,
                         is_recovery: false,
                     },
                     TableEvent::Append {

--- a/src/moonlink/src/table_handler/test_utils.rs
+++ b/src/moonlink/src/table_handler/test_utils.rs
@@ -256,6 +256,7 @@ impl TestEnvironment {
             row,
             lsn,
             xact_id,
+            delete_if_exists: false,
             is_recovery: false,
         };
         self.send_event(event.clone()).await;

--- a/src/moonlink/src/table_notify.rs
+++ b/src/moonlink/src/table_notify.rs
@@ -77,6 +77,7 @@ pub enum TableEvent {
         row: MoonlinkRow,
         lsn: u64,
         xact_id: Option<u32>,
+        delete_if_exists: bool,
         is_recovery: bool,
     },
     /// Commit all pending operations with a given LSN and xact_id

--- a/src/moonlink_connectors/src/pg_replicate/moonlink_sink.rs
+++ b/src/moonlink_connectors/src/pg_replicate/moonlink_sink.rs
@@ -293,6 +293,7 @@ impl Sink {
                             row: PostgresTableRow(old_table_row.unwrap()).into(),
                             lsn: final_lsn,
                             xact_id,
+                            delete_if_exists: false,
                             is_recovery: false,
                         },
                     )
@@ -325,6 +326,7 @@ impl Sink {
                             row: PostgresTableRow(table_row).into(),
                             lsn: final_lsn,
                             xact_id,
+                            delete_if_exists: false,
                             is_recovery: false,
                         },
                     )

--- a/src/moonlink_connectors/src/rest_ingest/event_request.rs
+++ b/src/moonlink_connectors/src/rest_ingest/event_request.rs
@@ -10,7 +10,7 @@ use tokio::sync::mpsc;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RowEventOperation {
     Insert,
-    Update,
+    Upsert,
     Delete,
 }
 

--- a/src/moonlink_service/src/rest_api.rs
+++ b/src/moonlink_service/src/rest_api.rs
@@ -505,7 +505,7 @@ async fn ingest_data(
     // Parse operation
     let operation = match payload.operation.as_str() {
         "insert" => RowEventOperation::Insert,
-        "update" => RowEventOperation::Update,
+        "upsert" => RowEventOperation::Upsert,
         "delete" => RowEventOperation::Delete,
         _ => {
             return Err((
@@ -513,7 +513,7 @@ async fn ingest_data(
                 Json(ErrorResponse {
                     error: "invalid_operation".to_string(),
                     message: format!(
-                        "Invalid operation '{}'. Must be 'insert', 'update', or 'delete'",
+                        "Invalid operation '{}'. Must be 'insert', 'upsert', or 'delete'",
                         payload.operation
                     ),
                 }),


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary
If the table have primary key,
regular INSERT/ UPDATE/ DELETE could error and event api is usually not designed to handle this kind of failure.

Introducing Upsert /Delete if not exists, which provide simpler semantics and will success in all cases.

Upsert is implemented as append + delete_if_not_exist.

## Related Issues

Closes #<issue-number> or links to related issues.

## Changes

- 
- 
- 

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
