### PR TITLE
Fix gitignore for certificates

### DIFF
--- a/.devcontainer/certs/.gitignore
+++ b/.devcontainer/certs/.gitignore
@@ -1,4 +1,0 @@
-*.cnf
-*.key
-*.crt
-*.csr

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.history
 /target/
 .vscode/
+.devcontainer/cert/
 .shared-nginx/


### PR DESCRIPTION
## Summary

```sh
vscode ➜ /workspaces/moonlink (hjiang/fix-iceberg-rest ✗) $ git add .devcontainer/
vscode ➜ /workspaces/moonlink (hjiang/fix-iceberg-rest ✗) $ git commit --amend --no-ed
[hjiang/fix-iceberg-rest 78700e67] fix ci
 Date: Sat Aug 30 20:36:07 2025 +0000
 31 files changed, 91 insertions(+), 78 deletions(-)
 create mode 100644 .devcontainer/certs/ca.srl # unintentionally add certificate file into git commit
```
Current certificates are not pushed simply because `.devcontainer` is a hidden directory, not all files are ignored by git.

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
