### PR TITLE
[storage] Fix deletion record remapping

### DIFF
--- a/src/moonlink/src/storage/iceberg/iceberg_table_syncer.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_syncer.rs
@@ -9,7 +9,6 @@ use crate::storage::iceberg::index::FileIndexBlob;
 use crate::storage::iceberg::io_utils as iceberg_io_utils;
 #[cfg(all(not(feature = "chaos-test"), any(test, debug_assertions)))]
 use crate::storage::iceberg::manifest_utils;
-use crate::storage::iceberg::manifest_utils::ManifestEntryCount;
 use crate::storage::iceberg::moonlink_catalog::PuffinBlobType;
 use crate::storage::iceberg::puffin_utils;
 use crate::storage::iceberg::puffin_utils::PuffinBlobRef;
@@ -260,7 +259,7 @@ impl IcebergTableManager {
 
             for old_row_idx in old_deleted_rows.into_iter() {
                 let old_record_location =
-                    RecordLocation::DiskFile(old_file_id.clone(), old_row_idx as usize);
+                    RecordLocation::DiskFile(*old_file_id, old_row_idx as usize);
                 if let Some(new_remapped_record_location) =
                     data_file_records_remap.get(&old_record_location)
                 {

--- a/src/moonlink/src/storage/iceberg/manifest_utils.rs
+++ b/src/moonlink/src/storage/iceberg/manifest_utils.rs
@@ -14,17 +14,6 @@ pub(crate) enum ManifestEntryType {
     FileIndex,
 }
 
-/// Entry count for different types of manifest entries.
-#[derive(Clone, Debug, Default, PartialEq)]
-pub(crate) struct ManifestEntryCount {
-    /// Number of data files entries.
-    pub(crate) data_file_entries: usize,
-    /// Number of deletion vector entries.
-    pub(crate) deletion_vector_entries: usize,
-    /// Number of file indices entries.
-    pub(crate) file_indices_entries: usize,
-}
-
 /// Util function to get type of the current manifest file.
 /// Precondition: one manifest file only stores one type of manifest entries.
 pub(crate) fn get_manifest_entry_type(
@@ -64,37 +53,4 @@ pub(crate) fn create_manifest_writer_builder(
         table_metadata.default_partition_spec().as_ref().clone(),
     );
     Ok(manifest_writer_builder)
-}
-
-/// Get manifest entry number for all types.
-#[cfg(all(not(feature = "chaos-test"), any(test, debug_assertions)))]
-pub(crate) async fn get_manifest_entries_number(
-    table_metadata: &TableMetadata,
-    file_io: FileIO,
-) -> ManifestEntryCount {
-    let mut entry_count = ManifestEntryCount::default();
-    let current_snapshot = table_metadata.current_snapshot();
-    if current_snapshot.is_none() {
-        return entry_count;
-    }
-    let snapshot_meta = current_snapshot.unwrap();
-    let manifest_list = snapshot_meta
-        .load_manifest_list(&file_io, table_metadata)
-        .await
-        .unwrap();
-
-    for manifest_file in manifest_list.entries().iter() {
-        let manifest = manifest_file.load_manifest(&file_io).await.unwrap();
-        let (manifest_entries, manifest_metadata) = manifest.into_parts();
-        let entry_type = get_manifest_entry_type(&manifest_entries, &manifest_metadata);
-        if entry_type == ManifestEntryType::DataFile {
-            entry_count.data_file_entries += manifest_entries.len();
-        } else if entry_type == ManifestEntryType::DeletionVector {
-            entry_count.deletion_vector_entries += manifest_entries.len();
-        } else {
-            entry_count.file_indices_entries += manifest_entries.len();
-        }
-    }
-
-    entry_count
 }

--- a/src/moonlink/src/storage/iceberg/tests.rs
+++ b/src/moonlink/src/storage/iceberg/tests.rs
@@ -3144,8 +3144,7 @@ async fn test_persisted_deletion_record_remap() {
             stored_iceberg_snapshot_result = Some(iceberg_snapshot_result.unwrap());
         } else {
             panic!(
-                "Expect either iceberg snapshot result and data compaction result but get {:?}",
-                notification
+                "Expect either iceberg snapshot result and data compaction result but get {notification:?}"
             );
         }
     }

--- a/src/moonlink/src/storage/iceberg/tests.rs
+++ b/src/moonlink/src/storage/iceberg/tests.rs
@@ -379,6 +379,7 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
             old_data_files_to_remove: vec![],
             new_file_indices_to_import: vec![],
             old_file_indices_to_remove: vec![],
+            data_file_records_remap: HashMap::new(),
         },
     };
 
@@ -432,6 +433,7 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
             old_data_files_to_remove: vec![],
             new_file_indices_to_import: vec![],
             old_file_indices_to_remove: vec![],
+            data_file_records_remap: HashMap::new(),
         },
     };
 
@@ -511,6 +513,7 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
             old_data_files_to_remove: vec![],
             new_file_indices_to_import: vec![],
             old_file_indices_to_remove: vec![],
+            data_file_records_remap: HashMap::new(),
         },
     };
     let persistence_file_params = PersistenceFileParams {
@@ -594,6 +597,7 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
             old_data_files_to_remove: vec![data_file_1.clone(), data_file_2.clone()],
             new_file_indices_to_import: vec![compacted_file_index.clone()],
             old_file_indices_to_remove: vec![merged_file_index.clone()],
+            data_file_records_remap: HashMap::new(),
         },
     };
     let persistence_file_params = PersistenceFileParams {
@@ -666,6 +670,7 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
             old_data_files_to_remove: vec![compacted_data_file.clone()],
             new_file_indices_to_import: vec![],
             old_file_indices_to_remove: vec![compacted_file_index.clone()],
+            data_file_records_remap: HashMap::new(),
         },
     };
     let persistence_file_params = PersistenceFileParams {

--- a/src/moonlink/src/storage/iceberg/tests.rs
+++ b/src/moonlink/src/storage/iceberg/tests.rs
@@ -27,7 +27,9 @@ use crate::storage::mooncake_table::table_operation_test_utils::*;
 use crate::storage::mooncake_table::test_utils_commons::ICEBERG_TEST_NAMESPACE;
 use crate::storage::mooncake_table::test_utils_commons::ICEBERG_TEST_TABLE;
 use crate::storage::mooncake_table::validation_test_utils::*;
+use crate::storage::mooncake_table::DataCompactionResult;
 use crate::storage::mooncake_table::IcebergSnapshotPayload;
+use crate::storage::mooncake_table::IcebergSnapshotResult;
 use crate::storage::mooncake_table::{
     IcebergSnapshotDataCompactionPayload, IcebergSnapshotImportPayload,
     IcebergSnapshotIndexMergePayload,
@@ -46,6 +48,7 @@ use crate::storage::wal::test_utils::WAL_TEST_TABLE_ID;
 use crate::storage::MooncakeTable;
 use crate::DataCompactionConfig;
 use crate::FileSystemAccessor;
+use crate::TableEvent;
 use crate::WalConfig;
 use crate::WalManager;
 
@@ -3021,4 +3024,169 @@ async fn test_schema_update_with_gcs() {
 
     // Common testing logic.
     test_schema_update_impl(iceberg_table_config.clone()).await;
+}
+
+/// ================================
+/// Test deletion record remap for compaction
+/// ================================
+///
+/// Committed deletion record could live in either committed deletion logs, or iceberg puffin file.
+/// This test verifies remap on already persisted deletion logs.
+#[tokio::test]
+async fn test_persisted_deletion_record_remap() {
+    // Local filesystem for iceberg.
+    let iceberg_temp_dir = tempdir().unwrap();
+    let iceberg_table_config = get_iceberg_table_config(&iceberg_temp_dir);
+
+    // Local filesystem to store write-through cache.
+    let table_temp_dir = tempdir().unwrap();
+    let local_table_directory = table_temp_dir.path().to_str().unwrap().to_string();
+
+    // Create mooncake metadata.
+    let file_index_config = FileIndexMergeConfig::disabled();
+    let data_compaction_config = DataCompactionConfig {
+        min_data_file_to_compact: 2,
+        max_data_file_to_compact: u32::MAX,
+        data_file_final_size: u64::MAX,
+        data_file_deletion_percentage: 0,
+    };
+    let iceberg_persistence_config = IcebergPersistenceConfig {
+        new_data_file_count: 1,
+        new_committed_deletion_log: 1,
+        new_compacted_data_file_count: 1,
+        old_compacted_data_file_count: 1,
+        old_merged_file_indices_count: usize::MAX,
+    };
+    let mut config = MooncakeTableConfig::new(table_temp_dir.path().to_str().unwrap().to_string());
+    config.file_index_config = file_index_config;
+    config.data_compaction_config = data_compaction_config;
+    config.persistence_config = iceberg_persistence_config;
+    let mooncake_table_metadata =
+        create_test_table_metadata_with_config(local_table_directory, config);
+
+    // Local filesystem to store read-through cache.
+    let cache_temp_dir = tempdir().unwrap();
+    let object_storage_cache = create_test_object_storage_cache(&cache_temp_dir);
+
+    let (mut table, mut notify_rx) = create_mooncake_table_and_notify(
+        mooncake_table_metadata.clone(),
+        iceberg_table_config.clone(),
+        object_storage_cache.clone(),
+    )
+    .await;
+    let row = test_row_1();
+
+    // Data file and deletion records setup:
+    //
+    // disk file 1:
+    // one row, in mooncake and iceberg
+    // deleted, in batch deletion vector and puffin
+    //
+    // disk file 2:
+    // one row, in mooncake and iceberg
+    // deleted, in batch deletion vector but not puffin
+    //
+    // disk file 3:
+    // one row, not in iceberg
+    // no deletion
+    //
+    // Initial append.
+    table.append(row.clone()).unwrap();
+    table.commit(/*lsn=*/ 1);
+    flush_table_and_sync(&mut table, &mut notify_rx, /*lsn=*/ 1)
+        .await
+        .unwrap();
+    create_mooncake_and_persist_for_test(&mut table, &mut notify_rx).await;
+
+    // Overwrite.
+    table.delete(row.clone(), /*lsn=*/ 2).await;
+    table.append(row.clone()).unwrap();
+    table.commit(/*lsn=*/ 3);
+    flush_table_and_sync(&mut table, &mut notify_rx, /*lsn=*/ 3)
+        .await
+        .unwrap();
+    create_mooncake_and_persist_for_test(&mut table, &mut notify_rx).await;
+
+    // Overwrite.
+    table.delete(row.clone(), /*lsn=*/ 4).await;
+    table.append(row.clone()).unwrap();
+    table.commit(/*lsn=*/ 5);
+    flush_table_and_sync(&mut table, &mut notify_rx, /*lsn=*/ 5)
+        .await
+        .unwrap();
+    let (_, iceberg_payload, _, data_compaction_payload, _) =
+        create_mooncake_snapshot_for_test(&mut table, &mut notify_rx).await;
+
+    // Initiate an iceberg snapshot.
+    table.persist_iceberg_snapshot(iceberg_payload.unwrap());
+
+    // Perform data compaction.
+    let data_compaction_payload = data_compaction_payload.take_payload().unwrap();
+    table.perform_data_compaction(data_compaction_payload);
+
+    // Block wait both operations to finish.
+    let mut stored_data_compaction_result: Option<DataCompactionResult> = None;
+    let mut stored_iceberg_snapshot_result: Option<IcebergSnapshotResult> = None;
+
+    for _ in 0..2 {
+        let notification = notify_rx.recv().await.unwrap();
+        if let TableEvent::DataCompactionResult {
+            data_compaction_result,
+        } = notification
+        {
+            assert!(stored_data_compaction_result.is_none());
+            stored_data_compaction_result = Some(data_compaction_result.unwrap());
+        } else if let TableEvent::IcebergSnapshotResult {
+            iceberg_snapshot_result,
+        } = notification
+        {
+            assert!(stored_iceberg_snapshot_result.is_none());
+            stored_iceberg_snapshot_result = Some(iceberg_snapshot_result.unwrap());
+        } else {
+            panic!(
+                "Expect either iceberg snapshot result and data compaction result but get {:?}",
+                notification
+            );
+        }
+    }
+    assert!(stored_data_compaction_result.is_some());
+    assert!(stored_iceberg_snapshot_result.is_some());
+
+    // Reflect iceberg snapshot result to mooncake snapshot.
+    table.set_iceberg_snapshot_res(stored_iceberg_snapshot_result.unwrap());
+
+    // Create mooncake snapshot and sync.
+    create_mooncake_snapshot_for_test(&mut table, &mut notify_rx).await;
+
+    // Reflect data compaction result.
+    table.set_data_compaction_res(stored_data_compaction_result.unwrap());
+
+    // Create mooncake snapshot and sync.
+    let (_, iceberg_payload, _, _, _) =
+        create_mooncake_snapshot_for_test(&mut table, &mut notify_rx).await;
+    assert!(iceberg_payload.is_some());
+
+    // Create iceberg snapshot and sync.
+    let iceberg_snapshot_result =
+        create_iceberg_snapshot(&mut table, iceberg_payload, &mut notify_rx)
+            .await
+            .unwrap(); // <----
+    table.set_iceberg_snapshot_res(iceberg_snapshot_result);
+
+    // Validate iceberg snapshot content.
+    let filesystem_accessor = create_test_filesystem_accessor(&iceberg_table_config);
+    let mut iceberg_table_manager_for_recovery = IcebergTableManager::new(
+        mooncake_table_metadata.clone(),
+        create_test_object_storage_cache(&cache_temp_dir), // Use separate cache for each table.
+        filesystem_accessor.clone(),
+        iceberg_table_config.clone(),
+    )
+    .unwrap();
+    let (_, snapshot) = iceberg_table_manager_for_recovery
+        .load_snapshot_from_table()
+        .await
+        .unwrap();
+
+    // Validate iceberg snapshot.
+    verify_recovered_mooncake_snapshot(&snapshot, /*expected_ids=*/ &[1]).await;
 }

--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -1493,6 +1493,10 @@ impl MooncakeTable {
             .data_compaction_payload
             .old_file_indices_to_remove
             .clone();
+        let data_file_record_remap_by_compaction = snapshot_payload
+            .data_compaction_payload
+            .data_file_records_remap
+            .clone();
 
         let persistence_file_params = PersistenceFileParams {
             table_auto_incr_ids,
@@ -1566,6 +1570,7 @@ impl MooncakeTable {
                     [new_file_indices_cutoff_index_2..new_file_indices_cutoff_index_3]
                     .to_vec(),
                 old_file_indices_removed: old_file_indices_to_remove_by_compaction,
+                data_file_records_remap: data_file_record_remap_by_compaction,
             },
         };
 

--- a/src/moonlink/src/storage/mooncake_table/iceberg_persisted_records.rs
+++ b/src/moonlink/src/storage/mooncake_table/iceberg_persisted_records.rs
@@ -1,13 +1,12 @@
-use crate::storage::compaction::table_compaction::RemappedRecordLocation;
 use crate::storage::index::FileIndex;
 use crate::storage::mooncake_table::table_snapshot::IcebergSnapshotDataCompactionResult;
 use crate::storage::mooncake_table::table_snapshot::{
     IcebergSnapshotImportResult, IcebergSnapshotIndexMergeResult,
 };
+use crate::storage::storage_utils::FileId;
 use crate::storage::storage_utils::MooncakeDataFileRef;
-use crate::storage::storage_utils::{FileId, RecordLocation};
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 
 /// Record iceberg persisted records, used to sync to mooncake snapshot.
 #[derive(Debug, Default)]

--- a/src/moonlink/src/storage/mooncake_table/iceberg_persisted_records.rs
+++ b/src/moonlink/src/storage/mooncake_table/iceberg_persisted_records.rs
@@ -1,12 +1,13 @@
+use crate::storage::compaction::table_compaction::RemappedRecordLocation;
 use crate::storage::index::FileIndex;
 use crate::storage::mooncake_table::table_snapshot::IcebergSnapshotDataCompactionResult;
 use crate::storage::mooncake_table::table_snapshot::{
     IcebergSnapshotImportResult, IcebergSnapshotIndexMergeResult,
 };
-use crate::storage::storage_utils::FileId;
 use crate::storage::storage_utils::MooncakeDataFileRef;
+use crate::storage::storage_utils::{FileId, RecordLocation};
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 /// Record iceberg persisted records, used to sync to mooncake snapshot.
 #[derive(Debug, Default)]
@@ -28,6 +29,7 @@ impl IcebergPersistedRecords {
         if self.flush_lsn.is_none() {
             assert!(self.import_result.is_empty());
             assert!(self.index_merge_result.is_empty());
+            assert!(self.data_compaction_result.is_empty());
             assert!(self.data_compaction_result.is_empty());
             return true;
         }

--- a/src/moonlink/src/storage/mooncake_table/persistence_buffer.rs
+++ b/src/moonlink/src/storage/mooncake_table/persistence_buffer.rs
@@ -48,7 +48,7 @@ pub(crate) struct UnpersistedRecords {
     compacted_file_indices_to_add: Vec<GlobalIndex>,
     /// Un-applied remapped record.
     ///
-    /// For an uncommitted deletion record, it could appear in two places: committed deletion log, or iceberg deletion vector puffin blob.
+    /// For a committed deletion record, it could appear in two places: committed deletion log, or iceberg deletion vector puffin blob.
     compacted_data_file_remap: HashMap<RecordLocation, RemappedRecordLocation>,
 }
 

--- a/src/moonlink/src/storage/mooncake_table/persistence_buffer.rs
+++ b/src/moonlink/src/storage/mooncake_table/persistence_buffer.rs
@@ -1,9 +1,10 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
+use crate::storage::compaction::table_compaction::RemappedRecordLocation;
 use crate::storage::index::persisted_bucket_hash_map::GlobalIndex;
 use crate::storage::mooncake_table::SnapshotTask;
 use crate::storage::mooncake_table_config::MooncakeTableConfig;
-use crate::storage::storage_utils::MooncakeDataFileRef;
+use crate::storage::storage_utils::{MooncakeDataFileRef, RecordLocation};
 
 use more_asserts as ma;
 
@@ -45,6 +46,10 @@ pub(crate) struct UnpersistedRecords {
     compacted_file_indices_to_remove: Vec<GlobalIndex>,
     /// Unpersisted new compacted file indices, which should be added in the later iceberg snapshots.
     compacted_file_indices_to_add: Vec<GlobalIndex>,
+    /// Un-applied remapped record.
+    ///
+    /// For an uncommitted deletion record, it could appear in two places: committed deletion log, or iceberg deletion vector puffin blob.
+    compacted_data_file_remap: HashMap<RecordLocation, RemappedRecordLocation>,
 }
 
 impl UnpersistedRecords {
@@ -84,6 +89,11 @@ impl UnpersistedRecords {
     }
     pub(crate) fn get_compacted_file_indices_to_remove(&self) -> Vec<GlobalIndex> {
         self.compacted_file_indices_to_remove.clone()
+    }
+    pub(crate) fn get_compacted_data_file_remap(
+        &self,
+    ) -> HashMap<RecordLocation, RemappedRecordLocation> {
+        self.compacted_data_file_remap.clone()
     }
 
     /// Get unpersisted data files as hash set for lookup.
@@ -151,6 +161,9 @@ impl UnpersistedRecords {
             .extend(data_compaction_res.new_file_indices);
         self.compacted_file_indices_to_remove
             .extend(data_compaction_res.old_file_indices);
+
+        assert!(self.compacted_data_file_remap.is_empty());
+        self.compacted_data_file_remap = data_compaction_res.remapped_data_files;
     }
 
     /// Buffer unpersisted records.
@@ -240,6 +253,14 @@ impl UnpersistedRecords {
         );
         self.compacted_file_indices_to_remove
             .drain(0..persisted_compaction_res.old_file_indices_removed.len());
+
+        if !persisted_compaction_res.data_file_records_remap.is_empty() {
+            assert_eq!(
+                persisted_compaction_res.data_file_records_remap.len(),
+                self.compacted_data_file_remap.len()
+            );
+            self.compacted_data_file_remap.clear();
+        }
     }
 
     /// Prune persisted records.

--- a/src/moonlink/src/storage/mooncake_table/snapshot_persistence.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot_persistence.rs
@@ -65,6 +65,7 @@ impl SnapshotTableState {
                 old_file_indices_to_remove: self
                     .unpersisted_records
                     .get_compacted_file_indices_to_remove(),
+                data_file_records_remap: self.unpersisted_records.get_compacted_data_file_remap(),
             },
         }
     }

--- a/src/moonlink/src/storage/mooncake_table/table_snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_snapshot.rs
@@ -1,3 +1,4 @@
+use crate::storage::compaction::table_compaction::RemappedRecordLocation;
 use crate::storage::iceberg::puffin_utils::PuffinBlobRef;
 use crate::storage::index::persisted_bucket_hash_map::GlobalIndex;
 /// Items needed for iceberg snapshot.
@@ -6,6 +7,7 @@ use crate::storage::mooncake_table::delete_vector::BatchDeletionVector;
 use crate::storage::mooncake_table::TableMetadata as MooncakeTableMetadata;
 use crate::storage::storage_utils::FileId;
 use crate::storage::storage_utils::MooncakeDataFileRef;
+use crate::storage::storage_utils::RecordLocation;
 use crate::storage::TableManager;
 
 use std::collections::{HashMap, HashSet};
@@ -84,6 +86,8 @@ pub struct IcebergSnapshotDataCompactionPayload {
     pub(crate) new_file_indices_to_import: Vec<MooncakeFileIndex>,
     /// Old file indices to remove from the iceberg table.
     pub(crate) old_file_indices_to_remove: Vec<MooncakeFileIndex>,
+    /// Data file records remapping.
+    pub(crate) data_file_records_remap: HashMap<RecordLocation, RemappedRecordLocation>,
 }
 
 impl std::fmt::Debug for IcebergSnapshotDataCompactionPayload {
@@ -105,6 +109,10 @@ impl std::fmt::Debug for IcebergSnapshotDataCompactionPayload {
                 "old file indices to remove count",
                 &self.old_file_indices_to_remove.len(),
             )
+            .field(
+                "data file records remap count",
+                &self.data_file_records_remap.len(),
+            )
             .finish()
     }
 }
@@ -116,6 +124,7 @@ impl IcebergSnapshotDataCompactionPayload {
             assert!(self.new_data_files_to_import.is_empty());
             assert!(self.new_file_indices_to_import.is_empty());
             assert!(self.old_file_indices_to_remove.is_empty());
+            assert!(self.data_file_records_remap.is_empty());
             return true;
         }
 
@@ -310,6 +319,8 @@ pub struct IcebergSnapshotDataCompactionResult {
     pub(crate) new_file_indices_imported: Vec<MooncakeFileIndex>,
     /// Old data files to remove from the iceberg table.
     pub(crate) old_file_indices_removed: Vec<MooncakeFileIndex>,
+    /// Data file record mapping (due to compaction).
+    pub(crate) data_file_records_remap: HashMap<RecordLocation, RemappedRecordLocation>,
 }
 
 impl IcebergSnapshotDataCompactionResult {
@@ -319,6 +330,7 @@ impl IcebergSnapshotDataCompactionResult {
             assert!(self.new_data_files_imported.is_empty());
             assert!(self.new_file_indices_imported.is_empty());
             assert!(self.old_file_indices_removed.is_empty());
+            assert!(self.data_file_records_remap.is_empty());
             return true;
         }
 
@@ -345,6 +357,10 @@ impl std::fmt::Debug for IcebergSnapshotDataCompactionResult {
             .field(
                 "old file indices removed count",
                 &self.old_file_indices_removed.len(),
+            )
+            .field(
+                "data file records remap count",
+                &self.data_file_records_remap.len(),
             )
             .finish()
     }

--- a/src/moonlink/src/storage/mooncake_table/table_snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_snapshot.rs
@@ -171,6 +171,7 @@ impl IcebergSnapshotPayload {
     pub fn get_new_file_ids_num(&self) -> u32 {
         // Only deletion vector puffin blobs create files with new file ids.
         self.import_payload.new_deletion_vector.len() as u32
+            + self.data_compaction_payload.data_file_records_remap.len() as u32
     }
 
     /// Return whether the payload contains table maintenance content.


### PR DESCRIPTION
## Summary

A committed deletion record could appear in two places: in-memory committed deletion logs at snapshot, or persisted deletion vector.
After compaction we need to do remapping on both.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1793

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
