### PR TITLE
Swap send and receive order

### DIFF
--- a/src/moonlink/src/union_read/read_state_manager.rs
+++ b/src/moonlink/src/union_read/read_state_manager.rs
@@ -106,9 +106,9 @@ impl ReadStateManager {
 
         loop {
             let current_snapshot_lsn = *table_snapshot_rx.borrow();
+            let last_commit_lsn_val = *last_commit_lsn.borrow();
             let current_replication_lsn = *replication_lsn_rx.borrow();
 
-            let last_commit_lsn_val = *last_commit_lsn.borrow();
             if self.can_satisfy_read_from_snapshot(
                 requested_lsn,
                 current_snapshot_lsn,


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

Rather than trying to consolidate over a single channel, we can simply swap the send and receive order of our commit and replication LSNs respectively. 

This should prevent the replication LSN from racing ahead of the commit LSN at commit time, however there is no actual mechanism in place that guarantees this. We are using watch channels so the update to these values should be almost instantaneous. If we still see race conditions around read we may need a larger refactor. 

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/2055

## Changes

- 
- 
- 

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
