### PR TITLE
[storage] Add basic unit test for iceberg rest

### DIFF
--- a/src/moonlink/src/storage/iceberg.rs
+++ b/src/moonlink/src/storage/iceberg.rs
@@ -81,3 +81,7 @@ mod snapshot_fetcher_test;
 
 #[cfg(test)]
 mod catalog_test_impl;
+
+#[cfg(feature = "catalog-rest")]
+#[cfg(test)]
+mod iceberg_rest_catalog_test;

--- a/src/moonlink/src/storage/iceberg/iceberg_rest_catalog_test.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_rest_catalog_test.rs
@@ -1,0 +1,241 @@
+use crate::row::MoonlinkRow;
+use crate::row::RowValue;
+use crate::storage::iceberg::iceberg_table_config::IcebergTableConfig;
+use crate::storage::iceberg::iceberg_table_manager::IcebergTableManager;
+use crate::storage::iceberg::rest_catalog_test_utils::*;
+use crate::storage::iceberg::schema_utils::assert_is_same_schema;
+use crate::storage::iceberg::table_manager::TableManager;
+use crate::storage::mooncake_table::table_creation_test_utils::*;
+use crate::storage::mooncake_table::table_operation_test_utils::*;
+
+use iceberg::arrow::arrow_schema_to_schema;
+use tempfile::tempdir;
+
+/// Test util functions to create moonlink rows.
+fn test_row_1() -> MoonlinkRow {
+    MoonlinkRow::new(vec![
+        RowValue::Int32(1),
+        RowValue::ByteArray("John".as_bytes().to_vec()),
+        RowValue::Int32(10),
+    ])
+}
+
+/// Test util function to create moonlink row with updated schema with [`create_test_updated_arrow_schema`].
+fn test_row_with_updated_schema() -> MoonlinkRow {
+    MoonlinkRow::new(vec![
+        RowValue::Int32(100),
+        RowValue::ByteArray("new_string".as_bytes().to_vec()),
+    ])
+}
+
+/// This file test iceberg table manager integration with rest catalog.
+///
+/// ================================
+/// Test update schema with update
+/// ================================
+///
+/// Testing scenario: perform a table schema update when there's no table update.
+async fn test_schema_update_with_no_table_write_impl(iceberg_table_config: IcebergTableConfig) {
+    // Local filesystem to store write-through cache.
+    let table_temp_dir = tempdir().unwrap();
+    let local_table_directory = table_temp_dir.path().to_str().unwrap().to_string();
+    let mooncake_table_metadata = create_test_table_metadata(local_table_directory.clone());
+
+    // Local filesystem to store read-through cache.
+    let cache_temp_dir = tempdir().unwrap();
+    let object_storage_cache = create_test_object_storage_cache(&cache_temp_dir);
+
+    // Append, commit, flush and persist.
+    let (mut table, mut notify_rx) = create_mooncake_table_and_notify(
+        mooncake_table_metadata.clone(),
+        iceberg_table_config.clone(),
+        object_storage_cache.clone(),
+    )
+    .await;
+
+    let updated_mooncake_table_metadata =
+        alter_table_and_persist_to_iceberg(&mut table, &mut notify_rx).await;
+
+    // Now the iceberg table has been created, create an iceberg table manager and check table status.
+    let filesystem_accessor = create_test_filesystem_accessor(&iceberg_table_config);
+    let mut iceberg_table_manager_for_load = IcebergTableManager::new(
+        updated_mooncake_table_metadata.clone(),
+        object_storage_cache.clone(),
+        filesystem_accessor,
+        iceberg_table_config.clone(),
+    )
+    .await
+    .unwrap();
+    let (next_file_id, snapshot) = iceberg_table_manager_for_load
+        .load_snapshot_from_table()
+        .await
+        .unwrap();
+    assert_eq!(next_file_id, 0);
+    assert_eq!(snapshot.flush_lsn, Some(0));
+    assert!(snapshot.disk_files.is_empty());
+    assert!(snapshot.indices.file_indices.is_empty());
+
+    let loaded_table = iceberg_table_manager_for_load
+        .iceberg_table
+        .as_ref()
+        .unwrap();
+    let actual_schema = loaded_table.metadata().current_schema();
+    let expected_schema =
+        arrow_schema_to_schema(updated_mooncake_table_metadata.schema.as_ref()).unwrap();
+    assert_is_same_schema(actual_schema.as_ref().clone(), expected_schema);
+
+    // =======================================
+    // Table write after schema update
+    // =======================================
+    //
+    // Perform more data file with the new schema should go through with no issue.
+    let row = test_row_with_updated_schema();
+    table.append(row.clone()).unwrap();
+    table.commit(/*lsn=*/ 20);
+    flush_table_and_sync(&mut table, &mut notify_rx, /*lsn=*/ 20)
+        .await
+        .unwrap();
+
+    // Create a mooncake and iceberg snapshot to reflect new data file changes.
+    create_mooncake_and_persist_for_test(&mut table, &mut notify_rx).await;
+
+    // Now the iceberg table has been created, create an iceberg table manager and check table status.
+    let filesystem_accessor = create_test_filesystem_accessor(&iceberg_table_config);
+    let mut iceberg_table_manager_for_load = IcebergTableManager::new(
+        updated_mooncake_table_metadata.clone(),
+        object_storage_cache.clone(),
+        filesystem_accessor,
+        iceberg_table_config.clone(),
+    )
+    .await
+    .unwrap();
+    let (next_file_id, snapshot) = iceberg_table_manager_for_load
+        .load_snapshot_from_table()
+        .await
+        .unwrap();
+    assert_eq!(next_file_id, 2); // one data file, one file index
+    assert_eq!(snapshot.flush_lsn, Some(20));
+    assert_eq!(snapshot.disk_files.len(), 1);
+    assert_eq!(snapshot.indices.file_indices.len(), 1);
+
+    let loaded_table = iceberg_table_manager_for_load
+        .iceberg_table
+        .as_ref()
+        .unwrap();
+    let actual_schema = loaded_table.metadata().current_schema();
+    let expected_schema =
+        arrow_schema_to_schema(updated_mooncake_table_metadata.schema.as_ref()).unwrap();
+    assert_is_same_schema(actual_schema.as_ref().clone(), expected_schema);
+}
+
+#[tokio::test]
+async fn test_schema_update_with_no_table_write() {
+    // Local filesystem for iceberg.
+    let iceberg_temp_dir = tempdir().unwrap();
+    let iceberg_table_config = get_rest_iceberg_table_config(&iceberg_temp_dir);
+
+    // Common testing logic.
+    test_schema_update_with_no_table_write_impl(iceberg_table_config).await;
+}
+
+/// ================================
+/// Test update schema
+/// ================================
+///
+/// Testing scenario: perform schema update after a sync operation.
+async fn test_schema_update_impl(iceberg_table_config: IcebergTableConfig) {
+    // Local filesystem to store write-through cache.
+    let table_temp_dir = tempdir().unwrap();
+    let local_table_directory = table_temp_dir.path().to_str().unwrap().to_string();
+    let mooncake_table_metadata = create_test_table_metadata(local_table_directory.clone());
+
+    // Local filesystem to store read-through cache.
+    let cache_temp_dir = tempdir().unwrap();
+    let object_storage_cache = create_test_object_storage_cache(&cache_temp_dir);
+
+    // Append, commit, flush and persist.
+    let (mut table, mut notify_rx) = create_mooncake_table_and_notify(
+        mooncake_table_metadata.clone(),
+        iceberg_table_config.clone(),
+        object_storage_cache.clone(),
+    )
+    .await;
+    let row = test_row_1();
+    table.append(row.clone()).unwrap();
+    table.commit(/*lsn=*/ 10);
+    flush_table_and_sync(&mut table, &mut notify_rx, /*lsn=*/ 10)
+        .await
+        .unwrap();
+
+    // Perform an schema update.
+    let updated_mooncake_table_metadata =
+        alter_table_and_persist_to_iceberg(&mut table, &mut notify_rx).await;
+
+    // Now the iceberg table has been created, create an iceberg table manager and check table status.
+    let filesystem_accessor = create_test_filesystem_accessor(&iceberg_table_config);
+    let mut iceberg_table_manager_for_load = IcebergTableManager::new(
+        updated_mooncake_table_metadata.clone(),
+        object_storage_cache.clone(),
+        filesystem_accessor,
+        iceberg_table_config.clone(),
+    )
+    .await
+    .unwrap();
+    let (next_file_id, snapshot) = iceberg_table_manager_for_load
+        .load_snapshot_from_table()
+        .await
+        .unwrap();
+    assert_eq!(next_file_id, 2);
+    assert_eq!(snapshot.flush_lsn, Some(10));
+    assert_eq!(snapshot.disk_files.len(), 1);
+    assert_eq!(snapshot.indices.file_indices.len(), 1);
+
+    let loaded_table = iceberg_table_manager_for_load
+        .iceberg_table
+        .as_ref()
+        .unwrap();
+    let actual_schema = loaded_table.metadata().current_schema();
+    let expected_schema =
+        arrow_schema_to_schema(updated_mooncake_table_metadata.schema.as_ref()).unwrap();
+    assert_is_same_schema(actual_schema.as_ref().clone(), expected_schema);
+
+    // Perform more data file with the new schema should go through with no issue.
+    let row = test_row_with_updated_schema();
+    table.append(row.clone()).unwrap();
+    table.commit(/*lsn=*/ 20);
+    flush_table_and_sync(&mut table, &mut notify_rx, /*lsn=*/ 20)
+        .await
+        .unwrap();
+
+    // Create a mooncake and iceberg snapshot to reflect new data file changes.
+    create_mooncake_and_persist_for_test(&mut table, &mut notify_rx).await;
+
+    // Check iceberg snapshot after write following schema update.
+    let filesystem_accessor = create_test_filesystem_accessor(&iceberg_table_config);
+    let mut iceberg_table_manager_for_load = IcebergTableManager::new(
+        updated_mooncake_table_metadata.clone(),
+        object_storage_cache.clone(),
+        filesystem_accessor,
+        iceberg_table_config.clone(),
+    )
+    .await
+    .unwrap();
+    let (next_file_id, snapshot) = iceberg_table_manager_for_load
+        .load_snapshot_from_table()
+        .await
+        .unwrap();
+    assert_eq!(next_file_id, 4); // two data files, two file indices
+    assert_eq!(snapshot.flush_lsn, Some(20));
+    assert_eq!(snapshot.disk_files.len(), 2);
+    assert_eq!(snapshot.indices.file_indices.len(), 2);
+}
+
+#[tokio::test]
+async fn test_schema_update() {
+    // Local filesystem for iceberg.
+    let iceberg_temp_dir = tempdir().unwrap();
+    let iceberg_table_config = get_rest_iceberg_table_config(&iceberg_temp_dir);
+
+    // Common testing logic.
+    test_schema_update_impl(iceberg_table_config).await;
+}

--- a/src/moonlink/src/storage/iceberg/rest_catalog_test_guard.rs
+++ b/src/moonlink/src/storage/iceberg/rest_catalog_test_guard.rs
@@ -20,7 +20,7 @@ impl RestCatalogTestGuard {
             create_test_table_schema().unwrap(),
         )
         .await
-        .expect("Catalog creation fail");
+        .unwrap();
         let ns_ident = NamespaceIdent::new(namespace);
         catalog.create_namespace(&ns_ident, HashMap::new()).await?;
         let table_ident = if let Some(t) = table {
@@ -53,7 +53,7 @@ impl Drop for RestCatalogTestGuard {
                     create_test_table_schema().unwrap(),
                 )
                 .await
-                .expect("Catalog creation fail");
+                .unwrap();
                 if let Some(t) = table {
                     catalog.drop_table(&t).await.unwrap();
                 }

--- a/src/moonlink/src/storage/iceberg/rest_catalog_test_utils.rs
+++ b/src/moonlink/src/storage/iceberg/rest_catalog_test_utils.rs
@@ -1,10 +1,11 @@
 use crate::storage::iceberg::iceberg_table_config::RestCatalogConfig;
 use crate::storage::mooncake_table::test_utils_commons::REST_CATALOG_TEST_URI;
-use crate::{AccessorConfig, StorageConfig};
+use crate::{AccessorConfig, FsRetryConfig, FsTimeoutConfig, IcebergTableConfig, StorageConfig};
 use iceberg::spec::{NestedField, PrimitiveType, Schema, Type};
 use iceberg::TableCreation;
 use rand::{distr::Alphanumeric, Rng};
 use std::collections::HashMap;
+use tempfile::TempDir;
 
 const DEFAULT_REST_CATALOG_NAME: &str = "test";
 const DEFAULT_WAREHOUSE_PATH: &str = "/tmp/moonlink_iceberg";
@@ -31,6 +32,30 @@ pub(crate) fn default_rest_catalog_config() -> RestCatalogConfig {
         uri: REST_CATALOG_TEST_URI.to_string(),
         warehouse: DEFAULT_WAREHOUSE_PATH.to_string(),
         props: HashMap::new(),
+    }
+}
+
+pub(crate) fn get_accessor_config(tmp_dir: &TempDir) -> AccessorConfig {
+    let storage_config = StorageConfig::FileSystem {
+        root_directory: tmp_dir.path().to_str().unwrap().to_string(),
+        atomic_write_dir: None,
+    };
+    AccessorConfig {
+        storage_config,
+        retry_config: FsRetryConfig::default(),
+        timeout_config: FsTimeoutConfig::default(),
+        chaos_config: None,
+    }
+}
+
+pub(crate) fn get_rest_iceberg_table_config(tmp_dir: &TempDir) -> IcebergTableConfig {
+    IcebergTableConfig {
+        namespace: vec![get_random_string()],
+        table_name: get_random_string(),
+        data_accessor_config: get_accessor_config(tmp_dir),
+        metadata_accessor_config: crate::IcebergCatalogConfig::Rest {
+            rest_catalog_config: default_rest_catalog_config(),
+        },
     }
 }
 


### PR DESCRIPTION
## Summary

This PR adds the basic unit test for iceberg rest catalog. 

To me, most of the rest catalog functionality should be fairly straightforward, since it's directly delegating to internal rest catalog without any additional logic; there're a few key things I'm concerned about:
- table creation
- schema setting (at table creation) and evolution
- table update / transaction commmit

These three items are the places we do our own hack. In this PR, I added least unit tests which cover these topics.

The ideal state for catalog test is to share the same testing logic with file catalog and maybe glue in the future, but there're certain blockers:
- file catalog unit tests use temporary directories, which are naturally isolated with each other; no extra test guard needed, no random table and namespace name needed
- but for rest catalog, all unit tests are accessing the devcontainer at the same time, which means they interfere with each other if we use the same namespace / table; tried to do some refactoring on random tables, but that requires huge refactor which I cannot afford at the moment

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
