### PR TITLE
[storage] Move file deletion into file handle

### DIFF
--- a/src/moonlink/src/storage/compaction/table_compaction.rs
+++ b/src/moonlink/src/storage/compaction/table_compaction.rs
@@ -109,8 +109,6 @@ pub struct DataCompactionResult {
     /// New compacted file indices.
     pub(crate) new_file_indices: Vec<FileIndex>,
     /// Compaction interacts with object storage cache, this field records evicted files to delete.
-    ///
-    /// TODO(hjiang): No need to pass the files out, could directly delete in compaction.
     pub(crate) evicted_files_to_delete: Vec<String>,
 }
 

--- a/src/moonlink/src/storage/iceberg/table_manager.rs
+++ b/src/moonlink/src/storage/iceberg/table_manager.rs
@@ -31,6 +31,8 @@ pub struct PersistenceResult {
     pub(crate) remote_file_indices: Vec<FileIndex>,
     /// Maps from remote data files to their deletion vector puffin blob.
     pub(crate) puffin_blob_ref: HashMap<FileId, PuffinBlobRef>,
+    /// Evicted files to delete from object storage cache.
+    pub(crate) evicted_files_to_delete: Vec<String>,
 }
 
 #[async_trait]

--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -1571,6 +1571,7 @@ impl MooncakeTable {
                 old_file_indices_removed: old_file_indices_to_remove_by_compaction,
                 data_file_records_remap: data_file_record_remap_by_compaction,
             },
+            evicted_files_to_delete: iceberg_persistence_res.evicted_files_to_delete,
         };
 
         // Send back completion notification to table handler.
@@ -1630,6 +1631,7 @@ mod mooncake_tests {
             },
             index_merge_result: IcebergSnapshotIndexMergeResult::default(),
             data_compaction_result: IcebergSnapshotDataCompactionResult::default(),
+            evicted_files_to_delete: Vec::new(),
         };
         // Valid snapshot result.
         MooncakeTable::assert_flush_lsn_on_iceberg_snapshot_res(

--- a/src/moonlink/src/storage/mooncake_table/table_snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_snapshot.rs
@@ -384,6 +384,8 @@ pub struct IcebergSnapshotResult {
     pub(crate) index_merge_result: IcebergSnapshotIndexMergeResult,
     /// Iceberg data file compaction result.
     pub(crate) data_compaction_result: IcebergSnapshotDataCompactionResult,
+    /// Evicted files to delete by object storage cache.
+    pub(crate) evicted_files_to_delete: Vec<String>,
 }
 
 impl Clone for IcebergSnapshotResult {
@@ -397,6 +399,7 @@ impl Clone for IcebergSnapshotResult {
             import_result: self.import_result.clone(),
             index_merge_result: self.index_merge_result.clone(),
             data_compaction_result: self.data_compaction_result.clone(),
+            evicted_files_to_delete: self.evicted_files_to_delete.clone(),
         }
     }
 }
@@ -426,6 +429,10 @@ impl std::fmt::Debug for IcebergSnapshotResult {
             .field("import_result", &self.import_result)
             .field("index_merge_result", &self.index_merge_result)
             .field("data_compaction_result", &self.data_compaction_result)
+            .field(
+                "evicted files to delete count",
+                &self.evicted_files_to_delete.len(),
+            )
             .finish()
     }
 }

--- a/src/moonlink/src/table_handler/chaos_replay.rs
+++ b/src/moonlink/src/table_handler/chaos_replay.rs
@@ -609,9 +609,14 @@ pub(crate) async fn replay(replay_filepath: &str) {
                         guard.remove(&snapshot_completion_event.uuid)
                     };
                     if let Some(completed_iceberg_snapshot) = completed_iceberg_snapshot_event {
-                        table.set_iceberg_snapshot_res(
-                            completed_iceberg_snapshot.iceberg_snapshot_result,
-                        );
+                        let iceberg_snapshot_result =
+                            completed_iceberg_snapshot.iceberg_snapshot_result;
+                        io_utils::delete_local_files(
+                            &iceberg_snapshot_result.evicted_files_to_delete,
+                        )
+                        .await
+                        .unwrap();
+                        table.set_iceberg_snapshot_res(iceberg_snapshot_result);
                         break;
                     }
                     // Otherwise block until the corresponding flush event completes.

--- a/src/moonlink/src/table_handler/chaos_replay.rs
+++ b/src/moonlink/src/table_handler/chaos_replay.rs
@@ -597,7 +597,6 @@ pub(crate) async fn replay(replay_filepath: &str) {
                 assert!(ongoing_iceberg_snapshot_id.insert(snapshot_initiation_event.uuid));
                 let payload = {
                     let mut guard = pending_iceberg_snapshot_payloads_clone.lock().await;
-
                     guard.remove(&snapshot_initiation_event.uuid).unwrap()
                 };
                 table.persist_iceberg_snapshot(payload);
@@ -688,6 +687,11 @@ pub(crate) async fn replay(replay_filepath: &str) {
                     if let Some(completed_data_compaction) = completed_data_compaction_event {
                         let data_compaction_result =
                             completed_data_compaction.data_compaction_result;
+                        io_utils::delete_local_files(
+                            &data_compaction_result.evicted_files_to_delete,
+                        )
+                        .await
+                        .unwrap();
                         table.set_data_compaction_res(data_compaction_result);
                         break;
                     }

--- a/src/moonlink/src/table_handler/failure_tests.rs
+++ b/src/moonlink/src/table_handler/failure_tests.rs
@@ -194,6 +194,7 @@ async fn test_force_index_merge_with_failed_iceberg_persistence() {
                     remote_data_files: snapshot_payload.import_payload.data_files.clone(),
                     remote_file_indices: snapshot_payload.import_payload.file_indices.clone(),
                     puffin_blob_ref: HashMap::new(),
+                    evicted_files_to_delete: Vec::new(),
                 };
                 Ok(mock_persistence_result)
             })
@@ -207,6 +208,7 @@ async fn test_force_index_merge_with_failed_iceberg_persistence() {
                     remote_data_files: snapshot_payload.import_payload.data_files.clone(),
                     remote_file_indices: snapshot_payload.import_payload.file_indices.clone(),
                     puffin_blob_ref: HashMap::new(),
+                    evicted_files_to_delete: Vec::new(),
                 };
                 Ok(mock_persistence_result)
             })
@@ -301,6 +303,7 @@ async fn test_force_data_compaction_with_failed_iceberg_persistence() {
                     remote_data_files: snapshot_payload.import_payload.data_files.clone(),
                     remote_file_indices: snapshot_payload.import_payload.file_indices.clone(),
                     puffin_blob_ref: HashMap::new(),
+                    evicted_files_to_delete: Vec::new(),
                 };
                 Ok(mock_persistence_result)
             })
@@ -314,6 +317,7 @@ async fn test_force_data_compaction_with_failed_iceberg_persistence() {
                     remote_data_files: snapshot_payload.import_payload.data_files.clone(),
                     remote_file_indices: snapshot_payload.import_payload.file_indices.clone(),
                     puffin_blob_ref: HashMap::new(),
+                    evicted_files_to_delete: Vec::new(),
                 };
                 Ok(mock_persistence_result)
             })
@@ -409,6 +413,7 @@ async fn test_force_full_compaction_with_failed_iceberg_persistence() {
                     remote_data_files: snapshot_payload.import_payload.data_files.clone(),
                     remote_file_indices: snapshot_payload.import_payload.file_indices.clone(),
                     puffin_blob_ref: HashMap::new(),
+                    evicted_files_to_delete: Vec::new(),
                 };
                 Ok(mock_persistence_result)
             })
@@ -422,6 +427,7 @@ async fn test_force_full_compaction_with_failed_iceberg_persistence() {
                     remote_data_files: snapshot_payload.import_payload.data_files.clone(),
                     remote_file_indices: snapshot_payload.import_payload.file_indices.clone(),
                     puffin_blob_ref: HashMap::new(),
+                    evicted_files_to_delete: Vec::new(),
                 };
                 Ok(mock_persistence_result)
             })


### PR DESCRIPTION
## Summary

When debugging a file not found error, I found most of the file deletion today inside of moonlink is scattered everywhere.
It's bad for replay system since it makes replay non-deterministic and impossible to stably repro.

This PR is a no-op change, simply move the deletion logic into result and applied in a centralized place table handler.

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
