### PR TITLE
[storage] Set parquet config for compaction

### DIFF
--- a/src/moonlink/src/storage/compaction/compactor.rs
+++ b/src/moonlink/src/storage/compaction/compactor.rs
@@ -140,7 +140,7 @@ impl CompactionBuilder {
         self.cur_new_data_file = Some(self.create_new_data_file());
         let write_file =
             tokio::fs::File::create(self.cur_new_data_file.as_ref().unwrap().file_path()).await?;
-        let properties = parquet_utils::get_default_parquet_properties();
+        let properties = parquet_utils::get_compaction_parquet_properties();
         let writer: AsyncArrowWriter<tokio::fs::File> =
             AsyncArrowWriter::try_new(write_file, self.schema.clone(), Some(properties))?;
         self.cur_arrow_writer = Some(writer);

--- a/src/moonlink/src/storage/parquet_utils.rs
+++ b/src/moonlink/src/storage/parquet_utils.rs
@@ -1,12 +1,20 @@
 /// This module contains parquet related constants and utils.
-use parquet::basic::Compression;
+use parquet::basic::{Compression, ZstdLevel};
 use parquet::file::properties::WriterProperties;
 
 /// Default compression.
 const DEFAULT_COMPRESSION: Compression = parquet::basic::Compression::SNAPPY;
 
+/// Get the parquet write properties for disk slices.
 pub fn get_default_parquet_properties() -> WriterProperties {
     WriterProperties::builder()
         .set_compression(DEFAULT_COMPRESSION)
+        .build()
+}
+
+/// Get the parquet write properties for compacted files.
+pub fn get_compaction_parquet_properties() -> WriterProperties {
+    WriterProperties::builder()
+        .set_compression(Compression::ZSTD(ZstdLevel::try_new(4).unwrap()))
         .build()
 }


### PR DESCRIPTION
## Summary

This PR updates parquet config for compacted parquet files and uncompacted ones.
Follows delta's config: optimize operation uses zstd with compression level 4: https://github.com/delta-io/delta-rs/blob/19e1eb2d67460b2ab32b44782e48dbb7c45d29d6/crates/core/src/operations/optimize.rs#L324-L328

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/2029

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
