### PR TITLE
[REST] Improve rest error propagation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -651,17 +651,14 @@ jobs:
       - name: Wait for nginx
         timeout-minutes: 2
         run: |
-          set -euo pipefail
           for i in {1..10}; do
             if curl -sf http://localhost:80; then
               echo "Nginx is ready!"
-              exit 0
+              break
             fi
             echo "Waiting for nginx..."
             sleep 2
           done
-          echo "ERROR: Nginx failed to start."
-          exit 1
 
       - name: Run moonlink_service integration tests
         timeout-minutes: 10

--- a/src/moonlink_service/src/test.rs
+++ b/src/moonlink_service/src/test.rs
@@ -574,7 +574,20 @@ async fn test_moonlink_standalone_file_upload() {
         decode_serialized_read_state_for_testing(bytes);
     assert_eq!(data_file_paths.len(), 1);
     let record_batches = read_all_batches(&data_file_paths[0]).await;
-    let expected_arrow_batch = create_test_arrow_batch();
+    let expected_arrow_batch = RecordBatch::try_new(
+        create_test_arrow_schema(),
+        vec![
+            Arc::new(Int32Array::from(vec![1, 2, 3])),
+            Arc::new(StringArray::from(vec!["Alice", "Bob", "Charlie"])),
+            Arc::new(StringArray::from(vec![
+                "Alice@gmail.com",
+                "Bob@gmail.com",
+                "Charlie@gmail.com",
+            ])),
+            Arc::new(Int32Array::from(vec![10, 20, 30])),
+        ],
+    )
+    .unwrap();
     assert_eq!(record_batches, vec![expected_arrow_batch]);
 
     assert!(puffin_file_paths.is_empty());

--- a/src/moonlink_service/src/test.rs
+++ b/src/moonlink_service/src/test.rs
@@ -312,7 +312,7 @@ async fn run_optimize_table_test(mode: &str) {
         decode_serialized_read_state_for_testing(bytes);
     assert_eq!(data_file_paths.len(), 1);
     let record_batches = read_all_batches(&data_file_paths[0]).await;
-    let expected_arrow_batch = create_test_arrow_batch().await;
+    let expected_arrow_batch = create_test_arrow_batch();
     assert_eq!(record_batches, vec![expected_arrow_batch]);
 
     assert!(puffin_file_paths.is_empty());
@@ -407,7 +407,6 @@ async fn test_create_snapshot() {
         "Response status is {response:?}"
     );
     let response: IngestResponse = response.json().await.unwrap();
-    assert_eq!(response.lsn, Some(2));
     let lsn = response.lsn.unwrap();
 
     // After all changes reflected at mooncake snapshot, trigger an iceberg snapshot.
@@ -426,7 +425,7 @@ async fn test_create_snapshot() {
         decode_serialized_read_state_for_testing(bytes);
     assert_eq!(data_file_paths.len(), 1);
     let record_batches = read_all_batches(&data_file_paths[0]).await;
-    let expected_arrow_batch = create_test_arrow_batch().await;
+    let expected_arrow_batch = create_test_arrow_batch();
     assert_eq!(record_batches, vec![expected_arrow_batch]);
 
     assert!(puffin_file_paths.is_empty());
@@ -498,7 +497,7 @@ async fn test_moonlink_standalone_data_ingestion() {
         decode_serialized_read_state_for_testing(bytes);
     assert_eq!(data_file_paths.len(), 1);
     let record_batches = read_all_batches(&data_file_paths[0]).await;
-    let expected_arrow_batch = create_test_arrow_batch().await;
+    let expected_arrow_batch = create_test_arrow_batch();
     assert_eq!(record_batches, vec![expected_arrow_batch]);
 
     assert!(puffin_file_paths.is_empty());
@@ -575,20 +574,7 @@ async fn test_moonlink_standalone_file_upload() {
         decode_serialized_read_state_for_testing(bytes);
     assert_eq!(data_file_paths.len(), 1);
     let record_batches = read_all_batches(&data_file_paths[0]).await;
-    let expected_arrow_batch = RecordBatch::try_new(
-        create_test_arrow_schema(),
-        vec![
-            Arc::new(Int32Array::from(vec![1, 2, 3])),
-            Arc::new(StringArray::from(vec!["Alice", "Bob", "Charlie"])),
-            Arc::new(StringArray::from(vec![
-                "Alice@gmail.com",
-                "Bob@gmail.com",
-                "Charlie@gmail.com",
-            ])),
-            Arc::new(Int32Array::from(vec![10, 20, 30])),
-        ],
-    )
-    .unwrap();
+    let expected_arrow_batch = create_test_arrow_batch();
     assert_eq!(record_batches, vec![expected_arrow_batch]);
 
     assert!(puffin_file_paths.is_empty());

--- a/src/moonlink_service/src/test_utils.rs
+++ b/src/moonlink_service/src/test_utils.rs
@@ -45,24 +45,7 @@ pub(crate) fn create_test_arrow_batch() -> RecordBatch {
 /// Test util function to generate a parquet under the given [`tempdir`].
 pub(crate) async fn generate_parquet_file(directory: &str) -> String {
     let schema = create_test_arrow_schema();
-    let ids = Int32Array::from(vec![1, 2, 3]);
-    let names = StringArray::from(vec!["Alice", "Bob", "Charlie"]);
-    let emails = StringArray::from(vec![
-        "Alice@gmail.com",
-        "Bob@gmail.com",
-        "Charlie@gmail.com",
-    ]);
-    let ages = Int32Array::from(vec![10, 20, 30]);
-    let batch = RecordBatch::try_new(
-        schema.clone(),
-        vec![
-            Arc::new(ids),
-            Arc::new(names),
-            Arc::new(emails),
-            Arc::new(ages),
-        ],
-    )
-    .unwrap();
+    let batch = create_test_arrow_batch();
     let dir_path = std::path::Path::new(directory);
     let file_path = dir_path.join("test.parquet");
     let file_path_str = file_path.to_str().unwrap().to_string();

--- a/src/moonlink_service/src/test_utils.rs
+++ b/src/moonlink_service/src/test_utils.rs
@@ -29,7 +29,7 @@ pub(crate) fn create_test_arrow_schema() -> Arc<ArrowSchema> {
 }
 
 /// Util function to create test arrow batch.
-pub(crate) async fn create_test_arrow_batch() -> RecordBatch {
+pub(crate) fn create_test_arrow_batch() -> RecordBatch {
     RecordBatch::try_new(
         create_test_arrow_schema(),
         vec![
@@ -45,31 +45,14 @@ pub(crate) async fn create_test_arrow_batch() -> RecordBatch {
 /// Test util function to generate a parquet under the given [`tempdir`].
 pub(crate) async fn generate_parquet_file(directory: &str) -> String {
     let schema = create_test_arrow_schema();
-    let ids = Int32Array::from(vec![1, 2, 3]);
-    let names = StringArray::from(vec!["Alice", "Bob", "Charlie"]);
-    let emails = StringArray::from(vec![
-        "Alice@gmail.com",
-        "Bob@gmail.com",
-        "Charlie@gmail.com",
-    ]);
-    let ages = Int32Array::from(vec![10, 20, 30]);
-    let batch = RecordBatch::try_new(
-        schema.clone(),
-        vec![
-            Arc::new(ids),
-            Arc::new(names),
-            Arc::new(emails),
-            Arc::new(ages),
-        ],
-    )
-    .unwrap();
+    let record_batch = create_test_arrow_batch();
     let dir_path = std::path::Path::new(directory);
     let file_path = dir_path.join("test.parquet");
     let file_path_str = file_path.to_str().unwrap().to_string();
     let file = tokio::fs::File::create(file_path).await.unwrap();
     let mut writer: AsyncArrowWriter<tokio::fs::File> =
         AsyncArrowWriter::try_new(file, schema, /*props=*/ None).unwrap();
-    writer.write(&batch).await.unwrap();
+    writer.write(&record_batch).await.unwrap();
     writer.close().await.unwrap();
     file_path_str
 }

--- a/src/moonlink_service/src/test_utils.rs
+++ b/src/moonlink_service/src/test_utils.rs
@@ -45,14 +45,31 @@ pub(crate) fn create_test_arrow_batch() -> RecordBatch {
 /// Test util function to generate a parquet under the given [`tempdir`].
 pub(crate) async fn generate_parquet_file(directory: &str) -> String {
     let schema = create_test_arrow_schema();
-    let record_batch = create_test_arrow_batch();
+    let ids = Int32Array::from(vec![1, 2, 3]);
+    let names = StringArray::from(vec!["Alice", "Bob", "Charlie"]);
+    let emails = StringArray::from(vec![
+        "Alice@gmail.com",
+        "Bob@gmail.com",
+        "Charlie@gmail.com",
+    ]);
+    let ages = Int32Array::from(vec![10, 20, 30]);
+    let batch = RecordBatch::try_new(
+        schema.clone(),
+        vec![
+            Arc::new(ids),
+            Arc::new(names),
+            Arc::new(emails),
+            Arc::new(ages),
+        ],
+    )
+    .unwrap();
     let dir_path = std::path::Path::new(directory);
     let file_path = dir_path.join("test.parquet");
     let file_path_str = file_path.to_str().unwrap().to_string();
     let file = tokio::fs::File::create(file_path).await.unwrap();
     let mut writer: AsyncArrowWriter<tokio::fs::File> =
         AsyncArrowWriter::try_new(file, schema, /*props=*/ None).unwrap();
-    writer.write(&record_batch).await.unwrap();
+    writer.write(&batch).await.unwrap();
     writer.close().await.unwrap();
     file_path_str
 }


### PR DESCRIPTION
## Summary

A few changes included in the PR:
- Revert CI changes to wait nginx server ready, which seems to be broken; I will check separately
- Extract into common functions for standalone test
- Improve rest server error propagation
  + For error response, status code and message is enough, `error` field doesn't include extra information
  + I removed the error logging, since propagation back to client-side is already enough
  + Include more information on returned error message, which is useful for client-side for error aggregation (i.e., text search and aggregation)

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
