### PR TITLE
[chaos] Decrease disk slice chaos event count

### DIFF
--- a/src/moonlink/src/table_handler/chaos_test.rs
+++ b/src/moonlink/src/table_handler/chaos_test.rs
@@ -1147,7 +1147,7 @@ async fn test_disk_slice_chaos_on_local_fs() {
         special_table_option: SpecialTableOption::None,
         maintenance_option: TableMaintenanceOption::NoTableMaintenance,
         error_injection_enabled: false,
-        event_count: 2000,
+        event_count: 1500,
         storage_config: StorageConfig::FileSystem {
             root_directory,
             atomic_write_dir: None,


### PR DESCRIPTION
## Summary

We have flaky test for disk slice latency injection chaos test: https://github.com/Mooncake-Labs/moonlink/actions/runs/17535605279/job/49798301807
I checked with the random seed and replay log, don't see anything suspicious: the pipeline is running properly, not getting stuck anywhere.

I suspect https://github.com/Mooncake-Labs/moonlink/pull/1956 is causing larger latency for iceberg snapshot (in particularly, force snapshot request).
This PR simply decrease the event count.

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
