### PR TITLE
[storage] Revert default iceberg table directory

### DIFF
--- a/src/moonlink_backend/src/config_utils.rs
+++ b/src/moonlink_backend/src/config_utils.rs
@@ -10,14 +10,14 @@ pub(crate) fn parse_event_table_config(
     moonlink_table_config: &str,
     mooncake_table_id: &MooncakeTableId,
     table_base_path: &str,
+    temp_files_dir: &str,
 ) -> Result<MoonlinkTableConfig> {
     let mut table_config =
         TableConfig::from_json_or_default(moonlink_table_config, table_base_path)?;
 
     // If table config is already valid, directly transform to moonlink config and return.
     if table_config.is_valid() {
-        return table_config
-            .take_as_moonlink_config(table_base_path.to_string(), mooncake_table_id);
+        return table_config.take_as_moonlink_config(temp_files_dir.to_string(), mooncake_table_id);
     }
 
     // Otherwise manually set based on event table native properties.
@@ -47,7 +47,7 @@ pub(crate) fn parse_event_table_config(
     {
         mooncake_config.append_only = Some(true);
     }
-    table_config.take_as_moonlink_config(table_base_path.to_string(), mooncake_table_id)
+    table_config.take_as_moonlink_config(temp_files_dir.to_string(), mooncake_table_id)
 }
 
 /// Parse replication table config, and fill in default value if unassigned.
@@ -55,10 +55,11 @@ pub(crate) fn parse_replication_table_config(
     moonlink_table_config: &str,
     mooncake_table_id: &MooncakeTableId,
     table_base_path: &str,
+    temp_files_dir: &str,
 ) -> Result<MoonlinkTableConfig> {
     let mut table_config =
         TableConfig::from_json_or_default(moonlink_table_config, table_base_path)?;
     table_config.mooncake_config.row_identity = Some(IdentityProp::FullRow);
     table_config.mooncake_config.append_only = Some(false);
-    table_config.take_as_moonlink_config(table_base_path.to_string(), mooncake_table_id)
+    table_config.take_as_moonlink_config(temp_files_dir.to_string(), mooncake_table_id)
 }

--- a/src/moonlink_backend/src/lib.rs
+++ b/src/moonlink_backend/src/lib.rs
@@ -180,6 +180,7 @@ impl MoonlinkBackend {
                     &table_config,
                     &mooncake_table_id,
                     &self.base_path,
+                    &self.temp_files_dir,
                 )?;
                 manager
                     .add_rest_table(
@@ -197,6 +198,7 @@ impl MoonlinkBackend {
                 let mut cur_moonlink_table_config = config_utils::parse_replication_table_config(
                     &table_config,
                     &mooncake_table_id,
+                    &self.base_path,
                     &self.temp_files_dir,
                 )?;
                 // Moonlink table config will get updated later at replication manager.


### PR DESCRIPTION
## Summary

https://github.com/Mooncake-Labs/moonlink/pull/1800 introduces a weird regression:
- default iceberg warehouse uri (if unspecified) should be placed under `<base>/<database>/<table>`
- but the above PR updates it to `<base>/temp/<database>/<table>`

I manually verifies with pg_mooncake

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
