### PR TITLE
Add table handshake

### DIFF
--- a/src/moonlink_backend/src/lib.rs
+++ b/src/moonlink_backend/src/lib.rs
@@ -213,7 +213,6 @@ impl MoonlinkBackend {
                         /*is_recovery=*/ false,
                     )
                     .await?;
-                manager.start_replication(&src_uri).await?;
                 Ok(cur_moonlink_table_config)
             }
         };


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

Currently no coordination between when the schema is actually added to the `CdcStream` and when logical replication events will begin streaming. 

In this PR we add a `oneshot` channel to notify the caller that the table has been added to the stream and its safe to proceed. 

We also do a small refactor to lazily create and start the replication connection as part of add table. Note that we now spawn the replication task first, then add the table. 

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1790

## Changes

- 
- 
- 

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
