### PR TITLE
Fix gitigore for devcontainer certs directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /.history
 /target/
 .vscode/
-.devcontainer/cert/
+.devcontainer/certs/
 .shared-nginx/


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

The .gitignore directory is incorrect; it should be `.devcontainer/certs/`.

## Related Issues

Related #1819.

## Changes


## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [x] Documentation updated if necessary
- [x] I have reviewed my own changes
