### PR TITLE
[REST] Fix improper naming

### DIFF
--- a/src/moonlink_service/src/test.rs
+++ b/src/moonlink_service/src/test.rs
@@ -99,7 +99,7 @@ async fn test_schema() {
     );
     let response: CreateTableResponse = response.json().await.unwrap();
     assert_eq!(response.database, DATABASE);
-    assert_eq!(response.table, crafted_src_table_name);
+    assert_eq!(response.table, TABLE);
     assert_eq!(response.lsn, 1);
 }
 


### PR DESCRIPTION
## Summary

We are currently mixing "table" (mooncake table concept) and "src table name" (similar to pg table source table concept) which is really bad, this PR tries to unify the naming style for all APIs:
- Use src table name for HTTP endpoints
- Use database and table name in the request and response payload

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
