### PR TITLE
[storage] Apply schema evolution mechanisms to iceberg index data structure

### DIFF
--- a/src/moonlink/src/storage/iceberg/index.rs
+++ b/src/moonlink/src/storage/iceberg/index.rs
@@ -24,9 +24,13 @@ pub(crate) const MOONCAKE_HASH_INDEX_V1_CARDINALITY: &str = "cardinality";
 /// Corresponds to [storage::index::IndexBlock], which records the metadata for each index block.
 #[derive(Deserialize, PartialEq, Serialize)]
 pub(crate) struct IndexBlock {
+    #[serde(default, rename = "bucket_start_idx")] 
     bucket_start_idx: u32,
+    #[serde(default, rename = "bucket_end_idx")] 
     bucket_end_idx: u32,
+    #[serde(default, rename = "bucket_start_offset")] 
     bucket_start_offset: u64,
+    #[serde(default, rename = "filepath")] 
     pub(crate) filepath: String,
 }
 
@@ -34,16 +38,25 @@ pub(crate) struct IndexBlock {
 #[derive(Default, Deserialize, Serialize)]
 pub(crate) struct FileIndex {
     /// Data file paths at iceberg table.
+    #[serde(default, rename = "data_files")] 
     data_files: Vec<String>,
     /// Corresponds to [storage::index::IndexBlock].
+    #[serde(default, rename = "index_block_files")] 
     pub index_block_files: Vec<IndexBlock>, // TODO
     /// Hash related fields.
+    #[serde(default, rename = "num_rows")] 
     num_rows: u32,
+    #[serde(default, rename = "hash_bits")] 
     hash_bits: u32,
+    #[serde(default, rename = "hash_upper_bits")] 
     hash_upper_bits: u32,
+    #[serde(default, rename = "hash_lower_bits")] 
     hash_lower_bits: u32,
+    #[serde(default, rename = "seg_id_bits")] 
     seg_id_bits: u32,
+    #[serde(default, rename = "row_id_bits")] 
     row_id_bits: u32,
+    #[serde(default, rename = "bucket_bits")] 
     bucket_bits: u32,
 }
 

--- a/src/moonlink/src/storage/iceberg/index.rs
+++ b/src/moonlink/src/storage/iceberg/index.rs
@@ -24,13 +24,13 @@ pub(crate) const MOONCAKE_HASH_INDEX_V1_CARDINALITY: &str = "cardinality";
 /// Corresponds to [storage::index::IndexBlock], which records the metadata for each index block.
 #[derive(Deserialize, PartialEq, Serialize)]
 pub(crate) struct IndexBlock {
-    #[serde(default, rename = "bucket_start_idx")]
+    #[serde(rename = "bucket_start_idx")]
     bucket_start_idx: u32,
-    #[serde(default, rename = "bucket_end_idx")]
+    #[serde(rename = "bucket_end_idx")]
     bucket_end_idx: u32,
-    #[serde(default, rename = "bucket_start_offset")]
+    #[serde(rename = "bucket_start_offset")]
     bucket_start_offset: u64,
-    #[serde(default, rename = "filepath")]
+    #[serde(rename = "filepath")]
     pub(crate) filepath: String,
 }
 
@@ -38,25 +38,25 @@ pub(crate) struct IndexBlock {
 #[derive(Default, Deserialize, Serialize)]
 pub(crate) struct FileIndex {
     /// Data file paths at iceberg table.
-    #[serde(default, rename = "data_files")]
+    #[serde(rename = "data_files")]
     data_files: Vec<String>,
     /// Corresponds to [storage::index::IndexBlock].
-    #[serde(default, rename = "index_block_files")]
+    #[serde(rename = "index_block_files")]
     pub index_block_files: Vec<IndexBlock>, // TODO
     /// Hash related fields.
-    #[serde(default, rename = "num_rows")]
+    #[serde(rename = "num_rows")]
     num_rows: u32,
-    #[serde(default, rename = "hash_bits")]
+    #[serde(rename = "hash_bits")]
     hash_bits: u32,
-    #[serde(default, rename = "hash_upper_bits")]
+    #[serde(rename = "hash_upper_bits")]
     hash_upper_bits: u32,
-    #[serde(default, rename = "hash_lower_bits")]
+    #[serde(rename = "hash_lower_bits")]
     hash_lower_bits: u32,
-    #[serde(default, rename = "seg_id_bits")]
+    #[serde(rename = "seg_id_bits")]
     seg_id_bits: u32,
-    #[serde(default, rename = "row_id_bits")]
+    #[serde(rename = "row_id_bits")]
     row_id_bits: u32,
-    #[serde(default, rename = "bucket_bits")]
+    #[serde(rename = "bucket_bits")]
     bucket_bits: u32,
 }
 

--- a/src/moonlink/src/storage/iceberg/index.rs
+++ b/src/moonlink/src/storage/iceberg/index.rs
@@ -24,13 +24,13 @@ pub(crate) const MOONCAKE_HASH_INDEX_V1_CARDINALITY: &str = "cardinality";
 /// Corresponds to [storage::index::IndexBlock], which records the metadata for each index block.
 #[derive(Deserialize, PartialEq, Serialize)]
 pub(crate) struct IndexBlock {
-    #[serde(default, rename = "bucket_start_idx")] 
+    #[serde(default, rename = "bucket_start_idx")]
     bucket_start_idx: u32,
-    #[serde(default, rename = "bucket_end_idx")] 
+    #[serde(default, rename = "bucket_end_idx")]
     bucket_end_idx: u32,
-    #[serde(default, rename = "bucket_start_offset")] 
+    #[serde(default, rename = "bucket_start_offset")]
     bucket_start_offset: u64,
-    #[serde(default, rename = "filepath")] 
+    #[serde(default, rename = "filepath")]
     pub(crate) filepath: String,
 }
 
@@ -38,25 +38,25 @@ pub(crate) struct IndexBlock {
 #[derive(Default, Deserialize, Serialize)]
 pub(crate) struct FileIndex {
     /// Data file paths at iceberg table.
-    #[serde(default, rename = "data_files")] 
+    #[serde(default, rename = "data_files")]
     data_files: Vec<String>,
     /// Corresponds to [storage::index::IndexBlock].
-    #[serde(default, rename = "index_block_files")] 
+    #[serde(default, rename = "index_block_files")]
     pub index_block_files: Vec<IndexBlock>, // TODO
     /// Hash related fields.
-    #[serde(default, rename = "num_rows")] 
+    #[serde(default, rename = "num_rows")]
     num_rows: u32,
-    #[serde(default, rename = "hash_bits")] 
+    #[serde(default, rename = "hash_bits")]
     hash_bits: u32,
-    #[serde(default, rename = "hash_upper_bits")] 
+    #[serde(default, rename = "hash_upper_bits")]
     hash_upper_bits: u32,
-    #[serde(default, rename = "hash_lower_bits")] 
+    #[serde(default, rename = "hash_lower_bits")]
     hash_lower_bits: u32,
-    #[serde(default, rename = "seg_id_bits")] 
+    #[serde(default, rename = "seg_id_bits")]
     seg_id_bits: u32,
-    #[serde(default, rename = "row_id_bits")] 
+    #[serde(default, rename = "row_id_bits")]
     row_id_bits: u32,
-    #[serde(default, rename = "bucket_bits")] 
+    #[serde(default, rename = "bucket_bits")]
     bucket_bits: u32,
 }
 


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

add serde default & rename annotatinos to IndexBlock & FileIndex, ensuring that struct field modifications maintain backward compatibility for serialization and deserialization.

## Related Issues

https://github.com/Mooncake-Labs/moonlink/issues/1573

## Changes

- add serde default & rename annotatinos to IndexBlock & FileIndex
- 
- 

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
