### PR TITLE
No panic on mark

### DIFF
--- a/src/moonlink_connectors/src/replication_state.rs
+++ b/src/moonlink_connectors/src/replication_state.rs
@@ -34,7 +34,8 @@ impl ReplicationState {
     pub fn mark(&self, lsn: u64) {
         if lsn > self.current.load(Ordering::SeqCst) {
             self.current.store(lsn, Ordering::SeqCst);
-            self.tx.send(lsn).unwrap();
+            // Ignore send error if there are no subscribers (e.g., during shutdown)
+            let _ = self.tx.send(lsn);
         }
     }
 


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

During startup or shutdown `mark` may be called (on keepalive) causing a panic if the subscriber is dropped. Here we change mark to best-effort. 

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1846

## Changes

- Change mark to best effort
- Add regression test
- 

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
