### PR TITLE
[REST] Support flush table

### DIFF
--- a/src/moonlink_backend/src/lib.rs
+++ b/src/moonlink_backend/src/lib.rs
@@ -14,8 +14,8 @@ pub use moonlink::ReadState;
 use moonlink::{MooncakeTableId, MoonlinkTableConfig};
 use moonlink::{ReadStateFilepathRemap, TableEventManager};
 pub use moonlink_connectors::rest_ingest::event_request::{
-    EventRequest, FileEventOperation, FileEventRequest, IngestRequestPayload, RowEventOperation,
-    RowEventRequest, SnapshotRequest,
+    EventRequest, FileEventOperation, FileEventRequest, FlushRequest, IngestRequestPayload,
+    RowEventOperation, RowEventRequest, SnapshotRequest,
 };
 pub use moonlink_connectors::rest_ingest::rest_event::RestEvent;
 pub use moonlink_connectors::rest_ingest::rest_source::RestSource;
@@ -363,7 +363,6 @@ impl MoonlinkBackend {
 
     /// Wait for the WAL flush LSN to reach the requested LSN. Note that WAL flush LSN will update
     /// up till the latest commit that has been persisted in to the WAL.
-    #[cfg(feature = "test-utils")]
     pub async fn wait_for_wal_flush(
         &self,
         database: String,

--- a/src/moonlink_connectors/src/rest_ingest/event_request.rs
+++ b/src/moonlink_connectors/src/rest_ingest/event_request.rs
@@ -73,6 +73,20 @@ pub struct SnapshotRequest {
 }
 
 /// ======================
+/// Table flush request
+/// ======================
+///
+#[derive(Debug, Clone)]
+pub struct FlushRequest {
+    /// Src table name.
+    pub src_table_name: String,
+    /// Requested LSN.
+    pub lsn: u64,
+    /// Channel used to synchronize flush completion.
+    pub tx: mpsc::Sender<u64>,
+}
+
+/// ======================
 /// Event request
 /// ======================
 ///
@@ -81,6 +95,7 @@ pub enum EventRequest {
     RowRequest(RowEventRequest),
     FileRequest(FileEventRequest),
     SnapshotRequest(SnapshotRequest),
+    FlushRequest(FlushRequest),
 }
 
 impl EventRequest {
@@ -90,6 +105,7 @@ impl EventRequest {
             EventRequest::RowRequest(req) => req.tx.clone(),
             EventRequest::FileRequest(req) => req.tx.clone(),
             EventRequest::SnapshotRequest(req) => Some(req.tx.clone()),
+            EventRequest::FlushRequest(req) => Some(req.tx.clone()),
         }
     }
 }

--- a/src/moonlink_connectors/src/rest_ingest/rest_event.rs
+++ b/src/moonlink_connectors/src/rest_ingest/rest_event.rs
@@ -47,6 +47,10 @@ pub enum RestEvent {
         /// LSN to create snapshot.
         lsn: u64,
     },
+    Flush {
+        /// Source table id.
+        src_table_id: SrcTableId,
+    },
 }
 
 impl RestEvent {
@@ -58,6 +62,7 @@ impl RestEvent {
             RestEvent::FileInsertEvent { .. } => None,
             RestEvent::FileUploadEvent { lsn, .. } => Some(*lsn),
             RestEvent::Snapshot { .. } => None,
+            RestEvent::Flush { .. } => None,
         }
     }
 }


### PR DESCRIPTION
## Summary

This PR supports flush table in a blocking manner, which meets the requirement for kafka connector, who periodically explicitly requests to flush and commit.
Flushed WAL will be later used for recovery purpose.

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
