### PR TITLE
Add async flush test with iceberg snapshot

### DIFF
--- a/src/moonlink/src/storage/iceberg/tests.rs
+++ b/src/moonlink/src/storage/iceberg/tests.rs
@@ -3509,3 +3509,257 @@ async fn test_async_flush_for_streaming_partial_finish() {
     let iceberg_table_config = get_iceberg_table_config(&iceberg_temp_dir);
     test_async_flush_for_streaming_partial_finish_impl(iceberg_table_config).await;
 }
+
+/// ================================
+/// Test iceberg snapshot creation with completely reversed order of stream flush
+/// ================================
+///
+/// Testing scenario and event stream:
+/// - a non-streaming transaction finishes
+/// - start streaming txn 1, async flush, and commit
+/// - start streaming txn 2, async flush, commit and complete
+/// - commit the streaming transaction, still async flush ongoing
+/// - create mooncake and iceberg snapshot
+async fn test_reversed_order_of_completed_streaming_flush_impl(
+    iceberg_table_config: IcebergTableConfig,
+) {
+    // Local filesystem to store write-through cache.
+    let table_temp_dir = tempdir().unwrap();
+    let mooncake_table_metadata =
+        create_test_table_metadata(table_temp_dir.path().to_str().unwrap().to_string());
+
+    // Local filesystem to store read-through cache.
+    let cache_temp_dir = tempdir().unwrap();
+    let object_storage_cache = create_test_object_storage_cache(&cache_temp_dir);
+
+    // Create mooncake table and table event notification receiver.
+    let (mut table, mut notify_rx) = create_mooncake_table_and_notify(
+        mooncake_table_metadata.clone(),
+        iceberg_table_config.clone(),
+        object_storage_cache.clone(),
+    )
+    .await;
+
+    // Perform a non-streaming append, commit and flush.
+    let row1 = MoonlinkRow::new(vec![
+        RowValue::Int32(1),
+        RowValue::ByteArray("Alice".as_bytes().to_vec()),
+        RowValue::Int32(10),
+    ]);
+    table.append(row1.clone()).unwrap();
+    table.commit(/*lsn=*/ 1);
+    flush_table_and_sync(&mut table, &mut notify_rx, /*lsn=*/ 1)
+        .await
+        .unwrap();
+
+    // Perform a streaming append and commit, but not apply.
+    let row2 = MoonlinkRow::new(vec![
+        RowValue::Int32(2),
+        RowValue::ByteArray("Bob".as_bytes().to_vec()),
+        RowValue::Int32(20),
+    ]);
+    table
+        .append_in_stream_batch(row2.clone(), /*xact_id=*/ 2)
+        .unwrap();
+    table
+        .commit_transaction_stream(
+            /*xact_id=*/ 2,
+            /*lsn=*/ 2,
+            /*event_id=*/ uuid::Uuid::new_v4(),
+        )
+        .unwrap();
+    // Block wait its completion but not apply it to snapshot buffer.
+    let _ = get_flush_results(&mut notify_rx, /*expected_flushes=*/ 1).await;
+
+    // Perform a streaming append, commit, and apply.
+    let row3 = MoonlinkRow::new(vec![
+        RowValue::Int32(3),
+        RowValue::ByteArray("Cat".as_bytes().to_vec()),
+        RowValue::Int32(30),
+    ]);
+    table
+        .append_in_stream_batch(row3.clone(), /*xact_id=*/ 3)
+        .unwrap();
+    table
+        .commit_transaction_stream(
+            /*xact_id=*/ 3,
+            /*lsn=*/ 3,
+            /*event_id=*/ uuid::Uuid::new_v4(),
+        )
+        .unwrap();
+    // Block wait its completion but not apply it to snapshot buffer.
+    let disk_slices = get_flush_results(&mut notify_rx, /*expected_flushes=*/ 1).await;
+    let disk_slice = disk_slices.into_values().next().unwrap();
+    assert_eq!(*disk_slice.lsn().as_ref().unwrap(), 3);
+    table.apply_stream_flush_result(
+        /*xact_id=*/ 3,
+        disk_slice,
+        /*flush_event_id=*/ uuid::Uuid::new_v4(),
+    );
+
+    // Create mooncake and iceberg snapshot.
+    create_mooncake_and_persist_for_test(&mut table, &mut notify_rx).await;
+
+    // Validate iceberg snapshot content.
+    let filesystem_accessor = create_test_filesystem_accessor(&iceberg_table_config);
+    let mut iceberg_table_manager_for_recovery = IcebergTableManager::new(
+        mooncake_table_metadata.clone(),
+        create_test_object_storage_cache(&cache_temp_dir), // Use separate cache for each table.
+        filesystem_accessor.clone(),
+        iceberg_table_config.clone(),
+    )
+    .await
+    .unwrap();
+    let (_, snapshot) = iceberg_table_manager_for_recovery
+        .load_snapshot_from_table()
+        .await
+        .unwrap();
+    let data_files = snapshot
+        .disk_files
+        .iter()
+        .map(|f| f.0.file_path.clone())
+        .collect::<Vec<_>>();
+    // Now partially flushed transaction data files are in mooncake snapshot, we don't create new iceberg snapshot for now.
+    verify_files_and_deletions(
+        data_files.as_slice(),
+        /*puffin_file_paths=*/ &[],
+        /*position_deletes=*/ Vec::new(),
+        /*deletion_vectors=*/ Vec::new(),
+        /*expected_ids=*/ &[],
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_reversed_order_of_completed_streaming_flush() {
+    let iceberg_temp_dir = tempdir().unwrap();
+    let iceberg_table_config = get_iceberg_table_config(&iceberg_temp_dir);
+    test_reversed_order_of_completed_streaming_flush_impl(iceberg_table_config).await;
+}
+
+/// ================================
+/// Test iceberg snapshot creation with completely ordered stream flush
+/// ================================
+///
+/// Testing scenario and event stream:
+/// - a non-streaming transaction finishes
+/// - start streaming txn 1, async flush, commit
+/// - start streaming txn 2, async flush, commit
+/// - complete txn 1 stream flush and apply
+/// - create mooncake and iceberg snapshot
+async fn test_ordered_completed_streaming_flush_impl(iceberg_table_config: IcebergTableConfig) {
+    // Local filesystem to store write-through cache.
+    let table_temp_dir = tempdir().unwrap();
+    let mooncake_table_metadata =
+        create_test_table_metadata(table_temp_dir.path().to_str().unwrap().to_string());
+
+    // Local filesystem to store read-through cache.
+    let cache_temp_dir = tempdir().unwrap();
+    let object_storage_cache = create_test_object_storage_cache(&cache_temp_dir);
+
+    // Create mooncake table and table event notification receiver.
+    let (mut table, mut notify_rx) = create_mooncake_table_and_notify(
+        mooncake_table_metadata.clone(),
+        iceberg_table_config.clone(),
+        object_storage_cache.clone(),
+    )
+    .await;
+
+    // Perform a non-streaming append, commit and flush.
+    let row1 = MoonlinkRow::new(vec![
+        RowValue::Int32(1),
+        RowValue::ByteArray("Alice".as_bytes().to_vec()),
+        RowValue::Int32(10),
+    ]);
+    table.append(row1.clone()).unwrap();
+    table.commit(/*lsn=*/ 1);
+    flush_table_and_sync(&mut table, &mut notify_rx, /*lsn=*/ 1)
+        .await
+        .unwrap();
+
+    // Perform a streaming append and commit, but not apply.
+    let row2 = MoonlinkRow::new(vec![
+        RowValue::Int32(2),
+        RowValue::ByteArray("Bob".as_bytes().to_vec()),
+        RowValue::Int32(20),
+    ]);
+    table
+        .append_in_stream_batch(row2.clone(), /*xact_id=*/ 2)
+        .unwrap();
+    table
+        .commit_transaction_stream(
+            /*xact_id=*/ 2,
+            /*lsn=*/ 2,
+            /*event_id=*/ uuid::Uuid::new_v4(),
+        )
+        .unwrap();
+    // Block wait its completion but not apply it to snapshot buffer.
+    let disk_slices = get_flush_results(&mut notify_rx, /*expected_flushes=*/ 1).await;
+    let disk_slice = disk_slices.into_values().next().unwrap();
+    assert_eq!(*disk_slice.lsn().as_ref().unwrap(), 2);
+
+    // Perform a streaming append, commit, and apply.
+    let row3 = MoonlinkRow::new(vec![
+        RowValue::Int32(3),
+        RowValue::ByteArray("Cat".as_bytes().to_vec()),
+        RowValue::Int32(30),
+    ]);
+    table
+        .append_in_stream_batch(row3.clone(), /*xact_id=*/ 3)
+        .unwrap();
+    table
+        .commit_transaction_stream(
+            /*xact_id=*/ 3,
+            /*lsn=*/ 3,
+            /*event_id=*/ uuid::Uuid::new_v4(),
+        )
+        .unwrap();
+    // Block wait its completion but not apply it to snapshot buffer.
+    let _ = get_flush_results(&mut notify_rx, /*expected_flushes=*/ 1).await;
+
+    // Apply the first arriving flush result.
+    table.apply_stream_flush_result(
+        /*xact_id=*/ 2,
+        disk_slice,
+        /*flush_event_id=*/ uuid::Uuid::new_v4(),
+    );
+
+    // Create mooncake and iceberg snapshot.
+    create_mooncake_and_persist_for_test(&mut table, &mut notify_rx).await;
+
+    // Validate iceberg snapshot content.
+    let filesystem_accessor = create_test_filesystem_accessor(&iceberg_table_config);
+    let mut iceberg_table_manager_for_recovery = IcebergTableManager::new(
+        mooncake_table_metadata.clone(),
+        create_test_object_storage_cache(&cache_temp_dir), // Use separate cache for each table.
+        filesystem_accessor.clone(),
+        iceberg_table_config.clone(),
+    )
+    .await
+    .unwrap();
+    let (_, snapshot) = iceberg_table_manager_for_recovery
+        .load_snapshot_from_table()
+        .await
+        .unwrap();
+    let data_files = snapshot
+        .disk_files
+        .iter()
+        .map(|f| f.0.file_path.clone())
+        .collect::<Vec<_>>();
+    // Now partially flushed transaction data files are in mooncake snapshot, we don't create new iceberg snapshot for now.
+    verify_files_and_deletions(
+        data_files.as_slice(),
+        /*puffin_file_paths=*/ &[],
+        /*position_deletes=*/ Vec::new(),
+        /*deletion_vectors=*/ Vec::new(),
+        /*expected_ids=*/ &[1, 2],
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_ordered_completed_streaming_flush() {
+    let iceberg_temp_dir = tempdir().unwrap();
+    let iceberg_table_config = get_iceberg_table_config(&iceberg_temp_dir);
+    test_ordered_completed_streaming_flush_impl(iceberg_table_config).await;
+}


### PR DESCRIPTION
## Summary

Add more unit tests for different ordering of async flush, with mooncake and iceberg snapshot checked.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1955

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
