### PR TITLE
Add log rotation to moonlink service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2985,6 +2985,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "flexi_logger"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759bfa52db036a2db54f0b5f0ff164efa249b3014720459c5ea4198380c529bc"
+dependencies = [
+ "chrono",
+ "crossbeam-channel",
+ "crossbeam-queue",
+ "log",
+ "notify-debouncer-mini",
+ "nu-ansi-term",
+ "regex",
+ "serde",
+ "serde_derive",
+ "thiserror 2.0.16",
+ "toml",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "flume"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3042,6 +3063,15 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "fsevent-sys"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "function_name"
@@ -3795,6 +3825,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "inotify"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f37dccff2791ab604f9babef0ba14fbe0be30bd368dc541e2b08d07c8aa908f3"
+dependencies = [
+ "bitflags 2.9.4",
+ "inotify-sys",
+ "libc",
+]
+
+[[package]]
+name = "inotify-sys"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e05c02b5e89bff3b946cedeca278abc628fe811e604f027c45a8aa3cf793d0eb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "inout"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3944,6 +3994,26 @@ dependencies = [
  "serde",
  "serde_json",
  "simple_asn1",
+]
+
+[[package]]
+name = "kqueue"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac30106d7dce88daf4a3fcb4879ea939476d5074a9b7ddd0fb97fa4bed5596a"
+dependencies = [
+ "kqueue-sys",
+ "libc",
+]
+
+[[package]]
+name = "kqueue-sys"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed9625ffda8729b85e45cf04090035ac368927b8cebc34898e7c120f52e4838b"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
 ]
 
 [[package]]
@@ -4283,6 +4353,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
+ "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
 ]
@@ -4559,6 +4630,7 @@ dependencies = [
  "clap",
  "console-subscriber",
  "const_format",
+ "flexi_logger",
  "moonlink",
  "moonlink_backend",
  "moonlink_connectors",
@@ -4672,6 +4744,42 @@ dependencies = [
  "memchr",
  "minimal-lexical",
 ]
+
+[[package]]
+name = "notify"
+version = "8.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
+dependencies = [
+ "bitflags 2.9.4",
+ "fsevent-sys",
+ "inotify",
+ "kqueue",
+ "libc",
+ "log",
+ "mio",
+ "notify-types",
+ "walkdir",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-debouncer-mini"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a689eb4262184d9a1727f9087cd03883ea716682ab03ed24efec57d7716dccb8"
+dependencies = [
+ "log",
+ "notify",
+ "notify-types",
+ "tempfile",
+]
+
+[[package]]
+name = "notify-types"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e0826a989adedc2a244799e823aece04662b66609d96af8dff7ac6df9a8925d"
 
 [[package]]
 name = "nu-ansi-term"
@@ -6598,6 +6706,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7493,10 +7610,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -7505,9 +7637,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap 2.11.0",
+ "serde",
+ "serde_spanned",
  "toml_datetime",
+ "toml_write",
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"

--- a/src/moonlink_service/Cargo.toml
+++ b/src/moonlink_service/Cargo.toml
@@ -12,6 +12,7 @@ rest_api_demo = []
 standalone-test = []
 otel-integration = []
 postgres-integration = []
+log-rotation-test = []
 
 storage-s3 = ["moonlink/storage-s3"]
 storage-gcs = ["moonlink/storage-gcs"]
@@ -23,6 +24,7 @@ arrow-schema = { workspace = true }
 axum = "0.8"
 clap = { workspace = true }
 console-subscriber = { version = "0.4", optional = true }
+flexi_logger = { version = "0.31", features = ["trc"] }
 moonlink = { workspace = true }
 moonlink_backend = { workspace = true }
 moonlink_connectors = { workspace = true }

--- a/src/moonlink_service/examples/rest_api_demo.rs
+++ b/src/moonlink_service/examples/rest_api_demo.rs
@@ -26,6 +26,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             tcp_port: None,
             otel_api_port: None,
             data_server_uri: None,
+            log_directory: None,
         })
         .await
         {

--- a/src/moonlink_service/src/lib.rs
+++ b/src/moonlink_service/src/lib.rs
@@ -38,6 +38,8 @@ pub struct ServiceConfig {
     pub otel_api_port: Option<u16>,
     /// Used for moonlink standalone deployment.
     pub tcp_port: Option<u16>,
+    /// Log persistence directory.
+    pub log_directory: Option<String>,
 }
 
 impl ServiceConfig {
@@ -76,7 +78,7 @@ fn setup_readiness_probe() -> Arc<ServiceStatus> {
 
 pub async fn start_with_config(config: ServiceConfig) -> Result<()> {
     // Set logging config before service start.
-    logging::init_logging();
+    let _guard = logging::init_logging(config.log_directory.clone());
 
     // Register HTTP endpoint for readiness probe.
     let service_status = if config.in_standalone_deployment_mode() {

--- a/src/moonlink_service/src/logging.rs
+++ b/src/moonlink_service/src/logging.rs
@@ -1,25 +1,111 @@
-use tracing_subscriber::Layer;
+use std::path::Path;
 
-pub fn init_logging() {
-    use tracing_subscriber::{
-        fmt, fmt::time, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Registry,
-    };
+use flexi_logger::{
+    trc::{self, FormatConfig, SpecFileNotifier},
+    writers::{FileLogWriter, FileLogWriterHandle},
+    Cleanup, Criterion, FileSpec, LogSpecification, Naming, WriteMode,
+};
 
-    let env_filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+/// Default log file size upper bound (change as needed).
+pub const DEFAULT_LOG_FILE_SIZE: u64 = 4 * 1024 * 1024; // 4 MiB
+/// Default max number of log files to retain (change as needed).
+pub const DEFAULT_MAX_LOG_FILE_COUNT: usize = 1024;
 
-    let fmt_layer = fmt::layer()
-        .with_timer(time::ChronoLocal::new("%Y-%m-%d %H:%M:%S%:z".to_string()))
-        .with_target(false)
-        .with_file(true)
-        .with_line_number(true)
-        .with_ansi(false)
-        .with_filter(env_filter);
+/// Keep these alive for the lifetime of your program/test to keep logging active.
+pub struct LoggingGuard {
+    _writer: FileLogWriterHandle,
+    _spec_notifier: SpecFileNotifier,
+}
 
-    // Compose the subscriber.
-    let subscriber = Registry::default().with(fmt_layer);
+/// Initialize logging.
+/// - If [`log_directory`] is specified, install a global tracing subscriber that writes to **rotating files** (size-based), with retention limits.
+/// - If directory is not specified, logs will be streamed to stdout and stderr.
+///
+/// Returns a guard which needs to be kept alive.
+pub fn init_logging(log_directory: Option<impl AsRef<Path>>) -> Option<LoggingGuard> {
+    match log_directory {
+        Some(dir) => {
+            let spec = LogSpecification::env_or_parse("info").unwrap();
+            let flwb = FileLogWriter::builder(
+                FileSpec::default()
+                    .directory(dir.as_ref())
+                    .basename("moonlink")
+                    .suffix("log"),
+            )
+            .rotate(
+                Criterion::Size(DEFAULT_LOG_FILE_SIZE),
+                Naming::Numbers,
+                Cleanup::KeepLogFiles(DEFAULT_MAX_LOG_FILE_COUNT),
+            )
+            .write_mode(WriteMode::Async);
 
-    #[cfg(feature = "profiling")]
-    let subscriber = subscriber.with(console_subscriber::spawn());
+            let fmt_cfg = FormatConfig::default()
+                .with_time(true)
+                .with_file(true)
+                .with_line_number(true)
+                .with_target(false)
+                .with_ansi(false);
+            let (writer_handle, spec_notifier) =
+                trc::setup_tracing(spec, None, flwb, &fmt_cfg).unwrap();
 
-    let _ = subscriber.try_init();
+            Some(LoggingGuard {
+                _writer: writer_handle,
+                _spec_notifier: spec_notifier,
+            })
+        }
+        None => {
+            use tracing_subscriber::{
+                fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Registry,
+            };
+
+            let env_filter =
+                EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+
+            let fmt_layer = fmt::layer()
+                .with_timer(time::ChronoLocal::new("%Y-%m-%d %H:%M:%S%:z".to_string()))
+                .with_target(false)
+                .with_file(true)
+                .with_line_number(true)
+                .with_ansi(false)
+                .with_filter(env_filter);
+
+            // Compose the subscriber.
+            let subscriber = Registry::default().with(fmt_layer);
+
+            #[cfg(feature = "profiling")]
+            let subscriber = subscriber.with(console_subscriber::spawn());
+
+            let _ = subscriber.try_init();
+
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{init_logging, DEFAULT_LOG_FILE_SIZE};
+    use more_asserts as ma;
+    use tempfile::tempdir;
+    use tracing::info;
+
+    #[cfg(feature = "log-rotation-test")]
+    #[test]
+    fn test_log_rotation() {
+        let temp_dir = tempdir().unwrap();
+        let _guard = init_logging(Some(temp_dir.path())).unwrap();
+
+        // Write enough data to force rotation.
+        let target_size = (DEFAULT_LOG_FILE_SIZE as usize) / 4;
+        for _ in 0..400 {
+            let s = "a".repeat(target_size);
+            info!("{}", s);
+        }
+
+        let entries: Vec<_> = std::fs::read_dir(temp_dir.path())
+            .unwrap()
+            .map(|e| e.unwrap().path())
+            .collect();
+        ma::assert_gt!(entries.len(), 1);
+    }
 }

--- a/src/moonlink_service/src/logging.rs
+++ b/src/moonlink_service/src/logging.rs
@@ -5,6 +5,9 @@ use flexi_logger::{
     writers::{FileLogWriter, FileLogWriterHandle},
     Cleanup, Criterion, FileSpec, LogSpecification, Naming, WriteMode,
 };
+use tracing_subscriber::{
+    fmt, fmt::time, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer, Registry,
+};
 
 /// Default log file size upper bound (change as needed).
 pub const DEFAULT_LOG_FILE_SIZE: u64 = 4 * 1024 * 1024; // 4 MiB
@@ -22,6 +25,7 @@ pub struct LoggingGuard {
 /// - If directory is not specified, logs will be streamed to stdout and stderr.
 ///
 /// Returns a guard which needs to be kept alive.
+#[must_use]
 pub fn init_logging(log_directory: Option<impl AsRef<Path>>) -> Option<LoggingGuard> {
     match log_directory {
         Some(dir) => {
@@ -54,10 +58,6 @@ pub fn init_logging(log_directory: Option<impl AsRef<Path>>) -> Option<LoggingGu
             })
         }
         None => {
-            use tracing_subscriber::{
-                fmt, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Registry,
-            };
-
             let env_filter =
                 EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
 

--- a/src/moonlink_service/src/main.rs
+++ b/src/moonlink_service/src/main.rs
@@ -40,6 +40,10 @@ struct Cli {
     /// For example: http://34.19.1.175:8080.
     #[arg(long)]
     data_server_uri: Option<String>,
+
+    /// Log directory, stream to stdout/stderr if unspecified.
+    #[arg(long)]
+    log_dir: Option<String>,
 }
 
 #[tokio::main]
@@ -66,6 +70,7 @@ pub async fn main() -> Result<()> {
         } else {
             Some(cli.otel_port.unwrap_or(DEFAULT_OTEL_PORT))
         },
+        log_directory: None,
     };
 
     start_with_config(config).await

--- a/src/moonlink_service/src/test_utils.rs
+++ b/src/moonlink_service/src/test_utils.rs
@@ -53,6 +53,7 @@ pub(crate) fn get_service_config() -> ServiceConfig {
         rest_api_port: Some(REST_API_PORT),
         otel_api_port: Some(OTEL_API_PORT),
         tcp_port: Some(TCP_PORT),
+        log_directory: None,
     }
 }
 


### PR DESCRIPTION
## Summary

In production debugging, I found it painful to debug via redirected logging --- a super large file taking me tens of seconds to load and slow to navigate.

The standard way is log rotation, which chunks logging message into small files and cap upper bound for overall disk usage.
I choose to differentiate log rotation path and current logging path because no tracing library only support interval-based rotation (i.e., on daily basic) but not size-based one, which is not useful to debug peak load situation.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/1999

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
