### PR TITLE
Parallelize initial load parquet writers

### DIFF
--- a/src/moonlink_connectors/src/pg_replicate/initial_copy.rs
+++ b/src/moonlink_connectors/src/pg_replicate/initial_copy.rs
@@ -44,6 +44,8 @@ where
     let arrow_schema = Arc::new(arrow_schema);
 
     let mut config = config.unwrap_or_default();
+    // Use 4 parallel writers
+    config.num_writer_tasks = 4;
 
     // Create output directory for initial copy files
     let output_dir = std::env::temp_dir()


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

Spins up a worker pool of parquet writers to consume batches from the `mpsc` channel and write in parallel. 

Adds concept of `SharedBatchReceiver` which wraps the receiving end of the channel with a Mutex so writers can concurrently `recv` batches to write. 

Starting with arbitrary number of parallel writers (4). We will have a better idea of how to tune this once we start appending batches in parallel. 

As a rough upper bound, perf for 100M initial load goes from 2 minutes -> 24 seconds. 

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1240

## Changes

- Add worker pool of writers
- Concurrently get batches from mpsc channel
- Add unit and integration testing 

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [x] Documentation updated if necessary
- [x] I have reviewed my own changes
