### PR TITLE
Reset keepalive floor on reconnect

### DIFF
--- a/src/moonlink_connectors/src/pg_replicate.rs
+++ b/src/moonlink_connectors/src/pg_replicate.rs
@@ -677,6 +677,9 @@ pub async fn run_event_loop(
             }
         };
 
+        // Reset keepalive floor for this connection to the confirmed flush LSN
+        sink.reset_keepalive_floor();
+
         // Reset backoff after a successful stream creation
         current_backoff = Duration::from_secs(0);
 

--- a/src/moonlink_connectors/src/pg_replicate.rs
+++ b/src/moonlink_connectors/src/pg_replicate.rs
@@ -677,7 +677,7 @@ pub async fn run_event_loop(
             }
         };
 
-        // Reset keepalive floor for this connection to the confirmed flush LSN
+        // Reset keepalive floor for this connection
         sink.reset_keepalive_floor();
 
         // Reset backoff after a successful stream creation

--- a/src/moonlink_connectors/src/pg_replicate/moonlink_sink.rs
+++ b/src/moonlink_connectors/src/pg_replicate/moonlink_sink.rs
@@ -85,8 +85,7 @@ impl Sink {
         }
     }
 
-    /// Reset the per-connection keepalive floor. Should be called after establishing a new CDC stream
-    /// with the connection's confirmed flush LSN.
+    /// Reset the per-connection keepalive floor. Should be called after establishing a new CDC stream.
     pub fn reset_keepalive_floor(&mut self) {
         self.max_keepalive_lsn_seen = 0;
     }

--- a/src/moonlink_connectors/src/pg_replicate/moonlink_sink.rs
+++ b/src/moonlink_connectors/src/pg_replicate/moonlink_sink.rs
@@ -84,6 +84,12 @@ impl Sink {
             max_keepalive_lsn_seen: 0,
         }
     }
+
+    /// Reset the per-connection keepalive floor. Should be called after establishing a new CDC stream
+    /// with the connection's confirmed flush LSN.
+    pub fn reset_keepalive_floor(&mut self) {
+        self.max_keepalive_lsn_seen = 0;
+    }
 }
 
 pub struct SchemaChangeRequest(pub SrcTableId);


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

We can only assume the keepalive is monotonically increasing within a single connection, not across the entire moonlink process lifetime. We can simply reset the keepalive floor on replication reconnect.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1941

## Changes

- 
- 
- 

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
