### PR TITLE
[storage] Remove uninitialized max row size

### DIFF
--- a/src/moonlink/src/storage/iceberg/iceberg_table_loader.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_loader.rs
@@ -82,10 +82,11 @@ impl IcebergTableManager {
         }
 
         let data_file = entry.data_file();
+        let num_rows = data_file.record_count();
         assert_eq!(data_file.file_format(), DataFileFormat::Parquet);
         let new_data_file_entry = DataFileEntry {
             data_file: data_file.clone(),
-            deletion_vector: BatchDeletionVector::new(UNINITIALIZED_BATCH_DELETION_VECTOR_MAX_ROW),
+            deletion_vector: BatchDeletionVector::new(num_rows as usize),
         };
 
         self.persisted_data_files

--- a/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
@@ -30,9 +30,6 @@ use uuid::Uuid;
 ///
 /// Key for iceberg snapshot property, to record flush lsn.
 pub(super) const MOONCAKE_TABLE_FLUSH_LSN: &str = "moonlink.table-flush-lsn";
-/// Used to represent uninitialized deletion vector.
-/// TODO(hjiang): Consider using `Option<>` to represent uninitialized, which is more rust-idiometic.
-pub(super) const UNINITIALIZED_BATCH_DELETION_VECTOR_MAX_ROW: usize = 0;
 
 #[derive(Clone, Debug)]
 pub(crate) struct DataFileEntry {

--- a/src/moonlink/src/storage/iceberg/tests.rs
+++ b/src/moonlink/src/storage/iceberg/tests.rs
@@ -71,7 +71,7 @@ use tokio::sync::mpsc;
 fn test_committed_deletion_log_1(
     data_file: MooncakeDataFileRef,
 ) -> HashMap<MooncakeDataFileRef, BatchDeletionVector> {
-    let mut deletion_vector = BatchDeletionVector::new(MooncakeTableConfig::DEFAULT_BATCH_SIZE);
+    let mut deletion_vector = BatchDeletionVector::new(/*max_size=*/ 3);
     assert!(deletion_vector.delete_row(0));
 
     HashMap::<MooncakeDataFileRef, BatchDeletionVector>::from([(data_file, deletion_vector)])
@@ -87,7 +87,7 @@ fn test_committed_deletion_logs_to_persist_1(
 fn test_committed_deletion_log_2(
     data_file: MooncakeDataFileRef,
 ) -> HashMap<MooncakeDataFileRef, BatchDeletionVector> {
-    let mut deletion_vector = BatchDeletionVector::new(MooncakeTableConfig::DEFAULT_BATCH_SIZE);
+    let mut deletion_vector = BatchDeletionVector::new(/*max_size=*/ 3);
     assert!(deletion_vector.delete_row(1));
     assert!(deletion_vector.delete_row(2));
 


### PR DESCRIPTION
## Summary

Code change should be straightforward, the uninitialized max row size is not necessary, we could directly get it from iceberg data file attributes.

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
