### PR TITLE
[minor] Switch to unstable sort

### DIFF
--- a/src/moonlink/src/storage/index/persisted_bucket_hash_map.rs
+++ b/src/moonlink/src/storage/index/persisted_bucket_hash_map.rs
@@ -308,7 +308,7 @@ impl GlobalIndex {
         let mut ret = values
             .map(|value| (value, splitmix64(value)))
             .collect::<Vec<_>>();
-        ret.sort_by_key(|(_, hash)| *hash);
+        ret.sort_unstable_by_key(|(_, hash)| *hash);
         ret.dedup_by_key(|(_, hash)| *hash);
         ret
     }

--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -1043,7 +1043,8 @@ impl SnapshotTableState {
             }
         });
         self.add_processed_deletion(already_processed, task.commit_lsn_baseline);
-        new_deletions.sort_by(|a, b| a.lookup_key.cmp(&b.lookup_key).then(a.lsn.cmp(&b.lsn)));
+        new_deletions
+            .sort_unstable_by(|a, b| a.lookup_key.cmp(&b.lookup_key).then(a.lsn.cmp(&b.lsn)));
         if new_deletions.is_empty() {
             return;
         }
@@ -1063,7 +1064,7 @@ impl SnapshotTableState {
             .indices
             .find_records(&new_deletions)
             .await;
-        index_lookup_result.sort_by_key(|(key, _)| *key);
+        index_lookup_result.sort_unstable_by_key(|(key, _)| *key);
         let mut i = 0;
         let mut j = 0;
         while i < new_deletions.len() {


### PR DESCRIPTION
## Summary

Doing some random hunting on flame graph; found stable sorting takes ~1.59% CPU, switch to unstable ones seems to contribute ~0.6% reduction. A minor low-hanging fruit anyway.

## Checklist

- [x] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
