### PR TITLE
Fix batch index build

### DIFF
--- a/src/moonlink/src/row/moonlink_row.rs
+++ b/src/moonlink/src/row/moonlink_row.rs
@@ -357,6 +357,7 @@ impl IdentityProp {
         match self {
             IdentityProp::SinglePrimitiveKey(_) => row.values[0].to_u64_key(),
             IdentityProp::Keys(keys) => {
+                assert_eq!(row.values.len(), keys.len());
                 let mut hasher = AHasher::default();
                 for i in 0..keys.len() {
                     row.values[i].hash(&mut hasher);

--- a/src/moonlink/src/row/moonlink_row.rs
+++ b/src/moonlink/src/row/moonlink_row.rs
@@ -351,6 +351,29 @@ impl IdentityProp {
         }
     }
 
+    /// Compute lookup key assuming `row` contains only identity columns in identity order.
+    /// This is used when a Parquet projection mask has reduced the row to identity columns.
+    pub fn get_lookup_key_from_identity_row(&self, row: &MoonlinkRow) -> u64 {
+        match self {
+            IdentityProp::SinglePrimitiveKey(_) => row.values[0].to_u64_key(),
+            IdentityProp::Keys(keys) => {
+                let mut hasher = AHasher::default();
+                for i in 0..keys.len() {
+                    row.values[i].hash(&mut hasher);
+                }
+                hasher.finish()
+            }
+            IdentityProp::FullRow => {
+                let mut hasher = AHasher::default();
+                for value in row.values.iter() {
+                    value.hash(&mut hasher);
+                }
+                hasher.finish()
+            }
+            IdentityProp::None => 0,
+        }
+    }
+
     pub fn requires_identity_check_in_mem_slice(&self) -> bool {
         match self {
             IdentityProp::SinglePrimitiveKey(_) => false,


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

When reading the parquet for index build during batch ingestion we project only identity columns via `ProjectionMask`, but then compute the key using the generic `get_lookup_key` which assumes original column positions when indexing. This causes an out of bounds for any table that does not have the first column as a primary key. 

Added `get_lookup_key_from_identity_row` which assumes the row is already projected and contains only identity columns in identity order.

## Related Issues

Closes https://github.com/Mooncake-Labs/moonlink/issues/2105
## Changes

- Add `get_lookup_key_from_identity_row`
- Add regression test
- 

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
