### PR TITLE
[storage] Update default parquet setting

### DIFF
--- a/src/moonlink/src/storage/compaction/compactor.rs
+++ b/src/moonlink/src/storage/compaction/compactor.rs
@@ -140,7 +140,7 @@ impl CompactionBuilder {
         self.cur_new_data_file = Some(self.create_new_data_file());
         let write_file =
             tokio::fs::File::create(self.cur_new_data_file.as_ref().unwrap().file_path()).await?;
-        let properties = parquet_utils::get_parquet_properties_for_compaction();
+        let properties = parquet_utils::get_default_parquet_properties();
         let writer: AsyncArrowWriter<tokio::fs::File> =
             AsyncArrowWriter::try_new(write_file, self.schema.clone(), Some(properties))?;
         self.cur_arrow_writer = Some(writer);

--- a/src/moonlink/src/storage/parquet_utils.rs
+++ b/src/moonlink/src/storage/parquet_utils.rs
@@ -1,34 +1,12 @@
 /// This module contains parquet related constants and utils.
 use parquet::basic::Compression;
-use parquet::file::properties::{WriterProperties, WriterPropertiesBuilder};
+use parquet::file::properties::WriterProperties;
 
 /// Default compression.
 const DEFAULT_COMPRESSION: Compression = parquet::basic::Compression::SNAPPY;
 
-/// Default row group size from duckdb.
-const DEFAULT_ROW_GROUP_SIZE: usize = 122880;
-
-/// Default false positive probability (fpp).
-const DEFAULT_FPP: f64 = 0.01;
-
-fn get_default_parquet_properties_builder() -> WriterPropertiesBuilder {
+pub fn get_default_parquet_properties() -> WriterProperties {
     WriterProperties::builder()
         .set_compression(DEFAULT_COMPRESSION)
-        .set_dictionary_enabled(true)
-        .set_dictionary_page_size_limit(DEFAULT_ROW_GROUP_SIZE / 100)
-        .set_writer_version(parquet::file::properties::WriterVersion::PARQUET_1_0)
-}
-
-pub fn get_default_parquet_properties() -> WriterProperties {
-    let builder = get_default_parquet_properties_builder();
-    builder.build()
-}
-
-/// Parquet option for already compacted files.
-pub(crate) fn get_parquet_properties_for_compaction() -> WriterProperties {
-    let builder = get_default_parquet_properties_builder();
-    builder
-        .set_bloom_filter_enabled(true)
-        .set_bloom_filter_fpp(DEFAULT_FPP)
         .build()
 }


### PR DESCRIPTION
## Summary

Current parquet setup is broken, and especially bad for small files.
When the number of rows are small (say, <5), the parquet file size could reach to 4KiB...

This PR simply uses parquet's default setup, which already enables dictionary encoding, bloom filter, etc.
The snappy compression comes from pg_mooncake's v0.1 and nimtable's setup.

Reference:
- parquet default setup: https://github.com/apache/arrow-rs/blob/7e38bbb0c9f0d4379fe109884c90ab2254ce86af/parquet/src/file/properties.rs#L29-L64
- nimtable's setup: https://github.com/nimtable/iceberg-compaction/blob/23012c422989c9d443c5e7ba59df96d3f9522d1a/core/src/config/mod.rs#L38-L45 

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
