### PR TITLE
[storage] Validate iceberg snapshot payload

### DIFF
--- a/src/moonlink/src/storage/iceberg/iceberg_table_syncer.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_syncer.rs
@@ -72,10 +72,7 @@ impl IcebergTableManager {
     }
 
     // Validate data files to add don't belong to iceberg snapshot.
-    fn validate_new_data_files(
-        &self,
-        new_data_files: &Vec<MooncakeDataFileRef>,
-    ) -> IcebergResult<()> {
+    fn validate_new_data_files(&self, new_data_files: &[MooncakeDataFileRef]) -> IcebergResult<()> {
         for cur_data_file in new_data_files.iter() {
             if self
                 .persisted_data_files
@@ -91,10 +88,7 @@ impl IcebergTableManager {
     }
 
     // Validate data files to remove don't belong to iceberg snapshot.
-    fn validate_old_data_files(
-        &self,
-        old_data_files: &Vec<MooncakeDataFileRef>,
-    ) -> IcebergResult<()> {
+    fn validate_old_data_files(&self, old_data_files: &[MooncakeDataFileRef]) -> IcebergResult<()> {
         for cur_data_file in old_data_files.iter() {
             if !self
                 .persisted_data_files


### PR DESCRIPTION
## Summary

I met a weird bug that data files to import into iceberg table already exist in manifest file, so add a validation at iceberg table manager, hopefully we could scope down to either snapshot or iceberg table manager issue.

The assertion failure only appears <1/200, never reproduced on my end.

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
