### PR TITLE
fix: feature compilation error

### DIFF
--- a/src/moonlink_metadata_store/src/config_utils.rs
+++ b/src/moonlink_metadata_store/src/config_utils.rs
@@ -195,6 +195,7 @@ pub(crate) fn parse_moonlink_table_config(
 /// Recover filesystem config from persisted config and secret.
 ///
 /// For local filesystem, atomic write option is by default disabled, and it's caller's responsibility to enable if necessary.
+#[allow(unreachable_patterns)]
 fn reconstruct_storage_config_from_root(
     root_uri: &str,
     secret_entry: Option<MoonlinkTableSecret>,
@@ -230,6 +231,15 @@ fn reconstruct_storage_config_from_root(
                     root_directory: root_uri.to_string(),
                     atomic_write_dir: None,
                 };
+            }
+
+            _ => {
+                panic!(
+                    "Storage backend {:?} is not supported or feature not enabled. \
+                     Please enable the corresponding feature flag or check your
+            configuration.",
+                    secret_entry.secret_type
+                );
             }
         }
     }


### PR DESCRIPTION


<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

Fixes a non-exhaustive pattern matching error in the storage backend configuration when building with only a single storage feature flag (`storage-s3`, `storage-gcs`, or `storage-fs`).
Due to `#[cfg(feature = ...)]` attributes inside the `match` statement, the Rust compiler treated some `enum` variants as uncovered, triggering a "non-exhaustive patterns" error under partial feature selection.
This change adds a wildcard arm with fail-fast behavior, ensuring any unsupported or misconfigured backend is detected at startup instead of failing silently at runtime.

## Related Issues

Closes #1577

## Changes

- Add wildcard pattern to `reconstruct_storage_config_from_root` match
  statement in `config_utils.rs`

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
