### PR TITLE
Control plane retry for transport errors

### DIFF
--- a/src/moonlink_backend/Cargo.toml
+++ b/src/moonlink_backend/Cargo.toml
@@ -46,5 +46,5 @@ rstest = "0.26"
 serial_test = { workspace = true }
 tempfile = { workspace = true }
 thrift = "0.17"
-tokio-postgres = { workspace = true }
 tokio = { workspace = true, features = ["test-util"] }
+tokio-postgres = { workspace = true }

--- a/src/moonlink_backend/Cargo.toml
+++ b/src/moonlink_backend/Cargo.toml
@@ -47,3 +47,4 @@ serial_test = { workspace = true }
 tempfile = { workspace = true }
 thrift = "0.17"
 tokio-postgres = { workspace = true }
+tokio = { workspace = true, features = ["test-util"] }

--- a/src/moonlink_backend/tests/common.rs
+++ b/src/moonlink_backend/tests/common.rs
@@ -31,6 +31,7 @@ pub const SRC_URI: &str =
     "postgresql://postgres:postgres@postgres:5432/postgres?sslmode=verify-full";
 
 #[derive(Clone, Debug, Eq, PartialEq)]
+#[allow(dead_code)]
 pub enum TestGuardMode {
     /// Default test mode, which initiates all resource at construction and clean up at destruction.
     Normal,
@@ -45,6 +46,7 @@ pub struct TestGuard {
 }
 
 impl TestGuard {
+    #[allow(dead_code)]
     pub async fn new(table_name: Option<&'static str>, has_primary_key: bool) -> (Self, Client) {
         let (tmp, backend, client) = setup_backend(table_name, has_primary_key).await;
         let guard = Self {
@@ -59,6 +61,7 @@ impl TestGuard {
         &self.backend
     }
 
+    #[allow(dead_code)]
     pub fn get_serialized_table_config(&self) -> String {
         let root_directory = self
             .tmp

--- a/src/moonlink_backend/tests/control_plane_retry.rs
+++ b/src/moonlink_backend/tests/control_plane_retry.rs
@@ -5,7 +5,7 @@ mod control_plane_retry_tests {
     use super::common::{connect_to_postgres, SRC_URI};
     use moonlink_connectors::pg_replicate::PostgresConnection;
     use serial_test::serial;
-    use std::time::Instant;
+
     use tokio::task::yield_now;
     use tokio::time::{sleep, Duration};
     use tokio_postgres::SimpleQueryMessage;

--- a/src/moonlink_connectors/src/lib.rs
+++ b/src/moonlink_connectors/src/lib.rs
@@ -1,5 +1,5 @@
 pub mod error;
-mod pg_replicate;
+pub mod pg_replicate;
 mod replication_connection;
 mod replication_manager;
 pub mod replication_state;

--- a/src/moonlink_connectors/src/pg_replicate.rs
+++ b/src/moonlink_connectors/src/pg_replicate.rs
@@ -38,6 +38,7 @@ use tokio::task::JoinHandle;
 use tokio::time::sleep;
 use tokio_postgres::error::SqlState;
 use tokio_postgres::types::PgLsn;
+use tokio_postgres::SimpleQueryMessage;
 use tokio_postgres::{connect, Client, Config};
 use tokio_postgres::{Connection, Socket};
 use tracing::{debug, error, info_span, warn, Instrument};
@@ -130,11 +131,52 @@ impl PostgresConnection {
         })
     }
 
+    /// Reconnect the control-plane client and reapply session settings
+    async fn reconnect_control_client(&mut self) -> Result<()> {
+        let tls = build_tls_connector().map_err(PostgresSourceError::from)?;
+        let (client, connection) = connect(&self.uri, tls)
+            .await
+            .map_err(PostgresSourceError::from)?;
+        tokio::spawn(
+            async move {
+                if let Err(e) = connection.await {
+                    warn!("connection error: {}", e);
+                }
+            }
+            .instrument(info_span!("postgres_connection_monitor")),
+        );
+        // Reapply desired session settings
+        client
+            .simple_query("SET lock_timeout = '100ms';")
+            .await
+            .map_err(PostgresSourceError::from)?;
+        self.postgres_client = client;
+        Ok(())
+    }
+
+    /// Centralized control-plane query executor. Retries once on connection errors by reconnecting
+    pub async fn run_control_query(&mut self, sql: &str) -> Result<Vec<SimpleQueryMessage>> {
+        match self.postgres_client.simple_query(sql).await {
+            Ok(messages) => Ok(messages),
+            Err(e) => {
+                warn!(error = %e, "control query failed, attempting single reconnect+retry");
+                // Attempt to reconnect control-plane client once
+                if let Err(reconn_err) = self.reconnect_control_client().await {
+                    return Err(reconn_err);
+                }
+                self.postgres_client
+                    .simple_query(sql)
+                    .await
+                    .map_err(PostgresSourceError::from)
+                    .map_err(Into::into)
+            }
+        }
+    }
+
     /// Include full row in cdc stream (not just primary keys).
-    pub async fn alter_table_replica_identity(&self, table_name: &str) -> Result<()> {
-        self.postgres_client
-            .simple_query(&format!("ALTER TABLE {table_name} REPLICA IDENTITY FULL;"))
-            .await?;
+    pub async fn alter_table_replica_identity(&mut self, table_name: &str) -> Result<()> {
+        let sql = format!("ALTER TABLE {table_name} REPLICA IDENTITY FULL;");
+        let _ = self.run_control_query(&sql).await?;
         Ok(())
     }
 
@@ -251,20 +293,17 @@ impl PostgresConnection {
         })
     }
 
-    pub async fn drop_replication_slot(&self) -> Result<()> {
+    pub async fn drop_replication_slot(&mut self) -> Result<()> {
         // First, terminate any active connections using this slot
         let terminate_query = format!(
             "SELECT pg_terminate_backend(active_pid) FROM pg_replication_slots WHERE slot_name = '{}';",
             self.slot_name
         );
-        let _ = self.postgres_client.simple_query(&terminate_query).await;
+        let _ = self.run_control_query(&terminate_query).await;
 
         // Then drop the replication slot
         let drop_query = format!("SELECT pg_drop_replication_slot('{}');", self.slot_name);
-        self.postgres_client
-            .simple_query(&drop_query)
-            .await
-            .map_err(PostgresSourceError::from)?;
+        self.run_control_query(&drop_query).await?;
 
         Ok(())
     }
@@ -332,7 +371,7 @@ impl PostgresConnection {
             .await
             .or_else(|e| match e.code() {
                 Some(&SqlState::LOCK_NOT_AVAILABLE) => {
-                    warn!("lock not available, retrying");
+                    warn!("lock not available, retrying in background");
                     // Store the handle so we can track its completion
                     let handle = Self::retry_drop(&self.uri, drop_query);
                     self.retry_handles.push(handle);
@@ -340,6 +379,13 @@ impl PostgresConnection {
                 }
                 Some(&SqlState::UNDEFINED_TABLE) => {
                     warn!("table already dropped, skipping");
+                    Ok(vec![])
+                }
+                None => {
+                    // Likely transport/connection error. Retry in background.
+                    warn!("transport error on drop; retrying in background");
+                    let handle = Self::retry_drop(&self.uri, drop_query);
+                    self.retry_handles.push(handle);
                     Ok(vec![])
                 }
                 _ => Err(PostgresSourceError::from(e)),
@@ -356,7 +402,7 @@ impl PostgresConnection {
 
     /// Add table to PostgreSQL replication
     pub async fn add_table<T: std::fmt::Display>(
-        &self,
+        &mut self,
         table_name: &str,
         mooncake_table_id: &T,
         moonlink_table_config: &mut MoonlinkTableConfig,


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

Implements reconnection logic for any of the control plane commands we make to PG. Control plane commands are defined as short, one-off DDL/DCL commands we make to Postgres that happen outside of the replication task, and are usually part of some setup/tear down sequence. They are stateless and can be retried. These are in contrast to our data plane PG queries which happen from the replication task, and are usually stateful or depend on a specific sequencing for managing the CDC stream. For these commands we still fail fast, although respawning a failed replication task will be addressed as part of #1780 

We retry on any transport errors and implement a simple linear back-off with `MAX_DELAY` and `MAX_RETRIES`. In order to identify transport errors we look at the `SqlState` code returned. We categorize the following error codes as transport related:

```rust
    match sqlstate {
        None => true,
        Some(code) => {
            let c = code.code();
            code == &SqlState::ADMIN_SHUTDOWN
                || code == &SqlState::CRASH_SHUTDOWN
                || code == &SqlState::CANNOT_CONNECT_NOW
                || c.starts_with("08")
        }
    }
```

## Related Issues

Closes [#1779](https://github.com/Mooncake-Labs/moonlink/issues/1779)
## Changes

- Reconnect and retry queries on transport error
- Add linear backoff
- Add `control_plane_retry.rs` integration tests

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [x] Documentation updated if necessary
- [x] I have reviewed my own changes
