### PR TITLE
Add source code location to logging

### DIFF
--- a/src/moonlink_backend/src/logging.rs
+++ b/src/moonlink_backend/src/logging.rs
@@ -9,6 +9,7 @@ pub fn init_logging() {
 
     let fmt_layer = fmt::layer()
         .with_timer(time::ChronoLocal::new("%Y-%m-%d %H:%M:%S%:z".to_string()))
+        .with_target(false)
         .with_file(true)
         .with_line_number(true)
         .with_test_writer()

--- a/src/moonlink_backend/src/logging.rs
+++ b/src/moonlink_backend/src/logging.rs
@@ -9,6 +9,8 @@ pub fn init_logging() {
 
     let fmt_layer = fmt::layer()
         .with_timer(time::ChronoLocal::new("%Y-%m-%d %H:%M:%S%:z".to_string()))
+        .with_file(true)
+        .with_line_number(true)
         .with_test_writer()
         .with_ansi(true)
         .with_filter(env_filter);


### PR DESCRIPTION
## Summary

This PR adds file name and line number to logging, which is the default behavior for glog ([1](https://github.com/google/glog), [2](https://github.com/golang/glog))
I found it super useful for troubleshooting with source code location attached with message.

Effect:
```sh
2025-09-02 04:37:34+00:00  INFO src/moonlink_service/src/lib.rs:142: Moonlink service started successfully
2025-09-02 04:37:34+00:00  INFO src/moonlink_service/src/rpc_server.rs:78: Moonlink RPC server listening on TCP: 0.0.0.0:3031
2025-09-02 04:37:34+00:00  INFO src/moonlink_service/src/rpc_server.rs:57: Moonlink RPC server listening on Unix socket: "/tmp/temp_test_44553/moonlink.sock"
2025-09-02 04:37:34+00:00  INFO src/moonlink_service/src/rest_api.rs:649: Starting REST API server on 0.0.0.0:3030
```

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1847

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
