### PR TITLE
[storage] No prune compacted committed deletion records

### DIFF
--- a/src/moonlink/src/storage/compaction/table_compaction.rs
+++ b/src/moonlink/src/storage/compaction/table_compaction.rs
@@ -1,6 +1,7 @@
 use crate::storage::filesystem::accessor::base_filesystem_accessor::BaseFileSystemAccess;
 use crate::storage::iceberg::puffin_utils::PuffinBlobRef;
 use crate::storage::index::FileIndex;
+use crate::storage::storage_utils::FileId;
 use crate::storage::storage_utils::MooncakeDataFileRef;
 use crate::storage::storage_utils::RecordLocation;
 use crate::storage::storage_utils::TableUniqueFileId;
@@ -73,6 +74,14 @@ impl std::fmt::Debug for DataCompactionPayload {
 }
 
 impl DataCompactionPayload {
+    /// Get data file ids to compact.
+    pub fn get_data_files(&self) -> HashSet<FileId> {
+        self.disk_files
+            .iter()
+            .map(|f| f.file_id.file_id)
+            .collect::<HashSet<_>>()
+    }
+
     /// Get max possible number of new file ids number.
     pub fn get_new_compacted_data_file_ids_number(&self) -> u32 {
         // In worst case, we create two new files (one data file, one index block) per data file.

--- a/src/moonlink/src/storage/compaction/test_utils.rs
+++ b/src/moonlink/src/storage/compaction/test_utils.rs
@@ -221,7 +221,6 @@ pub(crate) async fn dump_deletion_vector_puffin(
         start_offset: 4_u32, // Puffin file starts with 4 magic bytes.
         blob_size: blob_size as u32,
         num_rows: deleted_rows_num,
-        deletion_vector: batch_deletion_vector,
     }
 }
 

--- a/src/moonlink/src/storage/iceberg/iceberg_table_loader.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_loader.rs
@@ -163,7 +163,6 @@ impl IcebergTableManager {
         let persisted_deletion_vector = PuffinBlobRef {
             // Deletion vector should be pinned on cache.
             puffin_file_cache_handle: cache_handle.unwrap(),
-            deletion_vector: batch_deletion_vector.clone(),
             start_offset: data_file.content_offset().unwrap() as u32,
             blob_size: data_file.content_size_in_bytes().unwrap() as u32,
             num_rows: num_rows as usize,

--- a/src/moonlink/src/storage/iceberg/iceberg_table_syncer.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_syncer.rs
@@ -166,7 +166,6 @@ impl IcebergTableManager {
 
         let puffin_blob_ref = PuffinBlobRef {
             puffin_file_cache_handle: cache_handle.unwrap(),
-            deletion_vector,
             start_offset: 4_u32, // Puffin file starts with 4 magic bytes.
             blob_size: blob_size as u32,
             num_rows: deleted_row_count,

--- a/src/moonlink/src/storage/iceberg/puffin_utils.rs
+++ b/src/moonlink/src/storage/iceberg/puffin_utils.rs
@@ -23,8 +23,6 @@ pub struct PuffinBlobRef {
     pub(crate) blob_size: u32,
     /// Number of rows deleted in the puffin blob.
     pub(crate) num_rows: usize,
-    /// Persisted deletion record.
-    pub(crate) deletion_vector: BatchDeletionVector,
 }
 
 /// Get puffin writer with the given file io.

--- a/src/moonlink/src/storage/mooncake_table/snapshot_maintenance.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot_maintenance.rs
@@ -425,4 +425,14 @@ impl SnapshotTableState {
             }
         }
     }
+
+    /// Prune committed deletion logs, which cannot be deleted previously due to ongoing compaction.
+    pub(super) fn prune_committed_deletion_logs_for_completed_compaction(
+        &mut self,
+        task: &SnapshotTask,
+    ) {
+        if !task.data_compaction_result.is_empty() {
+            self.committed_deletion_logs_in_compaction.clear();
+        }
+    }
 }

--- a/src/moonlink/src/storage/mooncake_table/snapshot_maintenance.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot_maintenance.rs
@@ -425,14 +425,4 @@ impl SnapshotTableState {
             }
         }
     }
-
-    /// Prune committed deletion logs, which cannot be deleted previously due to ongoing compaction.
-    pub(super) fn prune_committed_deletion_logs_for_completed_compaction(
-        &mut self,
-        task: &SnapshotTask,
-    ) {
-        if !task.data_compaction_result.is_empty() {
-            self.committed_deletion_logs_in_compaction.clear();
-        }
-    }
 }

--- a/src/moonlink/src/storage/mooncake_table/snapshot_validation.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot_validation.rs
@@ -86,24 +86,6 @@ impl SnapshotTableState {
                     .committed_deletion_vector
                     .get_num_rows_deleted()
             );
-
-            // Persisted deletion vector, which is the in-memory format for puffin blob, is a subset of batch deletion vector.
-            if cur_disk_file_entry.puffin_deletion_blob.is_none() {
-                continue;
-            }
-            let committed_deleted_rows = cur_disk_file_entry
-                .committed_deletion_vector
-                .collect_deleted_rows();
-            let committed_deleted_rows = committed_deleted_rows.into_iter().collect::<HashSet<_>>();
-            let persisted_deleted_rows = cur_disk_file_entry
-                .puffin_deletion_blob
-                .as_ref()
-                .unwrap()
-                .deletion_vector
-                .collect_deleted_rows();
-            for cur_row_idx in persisted_deleted_rows.into_iter() {
-                assert!(committed_deleted_rows.contains(&cur_row_idx));
-            }
         }
     }
 

--- a/src/moonlink/src/table_handler.rs
+++ b/src/moonlink/src/table_handler.rs
@@ -705,6 +705,7 @@ impl TableHandler {
                                 table.set_data_compaction_res(data_compaction_res)
                             }
                             Err(err) => {
+                                // TODO(hjiang): Need to record failed compaction result back to snapshot, so committed deletion logs could be pruned.
                                 error!(error = ?err, "failed to perform compaction");
                             }
                         }


### PR DESCRIPTION
## Summary

There're two performance issues with the current implementation:
- On snapshot read, when get committed deletion records, we iterate through all deleted rows and compare the difference between persisted deletion records and all committed ones: https://github.com/Mooncake-Labs/moonlink/blob/f1d6ead03cf505824e739be189751b39a5b017a7/src/moonlink/src/storage/mooncake_table/snapshot_read.rs#L115-L130
- To get the batch deletion vector difference, we make a copy for batch deletion vector

The fix here is to keep committed deletion records, which are being compacted.
There're two types of logs to prune then:
- Those being used in compaction will get dropped naturally after compaction
- Those not being used will be remapped to a new record location

This PR is a no-op change, existing unit tests (especially regression tests) are enough.

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
