### PR TITLE
[chaos] Fix non-deterministic replay event

### DIFF
--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -1537,22 +1537,8 @@ impl MooncakeTable {
         snapshot_payload: IcebergSnapshotPayload,
         table_notify: Sender<TableEvent>,
         table_auto_incr_ids: std::ops::Range<u32>,
-        event_replay_tx: Option<mpsc::UnboundedSender<MooncakeTableEvent>>,
         table_event_id: uuid::Uuid,
     ) {
-        // Record index merge event initiation.
-        if let Some(event_replay_tx) = &event_replay_tx {
-            let table_event = replay_events::create_iceberg_snapshot_event_initiation(
-                table_event_id,
-                &snapshot_payload,
-            );
-            event_replay_tx
-                .send(MooncakeTableEvent::IcebergSnapshotInitiation(Box::new(
-                    table_event,
-                )))
-                .unwrap();
-        }
-
         // Perform iceberg snapshot operation.
         let flush_lsn = snapshot_payload.flush_lsn;
         let new_table_schema = snapshot_payload.new_table_schema.clone();
@@ -1694,13 +1680,26 @@ impl MooncakeTable {
         let table_auto_incr_ids = self.next_file_id..(self.next_file_id + new_file_ids_to_create);
         self.next_file_id += new_file_ids_to_create;
         let table_event_id = snapshot_payload.uuid;
+
+        // Record index merge event initiation.
+        if let Some(event_replay_tx) = &self.event_replay_tx {
+            let table_event = replay_events::create_iceberg_snapshot_event_initiation(
+                table_event_id,
+                &snapshot_payload,
+            );
+            event_replay_tx
+                .send(MooncakeTableEvent::IcebergSnapshotInitiation(Box::new(
+                    table_event,
+                )))
+                .unwrap();
+        }
+
         tokio::task::spawn(
             Self::persist_iceberg_snapshot_impl(
                 iceberg_table_manager,
                 snapshot_payload,
                 self.table_notify.as_ref().unwrap().clone(),
                 table_auto_incr_ids,
-                self.event_replay_tx.clone(),
                 table_event_id,
             )
             .instrument(info_span!("persist_iceberg_snapshot")),

--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -611,6 +611,7 @@ impl SnapshotTableState {
         // TODO(hjiang): When there's only schema evolution, we should also flush even no flush.
         let flush_lsn = self.current_snapshot.flush_lsn.unwrap_or(0);
         let largest_flush_lsn = self.current_snapshot.largest_flush_lsn.unwrap_or(0);
+
         if opt.iceberg_snapshot_option != IcebergSnapshotOption::Skip
             && (force_empty_iceberg_payload || flush_by_table_write)
             && flush_lsn < task.min_ongoing_flush_lsn

--- a/src/moonlink/src/table_handler.rs
+++ b/src/moonlink/src/table_handler.rs
@@ -126,7 +126,7 @@ impl TableHandler {
         event_sync_sender: EventSyncSender,
         mut event_receiver: Receiver<TableEvent>,
         replication_lsn_rx: watch::Receiver<u64>,
-        event_replay_tx: Option<mpsc::UnboundedSender<TableEvent>>,
+        handler_event_replay_tx: Option<mpsc::UnboundedSender<TableEvent>>,
         mut table: MooncakeTable,
     ) {
         let iceberg_snapshot_lsn = table.get_iceberg_snapshot_lsn();
@@ -213,7 +213,7 @@ impl TableHandler {
             // Process events until the receiver is closed or a Shutdown event is received
             for event in buf.drain(..) {
                 // Record event if requested.
-                if let Some(replay_tx) = &event_replay_tx {
+                if let Some(replay_tx) = &handler_event_replay_tx {
                     replay_tx.send(event.clone()).unwrap();
                 }
                 match event {


### PR DESCRIPTION
## Summary

Recently we found replay tests failure, some event streams look like
```sh
{"MooncakeSnapshotInitiation":{"uuid":"15f92db5-c3e7-41d9-8588-f58cf696cbde","option":{"uuid":"15f92db5-c3e7-41d9-8588-f58cf696cbde","dump_snapshot":false,"force_create":true,"iceberg_snapshot_option":{"BestEffort":"f534c143-3ae0-42cd-9b28-526af9b1288d"},"index_merge_option":"Skip","data_compaction_option":"Skip"}}}
{"MooncakeSnapshotCompletion":{"uuid":"15f92db5-c3e7-41d9-8588-f58cf696cbde","lsn":729}}
{"IcebergSnapshotInitiation":{"uuid":"f534c143-3ae0-42cd-9b28-526af9b1288d","flush_lsn":729,"committed_deletion_logs":[[10000000000038700,120],[10000000000038700,65],[10000000000038700,102],[10000000000038700,133],[10000000000038700,114],[10000000000038700,124]],"import_payload":{"data_files":[10000000000038600],"new_deletion_vector":{"10000000000038700":[65,102,114,120,124,133]},"file_indices":[[10000000000038600]]},"index_merge_payload":{"new_file_indices":[],"old_file_indices":[]},"data_compaction_payload":{"new_data_files_to_import":[10000000000038700],"old_data_files_to_remove":[10000000000021700,10000000000014200,10000000000014100,10000000000019000,10000000000018000,10000000000023400,10000000000021000,10000000000007000,10000000000008700,10000000000031100,10000000000019500,10000000000033000,10000000000022800,10000000000022400,10000000000034300,10000000000007400,10000000000008800,10000000000017100,10000000000008900,10000000000031600,10000000000006600,10000000000033900,10000000000037000,10000000000012600,10000000000030500,10000000000031400,10000000000008300,10000000000015800,10000000000013500,10000000000011700,10000000000008400,10000000000007700,10000000000036800,10000000000035400,10000000000035000,10000000000008500,10000000000007600,10000000000031700,10000000000010400,10000000000030400,10000000000016200,10000000000019300,10000000000013200,10000000000016700,10000000000030200,10000000000031800,10000000000011500,10000000000019200,10000000000034200,10000000000033500,10000000000026000,10000000000011300,10000000000034100,10000000000003700,10000000000031500,10000000000020600,10000000000018200,10000000000010700,10000000000013600,10000000000021200,10000000000036900,10000000000013300,10000000000028700,10000000000026900,10000000000033300,10000000000029400,10000000000021400,10000000000012700,10000000000037300,10000000000029300,10000000000018700,10000000000013900,10000000000007100,10000000000008600,10000000000035200,10000000000014300,10000000000007300,10000000000007500,10000000000028800,10000000000011100,10000000000013100,10000000000035500,10000000000016500,10000000000037200,10000000000035600,10000000000035300,10000000000033400,10000000000017600,10000000000025000,10000000000023800,10000000000003600,10000000000013400,10000000000019400,10000000000011600,10000000000023700,10000000000009700,10000000000023100,10000000000006700,10000000000014400,10000000000025500,10000000000021300,10000000000019900,10000000000018800,10000000000010500,10000000000024900,10000000000011800,10000000000016100,10000000000030100,10000000000027000,10000000000017000,10000000000021100,10000000000037400,10000000000019100,10000000000021600,10000000000009500,10000000000018300,10000000000019600,10000000000027300,10000000000016400,10000000000030300,10000000000007800,10000000000011400,10000000000026100,10000000000032500,10000000000011900,10000000000030000,10000000000031000,10000000000021500,10000000000033800,10000000000022900,10000000000034000,10000000000027200,10000000000016600,10000000000023900,10000000000026500,10000000000003800,10000000000024800,10000000000027100,10000000000012800],"new_file_indices_to_import":[[10000000000038700]],"old_file_indices_to_remove":[[10000000000035200,10000000000035500,10000000000035300,10000000000035600,10000000000035400,10000000000035000,10000000000033900,10000000000033400,10000000000033500,10000000000033800,10000000000033000,10000000000032500,10000000000031500,10000000000031100,10000000000031000,10000000000030200,10000000000030500,10000000000030300,10000000000030400,10000000000029400,10000000000027000,10000000000027300,10000000000028800,10000000000027200,10000000000026900,10000000000028700,10000000000027100,10000000000026500,10000000000026100,10000000000025500,10000000000023400,10000000000023100,10000000000022400,10000000000021400,10000000000021600,10000000000021700,10000000000021500,10000000000021100,10000000000019600,10000000000019500,10000000000019300,10000000000019000,10000000000019400,10000000000018300,10000000000018700,10000000000016200,10000000000016500,10000000000013500,10000000000013900,10000000000014100,10000000000012800,10000000000012700,10000000000013100,10000000000013400,10000000000013200,10000000000013300,10000000000014400,10000000000014300,10000000000012600,10000000000011100,10000000000011600,10000000000011900,10000000000011400,10000000000010400,10000000000008900,10000000000008700,10000000000008300,10000000000008400,10000000000009500,10000000000008500,10000000000007000,10000000000007300,10000000000007500,10000000000003600,10000000000003800,10000000000003700,10000000000007400,10000000000007100,10000000000006700,10000000000007700,10000000000007800,10000000000007600,10000000000006600,10000000000008600,10000000000008800,10000000000009700,10000000000010700,10000000000010500,10000000000011800,10000000000011300,10000000000011700,10000000000011500,10000000000013600,10000000000014200,10000000000015800,10000000000016400,10000000000016700,10000000000016600,10000000000016100,10000000000017600,10000000000017100,10000000000017000,10000000000018000,10000000000018200,10000000000018800,10000000000019900,10000000000019200,10000000000019100,10000000000020600,10000000000021000,10000000000021300,10000000000021200,10000000000022900,10000000000022800,10000000000023700,10000000000023900,10000000000023800,10000000000024800,10000000000024900,10000000000025000,10000000000026000,10000000000029300,10000000000030000,10000000000030100,10000000000031800,10000000000031600,10000000000031400,10000000000031700,10000000000033300,10000000000034000,10000000000034200,10000000000034100,10000000000034300,10000000000036800,10000000000036900,10000000000037300,10000000000037000,10000000000037400,10000000000037200]]}}}
{"IcebergSnapshotCompletion":{"uuid":"f534c143-3ae0-42cd-9b28-526af9b1288d","lsn":729}}
{"Append":{"row":{"values":[{"Int32":295},{"ByteArray":[117,115,101,114]},{"Int32":0}]},"xact_id":109}}
{"FlushInitiation":{"uuid":"3ed44161-be25-4c7d-99fe-7df7a2774581","xact_id":109,"lsn":null,"commit_check_point":{"MemoryBatch":[193,1]}}}
{"Delete":{"row":{"values":[{"Int32":210},{"ByteArray":[117,115,101,114]},{"Int32":0}]},"lsn":null,"xact_id":109}}
{"FlushInitiation":{"uuid":"60e4241b-002a-4916-8316-ba093bc9acb7","xact_id":109,"lsn":null,"commit_check_point":{"MemoryBatch":[194,0]}}}
{"Abort":{"xact_id":109}}
{"Append":{"row":{"values":[{"Int32":296},{"ByteArray":[117,115,101,114]},{"Int32":1}]},"xact_id":null}}
{"Append":{"row":{"values":[{"Int32":297},{"ByteArray":[117,115,101,114]},{"Int32":2}]},"xact_id":null}}
{"Append":{"row":{"values":[{"Int32":298},{"ByteArray":[117,115,101,114]},{"Int32":3}]},"xact_id":null}}
{"Append":{"row":{"values":[{"Int32":299},{"ByteArray":[117,115,101,114]},{"Int32":4}]},"xact_id":null}}
{"Append":{"row":{"values":[{"Int32":300},{"ByteArray":[117,115,101,114]},{"Int32":0}]},"xact_id":null}}
{"Delete":{"row":{"values":[{"Int32":69},{"ByteArray":[117,115,101,114]},{"Int32":4}]},"lsn":737,"xact_id":null}}
{"Append":{"row":{"values":[{"Int32":301},{"ByteArray":[117,115,101,114]},{"Int32":1}]},"xact_id":null}}
{"Append":{"row":{"values":[{"Int32":302},{"ByteArray":[117,115,101,114]},{"Int32":2}]},"xact_id":null}}
{"Commit":{"xact_id":null,"lsn":740}}
{"FlushInitiation":{"uuid":"5b1234fe-a649-438b-9b9a-a5eae085c07f","xact_id":null,"lsn":740,"commit_check_point":{"MemoryBatch":[9223372036854775888,7]}}}
{"FlushCompletion":{"uuid":"60e4241b-002a-4916-8316-ba093bc9acb7","file_ids":[]}}

{"MooncakeSnapshotInitiation":{"uuid":"47e9026d-56ef-48b7-b768-c4aa7e3ec614","option":{"uuid":"47e9026d-56ef-48b7-b768-c4aa7e3ec614","dump_snapshot":false,"force_create":false,
    "iceberg_snapshot_option":{"BestEffort":"e6f149fe-a5e7-4414-b86c-d8f7b8c353de"},
    "index_merge_option":{"BestEffort":"ad7548a5-8787-48c8-a3ec-43672ee681c9"},
    "data_compaction_option":{"BestEffort":"3da06a93-63f0-46ec-b61b-bbccecd695d9"}
}}}
^ no iceberg snapshot issued
```
The issue is:
- Persisted and recorded event stream clearly shows we **shouldn't** have iceberg snapshot requests issued
- But in reality, event stream does record corresponding iceberg snapshot event

```sh
{"IcebergSnapshotInitiation":{"uuid":"e6f149fe-a5e7-4414-b86c-d8f7b8c353de","flush_lsn":729,"committed_deletion_logs":[],"import_payload":{"data_files":[],"new_deletion_vector":{},"file_indices":[]},"index_merge_payload":{"new_file_indices":[],"old_file_indices":[]},"data_compaction_payload":{"new_data_files_to_import":[],"old_data_files_to_remove":[],"new_file_indices_to_import":[],"old_file_indices_to_remove":[]}}}
```
So the only explanation is event record goes wrong, i.e., out of order.

This PR fixes the issue; the lesson I learned here is all replay event record should also be deterministic from the main eventloop thread and task.

## Related Issues

Closes #<issue-number> or links to related issues.

## Changes

- 
- 
- 

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
