### PR TITLE
No crash on invalid pg source table name

### DIFF
--- a/src/moonlink_connectors/src/pg_replicate/postgres_source.rs
+++ b/src/moonlink_connectors/src/pg_replicate/postgres_source.rs
@@ -43,6 +43,9 @@ pub enum PostgresSourceError {
 
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),
+
+    #[error("invalid source table name: {0}")]
+    InvalidSourceTableName(String),
 }
 
 pub struct PostgresSource {
@@ -165,7 +168,7 @@ impl PostgresSource {
         replication_client.begin_readonly_transaction().await?;
         let (src_table_id, table_name) = if src_table_id.is_none() {
             assert!(table_name.is_some());
-            let (schema, name) = TableName::parse_schema_name(table_name.unwrap());
+            let (schema, name) = TableName::parse_schema_name(table_name.unwrap())?;
             let table_name = TableName { schema, name };
             (
                 replication_client

--- a/src/moonlink_connectors/src/pg_replicate/table.rs
+++ b/src/moonlink_connectors/src/pg_replicate/table.rs
@@ -3,6 +3,8 @@ use std::fmt::Display;
 use pg_escape::quote_identifier;
 use tokio_postgres::types::Type;
 
+use crate::{Error, PostgresSourceError, Result};
+
 #[derive(Debug, Clone)]
 pub struct TableName {
     pub schema: String,
@@ -10,12 +12,18 @@ pub struct TableName {
 }
 
 impl TableName {
-    pub fn parse_schema_name(table_name: &str) -> (String, String) {
+    pub fn parse_schema_name(
+        table_name: &str,
+    ) -> std::result::Result<(String, String), PostgresSourceError> {
         let tokens: Vec<&str> = table_name.split('.').collect();
-        assert_eq!(tokens.len(), 2);
+        if tokens.len() != 2 {
+            return Err(PostgresSourceError::InvalidSourceTableName(
+                table_name.to_string(),
+            ));
+        }
         let schema = tokens[0].to_string();
         let name = tokens[1].to_string();
-        (schema, name)
+        Ok((schema, name))
     }
     pub fn get_schema_name(&self) -> String {
         format!("{}.{}", self.schema, self.name)


### PR DESCRIPTION
## Summary

For invalid postgres source table name, we shouldn't crash the thread.

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
