### PR TITLE
[REST] Fix flaky recovery test

### DIFF
--- a/src/moonlink_backend/src/lib.rs
+++ b/src/moonlink_backend/src/lib.rs
@@ -15,6 +15,7 @@ use moonlink::{MooncakeTableId, MoonlinkTableConfig};
 use moonlink::{ReadStateFilepathRemap, TableEventManager};
 pub use moonlink_connectors::rest_ingest::event_request::{
     EventRequest, FileEventOperation, FileEventRequest, RowEventOperation, RowEventRequest,
+    SnapshotRequest,
 };
 pub use moonlink_connectors::rest_ingest::rest_event::RestEvent;
 pub use moonlink_connectors::rest_ingest::rest_source::RestSource;

--- a/src/moonlink_backend/tests/test_backend.rs
+++ b/src/moonlink_backend/tests/test_backend.rs
@@ -486,7 +486,9 @@ mod tests {
             .unwrap();
 
         // Crash backend recovery and recreate backend.
-        backend.shutdown_connection(REST_API_URI, false).await;
+        backend
+            .shutdown_connection(REST_API_URI, /*postgres_drop_al*/ true)
+            .await;
         backend =
             create_backend_from_base_path(temp_dir.path().to_str().unwrap().to_string()).await;
         assert_scan_ids_eq(

--- a/src/moonlink_connectors/src/rest_ingest/event_request.rs
+++ b/src/moonlink_connectors/src/rest_ingest/event_request.rs
@@ -53,6 +53,20 @@ pub struct FileEventRequest {
 }
 
 /// ======================
+/// Table snapshot request
+/// ======================
+///
+#[derive(Debug, Clone)]
+pub struct SnapshotRequest {
+    /// Src table name.
+    pub src_table_name: String,
+    /// Requested LSN.
+    pub lsn: u64,
+    /// Channel used to synchronize snapshot completion.
+    pub tx: mpsc::Sender<u64>,
+}
+
+/// ======================
 /// Event request
 /// ======================
 ///
@@ -60,6 +74,7 @@ pub struct FileEventRequest {
 pub enum EventRequest {
     RowRequest(RowEventRequest),
     FileRequest(FileEventRequest),
+    SnapshotRequest(SnapshotRequest),
 }
 
 impl EventRequest {
@@ -68,6 +83,7 @@ impl EventRequest {
         match &self {
             EventRequest::RowRequest(req) => req.tx.clone(),
             EventRequest::FileRequest(req) => req.tx.clone(),
+            EventRequest::SnapshotRequest(req) => Some(req.tx.clone()),
         }
     }
 }

--- a/src/moonlink_connectors/src/rest_ingest/rest_event.rs
+++ b/src/moonlink_connectors/src/rest_ingest/rest_event.rs
@@ -41,6 +41,12 @@ pub enum RestEvent {
         /// LSN for the ingestion event.
         lsn: u64,
     },
+    Snapshot {
+        /// Source table id.
+        src_table_id: SrcTableId,
+        /// LSN to create snapshot.
+        lsn: u64,
+    },
 }
 
 impl RestEvent {
@@ -51,6 +57,7 @@ impl RestEvent {
             RestEvent::Commit { lsn, .. } => Some(*lsn),
             RestEvent::FileInsertEvent { .. } => None,
             RestEvent::FileUploadEvent { lsn, .. } => Some(*lsn),
+            RestEvent::Snapshot { .. } => None,
         }
     }
 }

--- a/src/moonlink_service/src/test.rs
+++ b/src/moonlink_service/src/test.rs
@@ -160,12 +160,12 @@ fn get_optimize_table_payload(database: &str, table: &str, mode: &str) -> serde_
 
 /// Util function to get create snapshot payload.
 fn get_create_snapshot_payload(database: &str, table: &str, lsn: u64) -> serde_json::Value {
-    let optimize_table_payload = json!({
+    let snapshot_creation_payload = json!({
         "database": database,
         "table": table,
         "lsn": lsn
     });
-    optimize_table_payload
+    snapshot_creation_payload
 }
 
 /// Util function to create table via REST API.


### PR DESCRIPTION
## Summary

For more details please see https://github.com/Mooncake-Labs/moonlink/issues/1831#issuecomment-3243112509

TLDR: current implementation doesn't guarantee snapshot creation request is sent after table ingestion at table handler side

I think the semantics for snapshot creation needs to be revisited after our openapi finalized. 

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
