### PR TITLE
[REST] Add timeout layer for rest server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4481,6 +4481,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.16",
  "tokio",
+ "tower 0.5.2",
  "tower-http",
  "tracing",
 ]

--- a/src/moonlink_service/Cargo.toml
+++ b/src/moonlink_service/Cargo.toml
@@ -32,6 +32,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
+tower = { version = "0.5" }
 tower-http = { version = "0.6", features = ["cors", "trace"] }
 tracing = { workspace = true }
 


### PR DESCRIPTION
## Summary

This PR adds a heuristic timeout layer for rest api, which applies to all requests.
The default is 30 second, which I expect is pretty much enough for all types of requests even for snapshot creation with s3 involved.

It's hard to have a proper unit test (you need to block wait), so I manually set the timeout and verified it works.

Two followup items:
- Have different timeout settings for different requests
- Have timeout value decided by metrics

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1923

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
