### PR TITLE
[storage] Set s3 endpoint for glue catalog properties

### DIFF
--- a/src/moonlink/src/storage/filesystem/storage_config.rs
+++ b/src/moonlink/src/storage/filesystem/storage_config.rs
@@ -125,6 +125,46 @@ impl StorageConfig {
         }
     }
 
+    /// Get region for object storage config.
+    pub fn get_region(&self) -> Option<String> {
+        match &self {
+            #[cfg(feature = "storage-fs")]
+            StorageConfig::FileSystem { .. } => None,
+            #[cfg(feature = "storage-gcs")]
+            StorageConfig::Gcs { region, .. } => Some(region.clone()),
+            #[cfg(feature = "storage-s3")]
+            StorageConfig::S3 { region, .. } => Some(region.clone()),
+        }
+    }
+
+    /// Get access key id.
+    pub fn get_access_key_id(&self) -> Option<String> {
+        match &self {
+            #[cfg(feature = "storage-fs")]
+            StorageConfig::FileSystem { .. } => None,
+            #[cfg(feature = "storage-gcs")]
+            StorageConfig::Gcs { access_key_id, .. } => Some(access_key_id.clone()),
+            #[cfg(feature = "storage-s3")]
+            StorageConfig::S3 { access_key_id, .. } => Some(access_key_id.clone()),
+        }
+    }
+
+    /// Get secret access key.
+    pub fn get_secret_access_key(&self) -> Option<String> {
+        match &self {
+            #[cfg(feature = "storage-fs")]
+            StorageConfig::FileSystem { .. } => None,
+            #[cfg(feature = "storage-gcs")]
+            StorageConfig::Gcs {
+                secret_access_key, ..
+            } => Some(secret_access_key.clone()),
+            #[cfg(feature = "storage-s3")]
+            StorageConfig::S3 {
+                secret_access_key, ..
+            } => Some(secret_access_key.clone()),
+        }
+    }
+
     /// Extract security metadata entry from current filesystem config.
     pub fn extract_security_metadata_entry(&self) -> Option<MoonlinkTableSecret> {
         match &self {

--- a/src/moonlink/src/storage/iceberg.rs
+++ b/src/moonlink/src/storage/iceberg.rs
@@ -24,6 +24,7 @@ mod table_update_proxy;
 
 #[cfg(feature = "catalog-glue")]
 pub(super) mod glue_catalog;
+
 #[cfg(feature = "catalog-rest")]
 pub(super) mod rest_catalog;
 
@@ -42,6 +43,9 @@ mod s3_test_utils;
 #[cfg(feature = "storage-gcs")]
 #[cfg(test)]
 mod gcs_test_utils;
+
+#[cfg(feature = "catalog-glue")]
+mod aws_security_config;
 
 #[cfg(test)]
 mod tests;

--- a/src/moonlink/src/storage/iceberg/aws_security_config.rs
+++ b/src/moonlink/src/storage/iceberg/aws_security_config.rs
@@ -1,0 +1,27 @@
+/// AWS security config.
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Deserialize, PartialEq, Serialize)]
+pub struct AwsSecurityConfig {
+    #[serde(rename = "access_key_id")]
+    #[serde(default)]
+    pub access_key_id: String,
+
+    #[serde(rename = "security_access_key")]
+    #[serde(default)]
+    pub security_access_key: String,
+
+    #[serde(rename = "region")]
+    #[serde(default)]
+    pub region: String,
+}
+
+impl std::fmt::Debug for AwsSecurityConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AwsSecurityConfig")
+            .field("access_key_id", &"xxxxx")
+            .field("security_access_key", &"xxxx")
+            .field("region", &self.region)
+            .finish()
+    }
+}

--- a/src/moonlink/src/storage/iceberg/iceberg_glue_catalog_test.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_glue_catalog_test.rs
@@ -1,6 +1,7 @@
 use crate::row::MoonlinkRow;
 use crate::row::RowValue;
 use crate::storage::filesystem::s3::s3_test_utils::create_s3_storage_config;
+use crate::storage::filesystem::s3::s3_test_utils::S3_TEST_ENDPOINT;
 use crate::storage::filesystem::s3::test_guard::TestGuard as S3TestGuard;
 use crate::storage::iceberg::catalog_test_utils::create_test_table_schema;
 use crate::storage::iceberg::glue_catalog::GlueCatalog;
@@ -39,13 +40,13 @@ fn test_row_with_updated_schema() -> MoonlinkRow {
 
 /// Test util function to create iceberg table config.
 fn create_iceberg_table_config(warehouse_uri: String) -> IcebergTableConfig {
-    let glue_catalog_props = create_glue_catalog_properties(warehouse_uri.clone());
     let glue_catalog_config = GlueCatalogConfig {
+        aws_security_config: create_aws_security_config(),
         name: get_random_glue_catalog_name(),
         uri: TEST_GLUE_ENDPOINT.to_string(),
         catalog_id: None,
         warehouse: warehouse_uri.clone(),
-        props: glue_catalog_props,
+        s3_endpoint: Some(S3_TEST_ENDPOINT.to_string()),
     };
 
     let accessor_config = create_s3_storage_config(&warehouse_uri);

--- a/src/moonlink/src/storage/iceberg/iceberg_table_config.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_config.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "catalog-glue")]
+use crate::storage::iceberg::aws_security_config::AwsSecurityConfig;
 use crate::{storage::filesystem::accessor_config::AccessorConfig, StorageConfig};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
@@ -33,10 +35,23 @@ pub struct RestCatalogConfig {
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct GlueCatalogConfig {
+    /// ========================
+    /// AWS security configs.
+    /// ========================
+    ///
+    #[cfg(feature = "catalog-glue")]
+    #[serde(rename = "aws_security_config")]
+    pub aws_security_config: AwsSecurityConfig,
+
+    /// ========================
+    /// Glue properties
+    /// ========================
+    ///
     #[serde(rename = "name")]
     #[serde(default)]
     pub name: String,
 
+    /// Glue catalog URI.
     #[serde(rename = "uri")]
     #[serde(default)]
     pub uri: String,
@@ -45,13 +60,15 @@ pub struct GlueCatalogConfig {
     #[serde(default)]
     pub catalog_id: Option<String>,
 
+    /// Notice, it should match data access config.
     #[serde(rename = "warehouse")]
     #[serde(default)]
     pub warehouse: String,
 
-    #[serde(rename = "props")]
+    /// If unassigned (default option), use https://s3.{s3_region}.amazonaws.com as endpoint.
+    #[serde(rename = "s3_endpoint")]
     #[serde(default)]
-    pub props: HashMap<String, String>,
+    pub s3_endpoint: Option<String>,
 }
 
 pub type FileCatalogConfig = AccessorConfig;


### PR DESCRIPTION
## Summary

When iceberg-rust creates `FileIO`, it resolves endpoint in the order of (1) first s3 endpoint; (2) then iceberg catalog URI.
Also there's another missing piece in the current implementation: aws security config, which decides whether glue catalog has the permission to create database, table, etc.

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
