### PR TITLE
Add profile test for append-only table

### DIFF
--- a/src/moonlink/Cargo.toml
+++ b/src/moonlink/Cargo.toml
@@ -40,7 +40,7 @@ catalog-glue = ["iceberg-catalog-glue"]
 bench = []
 
 chaos-test = ["function_name"]
-profile-test = ["pprof"]
+profile-test = ["pprof", "function_name"]
 
 [dependencies]
 ahash = "0.8"

--- a/src/moonlink/src/bin/profile_test.rs
+++ b/src/moonlink/src/bin/profile_test.rs
@@ -1,6 +1,7 @@
-use moonlink::test_normal_profile_on_local_fs;
+use moonlink::{test_append_only_table_profile_on_local_fs, test_normal_profile_on_local_fs};
 
 #[tokio::main]
 async fn main() {
     test_normal_profile_on_local_fs().await;
+    test_append_only_table_profile_on_local_fs().await;
 }

--- a/src/moonlink/src/lib.rs
+++ b/src/moonlink/src/lib.rs
@@ -45,4 +45,6 @@ pub use storage::GlobalIndex;
 pub use storage::GlobalIndexBuilder;
 
 #[cfg(feature = "profile-test")]
-pub use table_handler::profile_test::test_normal_profile_on_local_fs;
+pub use table_handler::profile_test::{
+    test_append_only_table_profile_on_local_fs, test_normal_profile_on_local_fs,
+};


### PR DESCRIPTION
## Summary

Add another profile test for append-only table, exactly the same CPU bottleneck as https://github.com/Mooncake-Labs/moonlink/issues/2089

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
