### PR TITLE
Bump rust-postgres

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4053,9 +4053,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
 name = "loom"
@@ -5239,7 +5239,7 @@ dependencies = [
 [[package]]
 name = "postgres-native-tls"
 version = "0.5.0"
-source = "git+https://github.com/Mooncake-Labs/rust-postgres.git?rev=a7398c75b5cfd62fc016306a71d83306ad4ddf35#a7398c75b5cfd62fc016306a71d83306ad4ddf35"
+source = "git+https://github.com/Mooncake-Labs/rust-postgres.git?rev=14c8e599f5551a8caa96ff5023685a6f537a1455#14c8e599f5551a8caa96ff5023685a6f537a1455"
 dependencies = [
  "native-tls",
  "tokio",
@@ -5250,7 +5250,7 @@ dependencies = [
 [[package]]
 name = "postgres-protocol"
 version = "0.6.7"
-source = "git+https://github.com/Mooncake-Labs/rust-postgres.git?rev=a7398c75b5cfd62fc016306a71d83306ad4ddf35#a7398c75b5cfd62fc016306a71d83306ad4ddf35"
+source = "git+https://github.com/Mooncake-Labs/rust-postgres.git?rev=14c8e599f5551a8caa96ff5023685a6f537a1455#14c8e599f5551a8caa96ff5023685a6f537a1455"
 dependencies = [
  "base64 0.22.1",
  "byteorder",
@@ -5267,7 +5267,7 @@ dependencies = [
 [[package]]
 name = "postgres-replication"
 version = "0.6.7"
-source = "git+https://github.com/Mooncake-Labs/rust-postgres.git?rev=a7398c75b5cfd62fc016306a71d83306ad4ddf35#a7398c75b5cfd62fc016306a71d83306ad4ddf35"
+source = "git+https://github.com/Mooncake-Labs/rust-postgres.git?rev=14c8e599f5551a8caa96ff5023685a6f537a1455#14c8e599f5551a8caa96ff5023685a6f537a1455"
 dependencies = [
  "byteorder",
  "bytes",
@@ -5282,7 +5282,7 @@ dependencies = [
 [[package]]
 name = "postgres-types"
 version = "0.2.7"
-source = "git+https://github.com/Mooncake-Labs/rust-postgres.git?rev=a7398c75b5cfd62fc016306a71d83306ad4ddf35#a7398c75b5cfd62fc016306a71d83306ad4ddf35"
+source = "git+https://github.com/Mooncake-Labs/rust-postgres.git?rev=14c8e599f5551a8caa96ff5023685a6f537a1455#14c8e599f5551a8caa96ff5023685a6f537a1455"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -7270,7 +7270,7 @@ dependencies = [
 [[package]]
 name = "tokio-postgres"
 version = "0.7.11"
-source = "git+https://github.com/Mooncake-Labs/rust-postgres.git?rev=a7398c75b5cfd62fc016306a71d83306ad4ddf35#a7398c75b5cfd62fc016306a71d83306ad4ddf35"
+source = "git+https://github.com/Mooncake-Labs/rust-postgres.git?rev=14c8e599f5551a8caa96ff5023685a6f537a1455#14c8e599f5551a8caa96ff5023685a6f537a1455"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -7511,9 +7511,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "twox-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b907da542cbced5261bd3256de1b3a1bf340a3d37f93425a07362a1d687de56"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "typed-builder"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,9 +60,9 @@ parquet = { version = "55", default-features = false, features = [
   "arrow_canonical_extension_types",
 ] }
 paste = "1"
-postgres-native-tls = { git = "https://github.com/Mooncake-labs/rust-postgres.git", rev = "a7398c75b5cfd62fc016306a71d83306ad4ddf35" }
-postgres-replication = { git = "https://github.com/Mooncake-labs/rust-postgres.git", rev = "a7398c75b5cfd62fc016306a71d83306ad4ddf35" }
-postgres-types = { git = "https://github.com/Mooncake-Labs/rust-postgres.git", rev = "a7398c75b5cfd62fc016306a71d83306ad4ddf35", features = [
+postgres-native-tls = { git = "https://github.com/Mooncake-labs/rust-postgres.git", rev = "14c8e599f5551a8caa96ff5023685a6f537a1455" }
+postgres-replication = { git = "https://github.com/Mooncake-labs/rust-postgres.git", rev = "14c8e599f5551a8caa96ff5023685a6f537a1455" }
+postgres-types = { git = "https://github.com/Mooncake-Labs/rust-postgres.git", rev = "14c8e599f5551a8caa96ff5023685a6f537a1455", features = [
   "with-serde_json-1",
 ] }
 prost = "0.13"
@@ -88,7 +88,7 @@ tokio = { version = "1.47", default-features = false, features = [
   "tracing",
 ] }
 tokio-bitstream-io = "0.0"
-tokio-postgres = { git = "https://github.com/Mooncake-labs/rust-postgres.git", rev = "a7398c75b5cfd62fc016306a71d83306ad4ddf35", features = [
+tokio-postgres = { git = "https://github.com/Mooncake-labs/rust-postgres.git", rev = "14c8e599f5551a8caa96ff5023685a6f537a1455", features = [
   "with-serde_json-1",
 ] }
 tracing = "0.1"
@@ -101,5 +101,5 @@ inherits = "release"
 debug = true
 
 [patch.crates-io]
-postgres-types = { git = "https://github.com/Mooncake-Labs/rust-postgres.git", rev = "a7398c75b5cfd62fc016306a71d83306ad4ddf35" }
-postgres-protocol = { git = "https://github.com/Mooncake-Labs/rust-postgres.git", rev = "a7398c75b5cfd62fc016306a71d83306ad4ddf35" }
+postgres-types = { git = "https://github.com/Mooncake-Labs/rust-postgres.git", rev = "14c8e599f5551a8caa96ff5023685a6f537a1455" }
+postgres-protocol = { git = "https://github.com/Mooncake-Labs/rust-postgres.git", rev = "14c8e599f5551a8caa96ff5023685a6f537a1455" }

--- a/deny.toml
+++ b/deny.toml
@@ -24,7 +24,7 @@ allow = [
 unknown-git = "deny"
 allow-git = [
     "https://github.com/apache/iceberg-rust.git",
-    "https://github.com/Mooncake-Labs/rust-postgres.git?rev=a7398c75b5cfd62fc016306a71d83306ad4ddf35",
+    "https://github.com/Mooncake-Labs/rust-postgres.git?rev=14c8e599f5551a8caa96ff5023685a6f537a1455",
 ]
 
 # TODO(hjiang): Cleanup these unmaintained crates.


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

Pull in changes for: 
https://github.com/Mooncake-Labs/rust-postgres/pull/13

This allows us to compute the `end_lsn` per `XLogData` block, providing more granular level LSN data (e.g no longer have to wait for stream commit for lsn data). 

This will be used in an upcoming change related to respawning the replication task, however I also think there are applications for our WAL writer in that this allows us to store partial transactions/not have to start from the beginning of a streamed transaction in PG during recovery(?) 

## Related Issues

Closes http://github.com/Mooncake-Labs/moonlink/issues/1895

## Changes

- 
- 
- 

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
