### PR TITLE
[otel] Fix multiple otel data ingestion

### DIFF
--- a/src/moonlink_service/src/otel/otel_state.rs
+++ b/src/moonlink_service/src/otel/otel_state.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 #[derive(Clone)]
 pub struct OtelState {
     /// Metrics handler.
-    pub(crate) metrics_handler: MetricsHandler,
+    pub(crate) metrics_handler: Arc<MetricsHandler>,
 }
 
 impl OtelState {
@@ -15,7 +15,8 @@ impl OtelState {
         rest_port: u16,
         moonlink_backend: Arc<moonlink_backend::MoonlinkBackend>,
     ) -> Result<Self> {
-        let metrics_handler = MetricsHandler::new(rest_port, moonlink_backend.clone()).await?;
+        let metrics_handler =
+            Arc::new(MetricsHandler::new(rest_port, moonlink_backend.clone()).await?);
         Ok(Self { metrics_handler })
     }
 }

--- a/src/moonlink_service/src/otel/service.rs
+++ b/src/moonlink_service/src/otel/service.rs
@@ -71,7 +71,7 @@ pub async fn start_otel_service(
 }
 
 async fn handle_metrics(
-    State(mut state): State<OtelState>,
+    State(state): State<OtelState>,
     _headers: HeaderMap,
     body: Bytes,
 ) -> (StatusCode, [(header::HeaderName, &'static str); 1], Vec<u8>) {


### PR DESCRIPTION
## Summary

The bug is:
- axum copies shared state for each request, so the created tables state inside of `OtelState` recreated every time, which breaks the precondition that one table should be created at most once
- It failed with existing unit test, but the error is not propagated to client side, it's **by otel design**

I rerun the test again with the fix, and confirmed there're no duplicated tables created.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1949

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
