### PR TITLE
Parallelize deletion vector sync

### DIFF
--- a/src/moonlink/src/storage/iceberg/catalog_utils.rs
+++ b/src/moonlink/src/storage/iceberg/catalog_utils.rs
@@ -6,16 +6,13 @@ use crate::storage::iceberg::glue_catalog::GlueCatalog;
 use crate::storage::iceberg::iceberg_table_config::IcebergCatalogConfig;
 use crate::storage::iceberg::iceberg_table_config::IcebergTableConfig;
 use crate::storage::iceberg::moonlink_catalog::MoonlinkCatalog;
-use crate::storage::iceberg::moonlink_catalog::PuffinBlobType;
 use crate::storage::iceberg::puffin_writer_proxy::append_puffin_metadata_and_rewrite;
-use crate::storage::iceberg::puffin_writer_proxy::get_puffin_metadata_and_close;
 #[cfg(feature = "catalog-rest")]
 use crate::storage::iceberg::rest_catalog::RestCatalog;
 use crate::storage::iceberg::table_commit_proxy::TableCommitProxy;
 use crate::storage::iceberg::table_update_proxy::TableUpdateProxy;
 
 use iceberg::io::FileIO;
-use iceberg::puffin::PuffinWriter;
 use iceberg::spec::Schema as IcebergSchema;
 use iceberg::spec::TableMetadata;
 use iceberg::table::Table;
@@ -144,18 +141,6 @@ pub fn create_catalog_with_filesystem_accessor(
         filesystem_accessor,
         iceberg_schema,
     )?))
-}
-
-/// Close puffin writer and record metadata in [`table_update_proxy`].
-pub(crate) async fn close_puffin_writer_and_record_metadata(
-    puffin_filepath: String,
-    puffin_writer: PuffinWriter,
-    puffin_blob_type: PuffinBlobType,
-    table_update_proxy: &mut TableUpdateProxy,
-) -> IcebergResult<()> {
-    let puffin_metadata = get_puffin_metadata_and_close(puffin_writer).await?;
-    table_update_proxy.record_puffin_metadata(puffin_filepath, puffin_metadata, puffin_blob_type);
-    Ok(())
 }
 
 /// Create table implementation, with schema de-normalized.

--- a/src/moonlink/src/storage/iceberg/file_catalog.rs
+++ b/src/moonlink/src/storage/iceberg/file_catalog.rs
@@ -2,9 +2,7 @@ use super::puffin_writer_proxy::append_puffin_metadata_and_rewrite;
 use crate::storage::filesystem::accessor::base_filesystem_accessor::BaseFileSystemAccess;
 use crate::storage::filesystem::accessor::factory::create_filesystem_accessor;
 use crate::storage::filesystem::accessor_config::AccessorConfig;
-use crate::storage::iceberg::catalog_utils::{
-    close_puffin_writer_and_record_metadata, reflect_table_updates, validate_table_requirements,
-};
+use crate::storage::iceberg::catalog_utils::{reflect_table_updates, validate_table_requirements};
 use crate::storage::iceberg::io_utils as iceberg_io_utils;
 use crate::storage::iceberg::moonlink_catalog::{
     CatalogAccess, PuffinBlobType, PuffinWrite, SchemaUpdate,
@@ -49,7 +47,6 @@ use tokio::sync::Mutex;
 
 use async_trait::async_trait;
 use iceberg::io::FileIO;
-use iceberg::puffin::PuffinWriter;
 use iceberg::spec::{
     Schema as IcebergSchema, TableMetadata, TableMetadataBuildResult, TableMetadataBuilder,
 };
@@ -247,21 +244,6 @@ impl PuffinWrite for FileCatalog {
             puffin_metadata,
             puffin_blob_type,
         );
-    }
-    async fn record_puffin_metadata_and_close(
-        &mut self,
-        puffin_filepath: String,
-        puffin_writer: PuffinWriter,
-        puffin_blob_type: PuffinBlobType,
-    ) -> IcebergResult<()> {
-        close_puffin_writer_and_record_metadata(
-            puffin_filepath,
-            puffin_writer,
-            puffin_blob_type,
-            &mut self.table_update_proxy,
-        )
-        .await?;
-        Ok(())
     }
 
     fn set_data_files_to_remove(&mut self, data_files: HashSet<String>) {

--- a/src/moonlink/src/storage/iceberg/glue_catalog.rs
+++ b/src/moonlink/src/storage/iceberg/glue_catalog.rs
@@ -1,8 +1,6 @@
 use super::moonlink_catalog::{CatalogAccess, PuffinBlobType, PuffinWrite, SchemaUpdate};
 use crate::storage::filesystem::accessor_config::AccessorConfig;
-use crate::storage::iceberg::catalog_utils::{
-    close_puffin_writer_and_record_metadata, create_table_impl, update_table_impl,
-};
+use crate::storage::iceberg::catalog_utils::{create_table_impl, update_table_impl};
 use crate::storage::iceberg::iceberg_table_config::GlueCatalogConfig;
 use crate::storage::iceberg::io_utils as iceberg_io_utils;
 use crate::storage::iceberg::puffin_writer_proxy::PuffinBlobMetadataProxy;
@@ -11,7 +9,6 @@ use crate::storage::iceberg::table_update_proxy::TableUpdateProxy;
 use crate::StorageConfig;
 use async_trait::async_trait;
 use iceberg::io::{FileIO, S3_ACCESS_KEY_ID, S3_ENDPOINT, S3_REGION, S3_SECRET_ACCESS_KEY};
-use iceberg::puffin::PuffinWriter;
 use iceberg::spec::{Schema as IcebergSchema, TableMetadata};
 use iceberg::table::Table;
 use iceberg::CatalogBuilder;
@@ -253,21 +250,6 @@ impl PuffinWrite for GlueCatalog {
             puffin_metadata,
             puffin_blob_type,
         );
-    }
-    async fn record_puffin_metadata_and_close(
-        &mut self,
-        puffin_filepath: String,
-        puffin_writer: PuffinWriter,
-        puffin_blob_type: PuffinBlobType,
-    ) -> IcebergResult<()> {
-        close_puffin_writer_and_record_metadata(
-            puffin_filepath,
-            puffin_writer,
-            puffin_blob_type,
-            &mut self.table_update_proxy,
-        )
-        .await?;
-        Ok(())
     }
 
     fn set_data_files_to_remove(&mut self, data_files: HashSet<String>) {

--- a/src/moonlink/src/storage/iceberg/iceberg_table_syncer.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_syncer.rs
@@ -1,4 +1,3 @@
-use crate::storage::cache::object_storage::base_cache::InlineEvictedFiles;
 use crate::storage::compaction::table_compaction::RemappedRecordLocation;
 use crate::storage::filesystem::accessor::base_filesystem_accessor::BaseFileSystemAccess;
 use crate::storage::iceberg::deletion_vector::DeletionVector;
@@ -25,7 +24,7 @@ use crate::storage::mooncake_table::IcebergSnapshotPayload;
 use crate::storage::mooncake_table::{
     take_data_files_to_import, take_file_indices_to_import, take_file_indices_to_remove,
 };
-use crate::storage::storage_utils;
+use crate::storage::storage_utils::{self, MooncakeDataFile};
 use crate::storage::storage_utils::{
     create_data_file, get_unique_file_id_for_flush, FileId, MooncakeDataFileRef, RecordLocation,
     TableId, TableUniqueFileId,
@@ -34,11 +33,12 @@ use crate::Result;
 
 use futures::{stream, StreamExt, TryStreamExt};
 use iceberg::table::Table;
+use smallvec::SmallVec;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::vec;
 
-use iceberg::puffin::CompressionCodec;
+use iceberg::puffin::{CompressionCodec, PuffinWriter};
 use iceberg::spec::DataFile;
 use iceberg::transaction::{ApplyTransactionAction, Transaction};
 use iceberg::{Error as IcebergError, Result as IcebergResult};
@@ -63,11 +63,6 @@ pub struct DataFileImportResult {
     remapped_deletion_records: HashMap<MooncakeDataFileRef, BatchDeletionVector>,
 }
 
-/// Result for writing one deletion vector into iceberg table.
-struct DeletionVectorWriteResult {
-    puffin_blob_ref: PuffinBlobRef,
-    evicted_files_to_delete: InlineEvictedFiles,
-}
 /// Result for writing deletion vectors into iceberg table.
 struct DeletionVectorsSyncResult {
     puffin_deletion_blobs: HashMap<FileId, PuffinBlobRef>,
@@ -84,6 +79,36 @@ struct SingleFileIndexImportResult {
     puffin_metadata: Vec<PuffinBlobMetadataProxy>,
     /// Puffin filepath.
     puffin_filepath: String,
+}
+
+/// A prepared deletion-vector blob ready for Puffin metadata recording.
+struct PreparedBlob {
+    /// Source data file in Iceberg.
+    data_file: Arc<MooncakeDataFile>,
+    /// Puffin index.
+    puffin_index: u64,
+    /// Blob size.
+    blob_size: usize,
+    /// Catalog entry for the associated data file.
+    entry: DataFileEntry,
+    /// Puffin file path the blob is stored.
+    puffin_filepath: String,
+    /// Puffin writier for the blob.
+    puffin_writer: Option<PuffinWriter>,
+    /// Deleted row count.
+    deleted_row_count: usize,
+}
+
+/// Result of finalizing a deletion-vector blob into the Iceberg table.
+struct FinalizeResult {
+    /// File id.
+    file_id: FileId,
+    /// Puffin blob reference.
+    puffin_blob_ref: PuffinBlobRef,
+    /// Evicted files.
+    evicted_files_to_delete: SmallVec<[String; 1]>,
+    /// Catalog entry describing the associated data file.
+    entry: DataFileEntry,
 }
 
 /// Import one single mooncake file index.
@@ -195,86 +220,6 @@ impl IcebergTableManager {
                 cur_file_idx,
             )),
         }
-    }
-
-    /// Write deletion vector to puffin file.
-    /// Precondition: batch deletion vector is not empty.
-    ///
-    /// Puffin blob write condition:
-    /// 1. No compression is performed, otherwise it's hard to get blob size without another read operation.
-    /// 2. We put one deletion vector within one puffin file.
-    async fn write_deletion_vector(
-        &mut self,
-        data_file: String,
-        deletion_vector: BatchDeletionVector,
-        file_params: &PersistenceFileParams,
-        puffin_index: u64,
-    ) -> IcebergResult<DeletionVectorWriteResult> {
-        let deleted_rows = deletion_vector.collect_deleted_rows();
-        assert!(!deleted_rows.is_empty());
-
-        let deleted_row_count = deleted_rows.len();
-        let mut iceberg_deletion_vector = DeletionVector::new();
-        iceberg_deletion_vector.mark_rows_deleted(deleted_rows);
-        let blob_properties = HashMap::from([
-            (DELETION_VECTOR_REFERENCED_DATA_FILE.to_string(), data_file),
-            (
-                DELETION_VECTOR_CADINALITY.to_string(),
-                deleted_row_count.to_string(),
-            ),
-            (
-                MOONCAKE_DELETION_VECTOR_NUM_ROWS.to_string(),
-                deletion_vector.get_max_rows().to_string(),
-            ),
-        ]);
-        let blob = iceberg_deletion_vector.serialize(blob_properties);
-        let blob_size = blob.data().len();
-        let puffin_filepath = self.get_unique_deletion_vector_filepath();
-        let mut puffin_writer = puffin_utils::create_puffin_writer(
-            self.iceberg_table.as_ref().unwrap().file_io(),
-            &puffin_filepath,
-        )
-        .await?;
-        puffin_writer.add(blob, CompressionCodec::None).await?;
-
-        self.catalog
-            .record_puffin_metadata_and_close(
-                puffin_filepath.clone(),
-                puffin_writer,
-                PuffinBlobType::DeletionVector,
-            )
-            .await?;
-
-        // Import the puffin file in object storage cache.
-        let unique_file_id =
-            self.get_unique_table_id_for_deletion_vector_puffin(file_params, puffin_index);
-        let (cache_handle, evicted_files_to_delete) = self
-            .object_storage_cache
-            .get_cache_entry(
-                unique_file_id,
-                &puffin_filepath,
-                self.filesystem_accessor.as_ref(),
-            )
-            .await
-            .map_err(|e| {
-                IcebergError::new(
-                    iceberg::ErrorKind::Unexpected,
-                    format!("Failed to get cache entry for {puffin_filepath}"),
-                )
-                .with_retryable(true)
-                .with_source(e)
-            })?;
-
-        let puffin_blob_ref = PuffinBlobRef {
-            puffin_file_cache_handle: cache_handle.unwrap(),
-            start_offset: 4_u32, // Puffin file starts with 4 magic bytes.
-            blob_size: blob_size as u32,
-            num_rows: deleted_row_count,
-        };
-        Ok(DeletionVectorWriteResult {
-            puffin_blob_ref,
-            evicted_files_to_delete,
-        })
     }
 
     /// Dump local data files into iceberg table.
@@ -415,7 +360,113 @@ impl IcebergTableManager {
         })
     }
 
+    async fn prepare_deletion_vector_blob(
+        &self,
+        puffin_index: u64,
+        data_file: Arc<MooncakeDataFile>,
+        new_deletion_vector: BatchDeletionVector,
+    ) -> IcebergResult<PreparedBlob> {
+        let mut entry = self
+            .persisted_data_files
+            .get(&data_file.file_id())
+            .unwrap()
+            .clone();
+        assert_eq!(
+            entry.deletion_vector.get_max_rows(),
+            new_deletion_vector.get_max_rows()
+        );
+        entry.deletion_vector.merge_with(&new_deletion_vector);
+        let iceberg_data_file = entry.data_file.file_path().to_string();
+
+        let deleted_rows = entry.deletion_vector.clone().collect_deleted_rows();
+        assert!(!deleted_rows.is_empty());
+
+        let deleted_row_count = deleted_rows.len();
+        let mut iceberg_deletion_vector = DeletionVector::new();
+        iceberg_deletion_vector.mark_rows_deleted(deleted_rows);
+
+        let blob_properties = HashMap::from([
+            (
+                DELETION_VECTOR_REFERENCED_DATA_FILE.to_string(),
+                iceberg_data_file.clone(),
+            ),
+            (
+                DELETION_VECTOR_CADINALITY.to_string(),
+                deleted_row_count.to_string(),
+            ),
+            (
+                MOONCAKE_DELETION_VECTOR_NUM_ROWS.to_string(),
+                entry.deletion_vector.get_max_rows().to_string(),
+            ),
+        ]);
+        let blob = iceberg_deletion_vector.serialize(blob_properties);
+        let blob_size = blob.data().len();
+        let puffin_filepath = self.get_unique_deletion_vector_filepath();
+        let mut puffin_writer = puffin_utils::create_puffin_writer(
+            self.iceberg_table.as_ref().unwrap().file_io(),
+            &puffin_filepath,
+        )
+        .await?;
+        puffin_writer.add(blob, CompressionCodec::None).await?;
+        Ok(PreparedBlob {
+            data_file,
+            puffin_index,
+            blob_size,
+            puffin_filepath,
+            puffin_writer: Some(puffin_writer),
+            deleted_row_count,
+            entry,
+        })
+    }
+
+    async fn finalize_deletion_vector(
+        &self,
+        file_params: &PersistenceFileParams,
+        puffin_out: PreparedBlob,
+    ) -> IcebergResult<FinalizeResult> {
+        let unique_file_id = self
+            .get_unique_table_id_for_deletion_vector_puffin(file_params, puffin_out.puffin_index);
+        let (cache_handle, evicted_files_to_delete) = self
+            .object_storage_cache
+            .get_cache_entry(
+                unique_file_id,
+                &puffin_out.puffin_filepath,
+                self.filesystem_accessor.as_ref(),
+            )
+            .await
+            .map_err(|e| {
+                IcebergError::new(
+                    iceberg::ErrorKind::Unexpected,
+                    format!(
+                        "Failed to get cache entry for {}",
+                        puffin_out.puffin_filepath
+                    ),
+                )
+                .with_retryable(true)
+                .with_source(e)
+            })?;
+
+        let puffin_blob_ref = PuffinBlobRef {
+            puffin_file_cache_handle: cache_handle.unwrap(),
+            start_offset: 4_u32, // Puffin file starts with 4 magic bytes.
+            blob_size: puffin_out.blob_size as u32,
+            num_rows: puffin_out.deleted_row_count,
+        };
+
+        Ok(FinalizeResult {
+            file_id: puffin_out.data_file.file_id(),
+            puffin_blob_ref,
+            evicted_files_to_delete,
+            entry: puffin_out.entry,
+        })
+    }
+
     /// Dump committed deletion logs into iceberg table, only the changed part will be persisted.
+    /// Precondition: batch deletion vector is not empty.
+    ///
+    /// Puffin blob write condition:
+    /// 1. No compression is performed, otherwise it's hard to get blob size without another read operation.
+    /// 2. We put one deletion vector within one puffin file.
     async fn sync_deletion_vector(
         &mut self,
         new_deletion_logs: HashMap<MooncakeDataFileRef, BatchDeletionVector>,
@@ -423,41 +474,58 @@ impl IcebergTableManager {
     ) -> IcebergResult<DeletionVectorsSyncResult> {
         let mut puffin_deletion_blobs = HashMap::with_capacity(new_deletion_logs.len());
         let mut evicted_files_to_delete = vec![];
-        for (puffin_index, (data_file, new_deletion_vector)) in
-            new_deletion_logs.into_iter().enumerate()
+        let prepared: Vec<IcebergResult<PreparedBlob>>;
+        let finalized: Vec<IcebergResult<FinalizeResult>>;
         {
-            let mut entry = self
-                .persisted_data_files
-                .get(&data_file.file_id())
-                .unwrap()
-                .clone();
-            assert_eq!(
-                entry.deletion_vector.get_max_rows(),
-                new_deletion_vector.get_max_rows()
-            );
-            entry.deletion_vector.merge_with(&new_deletion_vector);
-
-            // Data filepath in iceberg table.
-            let iceberg_data_file = entry.data_file.file_path();
-            let deletion_vector_write_result = self
-                .write_deletion_vector(
-                    iceberg_data_file.to_string(),
-                    entry.deletion_vector.clone(),
-                    file_params,
-                    puffin_index as u64,
+            let mgr: &Self = self;
+            prepared = stream::iter(new_deletion_logs.into_iter().enumerate().map(
+                |(puffin_index, (data_file, new_deletion_vector))| async move {
+                    let mgr = mgr;
+                    mgr.prepare_deletion_vector_blob(
+                        puffin_index as u64,
+                        data_file,
+                        new_deletion_vector,
+                    )
+                    .await
+                },
+            ))
+            .buffer_unordered(usize::MAX)
+            .collect()
+            .await;
+        }
+        let mut prepared: Vec<PreparedBlob> =
+            prepared.into_iter().collect::<IcebergResult<Vec<_>>>()?;
+        for task in &mut prepared {
+            let writer = task.puffin_writer.take().unwrap();
+            self.catalog
+                .record_puffin_metadata_and_close(
+                    task.puffin_filepath.clone(),
+                    writer,
+                    PuffinBlobType::DeletionVector,
                 )
                 .await?;
-            let puffin_blob_ref = deletion_vector_write_result.puffin_blob_ref;
-            let cur_evicted_files = deletion_vector_write_result.evicted_files_to_delete;
-            let old_entry = self.persisted_data_files.insert(data_file.file_id(), entry);
-            assert!(old_entry.is_some());
-
-            assert!(puffin_deletion_blobs
-                .insert(data_file.file_id(), puffin_blob_ref)
-                .is_none());
-            evicted_files_to_delete.extend(cur_evicted_files);
         }
-
+        {
+            let mgr: &Self = self;
+            finalized = stream::iter(prepared.into_iter().map(|task| async move {
+                let mgr = mgr;
+                mgr.finalize_deletion_vector(file_params, task).await
+            }))
+            .buffer_unordered(usize::MAX)
+            .collect()
+            .await;
+        }
+        for result in finalized {
+            let result = result?;
+            let old_entry = self
+                .persisted_data_files
+                .insert(result.file_id, result.entry);
+            assert!(old_entry.is_some());
+            assert!(puffin_deletion_blobs
+                .insert(result.file_id, result.puffin_blob_ref)
+                .is_none());
+            evicted_files_to_delete.extend(result.evicted_files_to_delete);
+        }
         Ok(DeletionVectorsSyncResult {
             puffin_deletion_blobs,
             evicted_files_to_delete,

--- a/src/moonlink/src/storage/iceberg/iceberg_table_syncer.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_syncer.rs
@@ -91,7 +91,7 @@ struct PreparedDeletionVectorBlob {
     puffin_index: u64,
     /// Blob size.
     blob_size: usize,
-    /// Catalog entry for the associated data file.
+    /// Data file entry
     entry: DataFileEntry,
     /// Puffin file path the blob is stored.
     puffin_filepath: String,
@@ -109,7 +109,7 @@ struct FinalizeDeletionVectorResult {
     puffin_blob_ref: PuffinBlobRef,
     /// Evicted files.
     evicted_files_to_delete: InlineEvictedFiles,
-    /// Catalog entry describing the associated data file.
+    /// Data file entry
     entry: DataFileEntry,
 }
 
@@ -469,7 +469,7 @@ impl IcebergTableManager {
     }
 
     /// Dump committed deletion logs into iceberg table, only the changed part will be persisted.
-    /// Precondition: batch deletion vector in new_deletion_logs is not empty.
+    /// Precondition: batch deletion vector in [`new_deletion_logs`] is not empty.
     ///
     /// Puffin blob write condition:
     /// 1. No compression is performed, otherwise it's hard to get blob size without another read operation.

--- a/src/moonlink/src/storage/iceberg/iceberg_table_syncer.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_syncer.rs
@@ -502,6 +502,7 @@ impl IcebergTableManager {
         }
         let mut prepared: Vec<PreparedDeletionVectorBlob> =
             prepared.into_iter().collect::<IcebergResult<Vec<_>>>()?;
+
         for task in &mut prepared {
             let puffin_metadata = task.puffin_metadata.take().unwrap();
             self.catalog.record_puffin_metadata(

--- a/src/moonlink/src/storage/iceberg/moonlink_catalog.rs
+++ b/src/moonlink/src/storage/iceberg/moonlink_catalog.rs
@@ -1,6 +1,4 @@
 use async_trait::async_trait;
-/// A trait which defines deletion vector write related interfaces.
-use iceberg::puffin::PuffinWriter;
 use iceberg::spec::{Schema as IcebergSchema, TableMetadata};
 use iceberg::table::Table;
 use iceberg::{Catalog, Result as IcebergResult, TableIdent};
@@ -25,14 +23,6 @@ pub trait PuffinWrite {
         puffin_metadata: Vec<PuffinBlobMetadataProxy>,
         puffin_blob_type: PuffinBlobType,
     );
-    /// Add puffin metadata from the writer, and close it.
-    #[allow(dead_code)]
-    async fn record_puffin_metadata_and_close(
-        &mut self,
-        puffin_filepath: String,
-        puffin_writer: PuffinWriter,
-        puffin_blob_type: PuffinBlobType,
-    ) -> IcebergResult<()>;
 
     /// Set data files to remove, their corresponding deletion vectors will be removed alongside.
     fn set_data_files_to_remove(&mut self, data_files: HashSet<String>);

--- a/src/moonlink/src/storage/iceberg/moonlink_catalog.rs
+++ b/src/moonlink/src/storage/iceberg/moonlink_catalog.rs
@@ -26,6 +26,7 @@ pub trait PuffinWrite {
         puffin_blob_type: PuffinBlobType,
     );
     /// Add puffin metadata from the writer, and close it.
+    #[allow(dead_code)]
     async fn record_puffin_metadata_and_close(
         &mut self,
         puffin_filepath: String,

--- a/src/moonlink/src/storage/iceberg/rest_catalog.rs
+++ b/src/moonlink/src/storage/iceberg/rest_catalog.rs
@@ -1,8 +1,6 @@
 use super::moonlink_catalog::{CatalogAccess, PuffinBlobType, PuffinWrite, SchemaUpdate};
 use crate::storage::filesystem::accessor_config::AccessorConfig;
-use crate::storage::iceberg::catalog_utils::{
-    close_puffin_writer_and_record_metadata, create_table_impl, update_table_impl,
-};
+use crate::storage::iceberg::catalog_utils::{create_table_impl, update_table_impl};
 use crate::storage::iceberg::iceberg_table_config::RestCatalogConfig;
 use crate::storage::iceberg::io_utils as iceberg_io_utils;
 use crate::storage::iceberg::puffin_writer_proxy::PuffinBlobMetadataProxy;
@@ -10,7 +8,6 @@ use crate::storage::iceberg::table_commit_proxy::TableCommitProxy;
 use crate::storage::iceberg::table_update_proxy::TableUpdateProxy;
 use async_trait::async_trait;
 use iceberg::io::FileIO;
-use iceberg::puffin::PuffinWriter;
 use iceberg::spec::{Schema as IcebergSchema, TableMetadata};
 use iceberg::table::Table;
 use iceberg::CatalogBuilder;
@@ -192,21 +189,6 @@ impl PuffinWrite for RestCatalog {
             puffin_metadata,
             puffin_blob_type,
         );
-    }
-    async fn record_puffin_metadata_and_close(
-        &mut self,
-        puffin_filepath: String,
-        puffin_writer: PuffinWriter,
-        puffin_blob_type: PuffinBlobType,
-    ) -> IcebergResult<()> {
-        close_puffin_writer_and_record_metadata(
-            puffin_filepath,
-            puffin_writer,
-            puffin_blob_type,
-            &mut self.table_update_proxy,
-        )
-        .await?;
-        Ok(())
     }
 
     fn set_data_files_to_remove(&mut self, data_files: HashSet<String>) {


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary
Refactor deletion-vector sync workflow

- Merged `write_deletion_vector` into `sync_deletion_vector`.
- Introduced `prepare_deletion_vector_blob` and `finalize_deletion_vector`
  to enable parallel execution.

I only tested the code using `cargo test -p moonlink`.

## Related Issues
https://github.com/Mooncake-Labs/moonlink/issues/2046

Closes #<issue-number> or links to related issues.

## Checklist

- [✓] Code builds correctly
