### PR TITLE
[otel] Implement end-to-end otel metrics ingestion server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4474,6 +4474,7 @@ dependencies = [
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry-proto",
+ "opentelemetry-semantic-conventions",
  "opentelemetry_sdk",
  "parquet",
  "prost",
@@ -4894,6 +4895,12 @@ dependencies = [
  "prost",
  "tonic 0.13.1",
 ]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83d059a296a47436748557a353c5e6c5705b9470ef6c95cfc52c21a8814ddac2"
 
 [[package]]
 name = "opentelemetry_sdk"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ object_store = "0.12"
 opendal = { version = "0.54", default-features = false }
 opentelemetry = { version = "0.30", features = ["trace", "metrics", "logs"] }
 opentelemetry-otlp = { version = "0.30", features = ["reqwest-blocking-client", "http-proto", "trace", "metrics", "logs"] }
+opentelemetry-semantic-conventions = { version = "0.30" }
 opentelemetry_sdk = { version = "0.30", features = ["trace", "metrics", "logs"] }
 parquet = { version = "55", default-features = false, features = [
   "arrow",
@@ -72,6 +73,7 @@ prost = "0.13"
 prost-types = "0.13"
 rand = "0.9"
 regex = "1.11"
+reqwest = { version = "0.12", features = ["json"] }
 roaring = "0.11"
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 serde_json = "1"

--- a/src/moonlink/Cargo.toml
+++ b/src/moonlink/Cargo.toml
@@ -16,7 +16,6 @@ storage-s3 = [
     "base64",
     "hmac",
     "sha1",
-    "reqwest",
 ]
 
 # iceberg gcs io doesn't support HMAC key, so have to leverage S3 sdk.
@@ -28,7 +27,6 @@ storage-gcs = [
     "base64",
     "hmac",
     "sha1",
-    "reqwest",
 ]
 
 catalog-rest = ["iceberg-catalog-rest"]
@@ -75,7 +73,7 @@ opendal = { workspace = true }
 parquet = { workspace = true }
 prost = { workspace = true }
 rand = { workspace = true }
-reqwest = { version = "0.12", features = ["json"], optional = true }
+reqwest = { workspace = true }
 roaring = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/src/moonlink_service/Cargo.toml
+++ b/src/moonlink_service/Cargo.toml
@@ -6,7 +6,7 @@ license = { workspace = true }
 
 [features]
 default = ["storage-fs"]
-rest_api_demo = ["dep:reqwest"]
+rest_api_demo = []
 standalone-test = []
 otel-integration = []
 
@@ -29,9 +29,10 @@ moonlink_rpc = { path = "../moonlink_rpc" }
 opentelemetry = { workspace = true }
 opentelemetry-otlp = { workspace = true }
 opentelemetry-proto = { version = "0.30", default-features = false, features = ["gen-tonic", "metrics"] }
+opentelemetry-semantic-conventions = { workspace = true }
 opentelemetry_sdk = { workspace = true }
 prost = { workspace = true }
-reqwest = { version = "0.12", features = ["json"], optional = true }
+reqwest = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }

--- a/src/moonlink_service/src/otel.rs
+++ b/src/moonlink_service/src/otel.rs
@@ -1,4 +1,6 @@
+mod metrics_handler;
 pub(crate) mod otel_schema;
+pub(crate) mod otel_state;
 pub(crate) mod otel_to_moonlink_pb;
 pub(crate) mod service;
 #[cfg(feature = "otel-integration")]

--- a/src/moonlink_service/src/otel/metrics_handler.rs
+++ b/src/moonlink_service/src/otel/metrics_handler.rs
@@ -1,0 +1,201 @@
+use std::collections::HashSet;
+use std::sync::Arc;
+
+/// Handler to process metrics ingestion.
+use crate::error::{Error, Result};
+use crate::otel::otel_schema::otlp_metrics_gsh_schema;
+use crate::otel::otel_to_moonlink_pb;
+use crate::rest_api::ListTablesResponse;
+use moonlink_backend::REST_API_URI;
+use moonlink_proto::moonlink as moonlink_pb;
+
+use opentelemetry_proto::tonic::collector::metrics::v1::{
+    ExportMetricsServiceRequest, ExportMetricsServiceResponse,
+};
+use serde_json::json;
+use tracing::error;
+
+/// Database which manages all moonlink internal metrics.
+const DATABASE: &str = "__reserved_moonlink_internal_metrics__";
+/// Metrics attributes key for mooncake table id.
+const MOONCAKE_TABLE_ID_KEY: &str = "moonlink.mooncake_table_id";
+
+#[derive(Clone)]
+pub(crate) struct MetricsHandler {
+    /// IP/port for REST API.
+    rest_addr: String,
+    /// HTTP request client, used to access REST API.
+    rest_client: reqwest::Client,
+    /// All table names.
+    tables: HashSet<String>,
+    /// Moonlink backend.
+    moonlink_backend: Arc<moonlink_backend::MoonlinkBackend>,
+}
+
+/// Get string value from otel anyvalue.
+fn anyvalue_as_str(v: &opentelemetry_proto::tonic::common::v1::AnyValue) -> Option<&str> {
+    match &v.value {
+        Some(opentelemetry_proto::tonic::common::v1::any_value::Value::StringValue(s)) => {
+            Some(s.as_str())
+        }
+        _ => None,
+    }
+}
+
+/// Util function to deterministically get table name.
+fn get_metrics_table_name(moonlink_table_name: &str, metrics_type: &str) -> String {
+    format!("{moonlink_table_name}.{metrics_type}")
+}
+
+/// Util function to get metrics table name from the request.
+fn get_metrics_table_name_from_request(req: &ExportMetricsServiceRequest) -> String {
+    for rm in &req.resource_metrics {
+        for sm in &rm.scope_metrics {
+            for metric in &sm.metrics {
+                match &metric.data {
+                    Some(opentelemetry_proto::tonic::metrics::v1::metric::Data::Gauge(g)) => {
+                        for dp in &g.data_points {
+                            for attr in &dp.attributes {
+                                if attr.key == MOONCAKE_TABLE_ID_KEY {
+                                    let attr_value = attr.value.as_ref().unwrap();
+                                    let mooncake_table_id = anyvalue_as_str(attr_value).unwrap();
+                                    return get_metrics_table_name(mooncake_table_id, "gauge");
+                                }
+                            }
+                        }
+                    }
+                    Some(opentelemetry_proto::tonic::metrics::v1::metric::Data::Sum(s)) => {
+                        for dp in &s.data_points {
+                            for attr in &dp.attributes {
+                                if attr.key == MOONCAKE_TABLE_ID_KEY {
+                                    let attr_value = attr.value.as_ref().unwrap();
+                                    let mooncake_table_id = anyvalue_as_str(attr_value).unwrap();
+                                    return get_metrics_table_name(mooncake_table_id, "sum");
+                                }
+                            }
+                        }
+                    }
+                    Some(opentelemetry_proto::tonic::metrics::v1::metric::Data::Histogram(h)) => {
+                        for dp in &h.data_points {
+                            for attr in &dp.attributes {
+                                if attr.key == MOONCAKE_TABLE_ID_KEY {
+                                    let attr_value = attr.value.as_ref().unwrap();
+                                    let mooncake_table_id = anyvalue_as_str(attr_value).unwrap();
+                                    return get_metrics_table_name(mooncake_table_id, "histogram");
+                                }
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+
+    panic!("Cannot find mooncake table id from the data points");
+}
+
+impl MetricsHandler {
+    pub(crate) async fn new(
+        rest_port: u16,
+        moonlink_backend: Arc<moonlink_backend::MoonlinkBackend>,
+    ) -> Result<Self> {
+        let rest_addr = format!("http://0.0.0.0:{rest_port}");
+        let rest_client = reqwest::Client::new();
+        let response = rest_client
+            .get(format!("{rest_addr}/tables"))
+            .header("content-type", "application/json")
+            .send()
+            .await?;
+        // TODO(hjiang): Error propagation.
+        if !response.status().is_success() {
+            return Err(Error::http_error(response.status()));
+        }
+
+        // List all internal metrics tables.
+        let response: ListTablesResponse = response.json().await?;
+        let tables = response
+            .tables
+            .into_iter()
+            .filter(|cur_table_status| cur_table_status.database == DATABASE)
+            .map(|cur_table_status| cur_table_status.table)
+            .collect::<HashSet<_>>();
+        Ok(Self {
+            rest_addr,
+            rest_client,
+            tables,
+            moonlink_backend,
+        })
+    }
+
+    /// Create a mooncake table for an otel request.
+    async fn create_table(&mut self, mooncake_table_id: &str) -> Result<()> {
+        let crafted_src_table_name = format!("{DATABASE}.{mooncake_table_id}");
+        // Fake REST ingestion.
+        let serialized_table_config = json!({
+            "mooncake": {
+                "append_only": true,
+                "row_identity": "None"
+            }
+        })
+        .to_string();
+        self.moonlink_backend
+            .create_table(
+                DATABASE.to_string(),
+                mooncake_table_id.to_string(),
+                crafted_src_table_name,
+                REST_API_URI.to_string(),
+                serialized_table_config,
+                Some(otlp_metrics_gsh_schema()),
+            )
+            .await?;
+        assert!(self.tables.insert(mooncake_table_id.to_string()));
+        Ok(())
+    }
+
+    /// Insert one single row via REST API, which handles LSN internally.
+    /// Here we use asynchronous ingestion as best-effort attempt without flush or snapshot semantics.
+    ///
+    /// For any errors encountered during ingestion, simply log and proceed.
+    async fn insert_row(&self, mooncake_table_id: &str, row_pb: moonlink_pb::MoonlinkRow) {
+        let mut buf = Vec::new();
+        // Serialization doesn't expect failure.
+        prost::Message::encode(&row_pb, &mut buf).unwrap();
+        let insert_payload = json!({
+            "operation": "insert",
+            "request_mode": "async",
+            "data": buf
+        });
+        let crafted_src_table_name = format!("{DATABASE}.{mooncake_table_id}");
+        let response = self
+            .rest_client
+            .post(format!(
+                "{}/ingestpb/{}",
+                self.rest_addr, crafted_src_table_name
+            ))
+            .header("content-type", "application/json")
+            .json(&insert_payload)
+            .send()
+            .await;
+        if response.is_err() {
+            error!("Failed to ingest otel data: {:?}", response.unwrap_err());
+        }
+    }
+
+    /// Handle request for the incoming metrics request.
+    pub(crate) async fn handle_request(
+        &mut self,
+        request: ExportMetricsServiceRequest,
+    ) -> Result<ExportMetricsServiceResponse> {
+        // TODO(hjiang): Currently only supports metrics from one single table.
+        let mooncake_table_id = get_metrics_table_name_from_request(&request);
+        if !self.tables.contains(&mooncake_table_id) {
+            self.create_table(&mooncake_table_id).await?;
+        }
+        let moonlink_row_pbs = otel_to_moonlink_pb::export_metrics_to_moonlink_rows(&request);
+        for cur_row_pb in moonlink_row_pbs.into_iter() {
+            self.insert_row(&mooncake_table_id, cur_row_pb).await;
+        }
+        Ok(ExportMetricsServiceResponse::default())
+    }
+}

--- a/src/moonlink_service/src/otel/otel_schema.rs
+++ b/src/moonlink_service/src/otel/otel_schema.rs
@@ -1,4 +1,4 @@
-use arrow_schema::{DataType, Field, Fields, Schema, SchemaRef};
+use arrow_schema::{DataType, Field, Fields, Schema};
 use std::{collections::HashMap, sync::Arc};
 
 fn get_next_metadata(ids: &mut i32) -> HashMap<String, String> {
@@ -264,13 +264,13 @@ fn histogram_point_fields(ids: &mut i32) -> Vec<Field> {
 
 /// Unified Arrow schema for Gauge / Sum / Histogram rows (one row per datapoint).
 #[allow(unused)]
-pub(crate) fn otlp_metrics_gsh_schema() -> SchemaRef {
+pub(crate) fn otlp_metrics_gsh_schema() -> Schema {
     let mut ids = 0;
     let mut fields = Vec::new();
     fields.extend(common_metric_fields(&mut ids));
     fields.extend(number_point_fields(&mut ids));
     fields.extend(histogram_point_fields(&mut ids));
-    Arc::new(Schema::new(fields))
+    Schema::new(fields)
 }
 
 #[cfg(test)]
@@ -317,7 +317,7 @@ mod tests {
         let table_filesystem_accessor = Arc::new(FileSystemAccessor::new(accessor_config));
 
         let table = MooncakeTable::new(
-            otlp_metrics_gsh_schema().as_ref().clone(),
+            otlp_metrics_gsh_schema(),
             /*name=*/ "table".to_string(),
             /*table_id=*/ 0,
             /*base_path=*/ std::path::PathBuf::from(table_path.clone()),

--- a/src/moonlink_service/src/otel/otel_state.rs
+++ b/src/moonlink_service/src/otel/otel_state.rs
@@ -1,0 +1,21 @@
+use crate::otel::metrics_handler::MetricsHandler;
+use crate::Result;
+use std::sync::Arc;
+
+/// State for otel service.
+
+#[derive(Clone)]
+pub struct OtelState {
+    /// Metrics handler.
+    pub(crate) metrics_handler: MetricsHandler,
+}
+
+impl OtelState {
+    pub async fn new(
+        rest_port: u16,
+        moonlink_backend: Arc<moonlink_backend::MoonlinkBackend>,
+    ) -> Result<Self> {
+        let metrics_handler = MetricsHandler::new(rest_port, moonlink_backend.clone()).await?;
+        Ok(Self { metrics_handler })
+    }
+}

--- a/src/moonlink_service/src/otel/service.rs
+++ b/src/moonlink_service/src/otel/service.rs
@@ -1,27 +1,26 @@
+use crate::otel::otel_state::OtelState;
 use crate::Result;
 use axum::error_handling::HandleErrorLayer;
 use axum::http::Method;
 use axum::{
     body::Bytes,
+    extract::State,
     http::{header, HeaderMap, StatusCode},
     response::Response,
     routing::post,
     Router,
 };
-use opentelemetry_proto::tonic::collector::metrics::v1::{
-    ExportMetricsServiceRequest, ExportMetricsServiceResponse,
-};
+use opentelemetry_proto::tonic::collector::metrics::v1::ExportMetricsServiceRequest;
 use prost::Message;
+use std::sync::Arc;
 use tokio::sync::oneshot;
 use tower::timeout::TimeoutLayer;
 use tower::{BoxError, ServiceBuilder};
 use tower_http::cors::{Any, CorsLayer};
+use tracing::error;
 
 /// Default timeout for otel API calls.
 const DEFAULT_REST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
-
-#[derive(Clone)]
-pub struct OtelState;
 
 pub fn create_otel_router(state: OtelState) -> Router {
     let timeout_layer = ServiceBuilder::new()
@@ -52,14 +51,16 @@ pub fn create_otel_router(state: OtelState) -> Router {
 }
 
 pub async fn start_otel_service(
-    state: OtelState,
-    port: u16,
+    otel_port: u16,
+    rest_port: u16,
+    moonlink_backend: Arc<moonlink_backend::MoonlinkBackend>,
     shutdown_signal: oneshot::Receiver<()>,
 ) -> Result<()> {
-    let app = create_otel_router(state);
-    let addr = format!("0.0.0.0:{port}");
+    let otel_state = OtelState::new(rest_port, moonlink_backend).await?;
+    let app = create_otel_router(otel_state);
+    let otel_addr = format!("0.0.0.0:{otel_port}");
 
-    let listener = tokio::net::TcpListener::bind(&addr).await?;
+    let listener = tokio::net::TcpListener::bind(&otel_addr).await?;
     axum::serve(listener, app)
         .with_graceful_shutdown(async {
             shutdown_signal.await.ok();
@@ -70,21 +71,32 @@ pub async fn start_otel_service(
 }
 
 async fn handle_metrics(
+    State(mut state): State<OtelState>,
     _headers: HeaderMap,
     body: Bytes,
 ) -> (StatusCode, [(header::HeaderName, &'static str); 1], Vec<u8>) {
     match ExportMetricsServiceRequest::decode(body) {
         Ok(req) => {
-            // TODO(hjiang): Need to integrate with mooncake table.
-            println!("request = {req:?}");
-
-            let resp = ExportMetricsServiceResponse::default();
-            let bytes = resp.encode_to_vec();
-            (
-                StatusCode::OK,
-                [(header::CONTENT_TYPE, "application/x-protobuf")],
-                bytes,
-            )
+            match state.metrics_handler.handle_request(req).await {
+                Ok(resp) => {
+                    let bytes = resp.encode_to_vec();
+                    (
+                        StatusCode::OK,
+                        [(header::CONTENT_TYPE, "application/x-protobuf")],
+                        bytes,
+                    )
+                }
+                // TODO(hjiang): Better error propagation.
+                Err(err) => {
+                    // Different from general user-facing requests, failed otel request won't be processed usually, so to detect errors we log on server side.
+                    error!("Failed to process otel ingestion request: {:?}", err);
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        [(header::CONTENT_TYPE, "text/plain")],
+                        format!("protobuf decode failed: {err}").into_bytes(),
+                    )
+                }
+            }
         }
         Err(e) => (
             StatusCode::BAD_REQUEST,

--- a/src/moonlink_service/src/otel/test.rs
+++ b/src/moonlink_service/src/otel/test.rs
@@ -50,7 +50,7 @@ async fn test_opentelemetry_export() {
 
     // Update counter.
     for _ in 0..10 {
-        counter.add(1, &[KeyValue::new("key", "value")]);
+        counter.add(1, &[KeyValue::new("moonlink.mooncake_table_id", "id")]);
     }
 
     // Shutdown and flush.


### PR DESCRIPTION
## Summary

This PR implements the HTTP server side for otel ingestion, which is able to take otel requests in protobuf format and write into mooncake table, so in theory with otel sdk it's working end-to-end.

Current implementation is not production-ready yet, which requires a few more features:
- It only supports metrics, I plan to add support tracing
- It only supports most important metrics, gauge / counter / histogram, plan to add other types of metrics in the future
- Needs better error propagation handling

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1933

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
