### PR TITLE
[minor] Rename committed deletion vector

### DIFF
--- a/src/moonlink/src/storage/iceberg/compaction_tests.rs
+++ b/src/moonlink/src/storage/iceberg/compaction_tests.rs
@@ -233,7 +233,7 @@ async fn check_loaded_snapshot(
     // After compaction, there should be only one data file with no deletion vector.
     let (data_file, disk_file_entry) = snapshot.disk_files.iter().next().unwrap();
     assert!(disk_file_entry.puffin_deletion_blob.is_none());
-    assert!(disk_file_entry.batch_deletion_vector.is_empty());
+    assert!(disk_file_entry.committed_deletion_vector.is_empty());
     check_loaded_arrow_batches(data_file.file_path(), row_indices.clone()).await;
 
     let file_indice = snapshot.indices.file_indices.clone();
@@ -362,7 +362,7 @@ async fn test_compaction_1_1_1() {
     assert_eq!(disk_files.len(), 1);
     let (data_file, disk_file_entry) = disk_files.iter().next().unwrap();
     assert!(disk_file_entry.puffin_deletion_blob.is_none());
-    assert!(disk_file_entry.batch_deletion_vector.is_empty());
+    assert!(disk_file_entry.committed_deletion_vector.is_empty());
     // Check data files and file indices in mooncake table snapshot is the same as iceberg persisted ones.
     let actual_file_indices = get_file_indices_for_table(&table).await;
     check_snapshot_reflects_persistence_for_compaction(&snapshot, data_file, actual_file_indices)
@@ -428,7 +428,9 @@ async fn test_compaction_1_1_2() {
     assert_eq!(disk_files.len(), 1);
     let (compacted_data_file, disk_file_entry) = disk_files.iter().next().unwrap();
     assert!(disk_file_entry.puffin_deletion_blob.is_none());
-    let deleted_rows = disk_file_entry.batch_deletion_vector.collect_deleted_rows();
+    let deleted_rows = disk_file_entry
+        .committed_deletion_vector
+        .collect_deleted_rows();
     assert!(
         deleted_rows == vec![1] || deleted_rows == vec![3],
         "Deleted rows are {deleted_rows:?}"
@@ -517,7 +519,9 @@ async fn test_compaction_1_2_1() {
     assert_eq!(disk_files.len(), 1);
     let (compacted_data_file, disk_file_entry) = disk_files.iter().next().unwrap();
     assert!(disk_file_entry.puffin_deletion_blob.is_none());
-    let deleted_rows = disk_file_entry.batch_deletion_vector.collect_deleted_rows();
+    let deleted_rows = disk_file_entry
+        .committed_deletion_vector
+        .collect_deleted_rows();
     assert!(
         deleted_rows == vec![0] || deleted_rows == vec![2],
         "Deleted rows are {deleted_rows:?}"
@@ -606,7 +610,9 @@ async fn test_compaction_1_2_2() {
     assert_eq!(disk_files.len(), 1);
     let (compacted_data_file, disk_file_entry) = disk_files.iter().next().unwrap();
     assert!(disk_file_entry.puffin_deletion_blob.is_none());
-    let deleted_rows = disk_file_entry.batch_deletion_vector.collect_deleted_rows();
+    let deleted_rows = disk_file_entry
+        .committed_deletion_vector
+        .collect_deleted_rows();
     assert!(
         deleted_rows == vec![0, 1] || deleted_rows == vec![2, 3],
         "Deleted rows are {deleted_rows:?}"
@@ -709,7 +715,9 @@ async fn test_compaction_2_2_1() {
     assert_eq!(disk_files.len(), 1);
     let (compacted_data_file, disk_file_entry) = disk_files.iter().next().unwrap();
     assert!(disk_file_entry.puffin_deletion_blob.is_none());
-    let deleted_rows = disk_file_entry.batch_deletion_vector.collect_deleted_rows();
+    let deleted_rows = disk_file_entry
+        .committed_deletion_vector
+        .collect_deleted_rows();
     assert!(
         deleted_rows == vec![0] || deleted_rows == vec![1],
         "Deleted rows are {deleted_rows:?}"
@@ -801,7 +809,9 @@ async fn test_compaction_2_2_2() {
     assert_eq!(disk_files.len(), 1);
     let (compacted_data_file, disk_file_entry) = disk_files.iter().next().unwrap();
     assert!(disk_file_entry.puffin_deletion_blob.is_none());
-    let deleted_rows = disk_file_entry.batch_deletion_vector.collect_deleted_rows();
+    let deleted_rows = disk_file_entry
+        .committed_deletion_vector
+        .collect_deleted_rows();
     // Due to the non-deterministic nature of hashmap, the row indices in the compacted data file is also non-deterministic.
     assert!(
         deleted_rows == vec![0, 1] || deleted_rows == vec![0, 2],
@@ -908,7 +918,7 @@ async fn test_compaction_2_3_1() {
     assert_eq!(disk_files.len(), 1);
     let (data_file, disk_file_entry) = disk_files.iter().next().unwrap();
     assert!(disk_file_entry.puffin_deletion_blob.is_none());
-    assert!(disk_file_entry.batch_deletion_vector.is_empty());
+    assert!(disk_file_entry.committed_deletion_vector.is_empty());
     // Check data files and file indices in mooncake table snapshot is the same as iceberg persisted ones.
     let actual_file_indices = get_file_indices_for_table(&table).await;
     check_snapshot_reflects_persistence_for_compaction(&snapshot, data_file, actual_file_indices)
@@ -989,7 +999,7 @@ async fn test_compaction_2_3_2() {
     assert!(disk_file_entry.puffin_deletion_blob.is_none());
     // Deleted row index in the compacted data file.
     let committed_compacted_row_indice: Vec<usize> = disk_file_entry
-        .batch_deletion_vector
+        .committed_deletion_vector
         .collect_deleted_rows()
         .iter()
         .map(|idx| *idx as usize)
@@ -1094,7 +1104,9 @@ async fn test_compaction_3_2_1() {
     assert_eq!(disk_files.len(), 1);
     let (compacted_data_file, disk_file_entry) = disk_files.iter().next().unwrap();
     assert!(disk_file_entry.puffin_deletion_blob.is_none());
-    let deleted_rows = disk_file_entry.batch_deletion_vector.collect_deleted_rows();
+    let deleted_rows = disk_file_entry
+        .committed_deletion_vector
+        .collect_deleted_rows();
     assert_eq!(deleted_rows, vec![0, 1, 2, 3]);
 
     // Check data files and file indices in mooncake table snapshot is the same as iceberg persisted ones.

--- a/src/moonlink/src/storage/iceberg/iceberg_table_loader.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_loader.rs
@@ -205,7 +205,7 @@ impl IcebergTableManager {
                     file_size: data_file_entry.data_file.file_size_in_bytes() as usize,
                     cache_handle: None,
                     puffin_deletion_blob,
-                    batch_deletion_vector: data_file_entry.deletion_vector.clone(),
+                    committed_deletion_vector: data_file_entry.deletion_vector.clone(),
                 },
             );
         }

--- a/src/moonlink/src/storage/iceberg/state_tests.rs
+++ b/src/moonlink/src/storage/iceberg/state_tests.rs
@@ -151,15 +151,15 @@ async fn check_prev_data_files(
 
     // In the test suite, we only delete the second prepared row.
     assert!(!deletion_vector
-        .batch_deletion_vector
+        .committed_deletion_vector
         .is_deleted(/*row_idx=*/ 0));
     if deleted {
         assert!(deletion_vector
-            .batch_deletion_vector
+            .committed_deletion_vector
             .is_deleted(/*row_idx=*/ 1));
     } else {
         assert!(!deletion_vector
-            .batch_deletion_vector
+            .committed_deletion_vector
             .is_deleted(/*row_idx=*/ 1));
     }
 }
@@ -197,15 +197,15 @@ async fn check_new_data_files(
 
     // In the test suite, we only delete the second prepared row.
     assert!(!deletion_vector
-        .batch_deletion_vector
+        .committed_deletion_vector
         .is_deleted(/*row_idx=*/ 0));
     if deleted {
         assert!(deletion_vector
-            .batch_deletion_vector
+            .committed_deletion_vector
             .is_deleted(/*row_idx=*/ 1));
     } else {
         assert!(!deletion_vector
-            .batch_deletion_vector
+            .committed_deletion_vector
             .is_deleted(/*row_idx=*/ 1));
     }
 }
@@ -234,7 +234,7 @@ async fn check_prev_and_new_data_files(
             .await
             .unwrap();
         loaded_record_batches.push(cur_arrow_batch);
-        batch_deletion_vectors.push(&cur_deletion_vector.batch_deletion_vector);
+        batch_deletion_vectors.push(&cur_deletion_vector.committed_deletion_vector);
     }
     // In the test suite, the first record has two rows, and the second record has one row.
     if loaded_record_batches[0].num_rows() == 1 {

--- a/src/moonlink/src/storage/iceberg/tests.rs
+++ b/src/moonlink/src/storage/iceberg/tests.rs
@@ -629,7 +629,7 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
     // No deletion vector is expected.
     assert!(batch_deletion_vector.puffin_deletion_blob.is_none());
     assert!(batch_deletion_vector
-        .batch_deletion_vector
+        .committed_deletion_vector
         .collect_deleted_rows()
         .is_empty());
     // Check data file.
@@ -2000,7 +2000,9 @@ async fn test_small_batch_size_and_large_parquet_size() {
     assert_eq!(snapshot.disk_files.len(), 1);
     let deletion_vector = snapshot.disk_files.iter().next().unwrap().1.clone();
     assert_eq!(
-        deletion_vector.batch_deletion_vector.collect_deleted_rows(),
+        deletion_vector
+            .committed_deletion_vector
+            .collect_deleted_rows(),
         vec![1]
     );
     check_deletion_vector_consistency_for_snapshot(&snapshot).await;
@@ -2194,7 +2196,7 @@ async fn test_async_iceberg_snapshot_impl(iceberg_table_config: IcebergTableConf
         .unwrap();
     assert_eq!(actual_arrow_batch, expected_arrow_batch_1);
     assert!(deletion_vector_1
-        .batch_deletion_vector
+        .committed_deletion_vector
         .collect_deleted_rows()
         .is_empty());
     assert!(deletion_vector_1.puffin_deletion_blob.is_none());
@@ -2271,7 +2273,9 @@ async fn test_async_iceberg_snapshot_impl(iceberg_table_config: IcebergTableConf
     // Left arrow record 2 and 3, both don't have deletion vector.
     let deletion_entry = snapshot.disk_files.remove(&old_data_file).unwrap();
     assert_eq!(
-        deletion_entry.batch_deletion_vector.collect_deleted_rows(),
+        deletion_entry
+            .committed_deletion_vector
+            .collect_deleted_rows(),
         vec![0]
     );
     let mut arrow_batch_2_persisted = false;
@@ -2279,7 +2283,7 @@ async fn test_async_iceberg_snapshot_impl(iceberg_table_config: IcebergTableConf
     for (cur_data_file, cur_deletion_vector) in snapshot.disk_files.iter() {
         assert!(cur_deletion_vector.puffin_deletion_blob.is_none());
         assert!(cur_deletion_vector
-            .batch_deletion_vector
+            .committed_deletion_vector
             .collect_deleted_rows()
             .is_empty());
 
@@ -2442,7 +2446,9 @@ async fn mooncake_table_snapshot_persist_impl(iceberg_table_config: IcebergTable
         loaded_arrow_batch, expected_arrow_batch,
         "Expected arrow data is {expected_arrow_batch:?}, actual data is {loaded_arrow_batch:?}"
     );
-    let deleted_rows = deletion_vector.batch_deletion_vector.collect_deleted_rows();
+    let deleted_rows = deletion_vector
+        .committed_deletion_vector
+        .collect_deleted_rows();
     assert!(
         deleted_rows.is_empty(),
         "There should be no deletion vector in iceberg table."
@@ -2509,7 +2515,9 @@ async fn mooncake_table_snapshot_persist_impl(iceberg_table_config: IcebergTable
         "Expected arrow data is {expected_arrow_batch:?}, actual data is {loaded_arrow_batch:?}"
     );
 
-    let deleted_rows = deletion_vector.batch_deletion_vector.collect_deleted_rows();
+    let deleted_rows = deletion_vector
+        .committed_deletion_vector
+        .collect_deleted_rows();
     let expected_deleted_rows = vec![0_u64];
     assert_eq!(deleted_rows, expected_deleted_rows);
 
@@ -2573,7 +2581,9 @@ async fn mooncake_table_snapshot_persist_impl(iceberg_table_config: IcebergTable
         "Expected arrow data is {expected_arrow_batch:?}, actual data is {loaded_arrow_batch:?}"
     );
 
-    let deleted_rows = deletion_vector.batch_deletion_vector.collect_deleted_rows();
+    let deleted_rows = deletion_vector
+        .committed_deletion_vector
+        .collect_deleted_rows();
     let expected_deleted_rows = vec![0_u64, 1_u64];
     assert_eq!(deleted_rows, expected_deleted_rows);
 
@@ -2643,7 +2653,9 @@ async fn mooncake_table_snapshot_persist_impl(iceberg_table_config: IcebergTable
     .unwrap();
     assert_eq!(loaded_arrow_batch, expected_arrow_batch);
 
-    let deleted_rows = deletion_vector.batch_deletion_vector.collect_deleted_rows();
+    let deleted_rows = deletion_vector
+        .committed_deletion_vector
+        .collect_deleted_rows();
     assert!(
         deleted_rows.is_empty(),
         "The new appended data file should have no deletion vector aside, but actually it contains deletion vector {deleted_rows:?}"

--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -143,8 +143,8 @@ pub(crate) struct DiskFileEntry {
     pub(crate) num_rows: usize,
     /// File size.
     pub(crate) file_size: usize,
-    /// In-memory deletion vector, used for new deletion records in-memory processing.
-    pub(crate) batch_deletion_vector: BatchDeletionVector,
+    /// Committed deletion vector, used for new deletion records in-memory processing.
+    pub(crate) committed_deletion_vector: BatchDeletionVector,
     /// Persisted iceberg deletion vector puffin blob.
     pub(crate) puffin_deletion_blob: Option<PuffinBlobRef>,
 }

--- a/src/moonlink/src/storage/mooncake_table/batch_ingestion.rs
+++ b/src/moonlink/src/storage/mooncake_table/batch_ingestion.rs
@@ -120,7 +120,7 @@ impl MooncakeTable {
                         cache_handle: None,
                         num_rows,
                         file_size,
-                        batch_deletion_vector: BatchDeletionVector::new(num_rows),
+                        committed_deletion_vector: BatchDeletionVector::new(num_rows),
                         puffin_deletion_blob: None,
                     };
 

--- a/src/moonlink/src/storage/mooncake_table/snapshot_maintenance.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot_maintenance.rs
@@ -102,9 +102,11 @@ impl SnapshotTableState {
                 if data_file_deletion_percentage_threshold == 0 {
                     continue;
                 }
-                let deletion_percentage =
-                    disk_file_entry.batch_deletion_vector.get_num_rows_deleted() * 100
-                        / disk_file_entry.num_rows;
+                let deletion_percentage = disk_file_entry
+                    .committed_deletion_vector
+                    .get_num_rows_deleted()
+                    * 100
+                    / disk_file_entry.num_rows;
                 if deletion_percentage < data_file_deletion_percentage_threshold {
                     continue;
                 }

--- a/src/moonlink/src/storage/mooncake_table/snapshot_validation.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot_validation.rs
@@ -83,7 +83,7 @@ impl SnapshotTableState {
                     .as_ref()
                     .map_or(0, |cur_puffin_blob| cur_puffin_blob.num_rows),
                 cur_disk_file_entry
-                    .batch_deletion_vector
+                    .committed_deletion_vector
                     .get_num_rows_deleted()
             );
         }

--- a/src/moonlink/src/storage/mooncake_table/tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/tests.rs
@@ -2771,7 +2771,7 @@ async fn test_streaming_deletion_remap_sets_batch_deletion_vector() {
         let total_deleted: usize = stream_state
             .flushed_files
             .values()
-            .map(|entry| entry.batch_deletion_vector.get_num_rows_deleted())
+            .map(|entry| entry.committed_deletion_vector.get_num_rows_deleted())
             .sum();
         assert_eq!(
             total_deleted, 1,

--- a/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
+++ b/src/moonlink/src/storage/mooncake_table/transaction_stream.rs
@@ -284,7 +284,7 @@ impl MooncakeTable {
                                 .flushed_files
                                 .get_key_value_mut(&file_id)
                                 .expect("missing disk file");
-                            if disk_file_entry.batch_deletion_vector.is_deleted(row_id) {
+                            if disk_file_entry.committed_deletion_vector.is_deleted(row_id) {
                                 continue;
                             }
                             if record.row_identity.is_none()
@@ -303,7 +303,9 @@ impl MooncakeTable {
                                     pos: loc,
                                     lsn: record.lsn,
                                 });
-                                assert!(disk_file_entry.batch_deletion_vector.delete_row(row_id));
+                                assert!(disk_file_entry
+                                    .committed_deletion_vector
+                                    .delete_row(row_id));
                                 return;
                             }
                         }
@@ -474,7 +476,7 @@ impl MooncakeTable {
                 num_rows: file_attrs.row_num,
                 file_size: file_attrs.file_size,
                 cache_handle: None,
-                batch_deletion_vector: BatchDeletionVector::new(file_attrs.row_num),
+                committed_deletion_vector: BatchDeletionVector::new(file_attrs.row_num),
                 puffin_deletion_blob: None,
             };
             // Add now flushed files to stream state
@@ -503,7 +505,9 @@ impl MooncakeTable {
             {
                 for (file, disk_file_entry) in stream_state.flushed_files.iter_mut() {
                     if file.file_id() == file_id {
-                        assert!(disk_file_entry.batch_deletion_vector.delete_row(row_idx));
+                        assert!(disk_file_entry
+                            .committed_deletion_vector
+                            .delete_row(row_idx));
                         break;
                     }
                 }

--- a/src/moonlink/src/table_handler/tests.rs
+++ b/src/moonlink/src/table_handler/tests.rs
@@ -692,18 +692,18 @@ async fn test_iceberg_snapshot_creation_for_batch_write() {
         .unwrap();
     assert_eq!(next_file_id, 2); // one for data file, one for index block file
     assert_eq!(snapshot.disk_files.len(), 1);
-    let (cur_data_file, cur_deletion_vector) = snapshot.disk_files.into_iter().next().unwrap();
+    let (cur_data_file, cur_disk_file_entry) = snapshot.disk_files.into_iter().next().unwrap();
     // Check data file.
     let actual_arrow_batch = load_one_arrow_batch(cur_data_file.file_path()).await;
     let expected_arrow_batch = arrow_batch_1.clone();
     assert_eq!(actual_arrow_batch, expected_arrow_batch);
     // Check deletion vector.
-    assert!(cur_deletion_vector
-        .batch_deletion_vector
+    assert!(cur_disk_file_entry
+        .committed_deletion_vector
         .collect_deleted_rows()
         .is_empty());
-    check_deletion_vector_consistency(&cur_deletion_vector).await;
-    assert!(cur_deletion_vector.puffin_deletion_blob.is_none());
+    check_deletion_vector_consistency(&cur_disk_file_entry).await;
+    assert!(cur_disk_file_entry.puffin_deletion_blob.is_none());
     let old_data_file = cur_data_file;
 
     // ---- Create snapshot after new records appended and old records deleted ----
@@ -745,7 +745,7 @@ async fn test_iceberg_snapshot_creation_for_batch_write() {
             // Check the first deletion vector.
             assert_eq!(
                 cur_deletion_vector
-                    .batch_deletion_vector
+                    .committed_deletion_vector
                     .collect_deleted_rows(),
                 vec![0]
             );
@@ -759,7 +759,7 @@ async fn test_iceberg_snapshot_creation_for_batch_write() {
         assert_eq!(actual_arrow_batch, expected_arrow_batch);
         // Check the second deletion vector.
         let deleted_rows = cur_deletion_vector
-            .batch_deletion_vector
+            .committed_deletion_vector
             .collect_deleted_rows();
         assert!(
             deleted_rows.is_empty(),
@@ -799,7 +799,7 @@ async fn test_iceberg_snapshot_creation_for_batch_write() {
             // Check the first deletion vector.
             assert_eq!(
                 cur_deletion_vector
-                    .batch_deletion_vector
+                    .committed_deletion_vector
                     .collect_deleted_rows(),
                 vec![0]
             );
@@ -815,7 +815,7 @@ async fn test_iceberg_snapshot_creation_for_batch_write() {
         // Check the first deletion vector.
         assert_eq!(
             cur_deletion_vector
-                .batch_deletion_vector
+                .committed_deletion_vector
                 .collect_deleted_rows(),
             vec![0]
         );
@@ -899,18 +899,18 @@ async fn test_iceberg_snapshot_creation_for_streaming_write() {
         .unwrap();
     assert_eq!(next_file_id, 2); // one data file, one index block file
     assert_eq!(snapshot.disk_files.len(), 1);
-    let (cur_data_file, cur_deletion_vector) = snapshot.disk_files.into_iter().next().unwrap();
+    let (cur_data_file, cur_disk_file_entry) = snapshot.disk_files.into_iter().next().unwrap();
     // Check data file.
     let actual_arrow_batch = load_one_arrow_batch(cur_data_file.file_path()).await;
     let expected_arrow_batch = arrow_batch_1.clone();
     assert_eq!(actual_arrow_batch, expected_arrow_batch);
     // Check deletion vector.
-    assert!(cur_deletion_vector
-        .batch_deletion_vector
+    assert!(cur_disk_file_entry
+        .committed_deletion_vector
         .collect_deleted_rows()
         .is_empty());
-    check_deletion_vector_consistency(&cur_deletion_vector).await;
-    assert!(cur_deletion_vector.puffin_deletion_blob.is_none());
+    check_deletion_vector_consistency(&cur_disk_file_entry).await;
+    assert!(cur_disk_file_entry.puffin_deletion_blob.is_none());
     let old_data_file = cur_data_file;
 
     // ---- Create snapshot after new records appended and old records deleted ----
@@ -958,7 +958,7 @@ async fn test_iceberg_snapshot_creation_for_streaming_write() {
             // Check the first deletion vector.
             assert_eq!(
                 cur_deletion_vector
-                    .batch_deletion_vector
+                    .committed_deletion_vector
                     .collect_deleted_rows(),
                 vec![0]
             );
@@ -972,7 +972,7 @@ async fn test_iceberg_snapshot_creation_for_streaming_write() {
         assert_eq!(actual_arrow_batch, expected_arrow_batch);
         // Check the second deletion vector.
         let deleted_rows = cur_deletion_vector
-            .batch_deletion_vector
+            .committed_deletion_vector
             .collect_deleted_rows();
         assert!(
             deleted_rows.is_empty(),
@@ -1015,7 +1015,7 @@ async fn test_iceberg_snapshot_creation_for_streaming_write() {
             // Check the first deletion vector.
             assert_eq!(
                 cur_deletion_vector
-                    .batch_deletion_vector
+                    .committed_deletion_vector
                     .collect_deleted_rows(),
                 vec![0]
             );
@@ -1031,7 +1031,7 @@ async fn test_iceberg_snapshot_creation_for_streaming_write() {
         // Check the first deletion vector.
         assert_eq!(
             cur_deletion_vector
-                .batch_deletion_vector
+                .committed_deletion_vector
                 .collect_deleted_rows(),
             vec![0]
         );
@@ -1155,7 +1155,7 @@ async fn test_multiple_snapshot_requests() {
         .unwrap();
     assert_eq!(next_file_id, 2); // one data file, one index block file
     assert_eq!(snapshot.disk_files.len(), 1);
-    let (cur_data_file, cur_deletion_vector) = snapshot.disk_files.into_iter().next().unwrap();
+    let (cur_data_file, cur_disk_file_entry) = snapshot.disk_files.into_iter().next().unwrap();
 
     // Check the data file.
     let actual_arrow_batch = load_one_arrow_batch(cur_data_file.file_path()).await;
@@ -1170,11 +1170,11 @@ async fn test_multiple_snapshot_requests() {
     );
 
     // Check the deletion vector.
-    assert!(cur_deletion_vector
-        .batch_deletion_vector
+    assert!(cur_disk_file_entry
+        .committed_deletion_vector
         .collect_deleted_rows()
         .is_empty(),);
-    check_deletion_vector_consistency(&cur_deletion_vector).await;
+    check_deletion_vector_consistency(&cur_disk_file_entry).await;
 }
 
 /// Test that flush_lsn correctly reflects LSN ordering for batch operations


### PR DESCRIPTION
## Summary

This PR is a no-op change, simply renames batch deletion vector to its true meaning: committed deletion vector.

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [x] Documentation updated if necessary
- [x] I have reviewed my own changes
