### PR TITLE
Add timestamp to logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7346,6 +7346,7 @@ version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
+ "chrono",
  "matchers",
  "nu-ansi-term",
  "once_cell",

--- a/src/moonlink_backend/Cargo.toml
+++ b/src/moonlink_backend/Cargo.toml
@@ -37,7 +37,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "chrono"] }
 
 [dev-dependencies]
 iceberg = { workspace = true }

--- a/src/moonlink_backend/src/logging.rs
+++ b/src/moonlink_backend/src/logging.rs
@@ -2,14 +2,15 @@ use tracing_subscriber::Layer;
 
 pub fn init_logging() {
     use tracing_subscriber::{
-        fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Registry,
+        fmt, fmt::time, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Registry,
     };
 
     let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
 
     let fmt_layer = fmt::layer()
+        .with_timer(time::ChronoLocal::new("%Y-%m-%d %H:%M:%S%:z".to_string()))
         .with_test_writer()
-        .with_ansi(false)
+        .with_ansi(true)
         .with_filter(env_filter);
 
     // Compose the subscriber.


### PR DESCRIPTION
## Summary

This PR adds timestamp and color to logging, which is the default option by a few other logging libraries like [glog](https://github.com/google/glog).

Output:
![Uploading image.png…]()

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
