### PR TITLE
[storage] Parallelize index import at iceberg snapshot

### DIFF
--- a/src/moonlink/src/storage/iceberg/file_catalog.rs
+++ b/src/moonlink/src/storage/iceberg/file_catalog.rs
@@ -9,6 +9,7 @@ use crate::storage::iceberg::io_utils as iceberg_io_utils;
 use crate::storage::iceberg::moonlink_catalog::{
     CatalogAccess, PuffinBlobType, PuffinWrite, SchemaUpdate,
 };
+use crate::storage::iceberg::puffin_writer_proxy::PuffinBlobMetadataProxy;
 use crate::storage::iceberg::table_commit_proxy::TableCommitProxy;
 use crate::storage::iceberg::table_update_proxy::TableUpdateProxy;
 
@@ -235,6 +236,18 @@ impl FileCatalog {
 
 #[async_trait]
 impl PuffinWrite for FileCatalog {
+    fn record_puffin_metadata(
+        &mut self,
+        puffin_filepath: String,
+        puffin_metadata: Vec<PuffinBlobMetadataProxy>,
+        puffin_blob_type: PuffinBlobType,
+    ) {
+        self.table_update_proxy.record_puffin_metadata(
+            puffin_filepath,
+            puffin_metadata,
+            puffin_blob_type,
+        );
+    }
     async fn record_puffin_metadata_and_close(
         &mut self,
         puffin_filepath: String,

--- a/src/moonlink/src/storage/iceberg/glue_catalog.rs
+++ b/src/moonlink/src/storage/iceberg/glue_catalog.rs
@@ -232,6 +232,18 @@ impl Catalog for GlueCatalog {
 
 #[async_trait]
 impl PuffinWrite for GlueCatalog {
+    fn record_puffin_metadata(
+        &mut self,
+        puffin_filepath: String,
+        puffin_metadata: Vec<PuffinBlobMetadataProxy>,
+        puffin_blob_type: PuffinBlobType,
+    ) {
+        self.table_update_proxy.record_puffin_metadata(
+            puffin_filepath,
+            puffin_metadata,
+            puffin_blob_type,
+        );
+    }
     async fn record_puffin_metadata_and_close(
         &mut self,
         puffin_filepath: String,

--- a/src/moonlink/src/storage/iceberg/glue_catalog.rs
+++ b/src/moonlink/src/storage/iceberg/glue_catalog.rs
@@ -5,6 +5,7 @@ use crate::storage::iceberg::catalog_utils::{
 };
 use crate::storage::iceberg::iceberg_table_config::GlueCatalogConfig;
 use crate::storage::iceberg::io_utils as iceberg_io_utils;
+use crate::storage::iceberg::puffin_writer_proxy::PuffinBlobMetadataProxy;
 use crate::storage::iceberg::table_commit_proxy::TableCommitProxy;
 use crate::storage::iceberg::table_update_proxy::TableUpdateProxy;
 use crate::StorageConfig;

--- a/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
@@ -141,15 +141,6 @@ impl IcebergTableManager {
             &format!("{}-deletion-vector-v1-puffin.bin", Uuid::now_v7()),
         )
     }
-    pub(super) fn get_unique_hash_index_v1_filepath(&self) -> String {
-        let location_generator =
-            DefaultLocationGenerator::new(self.iceberg_table.as_ref().unwrap().metadata().clone())
-                .unwrap();
-        location_generator.generate_location(
-            /*partition_key=*/ None,
-            &format!("{}-hash-index-v1-puffin.bin", Uuid::now_v7()),
-        )
-    }
 
     /// Get or create an iceberg table based on the iceberg manager config.
     ///

--- a/src/moonlink/src/storage/iceberg/iceberg_table_syncer.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_syncer.rs
@@ -105,7 +105,7 @@ async fn import_one_file_index(
         let remote_index_block = iceberg_io_utils::upload_index_file(
             iceberg_table,
             cur_index_block.index_file.file_path(),
-            &*filesystem_accessor,
+            filesystem_accessor,
         )
         .await?;
         local_index_file_to_remote.insert(
@@ -532,7 +532,7 @@ impl IcebergTableManager {
             stream::iter(file_indices_to_import_clone.into_iter())
                 .map(move |mooncake_file_index: MooncakeFileIndex| {
                     let iceberg_table = iceberg_table;
-                    let puffin_filepath = get_unique_hash_index_v1_filepath(&iceberg_table);
+                    let puffin_filepath = get_unique_hash_index_v1_filepath(iceberg_table);
                     let filesystem_accessor = filesystem_accessor;
                     let local_data_file_to_remote_clone = local_data_file_to_remote_clone.clone();
 
@@ -547,7 +547,7 @@ impl IcebergTableManager {
                         .await
                     }
                 })
-                .buffered(DEFAULT_FILE_INDEX_IMPORT_CONCURRENCY)
+                .buffer_unordered(DEFAULT_FILE_INDEX_IMPORT_CONCURRENCY)
                 .try_collect()
                 .await?;
 

--- a/src/moonlink/src/storage/iceberg/moonlink_catalog.rs
+++ b/src/moonlink/src/storage/iceberg/moonlink_catalog.rs
@@ -7,6 +7,8 @@ use iceberg::{Catalog, Result as IcebergResult, TableIdent};
 
 use std::collections::HashSet;
 
+use crate::storage::iceberg::puffin_writer_proxy::PuffinBlobMetadataProxy;
+
 pub enum PuffinBlobType {
     DeletionVector,
     FileIndex,
@@ -16,6 +18,13 @@ pub enum PuffinBlobType {
 /// we record puffin metadata ourselves and rewrite manifest file before transaction commits.
 #[async_trait]
 pub trait PuffinWrite {
+    /// Record persisted puffin metadata.
+    fn record_puffin_metadata(
+        &mut self,
+        puffin_filepath: String,
+        puffin_metadata: Vec<PuffinBlobMetadataProxy>,
+        puffin_blob_type: PuffinBlobType,
+    );
     /// Add puffin metadata from the writer, and close it.
     async fn record_puffin_metadata_and_close(
         &mut self,

--- a/src/moonlink/src/storage/iceberg/rest_catalog.rs
+++ b/src/moonlink/src/storage/iceberg/rest_catalog.rs
@@ -180,6 +180,18 @@ impl Catalog for RestCatalog {
 
 #[async_trait]
 impl PuffinWrite for RestCatalog {
+    fn record_puffin_metadata(
+        &mut self,
+        puffin_filepath: String,
+        puffin_metadata: Vec<PuffinBlobMetadataProxy>,
+        puffin_blob_type: PuffinBlobType,
+    ) {
+        self.table_update_proxy.record_puffin_metadata(
+            puffin_filepath,
+            puffin_metadata,
+            puffin_blob_type,
+        );
+    }
     async fn record_puffin_metadata_and_close(
         &mut self,
         puffin_filepath: String,

--- a/src/moonlink/src/storage/iceberg/rest_catalog.rs
+++ b/src/moonlink/src/storage/iceberg/rest_catalog.rs
@@ -5,6 +5,7 @@ use crate::storage::iceberg::catalog_utils::{
 };
 use crate::storage::iceberg::iceberg_table_config::RestCatalogConfig;
 use crate::storage::iceberg::io_utils as iceberg_io_utils;
+use crate::storage::iceberg::puffin_writer_proxy::PuffinBlobMetadataProxy;
 use crate::storage::iceberg::table_commit_proxy::TableCommitProxy;
 use crate::storage::iceberg::table_update_proxy::TableUpdateProxy;
 use async_trait::async_trait;

--- a/src/moonlink/src/storage/iceberg/utils.rs
+++ b/src/moonlink/src/storage/iceberg/utils.rs
@@ -7,6 +7,8 @@ use arrow_schema::Schema as ArrowSchema;
 use iceberg::arrow as IcebergArrow;
 use iceberg::spec::{DataContentType, DataFileFormat, ManifestEntry};
 use iceberg::table::Table as IcebergTable;
+use iceberg::writer::file_writer::location_generator::DefaultLocationGenerator;
+use iceberg::writer::file_writer::location_generator::LocationGenerator;
 use iceberg::{NamespaceIdent, Result as IcebergResult, TableCreation, TableIdent};
 
 /// Return whether the given manifest entry represents data files.
@@ -135,4 +137,13 @@ pub(crate) async fn get_table_if_exists<C: MoonlinkCatalog + ?Sized>(
 
     let table = catalog.load_table(&table_ident).await?;
     Ok(Some(table))
+}
+
+pub(crate) fn get_unique_hash_index_v1_filepath(iceberg_table: &IcebergTable) -> String {
+    let location_generator =
+        DefaultLocationGenerator::new(iceberg_table.metadata().clone()).unwrap();
+    location_generator.generate_location(
+        /*partition_key=*/ None,
+        &format!("{}-hash-index-v1-puffin.bin", uuid::Uuid::now_v7()),
+    )
 }

--- a/src/moonlink/src/storage/iceberg/utils.rs
+++ b/src/moonlink/src/storage/iceberg/utils.rs
@@ -139,6 +139,7 @@ pub(crate) async fn get_table_if_exists<C: MoonlinkCatalog + ?Sized>(
     Ok(Some(table))
 }
 
+/// Get a unique remote index filepath.
 pub(crate) fn get_unique_hash_index_v1_filepath(iceberg_table: &IcebergTable) -> String {
     let location_generator =
         DefaultLocationGenerator::new(iceberg_table.metadata().clone()).unwrap();


### PR DESCRIPTION
## Summary

Current all IO operations (including file indices upload, manifest file write, etc) are all blocking and sequential IO, which means IO latency simply accumulates. 
It's a known issue, this PR parallelize the upload.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/2047

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
