### PR TITLE
proto uses vec<u8> instead of bytes

### DIFF
--- a/src/moonlink/src/row/proto_converter.rs
+++ b/src/moonlink/src/row/proto_converter.rs
@@ -61,9 +61,13 @@ fn proto_to_row_value(p: moonlink_pb::RowValue) -> Result<RowValue> {
             RowValue::Decimal(i128::from_be_bytes(arr))
         }
         Kind::Bool(x) => RowValue::Bool(x),
-        Kind::Bytes(b) => RowValue::ByteArray(b.to_vec()),
+        Kind::Bytes(b) => RowValue::ByteArray(b),
         Kind::FixedLenBytes(b) => {
-            assert_eq!(b.len(), 16, "fixed_len_bytes must be 16 bytes");
+            if b.len() != 16 {
+                return Err(Error::pb_conversion_error(
+                    "fixed_len_bytes must be 16 bytes".to_string(),
+                ));
+            }
             let mut arr = [0u8; 16];
             arr.copy_from_slice(&b);
             RowValue::FixedLenByteArray(arr)

--- a/src/moonlink_proto/build.rs
+++ b/src/moonlink_proto/build.rs
@@ -12,10 +12,6 @@ fn main() {
     println!("cargo:rerun-if-changed=build.rs");
 
     prost_build::Config::new()
-        .bytes([
-            ".moonlink.RowValue.bytes",
-            ".moonlink.RowValue.fixed_len_bytes",
-        ]) // map bytes fields to bytes::Bytes if desired
         .compile_protos(proto_files, proto_includes)
         .expect("Failed to compile protos");
 }

--- a/src/moonlink_proto/src/lib.rs
+++ b/src/moonlink_proto/src/lib.rs
@@ -34,12 +34,12 @@ pub mod moonlink {
         }
         pub fn bytes<B: Into<Vec<u8>>>(b: B) -> Self {
             Self {
-                kind: Some(row_value::Kind::Bytes(b.into().into())),
+                kind: Some(row_value::Kind::Bytes(b.into())),
             }
         }
         pub fn fixed_len_bytes<B: Into<Vec<u8>>>(b: B) -> Self {
             Self {
-                kind: Some(row_value::Kind::FixedLenBytes(b.into().into())),
+                kind: Some(row_value::Kind::FixedLenBytes(b.into())),
             }
         }
         pub fn array(a: Array) -> Self {


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

We were previously converting moonlink row value's protobuf `bytes` and `fixed_len_bytes` into rust Byte type - under the hood moonlink row value actually uses `vec<u8>`, so we directly let the proto type be `vec<u8>` instead of converting into the intermediate `Byte`.

## Related Issues

Follow on from #1872 
