### PR TITLE
[storage] Disable config load for S3 access

### DIFF
--- a/src/moonlink/src/storage/filesystem/accessor/operator_utils.rs
+++ b/src/moonlink/src/storage/filesystem/accessor/operator_utils.rs
@@ -51,7 +51,8 @@ fn create_opendal_operator_impl(storage_config: &StorageConfig) -> Result<Operat
                 .bucket(bucket)
                 .endpoint("https://storage.googleapis.com")
                 .access_key_id(access_key_id)
-                .secret_access_key(secret_access_key);
+                .secret_access_key(secret_access_key)
+                .disable_config_load();
             Ok(Operator::new(builder)?.finish())
         }
         #[cfg(feature = "storage-s3")]
@@ -66,7 +67,8 @@ fn create_opendal_operator_impl(storage_config: &StorageConfig) -> Result<Operat
                 .bucket(bucket)
                 .region(region)
                 .access_key_id(access_key_id)
-                .secret_access_key(secret_access_key);
+                .secret_access_key(secret_access_key)
+                .disable_config_load();
             if let Some(endpoint) = endpoint {
                 builder = builder.endpoint(endpoint);
             }


### PR DESCRIPTION
## Summary

```rs
if self.config.disable_config_load {
            cred_loader = cred_loader
                .with_disable_env()
                .with_disable_well_known_location();
        }
```
config load is used for two purpose:
- consider config env variables
- consider config files

For moonlink, we always use HMAC key in the foreseeable future, simply disable the config load for all object storage access.

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
