### PR TITLE
fix: add network alias for iceberg-rest service and update CI to use hostname

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -44,6 +44,10 @@ services:
 
   iceberg-rest:
     image: apache/iceberg-rest-fixture:latest
+    networks:
+      shared_network:
+        aliases:
+          - iceberg-rest.local
     ports:
       - "8181:8181"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,13 +231,18 @@ jobs:
             -p 8181:8181 \
             apache/iceberg-rest-fixture
 
+      # ─────────────── Add hostnames to /etc/hosts ──────────────────────────
+      - name: Add iceberg-rest.local to /etc/hosts
+        run: |
+          echo "127.0.0.1 iceberg-rest.local" | sudo tee -a /etc/hosts
+
       # ───────────────────── Wait for Iceberg-rest to be ready ───────────────────
       - name: Wait for Iceberg-rest-fixture ready
         timeout-minutes: 2
         run: |
           set -euo pipefail
           for i in {1..10}; do
-            if curl -sS http://localhost:8181/v1/config; then
+            if curl -sS http://iceberg-rest.local:8181/v1/config; then
               echo "Iceberg-rest-fixture is ready!"
               exit 0
             fi


### PR DESCRIPTION

<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

Fix rest catalog tests failef when running in devcontainer.

## Related Issues

No

## Changes

- 
- 
- 

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
