### PR TITLE
fix index build in initial copy

### DIFF
--- a/src/moonlink/src/row/moonlink_row.rs
+++ b/src/moonlink/src/row/moonlink_row.rs
@@ -277,7 +277,8 @@ pub enum IdentityProp {
 }
 
 impl IdentityProp {
-    pub fn new_key(columns: Vec<usize>, fields: &[Field]) -> Self {
+    pub fn new_key(mut columns: Vec<usize>, fields: &[Field]) -> Self {
+        columns.sort_unstable();
         if columns.len() == 1 {
             let width = fields[columns[0]].data_type().primitive_width();
             if width == Some(1) || width == Some(2) || width == Some(4) || width == Some(8) {


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary
Previously identity column can be arbitrarily ordered, and during initial copy, index build will read columns in asceding order, causing a mismatch.

Fix it by sort the columns in create Identity.

Briefly explain what this PR does.

## Related Issues

Closes #<issue-number> or links to related issues.

## Changes

- 
- 
- 

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
