### PR TITLE
Add missing depend on devcontainer

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - postgres
       - fake-gcs
       - nginx
+      - iceberg-rest
     command: sleep infinity
 
   postgres:


### PR DESCRIPTION
## Summary

Devcontainer needs to depend rest-catalog container to start first.

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
