### PR TITLE
[storage] Disable authentication by VM metadata service

### DIFF
--- a/src/moonlink/src/storage/filesystem/accessor/operator_utils.rs
+++ b/src/moonlink/src/storage/filesystem/accessor/operator_utils.rs
@@ -52,7 +52,8 @@ fn create_opendal_operator_impl(storage_config: &StorageConfig) -> Result<Operat
                 .endpoint("https://storage.googleapis.com")
                 .access_key_id(access_key_id)
                 .secret_access_key(secret_access_key)
-                .disable_config_load();
+                .disable_config_load()
+                .disable_ec2_metadata();
             Ok(Operator::new(builder)?.finish())
         }
         #[cfg(feature = "storage-s3")]
@@ -68,7 +69,8 @@ fn create_opendal_operator_impl(storage_config: &StorageConfig) -> Result<Operat
                 .region(region)
                 .access_key_id(access_key_id)
                 .secret_access_key(secret_access_key)
-                .disable_config_load();
+                .disable_config_load()
+                .disable_ec2_metadata();
             if let Some(endpoint) = endpoint {
                 builder = builder.endpoint(endpoint);
             }

--- a/src/moonlink/src/storage/iceberg/io_utils.rs
+++ b/src/moonlink/src/storage/iceberg/io_utils.rs
@@ -119,7 +119,8 @@ pub(crate) fn create_file_io(accessor_config: &AccessorConfig) -> IcebergResult<
                     .with_prop(iceberg::io::GCS_SERVICE_PATH, endpoint.as_ref().unwrap())
                     .with_prop(iceberg::io::GCS_NO_AUTH, "true")
                     .with_prop(iceberg::io::GCS_ALLOW_ANONYMOUS, "true")
-                    .with_prop(iceberg::io::GCS_DISABLE_CONFIG_LOAD, "true");
+                    .with_prop(iceberg::io::GCS_DISABLE_CONFIG_LOAD, "true")
+                    .with_prop(iceberg::io::GCS_DISABLE_VM_METADATA, "true");
                 return file_io_builder.build();
             }
 
@@ -129,7 +130,8 @@ pub(crate) fn create_file_io(accessor_config: &AccessorConfig) -> IcebergResult<
                 .with_prop(iceberg::io::S3_REGION, region)
                 .with_prop(iceberg::io::S3_ACCESS_KEY_ID, access_key_id)
                 .with_prop(iceberg::io::S3_SECRET_ACCESS_KEY, secret_access_key)
-                .with_prop(iceberg::io::S3_DISABLE_CONFIG_LOAD, "true");
+                .with_prop(iceberg::io::S3_DISABLE_CONFIG_LOAD, "true")
+                .with_prop(iceberg::io::S3_DISABLE_EC2_METADATA, "true");
             file_io_builder.build()
         }
         #[cfg(feature = "storage-s3")]
@@ -144,7 +146,8 @@ pub(crate) fn create_file_io(accessor_config: &AccessorConfig) -> IcebergResult<
                 .with_prop(iceberg::io::S3_REGION, region)
                 .with_prop(iceberg::io::S3_ACCESS_KEY_ID, access_key_id)
                 .with_prop(iceberg::io::S3_SECRET_ACCESS_KEY, secret_access_key)
-                .with_prop(iceberg::io::S3_DISABLE_CONFIG_LOAD, "true");
+                .with_prop(iceberg::io::S3_DISABLE_CONFIG_LOAD, "true")
+                .with_prop(iceberg::io::S3_DISABLE_EC2_METADATA, "true");
             if let Some(endpoint) = endpoint {
                 file_io_builder = file_io_builder.with_prop(iceberg::io::S3_ENDPOINT, endpoint);
             }


### PR DESCRIPTION
## Summary

GCS and S3 supports different ways to authenticate, and there're clear order for authentication fallback path.
Take GCS as an example: https://cloud.google.com/docs/authentication/application-default-credentials

For moonlink, which operates on different tables and different tenants (in the future), we should only allow HMAC-based auth, allowing others could actually lead to permanent failure, say, on config load failure.

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
