### PR TITLE
[storage] Remove useless mutable specifier

### DIFF
--- a/src/moonlink/src/storage/cache/object_storage/cache_handle.rs
+++ b/src/moonlink/src/storage/cache/object_storage/cache_handle.rs
@@ -46,14 +46,14 @@ impl NonEvictableHandle {
 
     /// Unreference the pinned cache file.
     #[must_use]
-    pub(crate) async fn unreference(&mut self) -> Vec<String> {
+    pub(crate) async fn unreference(&self) -> Vec<String> {
         let mut guard = self.cache.write().await;
         guard.unreference(self.file_id)
     }
 
     /// Unreference and pinned cache file and mark it as deleted.
     #[must_use]
-    pub(crate) async fn unreference_and_delete(&mut self) -> InlineEvictedFiles {
+    pub(crate) async fn unreference_and_delete(&self) -> InlineEvictedFiles {
         let mut guard = self.cache.write().await;
 
         // Total bytes within cache doesn't change, so current cache entry not evicted.
@@ -77,7 +77,7 @@ impl NonEvictableHandle {
     /// - Moonlink process restarts and recreates the cache directory.
     #[must_use]
     pub(crate) async fn unreference_and_replace_with_remote(
-        &mut self,
+        &self,
         remote_filepath: &str,
     ) -> Vec<String> {
         let mut guard = self.cache.write().await;

--- a/src/moonlink/src/storage/cache/object_storage/local_file_optimization_state_tests.rs
+++ b/src/moonlink/src/storage/cache/object_storage/local_file_optimization_state_tests.rs
@@ -64,7 +64,7 @@ async fn test_cache_state_3_persist_and_unreferenced_2() {
             file_size: CONTENT.len() as u64,
         },
     };
-    let (mut cache_handle, evicted_files_to_delete) =
+    let (cache_handle, evicted_files_to_delete) =
         cache.import_cache_entry(file_id, cache_entry.clone()).await;
     assert_eq!(
         cache_handle.cache_entry.cache_filepath,
@@ -107,7 +107,7 @@ async fn test_cache_state_3_persist_and_referenced_3() {
             file_size: CONTENT.len() as u64,
         },
     };
-    let (mut cache_handle_1, evicted_files_to_delete) =
+    let (cache_handle_1, evicted_files_to_delete) =
         cache.import_cache_entry(file_id, cache_entry.clone()).await;
     assert_eq!(
         cache_handle_1.cache_entry.cache_filepath,
@@ -220,7 +220,7 @@ async fn test_cache_state_2_request_to_delete_4() {
     let file_id = get_table_unique_file_id(0);
 
     // Import local cache entry.
-    let (mut cache_handle, evicted_files_to_delete) =
+    let (cache_handle, evicted_files_to_delete) =
         cache.import_cache_entry(file_id, cache_entry.clone()).await;
     assert_eq!(
         cache_handle.cache_entry.cache_filepath,
@@ -286,7 +286,7 @@ async fn test_cache_state_3_request_to_delete_5() {
     let file_id = get_table_unique_file_id(0);
 
     // Import local cache entry.
-    let (mut cache_handle_1, evicted_files_to_delete) =
+    let (cache_handle_1, evicted_files_to_delete) =
         cache.import_cache_entry(file_id, cache_entry.clone()).await;
     assert_eq!(
         cache_handle_1.cache_entry.cache_filepath,
@@ -339,7 +339,7 @@ async fn test_cache_state_5_unreference_4() {
     let file_id = get_table_unique_file_id(0);
 
     // Import local cache entry, and replace with remote one.
-    let (mut cache_handle, _) = cache.import_cache_entry(file_id, cache_entry.clone()).await;
+    let (cache_handle, _) = cache.import_cache_entry(file_id, cache_entry.clone()).await;
     let _ = cache_handle
         .unreference_and_replace_with_remote(test_remote_file.to_str().unwrap())
         .await;
@@ -407,7 +407,7 @@ async fn test_cache_state_2_new_entry_with_sufficient_space_4() {
             file_size: CONTENT.len() as u64,
         },
     };
-    let (mut cache_handle, _) = cache
+    let (cache_handle, _) = cache
         .import_cache_entry(file_id_1, cache_entry_1.clone())
         .await;
     let _ = cache_handle
@@ -469,7 +469,7 @@ async fn test_cache_state_2_new_entry_with_insufficient_space_1() {
             file_size: CONTENT.len() as u64,
         },
     };
-    let (mut cache_handle, _) = cache
+    let (cache_handle, _) = cache
         .import_cache_entry(file_id_1, cache_entry_1.clone())
         .await;
     let _ = cache_handle
@@ -519,7 +519,7 @@ async fn test_cache_state_2_request_to_read_sufficient_space_4() {
     let file_id = get_table_unique_file_id(0);
 
     // Import local cache entry.
-    let (mut cache_handle, evicted_files_to_delete) =
+    let (cache_handle, evicted_files_to_delete) =
         cache.import_cache_entry(file_id, cache_entry.clone()).await;
     assert_eq!(
         cache_handle.cache_entry.cache_filepath,

--- a/src/moonlink/src/storage/cache/object_storage/state_tests.rs
+++ b/src/moonlink/src/storage/cache/object_storage/state_tests.rs
@@ -225,7 +225,7 @@ async fn test_cache_2_new_entry_with_sufficient_space() {
             file_size: CONTENT.len() as u64,
         },
     };
-    let (mut cache_handle, files_to_evict) = cache
+    let (cache_handle, files_to_evict) = cache
         .import_cache_entry(/*file_id=*/ get_table_unique_file_id(0), cache_entry)
         .await;
     assert_non_evictable_cache_handle_ref_count(
@@ -289,7 +289,7 @@ async fn test_cache_2_new_entry_with_insufficient_space() {
             file_size: CONTENT.len() as u64,
         },
     };
-    let (mut cache_handle_1, files_to_evict) = cache
+    let (cache_handle_1, files_to_evict) = cache
         .import_cache_entry(/*file_id=*/ get_table_unique_file_id(0), cache_entry)
         .await;
     assert_non_evictable_cache_handle_ref_count(
@@ -460,7 +460,7 @@ async fn test_cache_2_requested_to_delete_4() {
             file_size: CONTENT.len() as u64,
         },
     };
-    let (mut cache_handle, files_to_evict) = cache
+    let (cache_handle, files_to_evict) = cache
         .import_cache_entry(/*file_id=*/ get_table_unique_file_id(0), cache_entry)
         .await;
     assert_non_evictable_cache_handle_ref_count(
@@ -606,7 +606,7 @@ async fn test_cache_5_usage_finish_and_not_referenced_4() {
             file_size: CONTENT.len() as u64,
         },
     };
-    let (mut cache_handle_1, files_to_evict) = cache
+    let (cache_handle_1, files_to_evict) = cache
         .import_cache_entry(/*file_id=*/ get_table_unique_file_id(0), cache_entry)
         .await;
     assert_non_evictable_cache_handle_ref_count(

--- a/src/moonlink/src/storage/compaction/compactor.rs
+++ b/src/moonlink/src/storage/compaction/compactor.rs
@@ -273,8 +273,7 @@ impl CompactionBuilder {
         }
 
         // Unpin cache handle after usage, if necessary.
-        // TODO(hjiang): Better error propagation, cache handle should be always unpinned whether success or failure.
-        if let Some(mut cache_handle) = cache_handle {
+        if let Some(cache_handle) = cache_handle {
             let evicted_files = cache_handle.unreference().await;
             evicted_files_to_delete.extend(evicted_files);
         }

--- a/src/moonlink/src/storage/mooncake_table/data_file_state_tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/data_file_state_tests.rs
@@ -1030,7 +1030,7 @@ async fn test_2_read_and_pinned_3_without_local_optimization(#[case] use_batch_w
     )
     .await;
     // Import second data file into cache, so the cached entry will be evicted.
-    let mut fake_cache_handle = import_fake_cache_entry(&temp_dir, &mut cache).await;
+    let fake_cache_handle = import_fake_cache_entry(&temp_dir, &mut cache).await;
 
     // State input: read, but no reference count hold within read state.
     let snapshot_read_output_1 = perform_read_request_for_test(&mut table).await;
@@ -1077,7 +1077,7 @@ async fn test_2_read_and_pinned_3_with_local_optimization(#[case] use_batch_writ
     );
 
     // Prepare initial state.
-    let (mut table, mut table_notify, mut fake_cache_handle) = prepare_state_2(
+    let (mut table, mut table_notify, fake_cache_handle) = prepare_state_2(
         &temp_dir,
         cache.clone(),
         use_batch_write,
@@ -1779,7 +1779,7 @@ async fn test_1_compact_1_5_without_local_optimization() {
     assert!(data_compaction_payload.has_payload());
 
     // Import second data file into cache, so the cached entry will be evicted.
-    let mut fake_cache_handle = import_fake_cache_entry(&temp_dir, &mut cache).await;
+    let fake_cache_handle = import_fake_cache_entry(&temp_dir, &mut cache).await;
     let evicted_files_to_delete = fake_cache_handle.unreference().await;
     assert!(evicted_files_to_delete.is_empty());
 
@@ -1855,7 +1855,7 @@ async fn test_1_compact_1_5_with_local_optimization() {
     assert!(data_compaction_payload.has_payload());
 
     // Import second data file into cache, so the cached entry will be evicted.
-    let mut fake_cache_handle = import_fake_cache_entry(&temp_dir, &mut cache).await;
+    let fake_cache_handle = import_fake_cache_entry(&temp_dir, &mut cache).await;
     let evicted_files_to_delete = fake_cache_handle.unreference().await;
     assert!(evicted_files_to_delete.is_empty());
 

--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -388,7 +388,7 @@ impl SnapshotTableState {
             //
             // If the old entry is pinned cache handle, unreference.
             let old_entry = old_entry.unwrap();
-            if let Some(mut cache_handle) = old_entry.cache_handle {
+            if let Some(cache_handle) = old_entry.cache_handle {
                 // The old entry is no longer needed for mooncake table, directly mark it deleted from cache, so we could reclaim the disk space back ASAP.
                 let cur_evicted_files = cache_handle.unreference_and_delete().await;
                 evicted_files_to_delete.extend(cur_evicted_files);
@@ -413,7 +413,7 @@ impl SnapshotTableState {
             }
 
             // Unpin and request to delete all cached puffin files.
-            if let Some(mut puffin_deletion_blob) = old_entry.puffin_deletion_blob {
+            if let Some(puffin_deletion_blob) = old_entry.puffin_deletion_blob {
                 let cur_evicted_files = puffin_deletion_blob
                     .puffin_file_cache_handle
                     .unreference_and_delete()

--- a/src/moonlink/src/storage/mooncake_table/snapshot_persistence.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot_persistence.rs
@@ -199,12 +199,12 @@ impl SnapshotTableState {
         // Aggregate the evicted files to delete.
         let mut evicted_files_to_delete = vec![];
 
-        for (file_id, mut puffin_blob_ref) in puffin_blob_ref.into_iter() {
+        for (file_id, puffin_blob_ref) in puffin_blob_ref.into_iter() {
             // The data file referenced by puffin blob still exist.
             if let Some(entry) = self.current_snapshot.disk_files.get_mut(&file_id) {
                 // Unreference and delete old cache handle if any.
                 let old_puffin_blob = entry.puffin_deletion_blob.take();
-                if let Some(mut old_puffin_blob) = old_puffin_blob {
+                if let Some(old_puffin_blob) = old_puffin_blob {
                     let cur_evicted_files = old_puffin_blob
                         .puffin_file_cache_handle
                         .unreference_and_delete()

--- a/src/moonlink/src/storage/mooncake_table/snapshot_read_output.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot_read_output.rs
@@ -215,13 +215,13 @@ impl ReadOutput {
             cache_handles.len() + self.puffin_cache_handles.len() + self.associated_files.len();
         let mut evicted_files_to_delete_on_error: Vec<String> = Vec::with_capacity(total_size);
         // Unpin all previously pinned cache handles before propagating error.
-        for mut handle in cache_handles.drain(..) {
+        for handle in cache_handles.drain(..) {
             let files_to_delete = handle.unreference().await;
             evicted_files_to_delete_on_error.extend(files_to_delete);
         }
 
         // Also unpin any puffin cache handles included in this read output.
-        for mut handle in self.puffin_cache_handles.drain(..) {
+        for handle in self.puffin_cache_handles.drain(..) {
             let files_to_delete = handle.unreference().await;
             evicted_files_to_delete_on_error.extend(files_to_delete);
         }

--- a/src/moonlink/src/union_read/read_state.rs
+++ b/src/moonlink/src/union_read/read_state.rs
@@ -34,7 +34,7 @@ impl Drop for ReadState {
         let cache_handles = std::mem::take(&mut self.cache_handles);
         tokio::spawn(async move {
             let mut evicted_files_to_delete = vec![];
-            for mut cur_cache_handle in cache_handles.into_iter() {
+            for cur_cache_handle in cache_handles.into_iter() {
                 let cur_evicted_files = cur_cache_handle.unreference().await;
                 evicted_files_to_delete.extend(cur_evicted_files);
             }


### PR DESCRIPTION
## Summary

No need for `mutable` to acquire / release mutex.

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
