### PR TITLE
Fix flaky directory deletion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,6 +472,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4405,6 +4416,7 @@ dependencies = [
  "arrow-array",
  "arrow-ipc",
  "arrow-schema",
+ "async-recursion",
  "axum 0.8.4",
  "bytes",
  "clap",

--- a/src/moonlink_service/Cargo.toml
+++ b/src/moonlink_service/Cargo.toml
@@ -34,6 +34,7 @@ tracing = { workspace = true }
 [dev-dependencies]
 arrow = { workspace = true }
 arrow-array = { workspace = true }
+async-recursion = "1"
 bytes = "1"
 parquet = { workspace = true }
 reqwest = { version = "0.12", features = ["json"] }


### PR DESCRIPTION
## Summary

tokio directory deletion doesn't allow content inside, so recursively delete internal files first;
also add type tests for more decimal types that we support.

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
