### PR TITLE
bump ubuntu build version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN rustup target add x86_64-unknown-linux-gnu
 RUN cargo build --target x86_64-unknown-linux-gnu --verbose
 
 # Use a slim image for docker image used for cloud deployment.
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 RUN apt-get update && \
     apt-get install -y ca-certificates libssl3 libpq5 && \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -15,7 +15,7 @@ RUN rustup target add aarch64-unknown-linux-gnu
 RUN cargo build --target aarch64-unknown-linux-gnu --verbose
 
 # Use a slim image for docker image used for cloud deployment.
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 RUN apt-get update && \
     apt-get install -y ca-certificates libssl3 libpq5 && \

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -15,7 +15,7 @@ RUN rustup target add x86_64-unknown-linux-gnu
 RUN cargo build --target x86_64-unknown-linux-gnu --verbose
 
 # Use a slim image for docker image used for cloud deployment.
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 RUN apt-get update && \
     apt-get install -y ca-certificates libssl3 libpq5 && \


### PR DESCRIPTION
## Summary

We need to do ubuntu versioning changes as we currently build the moonlink binaries using the latest rust devcontainer and then port it onto a slim ubuntu image. Recently, we encountered a GLIBC_2.38 requirement and therefore bump up the ubuntu image to `24.04`.
