### PR TITLE
Log error on replication eventloop failure

### DIFF
--- a/src/moonlink_connectors/src/pg_replicate.rs
+++ b/src/moonlink_connectors/src/pg_replicate.rs
@@ -611,7 +611,14 @@ impl PostgresConnection {
         let cfg = self.source.get_cdc_stream_config().unwrap();
         let source = self.source.clone();
 
-        tokio::spawn(async move { run_event_loop(cfg, sink, receiver, source).await })
+        tokio::spawn(async move {
+            run_event_loop(cfg, sink, receiver, source)
+                .await
+                .map_err(|err| {
+                    error!("Postgres replication eventloop failed: {:?}", err);
+                    err
+                })
+        })
     }
 }
 


### PR DESCRIPTION
## Summary

We don't have dedicated thread block wait for the replication eventloop handler, which means when error happened, there's no logging or panic for the current implementation, which makes debugging impossible.

I think the general practice is:
- Don't exit on failure inside of eventloop
- For background task, consider error logging instead of general error propagation

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
