### PR TITLE
refactor: make catalog creation and add data accessor config

### DIFF
--- a/src/moonlink/src/storage/iceberg/catalog_utils.rs
+++ b/src/moonlink/src/storage/iceberg/catalog_utils.rs
@@ -3,7 +3,7 @@ use crate::storage::filesystem::accessor::base_filesystem_accessor::BaseFileSyst
 use crate::storage::iceberg::file_catalog::FileCatalog;
 use crate::storage::iceberg::iceberg_table_config::IcebergCatalogConfig;
 use crate::storage::iceberg::moonlink_catalog::MoonlinkCatalog;
-
+use crate::AccessorConfig;
 use iceberg::spec::Schema as IcebergSchema;
 use iceberg::{spec::TableMetadataBuilder, Result as IcebergResult, TableUpdate};
 
@@ -11,7 +11,8 @@ use iceberg::{spec::TableMetadataBuilder, Result as IcebergResult, TableUpdate};
 ///
 /// It's worth noting catalog and warehouse uri are not 1-1 mapping; for example, rest catalog could handle warehouse.
 /// Here we simply deduce catalog type from warehouse because both filesystem and object storage catalog are only able to handle certain scheme.
-pub fn create_catalog(
+pub async fn create_catalog(
+    _data_accessor_config: AccessorConfig,
     catalog: IcebergCatalogConfig,
     iceberg_schema: IcebergSchema,
 ) -> IcebergResult<Box<dyn MoonlinkCatalog>> {
@@ -33,7 +34,8 @@ pub fn create_catalog(
 }
 
 /// Create a catalog with no schema provided.
-pub fn create_catalog_without_schema(
+pub async fn create_catalog_without_schema(
+    _data_accessor_config: AccessorConfig,
     catalog: IcebergCatalogConfig,
 ) -> IcebergResult<Box<dyn MoonlinkCatalog>> {
     match catalog {

--- a/src/moonlink/src/storage/iceberg/iceberg_snapshot_fetcher.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_snapshot_fetcher.rs
@@ -19,9 +19,12 @@ pub struct IcebergSnapshotFetcher {
 }
 
 impl IcebergSnapshotFetcher {
-    pub fn new(config: IcebergTableConfig) -> Result<Self> {
-        let catalog =
-            catalog_utils::create_catalog_without_schema(config.metadata_accessor_config.clone())?;
+    pub async fn new(config: IcebergTableConfig) -> Result<Self> {
+        let catalog = catalog_utils::create_catalog_without_schema(
+            config.data_accessor_config.clone(),
+            config.metadata_accessor_config.clone(),
+        )
+        .await?;
         Ok(Self { config, catalog })
     }
 }

--- a/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
@@ -73,7 +73,7 @@ pub struct IcebergTableManager {
 }
 
 impl IcebergTableManager {
-    pub fn new(
+    pub async fn new(
         mooncake_table_metadata: Arc<MooncakeTableMetadata>,
         object_storage_cache: Arc<dyn CacheTrait>,
         filesystem_accessor: Arc<dyn BaseFileSystemAccess>,

--- a/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
@@ -81,8 +81,12 @@ impl IcebergTableManager {
     ) -> IcebergResult<IcebergTableManager> {
         let iceberg_schema =
             iceberg::arrow::arrow_schema_to_schema(mooncake_table_metadata.schema.as_ref())?;
-        let catalog =
-            catalog_utils::create_catalog(config.metadata_accessor_config.clone(), iceberg_schema)?;
+        let catalog = catalog_utils::create_catalog(
+            config.data_accessor_config.clone(),
+            config.metadata_accessor_config.clone(),
+            iceberg_schema,
+        )
+        .await?;
         Ok(Self {
             snapshot_loaded: false,
             config,

--- a/src/moonlink/src/storage/iceberg/rest_catalog.rs
+++ b/src/moonlink/src/storage/iceberg/rest_catalog.rs
@@ -1,14 +1,21 @@
 use crate::storage::iceberg::iceberg_table_config::RestCatalogConfig;
+use crate::storage::iceberg::moonlink_catalog::SchemaUpdate;
 use async_trait::async_trait;
+use iceberg::puffin::PuffinWriter;
+use iceberg::spec::Schema as IcebergSchema;
 use iceberg::table::Table;
 use iceberg::CatalogBuilder;
 use iceberg::Result as IcebergResult;
-use iceberg::{Catalog, Namespace, NamespaceIdent, Result, TableCommit, TableCreation, TableIdent};
+use iceberg::{Catalog, Namespace, NamespaceIdent, TableCommit, TableCreation, TableIdent};
 use iceberg_catalog_rest::{
     RestCatalog as IcebergRestCatalog, RestCatalogBuilder as IcebergRestCatalogBuilder,
     REST_CATALOG_PROP_URI, REST_CATALOG_PROP_WAREHOUSE,
 };
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+
+use crate::AccessorConfig;
+
+use super::moonlink_catalog::{PuffinBlobType, PuffinWrite};
 
 #[derive(Debug)]
 pub struct RestCatalog {
@@ -16,7 +23,11 @@ pub struct RestCatalog {
 }
 
 impl RestCatalog {
-    pub async fn new(mut config: RestCatalogConfig) -> Result<Self> {
+    #[allow(dead_code)]
+    pub async fn new(
+        mut config: RestCatalogConfig,
+        _accessor_config: AccessorConfig,
+    ) -> IcebergResult<Self> {
         let builder = IcebergRestCatalogBuilder::default();
         config
             .props

--- a/src/moonlink/src/storage/iceberg/rest_catalog.rs
+++ b/src/moonlink/src/storage/iceberg/rest_catalog.rs
@@ -121,3 +121,38 @@ impl Catalog for RestCatalog {
         todo!("register existing table is not supported")
     }
 }
+
+#[async_trait]
+impl PuffinWrite for RestCatalog {
+    async fn record_puffin_metadata_and_close(
+        &mut self,
+        _puffin_filepath: String,
+        _puffin_writer: PuffinWriter,
+        _puffin_blob_type: PuffinBlobType,
+    ) -> IcebergResult<()> {
+        todo!("record puffin metadata and close is not supported")
+    }
+
+    fn set_data_files_to_remove(&mut self, _data_files: HashSet<String>) {
+        todo!("set data files to remove is not supported")
+    }
+
+    fn set_index_puffin_files_to_remove(&mut self, _puffin_filepaths: HashSet<String>) {
+        todo!("set index puffin files to remove is not supported")
+    }
+
+    fn clear_puffin_metadata(&mut self) {
+        todo!("clear puffin metadata is not supported")
+    }
+}
+
+#[async_trait]
+impl SchemaUpdate for RestCatalog {
+    async fn update_table_schema(
+        &mut self,
+        _new_schema: IcebergSchema,
+        _table_ident: TableIdent,
+    ) -> IcebergResult<Table> {
+        todo!("update table schema is not supported")
+    }
+}

--- a/src/moonlink/src/storage/iceberg/rest_catalog_test.rs
+++ b/src/moonlink/src/storage/iceberg/rest_catalog_test.rs
@@ -10,8 +10,9 @@ async fn test_create_table() {
     let mut guard = RestCatalogTestGuard::new(namespace.clone(), None)
         .await
         .unwrap_or_else(|_| panic!("Rest catalog test guard creation fail, namespace={namespace}"));
-    let config = default_rest_catalog_config();
-    let catalog = RestCatalog::new(config)
+    let rest_catalog_config = default_rest_catalog_config();
+    let accessor_config = default_accessor_config();
+    let catalog = RestCatalog::new(rest_catalog_config, accessor_config)
         .await
         .expect("Catalog creation fail");
     let namespace = NamespaceIdent::new(namespace);
@@ -31,8 +32,9 @@ async fn test_drop_table() {
     let mut guard = RestCatalogTestGuard::new(namespace.clone(), Some(table.clone()))
         .await
         .unwrap_or_else(|_| panic!("Rest catalog test guard creation fail, namespace={namespace}"));
-    let config = default_rest_catalog_config();
-    let catalog = RestCatalog::new(config)
+    let rest_catalog_config = default_rest_catalog_config();
+    let accessor_config = default_accessor_config();
+    let catalog = RestCatalog::new(rest_catalog_config, accessor_config)
         .await
         .expect("Catalog creation fail");
     let table_ident = guard.table.clone().unwrap();
@@ -62,8 +64,9 @@ async fn test_table_exists() {
     let guard = RestCatalogTestGuard::new(namespace.clone(), Some(table.clone()))
         .await
         .unwrap_or_else(|_| panic!("Rest catalog test guard creation fail, namespace={namespace}"));
-    let config = default_rest_catalog_config();
-    let catalog = RestCatalog::new(config)
+    let rest_catalog_config = default_rest_catalog_config();
+    let accessor_config = default_accessor_config();
+    let catalog = RestCatalog::new(rest_catalog_config, accessor_config)
         .await
         .expect("Catalog creation fail");
 
@@ -88,8 +91,9 @@ async fn test_load_table() {
     let guard = RestCatalogTestGuard::new(namespace.clone(), Some(table.clone()))
         .await
         .unwrap_or_else(|_| panic!("Rest catalog test guard creation fail, namespace={namespace}"));
-    let config = default_rest_catalog_config();
-    let catalog = RestCatalog::new(config)
+    let rest_catalog_config = default_rest_catalog_config();
+    let accessor_config = default_accessor_config();
+    let catalog = RestCatalog::new(rest_catalog_config, accessor_config)
         .await
         .expect("Catalog creation fail");
     let table_ident = guard.table.clone().unwrap();

--- a/src/moonlink/src/storage/iceberg/rest_catalog_test_guard.rs
+++ b/src/moonlink/src/storage/iceberg/rest_catalog_test_guard.rs
@@ -11,8 +11,9 @@ pub(crate) struct RestCatalogTestGuard {
 
 impl RestCatalogTestGuard {
     pub(crate) async fn new(namespace: String, table: Option<String>) -> Result<Self> {
-        let config = default_rest_catalog_config();
-        let catalog = RestCatalog::new(config)
+        let rest_catalog_config = default_rest_catalog_config();
+        let accessor_config = default_accessor_config();
+        let catalog = RestCatalog::new(rest_catalog_config, accessor_config)
             .await
             .expect("Catalog creation fail");
         let ns_ident = NamespaceIdent::new(namespace);
@@ -37,10 +38,11 @@ impl RestCatalogTestGuard {
 impl Drop for RestCatalogTestGuard {
     fn drop(&mut self) {
         let table = self.table.take();
-        let config = default_rest_catalog_config();
+        let rest_catalog_config = default_rest_catalog_config();
+        let accessor_config = default_accessor_config();
         tokio::task::block_in_place(|| {
             tokio::runtime::Handle::current().block_on(async move {
-                let catalog = RestCatalog::new(config)
+                let catalog = RestCatalog::new(rest_catalog_config, accessor_config)
                     .await
                     .expect("Catalog creation fail");
                 if let Some(t) = table {

--- a/src/moonlink/src/storage/iceberg/rest_catalog_test_utils.rs
+++ b/src/moonlink/src/storage/iceberg/rest_catalog_test_utils.rs
@@ -1,11 +1,13 @@
 use crate::storage::iceberg::iceberg_table_config::RestCatalogConfig;
+use crate::storage::mooncake_table::test_utils_commons::{
+    REST_CATALOG_TEST_NAME, REST_CATALOG_TEST_URI,
+};
+use crate::{AccessorConfig, StorageConfig};
 use iceberg::spec::{NestedField, PrimitiveType, Schema, Type};
 use iceberg::TableCreation;
 use rand::{distr::Alphanumeric, Rng};
 use std::collections::HashMap;
 
-const DEFAULT_REST_CATALOG_NAME: &str = "test";
-const DEFAULT_REST_CATALOG_URI: &str = "http://iceberg-rest.local:8181";
 const DEFAULT_WAREHOUSE_PATH: &str = "warehouse";
 
 pub(crate) fn get_random_string() -> String {
@@ -16,10 +18,18 @@ pub(crate) fn get_random_string() -> String {
         .collect()
 }
 
+pub(crate) fn default_accessor_config() -> AccessorConfig {
+    let storage_config = StorageConfig::FileSystem {
+        root_directory: DEFAULT_WAREHOUSE_PATH.to_string(),
+        atomic_write_dir: None,
+    };
+    AccessorConfig::new_with_storage_config(storage_config)
+}
+
 pub(crate) fn default_rest_catalog_config() -> RestCatalogConfig {
     RestCatalogConfig {
-        name: DEFAULT_REST_CATALOG_NAME.to_string(),
-        uri: DEFAULT_REST_CATALOG_URI.to_string(),
+        name: REST_CATALOG_TEST_NAME.to_string(),
+        uri: REST_CATALOG_TEST_URI.to_string(),
         warehouse: DEFAULT_WAREHOUSE_PATH.to_string(),
         props: HashMap::new(),
     }

--- a/src/moonlink/src/storage/iceberg/snapshot_fetcher_test.rs
+++ b/src/moonlink/src/storage/iceberg/snapshot_fetcher_test.rs
@@ -19,7 +19,7 @@ fn get_test_row() -> MoonlinkRow {
 async fn test_snapshot_for_empty_table() {
     let iceberg_temp_dir = tempdir().unwrap();
     let config = get_iceberg_table_config(&iceberg_temp_dir);
-    let snapshot_fetcher = IcebergSnapshotFetcher::new(config).unwrap();
+    let snapshot_fetcher = IcebergSnapshotFetcher::new(config).await.unwrap();
     let arrow_schema = snapshot_fetcher.fetch_table_schema().await.unwrap();
     assert!(arrow_schema.is_none());
     let flush_lsn = snapshot_fetcher.get_flush_lsn().await.unwrap();
@@ -37,7 +37,7 @@ async fn test_snapshot_fetch() {
     create_mooncake_and_persist_for_test(&mut table, &mut notify_rx).await;
 
     let config = get_iceberg_table_config(&temp_dir);
-    let snapshot_fetcher = IcebergSnapshotFetcher::new(config).unwrap();
+    let snapshot_fetcher = IcebergSnapshotFetcher::new(config).await.unwrap();
     let arrow_schema = snapshot_fetcher.fetch_table_schema().await.unwrap();
     assert_eq!(arrow_schema.unwrap(), *create_test_arrow_schema());
     let flush_lsn = snapshot_fetcher.get_flush_lsn().await.unwrap();

--- a/src/moonlink/src/storage/iceberg/tests.rs
+++ b/src/moonlink/src/storage/iceberg/tests.rs
@@ -238,6 +238,7 @@ async fn test_snapshot_load_for_multiple_times() {
         create_test_filesystem_accessor(&config),
         config.clone(),
     )
+    .await
     .unwrap();
 
     iceberg_table_manager
@@ -341,6 +342,7 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
         create_test_filesystem_accessor(&iceberg_table_config),
         iceberg_table_config.clone(),
     )
+    .await
     .unwrap();
     assert!(iceberg_table_manager.persisted_data_files.is_empty());
 
@@ -538,6 +540,7 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
         create_test_filesystem_accessor(&iceberg_table_config),
         iceberg_table_config.clone(),
     )
+    .await
     .unwrap();
     let (_, snapshot) = iceberg_table_manager_for_load
         .load_snapshot_from_table()
@@ -621,6 +624,7 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
         create_test_filesystem_accessor(&iceberg_table_config),
         iceberg_table_config.clone(),
     )
+    .await
     .unwrap();
     let (_, snapshot) = iceberg_table_manager_for_load
         .load_snapshot_from_table()
@@ -694,6 +698,7 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
         create_test_filesystem_accessor(&iceberg_table_config),
         iceberg_table_config.clone(),
     )
+    .await
     .unwrap();
     let (_, snapshot) = iceberg_table_manager_for_load
         .load_snapshot_from_table()
@@ -770,6 +775,7 @@ async fn test_drop_table_impl(iceberg_table_config: IcebergTableConfig) {
         filesystem_accessor.clone(),
         iceberg_table_config.clone(),
     )
+    .await
     .unwrap();
     iceberg_table_manager
         .initialize_iceberg_table_for_once()
@@ -854,6 +860,7 @@ async fn test_empty_snapshot_load_impl(iceberg_table_config: IcebergTableConfig)
         create_test_filesystem_accessor(&iceberg_table_config),
         iceberg_table_config.clone(),
     )
+    .await
     .unwrap();
     let (next_table_id, snapshot) = iceberg_table_manager
         .load_snapshot_from_table()
@@ -944,6 +951,7 @@ async fn test_recover_from_failed_snapshot_impl(iceberg_table_config: IcebergTab
         filesystem_accessor.clone(),
         iceberg_table_config.clone(),
     )
+    .await
     .unwrap();
     let iceberg_snapshot_payload = IcebergSnapshotPayload {
         uuid: uuid::Uuid::new_v4(),
@@ -991,6 +999,7 @@ async fn test_recover_from_failed_snapshot_impl(iceberg_table_config: IcebergTab
         filesystem_accessor.clone(),
         iceberg_table_config.clone(),
     )
+    .await
     .unwrap();
     let (next_file_id, snapshot) = iceberg_table_manager_for_recovery
         .load_snapshot_from_table()
@@ -1078,6 +1087,7 @@ async fn test_index_merge_and_create_snapshot_impl(iceberg_table_config: Iceberg
         filesystem_accessor.clone(),
         iceberg_table_config.clone(),
     )
+    .await
     .unwrap();
     let (next_file_id, snapshot) = iceberg_table_manager_for_recovery
         .load_snapshot_from_table()
@@ -1115,6 +1125,7 @@ async fn test_index_merge_and_create_snapshot_impl(iceberg_table_config: Iceberg
         filesystem_accessor.clone(),
         iceberg_table_config.clone(),
     )
+    .await
     .unwrap();
     let (next_file_id, snapshot) = iceberg_table_manager_for_recovery
         .load_snapshot_from_table()
@@ -1242,6 +1253,7 @@ async fn test_data_compaction_and_create_snapshot_impl(iceberg_table_config: Ice
         filesystem_accessor.clone(),
         iceberg_table_config.clone(),
     )
+    .await
     .unwrap();
     let (next_file_id, snapshot) = iceberg_table_manager_for_recovery
         .load_snapshot_from_table()
@@ -1285,6 +1297,7 @@ async fn test_data_compaction_and_create_snapshot_impl(iceberg_table_config: Ice
         filesystem_accessor.clone(),
         iceberg_table_config.clone(),
     )
+    .await
     .unwrap();
     let (next_file_id, snapshot) = iceberg_table_manager_for_recovery
         .load_snapshot_from_table()
@@ -1412,6 +1425,7 @@ async fn test_data_compaction_with_update_impl(iceberg_table_config: IcebergTabl
         filesystem_accessor.clone(),
         iceberg_table_config.clone(),
     )
+    .await
     .unwrap();
     let (next_file_id, snapshot) = iceberg_table_manager_for_recovery
         .load_snapshot_from_table()
@@ -1553,6 +1567,7 @@ async fn test_delayed_compaction_impl(iceberg_table_config: IcebergTableConfig) 
         filesystem_accessor.clone(),
         iceberg_table_config.clone(),
     )
+    .await
     .unwrap();
     let (next_file_id, snapshot) = iceberg_table_manager_for_recovery
         .load_snapshot_from_table()
@@ -1648,6 +1663,7 @@ async fn test_data_compaction_append_only_and_create_snapshot_impl(
         filesystem_accessor.clone(),
         iceberg_table_config.clone(),
     )
+    .await
     .unwrap();
     let (next_file_id, snapshot) = iceberg_table_manager_for_recovery
         .load_snapshot_from_table()
@@ -1785,6 +1801,7 @@ async fn test_data_compaction_by_deletion_and_create_snapshot_impl(
         filesystem_accessor.clone(),
         iceberg_table_config.clone(),
     )
+    .await
     .unwrap();
     let (next_file_id, snapshot) = iceberg_table_manager_for_recovery
         .load_snapshot_from_table()
@@ -1861,6 +1878,7 @@ async fn test_empty_content_snapshot_creation_impl(iceberg_table_config: Iceberg
         filesystem_accessor.clone(),
         iceberg_table_config.clone(),
     )
+    .await
     .unwrap();
     let iceberg_snapshot_payload = IcebergSnapshotPayload {
         uuid: uuid::Uuid::new_v4(),
@@ -1887,6 +1905,7 @@ async fn test_empty_content_snapshot_creation_impl(iceberg_table_config: Iceberg
         filesystem_accessor.clone(),
         iceberg_table_config.clone(),
     )
+    .await
     .unwrap();
     let (next_file_id, snapshot) = iceberg_table_manager_for_recovery
         .load_snapshot_from_table()
@@ -1984,6 +2003,7 @@ async fn test_snapshot_creation_with_duplicate_filename_impl(
         filesystem_accessor.clone(),
         iceberg_table_config.clone(),
     )
+    .await
     .unwrap();
     let iceberg_snapshot_payload = IcebergSnapshotPayload {
         uuid: uuid::Uuid::new_v4(),
@@ -2014,6 +2034,7 @@ async fn test_snapshot_creation_with_duplicate_filename_impl(
         filesystem_accessor.clone(),
         iceberg_table_config.clone(),
     )
+    .await
     .unwrap();
     let (next_file_id, snapshot) = iceberg_table_manager_for_recovery
         .load_snapshot_from_table()
@@ -2136,6 +2157,7 @@ async fn test_small_batch_size_and_large_parquet_size() {
         create_test_filesystem_accessor(&iceberg_table_config),
         iceberg_table_config.clone(),
     )
+    .await
     .unwrap();
     let (next_file_id, snapshot) = iceberg_table_manager
         .load_snapshot_from_table()
@@ -2318,6 +2340,7 @@ async fn test_async_iceberg_snapshot_impl(iceberg_table_config: IcebergTableConf
         filesystem_accessor.clone(),
         iceberg_table_config.clone(),
     )
+    .await
     .unwrap();
     let (next_file_id, snapshot) = iceberg_table_manager_for_recovery
         .load_snapshot_from_table()
@@ -2377,6 +2400,7 @@ async fn test_async_iceberg_snapshot_impl(iceberg_table_config: IcebergTableConf
         filesystem_accessor.clone(),
         iceberg_table_config.clone(),
     )
+    .await
     .unwrap();
     let (next_file_id, mut snapshot) = iceberg_table_manager_for_recovery
         .load_snapshot_from_table()
@@ -2540,6 +2564,7 @@ async fn mooncake_table_snapshot_persist_impl(iceberg_table_config: IcebergTable
         filesystem_accessor.clone(),
         iceberg_table_config.clone(),
     )
+    .await
     .unwrap();
     let (next_file_id, snapshot) = iceberg_table_manager
         .load_snapshot_from_table()
@@ -2616,6 +2641,7 @@ async fn mooncake_table_snapshot_persist_impl(iceberg_table_config: IcebergTable
         filesystem_accessor.clone(),
         iceberg_table_config.clone(),
     )
+    .await
     .unwrap();
     let (next_file_id, snapshot) = iceberg_table_manager
         .load_snapshot_from_table()
@@ -2683,6 +2709,7 @@ async fn mooncake_table_snapshot_persist_impl(iceberg_table_config: IcebergTable
         filesystem_accessor.clone(),
         iceberg_table_config.clone(),
     )
+    .await
     .unwrap();
     let (next_file_id, snapshot) = iceberg_table_manager
         .load_snapshot_from_table()
@@ -2754,6 +2781,7 @@ async fn mooncake_table_snapshot_persist_impl(iceberg_table_config: IcebergTable
         filesystem_accessor.clone(),
         iceberg_table_config.clone(),
     )
+    .await
     .unwrap();
     let (next_file_id, mut snapshot) = iceberg_table_manager
         .load_snapshot_from_table()
@@ -2879,6 +2907,7 @@ async fn test_schema_for_table_creation_impl(iceberg_table_config: IcebergTableC
         filesystem_accessor,
         iceberg_table_config.clone(),
     )
+    .await
     .unwrap();
 
     // Load table metadata and verify schema.
@@ -2963,6 +2992,7 @@ async fn test_schema_update_with_no_table_write_impl(iceberg_table_config: Icebe
         filesystem_accessor,
         iceberg_table_config.clone(),
     )
+    .await
     .unwrap();
     let (next_file_id, snapshot) = iceberg_table_manager_for_load
         .load_snapshot_from_table()
@@ -3005,6 +3035,7 @@ async fn test_schema_update_with_no_table_write_impl(iceberg_table_config: Icebe
         filesystem_accessor,
         iceberg_table_config.clone(),
     )
+    .await
     .unwrap();
     let (next_file_id, snapshot) = iceberg_table_manager_for_load
         .load_snapshot_from_table()
@@ -3100,6 +3131,7 @@ async fn test_schema_update_impl(iceberg_table_config: IcebergTableConfig) {
         filesystem_accessor,
         iceberg_table_config.clone(),
     )
+    .await
     .unwrap();
     let (next_file_id, snapshot) = iceberg_table_manager_for_load
         .load_snapshot_from_table()
@@ -3138,6 +3170,7 @@ async fn test_schema_update_impl(iceberg_table_config: IcebergTableConfig) {
         filesystem_accessor,
         iceberg_table_config.clone(),
     )
+    .await
     .unwrap();
     let (next_file_id, snapshot) = iceberg_table_manager_for_load
         .load_snapshot_from_table()
@@ -3337,6 +3370,7 @@ async fn test_persisted_deletion_record_remap() {
         filesystem_accessor.clone(),
         iceberg_table_config.clone(),
     )
+    .await
     .unwrap();
     let (_, snapshot) = iceberg_table_manager_for_recovery
         .load_snapshot_from_table()

--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -493,12 +493,15 @@ impl MooncakeTable {
             config: table_config.clone(),
             path: base_path,
         });
-        let iceberg_table_manager = Box::new(IcebergTableManager::new(
-            metadata.clone(),
-            object_storage_cache.clone(),
-            table_filesystem_accessor.clone(),
-            iceberg_table_config,
-        )?);
+        let iceberg_table_manager = Box::new(
+            IcebergTableManager::new(
+                metadata.clone(),
+                object_storage_cache.clone(),
+                table_filesystem_accessor.clone(),
+                iceberg_table_config,
+            )
+            .await?,
+        );
 
         Self::new_with_table_manager(
             metadata,

--- a/src/moonlink/src/storage/mooncake_table/deletion_vector_puffin_state_tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/deletion_vector_puffin_state_tests.rs
@@ -219,6 +219,7 @@ async fn test_1_recover_2_without_local_optimization(#[case] use_batch_write: bo
         create_test_filesystem_accessor(&iceberg_table_config),
         iceberg_table_config,
     )
+    .await
     .unwrap();
     let (next_file_id, mooncake_snapshot) = iceberg_table_manager_to_recover
         .load_snapshot_from_table()
@@ -278,6 +279,7 @@ async fn test_1_recover_2_with_local_optimization(#[case] use_batch_write: bool)
         create_test_filesystem_accessor(&iceberg_table_config),
         iceberg_table_config,
     )
+    .await
     .unwrap();
     let (next_file_id, mooncake_snapshot) = iceberg_table_manager_to_recover
         .load_snapshot_from_table()

--- a/src/moonlink/src/storage/mooncake_table/file_index_state_tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/file_index_state_tests.rs
@@ -114,6 +114,7 @@ async fn test_1_recover_3() {
         create_test_filesystem_accessor(&iceberg_table_config),
         iceberg_table_config,
     )
+    .await
     .unwrap();
     let (next_file_id, mooncake_snapshot) = iceberg_table_manager_to_recover
         .load_snapshot_from_table()

--- a/src/moonlink/src/storage/mooncake_table/table_creation_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_creation_test_utils.rs
@@ -386,6 +386,7 @@ pub(crate) async fn create_table_and_iceberg_manager_with_data_compaction_config
         create_test_filesystem_accessor(&iceberg_table_config),
         iceberg_table_config.clone(),
     )
+    .await
     .unwrap();
 
     let (notify_tx, notify_rx) = mpsc::channel(100);

--- a/src/moonlink/src/storage/mooncake_table/table_creation_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_creation_test_utils.rs
@@ -50,11 +50,20 @@ pub(crate) fn get_iceberg_table_config(temp_dir: &TempDir) -> IcebergTableConfig
         atomic_write_dir: None,
     };
     let accessor_config = AccessorConfig::new_with_storage_config(storage_config);
+    // Select catalog based solely on features: REST when `catalog-rest` is enabled; otherwise FILE.
+    let metadata_accessor_config = {
+        {
+            crate::IcebergCatalogConfig::File {
+                accessor_config: accessor_config.clone(),
+            }
+        }
+    };
+
     IcebergTableConfig {
         namespace: vec![ICEBERG_TEST_NAMESPACE.to_string()],
         table_name: ICEBERG_TEST_TABLE.to_string(),
         data_accessor_config: accessor_config.clone(),
-        metadata_accessor_config: crate::IcebergCatalogConfig::File { accessor_config },
+        metadata_accessor_config,
     }
 }
 
@@ -128,9 +137,17 @@ pub(crate) fn create_iceberg_table_config(warehouse_uri: String) -> IcebergTable
         AccessorConfig::new_with_storage_config(storage_config)
     };
 
+    let metadata_accessor_config = {
+        {
+            crate::IcebergCatalogConfig::File {
+                accessor_config: accessor_config.clone(),
+            }
+        }
+    };
+
     IcebergTableConfig {
         data_accessor_config: accessor_config.clone(),
-        metadata_accessor_config: crate::IcebergCatalogConfig::File { accessor_config },
+        metadata_accessor_config,
         ..Default::default()
     }
 }

--- a/src/moonlink/src/storage/mooncake_table/test_utils_commons.rs
+++ b/src/moonlink/src/storage/mooncake_table/test_utils_commons.rs
@@ -11,6 +11,10 @@ pub(crate) const ONE_FILE_CACHE_SIZE: u64 = FAKE_FILE_SIZE + INDEX_BLOCK_FILES_S
 /// Iceberg test namespace and table name.
 pub(crate) const ICEBERG_TEST_NAMESPACE: &str = "namespace";
 pub(crate) const ICEBERG_TEST_TABLE: &str = "test_table";
+#[cfg(feature = "catalog-rest")]
+pub(crate) const REST_CATALOG_TEST_URI: &str = "http://iceberg-rest.local:8181";
+#[cfg(feature = "catalog-rest")]
+pub(crate) const REST_CATALOG_TEST_NAME: &str = "test";
 /// Test constant for table id.
 pub(crate) const TEST_TABLE_ID: TableId = TableId(0);
 /// File attributes for a fake file.

--- a/src/moonlink/src/storage/mooncake_table/tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/tests.rs
@@ -3037,7 +3037,9 @@ async fn test_late_arriving_high_flush_lsn() {
     // Create mooncake and iceberg snapshot, so we could check flush LSN.
     create_mooncake_and_persist_for_test(&mut table, &mut event_completion_rx).await;
     let iceberg_table_config = test_iceberg_table_config(&context, "late_arriving_high_flush_lsn");
-    let iceberg_snapshot_fetcher = IcebergSnapshotFetcher::new(iceberg_table_config).unwrap();
+    let iceberg_snapshot_fetcher = IcebergSnapshotFetcher::new(iceberg_table_config)
+        .await
+        .unwrap();
     let flush_lsn = iceberg_snapshot_fetcher
         .get_flush_lsn()
         .await
@@ -3125,7 +3127,9 @@ async fn test_out_of_order_flush_for_iceberg_snapshot() {
     // Create mooncake and iceberg snapshot, so we could check flush LSN.
     create_mooncake_and_persist_for_test(&mut table, &mut event_completion_rx).await;
     let iceberg_table_config = test_iceberg_table_config(&context, "late_arriving_high_flush_lsn");
-    let iceberg_snapshot_fetcher = IcebergSnapshotFetcher::new(iceberg_table_config).unwrap();
+    let iceberg_snapshot_fetcher = IcebergSnapshotFetcher::new(iceberg_table_config)
+        .await
+        .unwrap();
     let flush_lsn = iceberg_snapshot_fetcher.get_flush_lsn().await.unwrap();
     assert!(flush_lsn.is_none());
 }

--- a/src/moonlink/src/table_handler/test_utils.rs
+++ b/src/moonlink/src/table_handler/test_utils.rs
@@ -176,7 +176,7 @@ impl TestEnvironment {
     }
 
     /// Create iceberg table manager.
-    pub fn create_iceberg_table_manager(
+    pub async fn create_iceberg_table_manager(
         &self,
         mooncake_table_config: MooncakeTableConfig,
     ) -> IcebergTableManager {
@@ -200,6 +200,7 @@ impl TestEnvironment {
             create_test_filesystem_accessor(&iceberg_table_config),
             iceberg_table_config.clone(),
         )
+        .await
         .unwrap()
     }
 

--- a/src/moonlink/src/table_handler/tests.rs
+++ b/src/moonlink/src/table_handler/tests.rs
@@ -685,7 +685,9 @@ async fn test_iceberg_snapshot_creation_for_batch_write() {
         .unwrap();
 
     // Load from iceberg table manager to check snapshot status.
-    let mut iceberg_table_manager = env.create_iceberg_table_manager(mooncake_table_config.clone());
+    let mut iceberg_table_manager = env
+        .create_iceberg_table_manager(mooncake_table_config.clone())
+        .await;
     let (next_file_id, snapshot) = iceberg_table_manager
         .load_snapshot_from_table()
         .await
@@ -729,7 +731,9 @@ async fn test_iceberg_snapshot_creation_for_batch_write() {
         .unwrap();
 
     // Load from iceberg table manager to check snapshot status.
-    let mut iceberg_table_manager = env.create_iceberg_table_manager(mooncake_table_config.clone());
+    let mut iceberg_table_manager = env
+        .create_iceberg_table_manager(mooncake_table_config.clone())
+        .await;
     let (next_file_id, snapshot) = iceberg_table_manager
         .load_snapshot_from_table()
         .await
@@ -783,7 +787,9 @@ async fn test_iceberg_snapshot_creation_for_batch_write() {
         .unwrap();
 
     // Load from iceberg table manager to check snapshot status.
-    let mut iceberg_table_manager = env.create_iceberg_table_manager(mooncake_table_config.clone());
+    let mut iceberg_table_manager = env
+        .create_iceberg_table_manager(mooncake_table_config.clone())
+        .await;
     let (next_file_id, snapshot) = iceberg_table_manager
         .load_snapshot_from_table()
         .await
@@ -892,7 +898,9 @@ async fn test_iceberg_snapshot_creation_for_streaming_write() {
         .unwrap();
 
     // Load from iceberg table manager to check snapshot status.
-    let mut iceberg_table_manager = env.create_iceberg_table_manager(mooncake_table_config.clone());
+    let mut iceberg_table_manager = env
+        .create_iceberg_table_manager(mooncake_table_config.clone())
+        .await;
     let (next_file_id, snapshot) = iceberg_table_manager
         .load_snapshot_from_table()
         .await
@@ -942,7 +950,9 @@ async fn test_iceberg_snapshot_creation_for_streaming_write() {
         .unwrap();
 
     // Load from iceberg table manager to check snapshot status.
-    let mut iceberg_table_manager = env.create_iceberg_table_manager(mooncake_table_config.clone());
+    let mut iceberg_table_manager = env
+        .create_iceberg_table_manager(mooncake_table_config.clone())
+        .await;
     let (next_file_id, snapshot) = iceberg_table_manager
         .load_snapshot_from_table()
         .await
@@ -999,7 +1009,9 @@ async fn test_iceberg_snapshot_creation_for_streaming_write() {
         .unwrap();
 
     // Load from iceberg table manager to check snapshot status.
-    let mut iceberg_table_manager = env.create_iceberg_table_manager(mooncake_table_config.clone());
+    let mut iceberg_table_manager = env
+        .create_iceberg_table_manager(mooncake_table_config.clone())
+        .await;
     let (next_file_id, snapshot) = iceberg_table_manager
         .load_snapshot_from_table()
         .await
@@ -1148,7 +1160,9 @@ async fn test_multiple_snapshot_requests() {
     }
 
     // Check iceberg snapshot content.
-    let mut iceberg_table_manager = env.create_iceberg_table_manager(mooncake_table_config.clone());
+    let mut iceberg_table_manager = env
+        .create_iceberg_table_manager(mooncake_table_config.clone())
+        .await;
     let (next_file_id, snapshot) = iceberg_table_manager
         .load_snapshot_from_table()
         .await
@@ -1255,8 +1269,9 @@ async fn test_flush_lsn_consistency_across_snapshots() {
         assert_eq!(*flush_lsn_rx.borrow(), lsn);
 
         // Verify persistence by loading from iceberg
-        let mut iceberg_table_manager =
-            env.create_iceberg_table_manager(MooncakeTableConfig::default());
+        let mut iceberg_table_manager = env
+            .create_iceberg_table_manager(MooncakeTableConfig::default())
+            .await;
         let (_, snapshot) = iceberg_table_manager
             .load_snapshot_from_table()
             .await
@@ -1369,8 +1384,9 @@ async fn test_periodical_force_snapshot() {
     .unwrap();
 
     // Check iceberg snapshot result.
-    let mut iceberg_table_manager =
-        env.create_iceberg_table_manager(MooncakeTableConfig::default());
+    let mut iceberg_table_manager = env
+        .create_iceberg_table_manager(MooncakeTableConfig::default())
+        .await;
     let (_, snapshot) = iceberg_table_manager
         .load_snapshot_from_table()
         .await
@@ -1412,8 +1428,9 @@ async fn test_index_merge_with_sufficient_file_indices() {
         .await;
 
     // Check iceberg snapshot result.
-    let mut iceberg_table_manager =
-        env.create_iceberg_table_manager(MooncakeTableConfig::default());
+    let mut iceberg_table_manager = env
+        .create_iceberg_table_manager(MooncakeTableConfig::default())
+        .await;
     let (next_file_id, snapshot) = iceberg_table_manager
         .load_snapshot_from_table()
         .await
@@ -1441,8 +1458,9 @@ async fn test_index_merge_with_sufficient_file_indices() {
         .await;
 
     // Check iceberg snapshot result.
-    let mut iceberg_table_manager =
-        env.create_iceberg_table_manager(MooncakeTableConfig::default());
+    let mut iceberg_table_manager = env
+        .create_iceberg_table_manager(MooncakeTableConfig::default())
+        .await;
     let (next_file_id, snapshot) = iceberg_table_manager
         .load_snapshot_from_table()
         .await
@@ -1487,8 +1505,9 @@ async fn test_data_compaction_with_sufficient_data_files() {
         .await;
 
     // Check iceberg snapshot result.
-    let mut iceberg_table_manager =
-        env.create_iceberg_table_manager(MooncakeTableConfig::default());
+    let mut iceberg_table_manager = env
+        .create_iceberg_table_manager(MooncakeTableConfig::default())
+        .await;
     let (next_file_id, snapshot) = iceberg_table_manager
         .load_snapshot_from_table()
         .await
@@ -1516,8 +1535,9 @@ async fn test_data_compaction_with_sufficient_data_files() {
         .await;
 
     // Check iceberg snapshot result.
-    let mut iceberg_table_manager =
-        env.create_iceberg_table_manager(MooncakeTableConfig::default());
+    let mut iceberg_table_manager = env
+        .create_iceberg_table_manager(MooncakeTableConfig::default())
+        .await;
     let (next_file_id, snapshot) = iceberg_table_manager
         .load_snapshot_from_table()
         .await
@@ -1580,8 +1600,9 @@ async fn test_full_maintenance_with_sufficient_data_files() {
         .await;
 
     // Check iceberg snapshot result.
-    let mut iceberg_table_manager =
-        env.create_iceberg_table_manager(MooncakeTableConfig::default());
+    let mut iceberg_table_manager = env
+        .create_iceberg_table_manager(MooncakeTableConfig::default())
+        .await;
     let (next_file_id, snapshot) = iceberg_table_manager
         .load_snapshot_from_table()
         .await
@@ -1609,8 +1630,9 @@ async fn test_full_maintenance_with_sufficient_data_files() {
         .await;
 
     // Check iceberg snapshot result.
-    let mut iceberg_table_manager =
-        env.create_iceberg_table_manager(MooncakeTableConfig::default());
+    let mut iceberg_table_manager = env
+        .create_iceberg_table_manager(MooncakeTableConfig::default())
+        .await;
     let (next_file_id, snapshot) = iceberg_table_manager
         .load_snapshot_from_table()
         .await
@@ -2175,7 +2197,9 @@ async fn test_append_only_table_full_pipeline() {
         .unwrap();
 
     // Verify snapshot was created successfully
-    let mut iceberg_table_manager = env.create_iceberg_table_manager(mooncake_table_config.clone());
+    let mut iceberg_table_manager = env
+        .create_iceberg_table_manager(mooncake_table_config.clone())
+        .await;
     let (next_file_id, snapshot) = iceberg_table_manager
         .load_snapshot_from_table()
         .await
@@ -2217,8 +2241,9 @@ async fn test_append_only_table_full_pipeline() {
         .unwrap();
 
     // Verify final snapshot
-    let mut final_iceberg_table_manager =
-        env.create_iceberg_table_manager(mooncake_table_config.clone());
+    let mut final_iceberg_table_manager = env
+        .create_iceberg_table_manager(mooncake_table_config.clone())
+        .await;
     let (final_next_file_id, final_snapshot) = final_iceberg_table_manager
         .load_snapshot_from_table()
         .await
@@ -2674,7 +2699,9 @@ async fn test_force_snapshot_for_empty_stream_flush() {
     // Verify iceberg snapshot content.
     let mooncake_table_config =
         MooncakeTableConfig::new(env.temp_dir.path().to_str().unwrap().to_string());
-    let mut iceberg_table_manager = env.create_iceberg_table_manager(mooncake_table_config);
+    let mut iceberg_table_manager = env
+        .create_iceberg_table_manager(mooncake_table_config)
+        .await;
     let (next_file_id, snapshot) = iceberg_table_manager
         .load_snapshot_from_table()
         .await

--- a/src/moonlink_backend/src/recovery_utils.rs
+++ b/src/moonlink_backend/src/recovery_utils.rs
@@ -29,7 +29,7 @@ async fn recover_rest_table(
         .moonlink_table_config
         .iceberg_table_config
         .clone();
-    let iceberg_snapshot_fetcher = IcebergSnapshotFetcher::new(iceberg_table_config)?;
+    let iceberg_snapshot_fetcher = IcebergSnapshotFetcher::new(iceberg_table_config).await?;
     let arrow_schema = iceberg_snapshot_fetcher.fetch_table_schema().await?;
     let flush_lsn = iceberg_snapshot_fetcher.get_flush_lsn().await?;
 


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

make catalog creation and add data accessor config
1. why make async: IcebergRestCatalogBuilder::load is async
2. why add data accessor config? rest catalog need both catalog accessor (rest api endpoint) and data layer accessor(fs, GCS, S3)

## Related Issues

Closes #<issue-number> or links to related issues.

## Changes

- 
- 
- 

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
