### PR TITLE
[REST] Fix rest table recreation

### DIFF
--- a/src/moonlink_connectors/src/replication_manager.rs
+++ b/src/moonlink_connectors/src/replication_manager.rs
@@ -229,7 +229,7 @@ impl ReplicationManager {
     /// If the table is not tracked, logs a message and returns successfully.
     /// Return whether the table is tracked by moonlink.
     pub async fn drop_table(&mut self, mooncake_table_id: &MooncakeTableId) -> Result<bool> {
-        let (table_uri, src_table_id) = match self.table_info.get(mooncake_table_id) {
+        let (table_uri, src_table_id) = match self.table_info.remove(mooncake_table_id) {
             Some(info) => info.clone(),
             None => {
                 debug!("attempted to drop table that is not tracked by moonlink - table may already be dropped");
@@ -242,7 +242,7 @@ impl ReplicationManager {
             .drop_table(mooncake_table_id, src_table_id)
             .await?;
         if repl_conn.table_count() == 0 && table_uri != REST_API_URI {
-            self.shutdown_connection(&table_uri, true);
+            self.shutdown_connection(&table_uri, /*postgres_drop_all=*/ true);
         }
 
         debug!(src_table_id, "table dropped through manager");

--- a/src/moonlink_service/src/test.rs
+++ b/src/moonlink_service/src/test.rs
@@ -820,7 +820,7 @@ async fn test_multiple_tables_creation() {
 
 #[tokio::test]
 #[serial]
-async fn test_drop_table() {
+async fn test_drop_and_recreate_table() {
     let _guard = TestGuard::new(&get_moonlink_backend_dir());
     let config = get_service_config();
     tokio::spawn(async move {
@@ -839,9 +839,16 @@ async fn test_drop_table() {
     // Drop test table.
     drop_table(&client, DATABASE, TABLE).await;
 
-    // List table before drop.
+    // List table after drop.
     let list_results = list_tables(&client).await;
     assert_eq!(list_results.len(), 0);
+
+    // Recreate the same table.
+    create_table(&client, DATABASE, TABLE, /*nested=*/ false).await;
+
+    // List table after recreation.
+    let list_results = list_tables(&client).await;
+    assert_eq!(list_results.len(), 1);
 }
 
 /// Testing scenario: create multiple tables, and check list table result.


### PR DESCRIPTION
## Summary

Current implementation doesn't remove table id from table info struct:
- We have different logic branch for pg and rest
- Pg has its own unique cleanup, not sure why

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1951

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
