### PR TITLE
Install mold directly

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,18 +2,10 @@ FROM mcr.microsoft.com/devcontainers/rust:latest
 
 RUN apt update \
  && apt install -y python3-pip \
+ && apt install -y mold \
  && rm -rf /var/lib/apt/lists/*
 
 USER vscode
-
-RUN cd ~ \
- && git clone --branch stable https://github.com/rui314/mold.git \
- && cd mold \
- && sudo ./install-build-deps.sh \
- && cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER=c++ -B build \
- && cmake --build build -j$(nproc) \
- && sudo cmake --build build --target install \
- && sudo ln -fs /usr/local/bin/mold /usr/bin/ld
 
 RUN cargo install cargo-deny cargo-sort
 


### PR DESCRIPTION
## Summary

Use `mold` directly instead of clone the repo and build from scratch.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1991

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
