### PR TITLE
[chaos] Fix chaos test precondition for delete if exists

### DIFF
--- a/src/moonlink/src/table_handler/chaos_test.rs
+++ b/src/moonlink/src/table_handler/chaos_test.rs
@@ -432,7 +432,11 @@ impl ChaosState {
 
     /// Get a random row to delete.
     fn get_random_row_to_delete(&mut self) -> MoonlinkRow {
-        if self.is_upsert_table && self.rng.random_range(0..100) < 50 {
+        // Delete if exists is only supported for non-streaming transaction.
+        if self.is_upsert_table
+            && self.get_cur_xact_id().is_none()
+            && self.rng.random_range(0..100) < 50
+        {
             // Delete a none existing row.
             let row = create_row(self.next_id, /*name=*/ "user", self.next_id % 5);
             self.next_id += 1;


### PR DESCRIPTION
## Summary

Delete if exists semantics is only supported for non-streaming transaction.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/pull/1776#discussion_r2312137092

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
