### PR TITLE
otel: Implement RAII latency guard

### DIFF
--- a/src/moonlink/src/observability/latency_exporter.rs
+++ b/src/moonlink/src/observability/latency_exporter.rs
@@ -1,0 +1,10 @@
+use crate::observability::latency_guard::LatencyGuard;
+
+/// An interface to export latency.
+pub(crate) trait BaseLatencyExporter: Send + Sync {
+    /// Start recording latency.
+    /// Returned latency guard will automatically records latency stats.
+    fn start<'a>(&'a self) -> LatencyGuard<'a>;
+    /// Export latency stats.
+    fn record(&self, latency: std::time::Duration, mooncake_table_id: String);
+}

--- a/src/moonlink/src/observability/latency_guard.rs
+++ b/src/moonlink/src/observability/latency_guard.rs
@@ -1,0 +1,32 @@
+/// A RAII wrapper to record latency metrics.
+use crate::observability::latency_exporter::BaseLatencyExporter;
+
+pub(crate) struct LatencyGuard<'a> {
+    /// Start timestamp.
+    start_timestamp: std::time::Instant,
+    /// Mooncake table id.
+    mooncake_table_id: String,
+    /// Latency exporter.
+    latency_exporter: &'a dyn BaseLatencyExporter,
+}
+
+impl<'a> LatencyGuard<'a> {
+    pub(crate) fn new(
+        mooncake_table_id: String,
+        latency_exporter: &'a dyn BaseLatencyExporter,
+    ) -> Self {
+        Self {
+            start_timestamp: std::time::Instant::now(),
+            mooncake_table_id,
+            latency_exporter,
+        }
+    }
+}
+
+impl<'a> Drop for LatencyGuard<'a> {
+    fn drop(&mut self) {
+        let latency = self.start_timestamp.elapsed();
+        let mooncake_table_id = std::mem::take(&mut self.mooncake_table_id);
+        self.latency_exporter.record(latency, mooncake_table_id);
+    }
+}

--- a/src/moonlink/src/observability/mod.rs
+++ b/src/moonlink/src/observability/mod.rs
@@ -1,2 +1,3 @@
+pub(crate) mod latency_exporter;
+pub(crate) mod latency_guard;
 pub(crate) mod snapshot_creation;
-pub(crate) use snapshot_creation::SnapshotCreationStats;

--- a/src/moonlink/src/observability/snapshot_creation.rs
+++ b/src/moonlink/src/observability/snapshot_creation.rs
@@ -1,26 +1,37 @@
+use crate::observability::latency_exporter::BaseLatencyExporter;
+use crate::observability::latency_guard::LatencyGuard;
 use opentelemetry::metrics::Histogram;
 use opentelemetry::{global, KeyValue};
-use std::sync::Arc;
 
 pub(crate) struct SnapshotCreationStats {
+    /// Otel latency histogram exporter.
     latency_hist: Histogram<u64>,
+    /// Mooncake table id.
+    mooncake_table_id: String,
 }
 
 impl SnapshotCreationStats {
-    pub(crate) fn new() -> Arc<Self> {
+    pub(crate) fn new(mooncake_table_id: String) -> Self {
         let meter = global::meter("snapshot_creation");
-        Arc::new(SnapshotCreationStats {
+        SnapshotCreationStats {
+            mooncake_table_id,
             latency_hist: meter
                 .u64_histogram("snapshot_creation_latency")
                 .with_description("snapshot create latency histogram (milliseconds)")
                 .with_boundaries(vec![50.0, 100.0, 200.0, 300.0, 400.0, 500.0])
                 .build(),
-        })
+        }
+    }
+}
+
+impl BaseLatencyExporter for SnapshotCreationStats {
+    fn start<'a>(&'a self) -> LatencyGuard<'a> {
+        LatencyGuard::new(self.mooncake_table_id.clone(), self)
     }
 
-    pub(crate) fn update(&self, t: u64, mooncake_table_id: String) {
+    fn record(&self, latency: std::time::Duration, mooncake_table_id: String) {
         self.latency_hist.record(
-            t,
+            latency.as_millis() as u64,
             &[KeyValue::new(
                 "moonlink.mooncake_table_id",
                 mooncake_table_id,


### PR DESCRIPTION
## Summary

Implement a RAII guard which exports latency stats at destruction, so we don't need to record timestamp twice (before and after operation) and emits automatically.

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
