### PR TITLE
Rename iceberg types and variables

### DIFF
--- a/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
@@ -11,7 +11,7 @@ use crate::storage::iceberg::table_manager::{
 use crate::storage::iceberg::utils;
 use crate::storage::index::FileIndex as MooncakeFileIndex;
 use crate::storage::mooncake_table::delete_vector::BatchDeletionVector;
-use crate::storage::mooncake_table::IcebergSnapshotPayload;
+use crate::storage::mooncake_table::PersistenceSnapshotPayload;
 use crate::storage::mooncake_table::Snapshot as MooncakeSnapshot;
 use crate::storage::mooncake_table::TableMetadata as MooncakeTableMetadata;
 use crate::storage::storage_utils::FileId;
@@ -194,7 +194,7 @@ impl TableManager for IcebergTableManager {
 
     async fn sync_snapshot(
         &mut self,
-        mut snapshot_payload: IcebergSnapshotPayload,
+        mut snapshot_payload: PersistenceSnapshotPayload,
         file_params: PersistenceFileParams,
     ) -> Result<PersistenceResult> {
         // Persist data files, deletion vectors, and file indices.

--- a/src/moonlink/src/storage/iceberg/iceberg_table_syncer.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_syncer.rs
@@ -22,7 +22,7 @@ use crate::storage::iceberg::utils::get_unique_hash_index_v1_filepath;
 use crate::storage::index::FileIndex as MooncakeFileIndex;
 use crate::storage::mooncake_table::delete_vector::BatchDeletionVector;
 use crate::storage::mooncake_table::take_data_files_to_remove;
-use crate::storage::mooncake_table::IcebergSnapshotPayload;
+use crate::storage::mooncake_table::PersistenceSnapshotPayload;
 use crate::storage::mooncake_table::{
     take_data_files_to_import, take_file_indices_to_import, take_file_indices_to_remove,
 };
@@ -722,7 +722,7 @@ impl IcebergTableManager {
 
     pub(crate) async fn sync_snapshot_impl(
         &mut self,
-        mut snapshot_payload: IcebergSnapshotPayload,
+        mut snapshot_payload: PersistenceSnapshotPayload,
         file_params: PersistenceFileParams,
     ) -> Result<PersistenceResult> {
         // Start recording overall snapshot synchronization latency.

--- a/src/moonlink/src/storage/iceberg/table_manager.rs
+++ b/src/moonlink/src/storage/iceberg/table_manager.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 use crate::storage::iceberg::puffin_utils::PuffinBlobRef;
 use crate::storage::index::FileIndex;
-use crate::storage::mooncake_table::IcebergSnapshotPayload;
+use crate::storage::mooncake_table::PersistenceSnapshotPayload;
 use crate::storage::mooncake_table::Snapshot as MooncakeSnapshot;
 use crate::storage::storage_utils::FileId;
 use crate::storage::storage_utils::MooncakeDataFileRef;
@@ -51,7 +51,7 @@ pub trait TableManager: Send {
     #[allow(async_fn_in_trait)]
     async fn sync_snapshot(
         &mut self,
-        snapshot_payload: IcebergSnapshotPayload,
+        snapshot_payload: PersistenceSnapshotPayload,
         file_params: PersistenceFileParams,
     ) -> Result<PersistenceResult>;
 

--- a/src/moonlink/src/storage/iceberg/tests.rs
+++ b/src/moonlink/src/storage/iceberg/tests.rs
@@ -33,8 +33,8 @@ use crate::storage::mooncake_table::DataCompactionResult;
 use crate::storage::mooncake_table::IcebergSnapshotResult;
 use crate::storage::mooncake_table::PersistenceSnapshotPayload;
 use crate::storage::mooncake_table::{
-    IcebergSnapshotDataCompactionPayload, IcebergSnapshotIndexMergePayload,
-    PersistenceSnapshotImportPayload,
+    PersistenceSnapshotDataCompactionPayload, PersistenceSnapshotImportPayload,
+    PersistenceSnapshotIndexMergePayload,
 };
 use crate::storage::mooncake_table_config::DiskSliceWriterConfig;
 use crate::storage::mooncake_table_config::IcebergPersistenceConfig;
@@ -380,11 +380,11 @@ async fn test_manifest_entries_write_with_pagination_impl(
             new_deletion_vector: HashMap::new(),
             file_indices: vec![],
         },
-        index_merge_payload: IcebergSnapshotIndexMergePayload {
+        index_merge_payload: PersistenceSnapshotIndexMergePayload {
             new_file_indices_to_import: vec![],
             old_file_indices_to_remove: vec![],
         },
-        data_compaction_payload: IcebergSnapshotDataCompactionPayload {
+        data_compaction_payload: PersistenceSnapshotDataCompactionPayload {
             new_data_files_to_import: vec![],
             old_data_files_to_remove: vec![],
             new_file_indices_to_import: vec![],
@@ -412,11 +412,11 @@ async fn test_manifest_entries_write_with_pagination_impl(
             new_deletion_vector: HashMap::new(),
             file_indices: vec![],
         },
-        index_merge_payload: IcebergSnapshotIndexMergePayload {
+        index_merge_payload: PersistenceSnapshotIndexMergePayload {
             new_file_indices_to_import: vec![],
             old_file_indices_to_remove: vec![],
         },
-        data_compaction_payload: IcebergSnapshotDataCompactionPayload {
+        data_compaction_payload: PersistenceSnapshotDataCompactionPayload {
             new_data_files_to_import: vec![],
             old_data_files_to_remove: vec![data_files_to_import[0].clone()],
             new_file_indices_to_import: vec![],
@@ -504,11 +504,11 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
             new_deletion_vector: test_committed_deletion_log_1(data_file_1.clone()),
             file_indices: vec![file_index_1.clone()],
         },
-        index_merge_payload: IcebergSnapshotIndexMergePayload {
+        index_merge_payload: PersistenceSnapshotIndexMergePayload {
             new_file_indices_to_import: vec![],
             old_file_indices_to_remove: vec![],
         },
-        data_compaction_payload: IcebergSnapshotDataCompactionPayload {
+        data_compaction_payload: PersistenceSnapshotDataCompactionPayload {
             new_data_files_to_import: vec![],
             old_data_files_to_remove: vec![],
             new_file_indices_to_import: vec![],
@@ -558,11 +558,11 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
             new_deletion_vector: test_committed_deletion_log_2(data_file_2.clone()),
             file_indices: vec![file_index_2.clone()],
         },
-        index_merge_payload: IcebergSnapshotIndexMergePayload {
+        index_merge_payload: PersistenceSnapshotIndexMergePayload {
             new_file_indices_to_import: vec![],
             old_file_indices_to_remove: vec![],
         },
-        data_compaction_payload: IcebergSnapshotDataCompactionPayload {
+        data_compaction_payload: PersistenceSnapshotDataCompactionPayload {
             new_data_files_to_import: vec![],
             old_data_files_to_remove: vec![],
             new_file_indices_to_import: vec![],
@@ -638,11 +638,11 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
             new_deletion_vector: HashMap::new(),
             file_indices: vec![],
         },
-        index_merge_payload: IcebergSnapshotIndexMergePayload {
+        index_merge_payload: PersistenceSnapshotIndexMergePayload {
             new_file_indices_to_import: vec![merged_file_index.clone()],
             old_file_indices_to_remove: vec![file_index_1.clone(), file_index_2.clone()],
         },
-        data_compaction_payload: IcebergSnapshotDataCompactionPayload {
+        data_compaction_payload: PersistenceSnapshotDataCompactionPayload {
             new_data_files_to_import: vec![],
             old_data_files_to_remove: vec![],
             new_file_indices_to_import: vec![],
@@ -723,11 +723,11 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
             new_deletion_vector: HashMap::new(),
             file_indices: vec![],
         },
-        index_merge_payload: IcebergSnapshotIndexMergePayload {
+        index_merge_payload: PersistenceSnapshotIndexMergePayload {
             new_file_indices_to_import: vec![],
             old_file_indices_to_remove: vec![],
         },
-        data_compaction_payload: IcebergSnapshotDataCompactionPayload {
+        data_compaction_payload: PersistenceSnapshotDataCompactionPayload {
             new_data_files_to_import: vec![compacted_data_file.clone()],
             old_data_files_to_remove: vec![data_file_1.clone(), data_file_2.clone()],
             new_file_indices_to_import: vec![compacted_file_index.clone()],
@@ -797,11 +797,11 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
             new_deletion_vector: HashMap::new(),
             file_indices: vec![],
         },
-        index_merge_payload: IcebergSnapshotIndexMergePayload {
+        index_merge_payload: PersistenceSnapshotIndexMergePayload {
             new_file_indices_to_import: vec![],
             old_file_indices_to_remove: vec![],
         },
-        data_compaction_payload: IcebergSnapshotDataCompactionPayload {
+        data_compaction_payload: PersistenceSnapshotDataCompactionPayload {
             new_data_files_to_import: vec![],
             old_data_files_to_remove: vec![compacted_data_file.clone()],
             new_file_indices_to_import: vec![],
@@ -1089,8 +1089,8 @@ async fn test_recover_from_failed_snapshot_impl(iceberg_table_config: IcebergTab
             new_deletion_vector: HashMap::new(),
             file_indices: Vec::new(),
         },
-        index_merge_payload: IcebergSnapshotIndexMergePayload::default(),
-        data_compaction_payload: IcebergSnapshotDataCompactionPayload::default(),
+        index_merge_payload: PersistenceSnapshotIndexMergePayload::default(),
+        data_compaction_payload: PersistenceSnapshotDataCompactionPayload::default(),
     };
 
     let persistence_file_params = PersistenceFileParams {
@@ -2012,8 +2012,8 @@ async fn test_empty_content_snapshot_creation_impl(iceberg_table_config: Iceberg
         new_table_schema: None,
         committed_deletion_logs: HashSet::new(),
         import_payload: PersistenceSnapshotImportPayload::default(),
-        index_merge_payload: IcebergSnapshotIndexMergePayload::default(),
-        data_compaction_payload: IcebergSnapshotDataCompactionPayload::default(),
+        index_merge_payload: PersistenceSnapshotIndexMergePayload::default(),
+        data_compaction_payload: PersistenceSnapshotDataCompactionPayload::default(),
     };
 
     let persistence_file_params = PersistenceFileParams {
@@ -2141,8 +2141,8 @@ async fn test_snapshot_creation_with_duplicate_filename_impl(
             new_deletion_vector: HashMap::new(),
             file_indices: Vec::new(),
         },
-        index_merge_payload: IcebergSnapshotIndexMergePayload::default(),
-        data_compaction_payload: IcebergSnapshotDataCompactionPayload::default(),
+        index_merge_payload: PersistenceSnapshotIndexMergePayload::default(),
+        data_compaction_payload: PersistenceSnapshotDataCompactionPayload::default(),
     };
 
     let persistence_file_params = PersistenceFileParams {

--- a/src/moonlink/src/storage/iceberg/tests.rs
+++ b/src/moonlink/src/storage/iceberg/tests.rs
@@ -30,8 +30,8 @@ use crate::storage::mooncake_table::test_utils_commons::ICEBERG_TEST_NAMESPACE;
 use crate::storage::mooncake_table::test_utils_commons::ICEBERG_TEST_TABLE;
 use crate::storage::mooncake_table::validation_test_utils::*;
 use crate::storage::mooncake_table::DataCompactionResult;
-use crate::storage::mooncake_table::IcebergSnapshotPayload;
 use crate::storage::mooncake_table::IcebergSnapshotResult;
+use crate::storage::mooncake_table::PersistenceSnapshotPayload;
 use crate::storage::mooncake_table::{
     IcebergSnapshotDataCompactionPayload, IcebergSnapshotImportPayload,
     IcebergSnapshotIndexMergePayload,
@@ -314,9 +314,9 @@ async fn test_skip_iceberg_snapshot() {
         index_merge_option: MaintenanceOption::BestEffort(uuid::Uuid::new_v4()),
         data_compaction_option: MaintenanceOption::BestEffort(uuid::Uuid::new_v4()),
     }));
-    let (_, iceberg_snapshot_payload, _, _, _) =
+    let (_, persistence_snapshot_payload, _, _, _) =
         sync_mooncake_snapshot(&mut table, &mut notify_rx).await;
-    assert!(iceberg_snapshot_payload.is_none());
+    assert!(persistence_snapshot_payload.is_none());
 }
 
 /// ================================
@@ -370,7 +370,7 @@ async fn test_manifest_entries_write_with_pagination_impl(
         stream::iter(tasks).buffer_unordered(1024).collect().await;
     data_files_to_import.extend(results);
 
-    let iceberg_snapshot_payload = IcebergSnapshotPayload {
+    let persistence_snapshot_payload = PersistenceSnapshotPayload {
         uuid: uuid::Uuid::new_v4(),
         flush_lsn: 0,
         new_table_schema: None,
@@ -397,12 +397,12 @@ async fn test_manifest_entries_write_with_pagination_impl(
         table_auto_incr_ids: 0..((DEFAULT_MAX_MANIFEST_ENTRY_COUNT + 1) as u32),
     };
     iceberg_table_manager
-        .sync_snapshot(iceberg_snapshot_payload, persistence_file_params)
+        .sync_snapshot(persistence_snapshot_payload, persistence_file_params)
         .await
         .unwrap();
 
     // Remove one data manifest entries.
-    let iceberg_snapshot_payload = IcebergSnapshotPayload {
+    let persistence_snapshot_payload = PersistenceSnapshotPayload {
         uuid: uuid::Uuid::new_v4(),
         flush_lsn: 0,
         new_table_schema: None,
@@ -428,7 +428,7 @@ async fn test_manifest_entries_write_with_pagination_impl(
         table_auto_incr_ids: 0..(DEFAULT_MAX_MANIFEST_ENTRY_COUNT + 1) as u32, // unused
     };
     iceberg_table_manager
-        .sync_snapshot(iceberg_snapshot_payload, persistence_file_params)
+        .sync_snapshot(persistence_snapshot_payload, persistence_file_params)
         .await
         .unwrap();
 }
@@ -494,7 +494,7 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
     write_arrow_record_batch_to_local(parquet_path.as_path(), arrow_schema.clone(), &batch_1).await;
     let file_index_1 = create_file_index(vec![data_file_1.clone()]);
 
-    let iceberg_snapshot_payload = IcebergSnapshotPayload {
+    let persistence_snapshot_payload = PersistenceSnapshotPayload {
         uuid: uuid::Uuid::new_v4(),
         flush_lsn: 0,
         new_table_schema: None,
@@ -521,7 +521,7 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
         table_auto_incr_ids: 1..2,
     };
     iceberg_table_manager
-        .sync_snapshot(iceberg_snapshot_payload, persistence_file_params)
+        .sync_snapshot(persistence_snapshot_payload, persistence_file_params)
         .await
         .unwrap();
 
@@ -548,7 +548,7 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
     write_arrow_record_batch_to_local(parquet_path.as_path(), arrow_schema.clone(), &batch_2).await;
     let file_index_2 = create_file_index(vec![data_file_2.clone()]);
 
-    let iceberg_snapshot_payload = IcebergSnapshotPayload {
+    let persistence_snapshot_payload = PersistenceSnapshotPayload {
         uuid: uuid::Uuid::new_v4(),
         flush_lsn: 1,
         new_table_schema: None,
@@ -575,7 +575,7 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
         table_auto_incr_ids: 3..4,
     };
     iceberg_table_manager
-        .sync_snapshot(iceberg_snapshot_payload, persistence_file_params)
+        .sync_snapshot(persistence_snapshot_payload, persistence_file_params)
         .await
         .unwrap();
 
@@ -628,7 +628,7 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
     //
     // Write third snapshot to iceberg table, with file indices to add and remove.
     let merged_file_index = create_file_index(remote_data_files.clone());
-    let iceberg_snapshot_payload = IcebergSnapshotPayload {
+    let persistence_snapshot_payload = PersistenceSnapshotPayload {
         uuid: uuid::Uuid::new_v4(),
         flush_lsn: 2,
         new_table_schema: None,
@@ -654,7 +654,7 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
         table_auto_incr_ids: 4..5,
     };
     iceberg_table_manager
-        .sync_snapshot(iceberg_snapshot_payload, persistence_file_params)
+        .sync_snapshot(persistence_snapshot_payload, persistence_file_params)
         .await
         .unwrap();
     assert_eq!(iceberg_table_manager.persisted_file_indices.len(), 1);
@@ -713,7 +713,7 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
     // ==============
     //
     // Attempt a fourth snapshot persistence, which goes after data file compaction.
-    let iceberg_snapshot_payload = IcebergSnapshotPayload {
+    let persistence_snapshot_payload = PersistenceSnapshotPayload {
         uuid: uuid::Uuid::new_v4(),
         flush_lsn: 3,
         new_table_schema: None,
@@ -739,7 +739,7 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
         table_auto_incr_ids: 6..7,
     };
     iceberg_table_manager
-        .sync_snapshot(iceberg_snapshot_payload, persistence_file_params)
+        .sync_snapshot(persistence_snapshot_payload, persistence_file_params)
         .await
         .unwrap();
 
@@ -787,7 +787,7 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
     // ==============
     //
     // Remove all existing data files and file indices.
-    let iceberg_snapshot_payload = IcebergSnapshotPayload {
+    let persistence_snapshot_payload = PersistenceSnapshotPayload {
         uuid: uuid::Uuid::new_v4(),
         flush_lsn: 4,
         new_table_schema: None,
@@ -813,7 +813,7 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
         table_auto_incr_ids: 7..8,
     };
     iceberg_table_manager
-        .sync_snapshot(iceberg_snapshot_payload, persistence_file_params)
+        .sync_snapshot(persistence_snapshot_payload, persistence_file_params)
         .await
         .unwrap();
 
@@ -1079,7 +1079,7 @@ async fn test_recover_from_failed_snapshot_impl(iceberg_table_config: IcebergTab
     )
     .await
     .unwrap();
-    let iceberg_snapshot_payload = IcebergSnapshotPayload {
+    let persistence_snapshot_payload = PersistenceSnapshotPayload {
         uuid: uuid::Uuid::new_v4(),
         flush_lsn: 1,
         new_table_schema: None,
@@ -1097,7 +1097,7 @@ async fn test_recover_from_failed_snapshot_impl(iceberg_table_config: IcebergTab
         table_auto_incr_ids: 0..1,
     };
     iceberg_table_manager_for_persistence
-        .sync_snapshot(iceberg_snapshot_payload, persistence_file_params)
+        .sync_snapshot(persistence_snapshot_payload, persistence_file_params)
         .await
         .unwrap();
 
@@ -1638,14 +1638,14 @@ async fn test_delayed_compaction_impl(iceberg_table_config: IcebergTableConfig) 
         .unwrap();
 
     // Attempt data compaction and flush to iceberg table.
-    let (_, iceberg_snapshot_payload, _, _, _) =
+    let (_, persistence_snapshot_payload, _, _, _) =
         create_mooncake_snapshot_for_test(&mut table, &mut notify_rx).await;
 
     // Persist iceberg snapshot and reflect to mooncake snapshot.
-    let iceberg_snapshot_payload = iceberg_snapshot_payload.unwrap();
+    let persistence_snapshot_payload = persistence_snapshot_payload.unwrap();
     let (_, _, _, data_compaction_payload, _) =
         create_iceberg_snapshot_and_reflect_to_mooncake_snapshot(
-            iceberg_snapshot_payload,
+            persistence_snapshot_payload,
             &mut table,
             &mut notify_rx,
         )
@@ -1676,11 +1676,11 @@ async fn test_delayed_compaction_impl(iceberg_table_config: IcebergTableConfig) 
     table.set_data_compaction_res(data_compaction_result);
 
     // Persist iceberg snapshot and reflect to mooncake snapshot.
-    let (_, iceberg_snapshot_payload, _, _, _) =
+    let (_, persistence_snapshot_payload, _, _, _) =
         create_mooncake_snapshot_for_test(&mut table, &mut notify_rx).await;
-    let iceberg_snapshot_payload = iceberg_snapshot_payload.unwrap();
+    let persistence_snapshot_payload = persistence_snapshot_payload.unwrap();
     create_iceberg_snapshot_and_reflect_to_mooncake_snapshot(
-        iceberg_snapshot_payload,
+        persistence_snapshot_payload,
         &mut table,
         &mut notify_rx,
     )
@@ -2006,7 +2006,7 @@ async fn test_empty_content_snapshot_creation_impl(iceberg_table_config: Iceberg
     )
     .await
     .unwrap();
-    let iceberg_snapshot_payload = IcebergSnapshotPayload {
+    let persistence_snapshot_payload = PersistenceSnapshotPayload {
         uuid: uuid::Uuid::new_v4(),
         flush_lsn: 0,
         new_table_schema: None,
@@ -2020,7 +2020,7 @@ async fn test_empty_content_snapshot_creation_impl(iceberg_table_config: Iceberg
         table_auto_incr_ids: 0..1,
     };
     iceberg_table_manager_for_persistence
-        .sync_snapshot(iceberg_snapshot_payload, persistence_file_params)
+        .sync_snapshot(persistence_snapshot_payload, persistence_file_params)
         .await
         .unwrap();
 
@@ -2131,7 +2131,7 @@ async fn test_snapshot_creation_with_duplicate_filename_impl(
     )
     .await
     .unwrap();
-    let iceberg_snapshot_payload = IcebergSnapshotPayload {
+    let persistence_snapshot_payload = PersistenceSnapshotPayload {
         uuid: uuid::Uuid::new_v4(),
         flush_lsn: 1,
         new_table_schema: None,
@@ -2149,7 +2149,7 @@ async fn test_snapshot_creation_with_duplicate_filename_impl(
         table_auto_incr_ids: 0..1,
     };
     iceberg_table_manager_for_persistence
-        .sync_snapshot(iceberg_snapshot_payload, persistence_file_params)
+        .sync_snapshot(persistence_snapshot_payload, persistence_file_params)
         .await
         .unwrap();
 
@@ -2441,7 +2441,7 @@ async fn test_async_iceberg_snapshot_impl(iceberg_table_config: IcebergTableConf
     flush_table_and_sync(&mut table, &mut notify_rx, /*lsn=*/ 10)
         .await
         .unwrap();
-    let (_, iceberg_snapshot_payload, _, _, _) =
+    let (_, persistence_snapshot_payload, _, _, _) =
         create_mooncake_snapshot_for_test(&mut table, &mut notify_rx).await;
 
     // Operation group 2: Append new rows and create mooncake snapshot.
@@ -2456,7 +2456,7 @@ async fn test_async_iceberg_snapshot_impl(iceberg_table_config: IcebergTableConf
 
     // Create iceberg snapshot for the first mooncake snapshot.
     let iceberg_snapshot_result =
-        create_iceberg_snapshot(&mut table, iceberg_snapshot_payload, &mut notify_rx).await;
+        create_iceberg_snapshot(&mut table, persistence_snapshot_payload, &mut notify_rx).await;
     table.set_iceberg_snapshot_res(iceberg_snapshot_result.unwrap());
 
     // Load and check iceberg snapshot.
@@ -2511,12 +2511,12 @@ async fn test_async_iceberg_snapshot_impl(iceberg_table_config: IcebergTableConf
     flush_table_and_sync(&mut table, &mut notify_rx, /*lsn=*/ 40)
         .await
         .unwrap();
-    let (_, iceberg_snapshot_payload, _, _, _) =
+    let (_, persistence_snapshot_payload, _, _, _) =
         create_mooncake_snapshot_for_test(&mut table, &mut notify_rx).await;
 
     // Create iceberg snapshot for the mooncake snapshot.
     let iceberg_snapshot_result =
-        create_iceberg_snapshot(&mut table, iceberg_snapshot_payload, &mut notify_rx).await;
+        create_iceberg_snapshot(&mut table, persistence_snapshot_payload, &mut notify_rx).await;
     table.set_iceberg_snapshot_res(iceberg_snapshot_result.unwrap());
 
     // Load and check iceberg snapshot.

--- a/src/moonlink/src/storage/iceberg/tests.rs
+++ b/src/moonlink/src/storage/iceberg/tests.rs
@@ -33,8 +33,8 @@ use crate::storage::mooncake_table::DataCompactionResult;
 use crate::storage::mooncake_table::IcebergSnapshotResult;
 use crate::storage::mooncake_table::PersistenceSnapshotPayload;
 use crate::storage::mooncake_table::{
-    IcebergSnapshotDataCompactionPayload, IcebergSnapshotImportPayload,
-    IcebergSnapshotIndexMergePayload,
+    IcebergSnapshotDataCompactionPayload, IcebergSnapshotIndexMergePayload,
+    PersistenceSnapshotImportPayload,
 };
 use crate::storage::mooncake_table_config::DiskSliceWriterConfig;
 use crate::storage::mooncake_table_config::IcebergPersistenceConfig;
@@ -375,7 +375,7 @@ async fn test_manifest_entries_write_with_pagination_impl(
         flush_lsn: 0,
         new_table_schema: None,
         committed_deletion_logs: HashSet::new(),
-        import_payload: IcebergSnapshotImportPayload {
+        import_payload: PersistenceSnapshotImportPayload {
             data_files: data_files_to_import.clone(),
             new_deletion_vector: HashMap::new(),
             file_indices: vec![],
@@ -407,7 +407,7 @@ async fn test_manifest_entries_write_with_pagination_impl(
         flush_lsn: 0,
         new_table_schema: None,
         committed_deletion_logs: HashSet::new(),
-        import_payload: IcebergSnapshotImportPayload {
+        import_payload: PersistenceSnapshotImportPayload {
             data_files: vec![],
             new_deletion_vector: HashMap::new(),
             file_indices: vec![],
@@ -499,7 +499,7 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
         flush_lsn: 0,
         new_table_schema: None,
         committed_deletion_logs: test_committed_deletion_logs_to_persist_1(data_file_1.clone()),
-        import_payload: IcebergSnapshotImportPayload {
+        import_payload: PersistenceSnapshotImportPayload {
             data_files: vec![data_file_1.clone()],
             new_deletion_vector: test_committed_deletion_log_1(data_file_1.clone()),
             file_indices: vec![file_index_1.clone()],
@@ -553,7 +553,7 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
         flush_lsn: 1,
         new_table_schema: None,
         committed_deletion_logs: test_committed_deletion_logs_to_persist_2(data_file_2.clone()),
-        import_payload: IcebergSnapshotImportPayload {
+        import_payload: PersistenceSnapshotImportPayload {
             data_files: vec![data_file_2.clone()],
             new_deletion_vector: test_committed_deletion_log_2(data_file_2.clone()),
             file_indices: vec![file_index_2.clone()],
@@ -633,7 +633,7 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
         flush_lsn: 2,
         new_table_schema: None,
         committed_deletion_logs: HashSet::new(),
-        import_payload: IcebergSnapshotImportPayload {
+        import_payload: PersistenceSnapshotImportPayload {
             data_files: vec![],
             new_deletion_vector: HashMap::new(),
             file_indices: vec![],
@@ -718,7 +718,7 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
         flush_lsn: 3,
         new_table_schema: None,
         committed_deletion_logs: HashSet::new(),
-        import_payload: IcebergSnapshotImportPayload {
+        import_payload: PersistenceSnapshotImportPayload {
             data_files: vec![],
             new_deletion_vector: HashMap::new(),
             file_indices: vec![],
@@ -792,7 +792,7 @@ async fn test_store_and_load_snapshot_impl(iceberg_table_config: IcebergTableCon
         flush_lsn: 4,
         new_table_schema: None,
         committed_deletion_logs: HashSet::new(),
-        import_payload: IcebergSnapshotImportPayload {
+        import_payload: PersistenceSnapshotImportPayload {
             data_files: vec![],
             new_deletion_vector: HashMap::new(),
             file_indices: vec![],
@@ -1084,7 +1084,7 @@ async fn test_recover_from_failed_snapshot_impl(iceberg_table_config: IcebergTab
         flush_lsn: 1,
         new_table_schema: None,
         committed_deletion_logs: HashSet::new(),
-        import_payload: IcebergSnapshotImportPayload {
+        import_payload: PersistenceSnapshotImportPayload {
             data_files: vec![data_file],
             new_deletion_vector: HashMap::new(),
             file_indices: Vec::new(),
@@ -2011,7 +2011,7 @@ async fn test_empty_content_snapshot_creation_impl(iceberg_table_config: Iceberg
         flush_lsn: 0,
         new_table_schema: None,
         committed_deletion_logs: HashSet::new(),
-        import_payload: IcebergSnapshotImportPayload::default(),
+        import_payload: PersistenceSnapshotImportPayload::default(),
         index_merge_payload: IcebergSnapshotIndexMergePayload::default(),
         data_compaction_payload: IcebergSnapshotDataCompactionPayload::default(),
     };
@@ -2136,7 +2136,7 @@ async fn test_snapshot_creation_with_duplicate_filename_impl(
         flush_lsn: 1,
         new_table_schema: None,
         committed_deletion_logs: HashSet::new(),
-        import_payload: IcebergSnapshotImportPayload {
+        import_payload: PersistenceSnapshotImportPayload {
             data_files: vec![data_file_1, data_file_2],
             new_deletion_vector: HashMap::new(),
             file_indices: Vec::new(),

--- a/src/moonlink/src/storage/iceberg/tests.rs
+++ b/src/moonlink/src/storage/iceberg/tests.rs
@@ -30,8 +30,8 @@ use crate::storage::mooncake_table::test_utils_commons::ICEBERG_TEST_NAMESPACE;
 use crate::storage::mooncake_table::test_utils_commons::ICEBERG_TEST_TABLE;
 use crate::storage::mooncake_table::validation_test_utils::*;
 use crate::storage::mooncake_table::DataCompactionResult;
-use crate::storage::mooncake_table::IcebergSnapshotResult;
 use crate::storage::mooncake_table::PersistenceSnapshotPayload;
+use crate::storage::mooncake_table::PersistenceSnapshotResult;
 use crate::storage::mooncake_table::{
     PersistenceSnapshotDataCompactionPayload, PersistenceSnapshotImportPayload,
     PersistenceSnapshotIndexMergePayload,
@@ -3442,7 +3442,7 @@ async fn test_persisted_deletion_record_remap() {
 
     // Block wait both operations to finish.
     let mut stored_data_compaction_result: Option<DataCompactionResult> = None;
-    let mut stored_iceberg_snapshot_result: Option<IcebergSnapshotResult> = None;
+    let mut stored_iceberg_snapshot_result: Option<PersistenceSnapshotResult> = None;
 
     for _ in 0..2 {
         let notification = notify_rx.recv().await.unwrap();
@@ -3452,7 +3452,7 @@ async fn test_persisted_deletion_record_remap() {
         {
             assert!(stored_data_compaction_result.is_none());
             stored_data_compaction_result = Some(data_compaction_result.unwrap());
-        } else if let TableEvent::IcebergSnapshotResult {
+        } else if let TableEvent::PersistenceSnapshotResult {
             iceberg_snapshot_result,
         } = notification
         {

--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -265,7 +265,7 @@ pub struct SnapshotTask {
     new_streaming_xact: Vec<TransactionStreamOutput>,
 
     /// Schema change, or force snapshot.
-    force_empty_iceberg_payload: bool,
+    force_empty_persistence_payload: bool,
 
     /// Committed deletion records, which have been persisted into iceberg, and should be pruned from mooncake snapshot.
     committed_deletion_logs: HashSet<(FileId, usize /*row idx*/)>,
@@ -305,7 +305,7 @@ impl SnapshotTask {
             new_largest_flush_lsn: None,
             new_commit_point: None,
             new_streaming_xact: Vec::new(),
-            force_empty_iceberg_payload: false,
+            force_empty_persistence_payload: false,
             // Committed deletion logs which have been persisted, and should be pruned from mooncake snapshot.
             committed_deletion_logs: HashSet::new(),
             // Index merge related fields.
@@ -350,7 +350,7 @@ impl SnapshotTask {
     pub fn should_create_snapshot(&self) -> bool {
         // If mooncake has new transaction commits.
         (self.commit_lsn_baseline > 0 && self.commit_lsn_baseline != self.prev_commit_lsn_baseline)
-            || self.force_empty_iceberg_payload
+            || self.force_empty_persistence_payload
         // If mooncake table has completed streaming transactions.
             || !self.new_streaming_xact.is_empty()
         // If mooncake table accumulated large enough writes.
@@ -1103,8 +1103,8 @@ impl MooncakeTable {
     }
 
     /// Mark next iceberg snapshot as force, even if the payload is empty.
-    pub(crate) fn force_empty_iceberg_payload(&mut self) {
-        self.next_snapshot_task.force_empty_iceberg_payload = true;
+    pub(crate) fn force_empty_persistence_payload(&mut self) {
+        self.next_snapshot_task.force_empty_persistence_payload = true;
     }
 
     pub(crate) fn notify_snapshot_reader(&self, lsn: u64) {

--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -48,12 +48,12 @@ use crate::storage::mooncake_table::shared_array::SharedRowBufferSnapshot;
 use crate::storage::mooncake_table::snapshot::MooncakeSnapshotOutput;
 pub use crate::storage::mooncake_table::snapshot_read_output::ReadOutput as SnapshotReadOutput;
 #[cfg(test)]
-pub(crate) use crate::storage::mooncake_table::table_snapshot::IcebergSnapshotDataCompactionPayload;
+pub(crate) use crate::storage::mooncake_table::table_snapshot::PersistenceSnapshotDataCompactionPayload;
 pub(crate) use crate::storage::mooncake_table::table_snapshot::{
     take_data_files_to_import, take_data_files_to_remove, take_file_indices_to_import,
     take_file_indices_to_remove, FileIndiceMergePayload, FileIndiceMergeResult,
-    IcebergSnapshotDataCompactionResult, IcebergSnapshotIndexMergePayload, IcebergSnapshotResult,
-    PersistenceSnapshotImportPayload, PersistenceSnapshotPayload,
+    IcebergSnapshotDataCompactionResult, IcebergSnapshotResult, PersistenceSnapshotImportPayload,
+    PersistenceSnapshotIndexMergePayload, PersistenceSnapshotPayload,
 };
 use crate::storage::mooncake_table_config::MooncakeTableConfig;
 use crate::storage::snapshot_options::MaintenanceOption;

--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -673,7 +673,7 @@ impl MooncakeTable {
 
     /// Assert flush LSN doesn't regress.
     /// There're several cases for equal flush LSN, for example, force snapshot, table maintenance, etc.
-    fn assert_flush_lsn_on_iceberg_snapshot_res(
+    fn assert_flush_lsn_on_persistence_snapshot_res(
         persistence_lsn: Option<u64>,
         iceberg_snapshot_res: &PersistenceSnapshotResult,
     ) {
@@ -703,7 +703,7 @@ impl MooncakeTable {
 
         // ---- Update mooncake table fields ----
         let flush_lsn = iceberg_snapshot_res.flush_lsn;
-        Self::assert_flush_lsn_on_iceberg_snapshot_res(
+        Self::assert_flush_lsn_on_persistence_snapshot_res(
             self.last_persistence_snapshot_lsn,
             &iceberg_snapshot_res,
         );
@@ -1738,14 +1738,14 @@ mod mooncake_tests {
             evicted_files_to_delete: Vec::new(),
         };
         // Valid snapshot result.
-        MooncakeTable::assert_flush_lsn_on_iceberg_snapshot_res(
+        MooncakeTable::assert_flush_lsn_on_persistence_snapshot_res(
             /*persistence_lsn=*/ None,
             &iceberg_snapshot_result,
         );
         // Invalid snapshot result.
         let res_copy = iceberg_snapshot_result.clone();
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
-            MooncakeTable::assert_flush_lsn_on_iceberg_snapshot_res(Some(2), &res_copy);
+            MooncakeTable::assert_flush_lsn_on_persistence_snapshot_res(Some(2), &res_copy);
         }));
         assert!(result.is_err());
 
@@ -1760,13 +1760,13 @@ mod mooncake_tests {
             ..Default::default()
         };
         // Valid snapshot result.
-        MooncakeTable::assert_flush_lsn_on_iceberg_snapshot_res(
+        MooncakeTable::assert_flush_lsn_on_persistence_snapshot_res(
             /*persistence_lsn=*/ Some(1),
             &res_copy,
         );
         // Invalid snapshot result.
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
-            MooncakeTable::assert_flush_lsn_on_iceberg_snapshot_res(Some(2), &res_copy);
+            MooncakeTable::assert_flush_lsn_on_persistence_snapshot_res(Some(2), &res_copy);
         }));
         assert!(result.is_err());
 
@@ -1780,7 +1780,7 @@ mod mooncake_tests {
             ..Default::default()
         };
         // Valid snapshot result.
-        MooncakeTable::assert_flush_lsn_on_iceberg_snapshot_res(
+        MooncakeTable::assert_flush_lsn_on_persistence_snapshot_res(
             /*persistence_lsn=*/ Some(1),
             &res_copy,
         );

--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -72,7 +72,7 @@ pub(crate) use snapshot::SnapshotTableState;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::Arc;
-use table_snapshot::{IcebergSnapshotImportResult, IcebergSnapshotIndexMergeResult};
+use table_snapshot::{PersistenceSnapshotImportResult, PersistenceSnapshotIndexMergeResult};
 #[cfg(test)]
 use tokio::sync::mpsc::Receiver;
 use tokio::sync::mpsc::{self, Sender};
@@ -1623,7 +1623,7 @@ impl MooncakeTable {
             flush_lsn,
             new_table_schema,
             committed_deletion_logs,
-            import_result: IcebergSnapshotImportResult {
+            import_result: PersistenceSnapshotImportResult {
                 new_data_files: iceberg_persistence_res.remote_data_files
                     [0..new_data_files_cutoff_index_1]
                     .to_vec(),
@@ -1632,7 +1632,7 @@ impl MooncakeTable {
                     [0..new_file_indices_cutoff_index_1]
                     .to_vec(),
             },
-            index_merge_result: IcebergSnapshotIndexMergeResult {
+            index_merge_result: PersistenceSnapshotIndexMergeResult {
                 new_file_indices_imported: iceberg_persistence_res.remote_file_indices
                     [new_file_indices_cutoff_index_1..new_file_indices_cutoff_index_2]
                     .to_vec(),
@@ -1719,7 +1719,7 @@ mod mooncake_tests {
             flush_lsn: 1,
             new_table_schema: None,
             committed_deletion_logs: HashSet::new(),
-            import_result: IcebergSnapshotImportResult {
+            import_result: PersistenceSnapshotImportResult {
                 new_data_files: vec![create_data_file(
                     /*file_id=*/ 0,
                     "file_path".to_string(),
@@ -1727,7 +1727,7 @@ mod mooncake_tests {
                 puffin_blob_ref: HashMap::new(),
                 new_file_indices: vec![],
             },
-            index_merge_result: IcebergSnapshotIndexMergeResult::default(),
+            index_merge_result: PersistenceSnapshotIndexMergeResult::default(),
             data_compaction_result: IcebergSnapshotDataCompactionResult::default(),
             evicted_files_to_delete: Vec::new(),
         };
@@ -1745,7 +1745,7 @@ mod mooncake_tests {
 
         // Only data compaction result.
         let mut res_copy = iceberg_snapshot_result.clone();
-        res_copy.import_result = IcebergSnapshotImportResult::default();
+        res_copy.import_result = PersistenceSnapshotImportResult::default();
         res_copy.data_compaction_result = IcebergSnapshotDataCompactionResult {
             old_data_files_removed: vec![create_data_file(
                 /*file_id=*/ 0,

--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -52,8 +52,8 @@ pub(crate) use crate::storage::mooncake_table::table_snapshot::IcebergSnapshotDa
 pub(crate) use crate::storage::mooncake_table::table_snapshot::{
     take_data_files_to_import, take_data_files_to_remove, take_file_indices_to_import,
     take_file_indices_to_remove, FileIndiceMergePayload, FileIndiceMergeResult,
-    IcebergSnapshotDataCompactionResult, IcebergSnapshotImportPayload,
-    IcebergSnapshotIndexMergePayload, IcebergSnapshotResult, PersistenceSnapshotPayload,
+    IcebergSnapshotDataCompactionResult, IcebergSnapshotIndexMergePayload, IcebergSnapshotResult,
+    PersistenceSnapshotImportPayload, PersistenceSnapshotPayload,
 };
 use crate::storage::mooncake_table_config::MooncakeTableConfig;
 use crate::storage::snapshot_options::MaintenanceOption;

--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -53,7 +53,7 @@ pub(crate) use crate::storage::mooncake_table::table_snapshot::{
     take_data_files_to_import, take_data_files_to_remove, take_file_indices_to_import,
     take_file_indices_to_remove, FileIndiceMergePayload, FileIndiceMergeResult,
     IcebergSnapshotDataCompactionResult, IcebergSnapshotImportPayload,
-    IcebergSnapshotIndexMergePayload, IcebergSnapshotPayload, IcebergSnapshotResult,
+    IcebergSnapshotIndexMergePayload, IcebergSnapshotResult, PersistenceSnapshotPayload,
 };
 use crate::storage::mooncake_table_config::MooncakeTableConfig;
 use crate::storage::snapshot_options::MaintenanceOption;
@@ -1532,7 +1532,7 @@ impl MooncakeTable {
     /// Persist an iceberg snapshot.
     async fn persist_iceberg_snapshot_impl(
         mut iceberg_table_manager: Box<dyn TableManager>,
-        snapshot_payload: IcebergSnapshotPayload,
+        snapshot_payload: PersistenceSnapshotPayload,
         table_notify: Sender<TableEvent>,
         table_auto_incr_ids: std::ops::Range<u32>,
         table_event_id: uuid::Uuid,
@@ -1662,7 +1662,10 @@ impl MooncakeTable {
     }
 
     /// Create an iceberg snapshot.
-    pub(crate) fn persist_iceberg_snapshot(&mut self, snapshot_payload: IcebergSnapshotPayload) {
+    pub(crate) fn persist_iceberg_snapshot(
+        &mut self,
+        snapshot_payload: PersistenceSnapshotPayload,
+    ) {
         // Check invariant: there's at most one ongoing iceberg snapshot.
         let iceberg_table_manager = self.iceberg_table_manager.take().unwrap();
         assert!(

--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -424,7 +424,7 @@ impl SnapshotTask {
 #[derive(Clone, Debug, Default)]
 struct BackgroundTaskStatus {
     mooncake_snapshot_ongoing: bool,
-    iceberg_snapshot_ongoing: bool,
+    persistence_snapshot_ongoing: bool,
     index_merge_ongoing: bool,
     data_compaction_ongoing: bool,
 }
@@ -693,10 +693,10 @@ impl MooncakeTable {
     pub(crate) fn set_iceberg_snapshot_res(&mut self, iceberg_snapshot_res: IcebergSnapshotResult) {
         assert!(
             self.background_task_status_for_validation
-                .iceberg_snapshot_ongoing
+                .persistence_snapshot_ongoing
         );
         self.background_task_status_for_validation
-            .iceberg_snapshot_ongoing = false;
+            .persistence_snapshot_ongoing = false;
 
         // ---- Update mooncake table fields ----
         let flush_lsn = iceberg_snapshot_res.flush_lsn;
@@ -1668,10 +1668,10 @@ impl MooncakeTable {
         assert!(
             !self
                 .background_task_status_for_validation
-                .iceberg_snapshot_ongoing
+                .persistence_snapshot_ongoing
         );
         self.background_task_status_for_validation
-            .iceberg_snapshot_ongoing = true;
+            .persistence_snapshot_ongoing = true;
 
         // Create a detached task, whose completion will be notified separately.
         let new_file_ids_to_create = snapshot_payload.get_new_file_ids_num();

--- a/src/moonlink/src/storage/mooncake_table.rs
+++ b/src/moonlink/src/storage/mooncake_table.rs
@@ -841,7 +841,7 @@ impl MooncakeTable {
     }
 
     /// Get iceberg snapshot flush LSN.
-    pub fn get_iceberg_snapshot_lsn(&self) -> Option<u64> {
+    pub fn get_persistence_snapshot_lsn(&self) -> Option<u64> {
         self.last_persistence_snapshot_lsn
     }
 
@@ -1136,11 +1136,11 @@ impl MooncakeTable {
     /// * uuid: WAL persistence event unique id.
     #[must_use]
     pub(crate) fn do_wal_persistence_update(&mut self, uuid: uuid::Uuid) -> bool {
-        let latest_iceberg_snapshot_lsn = self.get_iceberg_snapshot_lsn();
+        let latest_persistence_snapshot_lsn = self.get_persistence_snapshot_lsn();
 
         let wal_persistence_update_result = self
             .wal_manager
-            .prepare_persistent_update(latest_iceberg_snapshot_lsn);
+            .prepare_persistent_update(latest_persistence_snapshot_lsn);
 
         if wal_persistence_update_result.should_do_persistence() {
             let event_sender_clone = self.table_notify.as_ref().unwrap().clone();

--- a/src/moonlink/src/storage/mooncake_table/persisted_records.rs
+++ b/src/moonlink/src/storage/mooncake_table/persisted_records.rs
@@ -8,10 +8,10 @@ use crate::storage::storage_utils::MooncakeDataFileRef;
 
 use std::collections::HashSet;
 
-/// Record iceberg persisted records, used to sync to mooncake snapshot.
+/// Record persisted records, used to sync to mooncake snapshot.
 #[derive(Debug, Default)]
-pub(crate) struct IcebergPersistedRecords {
-    /// Flush LSN for iceberg snapshot.
+pub(crate) struct PersistedRecords {
+    /// Flush LSN for snapshot.
     pub(crate) flush_lsn: Option<u64>,
     /// New data file, puffin file and file indices result.
     pub(crate) import_result: IcebergSnapshotImportResult,
@@ -21,7 +21,7 @@ pub(crate) struct IcebergPersistedRecords {
     pub(crate) data_compaction_result: IcebergSnapshotDataCompactionResult,
 }
 
-impl IcebergPersistedRecords {
+impl PersistedRecords {
     /// Return whether persistence result is empty.
     #[allow(dead_code)]
     pub fn is_empty(&self) -> bool {
@@ -53,7 +53,7 @@ impl IcebergPersistedRecords {
     ///
     /// Notice, we don't need to reflect file indices persistence for index merge and data compaction, since file indices are always cached on-disk, thus mooncake snapshot only access local cache files.
     ///
-    /// TODO(hjiang): It's actually better not to assume certain cache implementation, and only apply what iceberg table manager returns.
+    /// TODO(hjiang): It's actually better not to assume certain cache implementation, and only apply what table manager returns.
     pub fn get_file_indices_to_reflect_persistence(&self) -> (HashSet<FileId>, Vec<FileIndex>) {
         let mut persisted_file_indices = vec![];
         persisted_file_indices.extend(self.import_result.new_file_indices.iter().cloned());

--- a/src/moonlink/src/storage/mooncake_table/persisted_records.rs
+++ b/src/moonlink/src/storage/mooncake_table/persisted_records.rs
@@ -1,5 +1,5 @@
 use crate::storage::index::FileIndex;
-use crate::storage::mooncake_table::table_snapshot::IcebergSnapshotDataCompactionResult;
+use crate::storage::mooncake_table::table_snapshot::PersistenceSnapshotDataCompactionResult;
 use crate::storage::mooncake_table::table_snapshot::{
     PersistenceSnapshotImportResult, PersistenceSnapshotIndexMergeResult,
 };
@@ -18,7 +18,7 @@ pub(crate) struct PersistedRecords {
     /// Index merge persistence result.
     pub(crate) index_merge_result: PersistenceSnapshotIndexMergeResult,
     /// Data compaction persistence result.
-    pub(crate) data_compaction_result: IcebergSnapshotDataCompactionResult,
+    pub(crate) data_compaction_result: PersistenceSnapshotDataCompactionResult,
 }
 
 impl PersistedRecords {

--- a/src/moonlink/src/storage/mooncake_table/persisted_records.rs
+++ b/src/moonlink/src/storage/mooncake_table/persisted_records.rs
@@ -1,7 +1,7 @@
 use crate::storage::index::FileIndex;
 use crate::storage::mooncake_table::table_snapshot::IcebergSnapshotDataCompactionResult;
 use crate::storage::mooncake_table::table_snapshot::{
-    IcebergSnapshotImportResult, IcebergSnapshotIndexMergeResult,
+    PersistenceSnapshotImportResult, PersistenceSnapshotIndexMergeResult,
 };
 use crate::storage::storage_utils::FileId;
 use crate::storage::storage_utils::MooncakeDataFileRef;
@@ -14,9 +14,9 @@ pub(crate) struct PersistedRecords {
     /// Flush LSN for snapshot.
     pub(crate) flush_lsn: Option<u64>,
     /// New data file, puffin file and file indices result.
-    pub(crate) import_result: IcebergSnapshotImportResult,
+    pub(crate) import_result: PersistenceSnapshotImportResult,
     /// Index merge persistence result.
-    pub(crate) index_merge_result: IcebergSnapshotIndexMergeResult,
+    pub(crate) index_merge_result: PersistenceSnapshotIndexMergeResult,
     /// Data compaction persistence result.
     pub(crate) data_compaction_result: IcebergSnapshotDataCompactionResult,
 }

--- a/src/moonlink/src/storage/mooncake_table/persistence_buffer.rs
+++ b/src/moonlink/src/storage/mooncake_table/persistence_buffer.rs
@@ -181,17 +181,14 @@ impl UnpersistedRecords {
     ///
     /// Update unpersisted data files from successful iceberg snapshot operation.
     fn prune_persisted_data_files(&mut self, task: &SnapshotTask) {
-        let persisted_new_data_files = &task.iceberg_persisted_records.import_result.new_data_files;
+        let persisted_new_data_files = &task.persisted_records.import_result.new_data_files;
         ma::assert_ge!(self.new_data_files.len(), persisted_new_data_files.len());
         self.new_data_files.drain(0..persisted_new_data_files.len());
     }
 
     /// Update unpersisted file indices from successful iceberg snapshot operation.
     fn prune_persisted_file_indices(&mut self, task: &SnapshotTask) {
-        let persisted_new_file_indices = &task
-            .iceberg_persisted_records
-            .import_result
-            .new_file_indices;
+        let persisted_new_file_indices = &task.persisted_records.import_result.new_file_indices;
         ma::assert_ge!(
             self.new_file_indices.len(),
             persisted_new_file_indices.len()
@@ -202,7 +199,7 @@ impl UnpersistedRecords {
 
     fn prune_persisted_merged_indices(&mut self, task: &SnapshotTask) {
         let old_merged_file_indices = &task
-            .iceberg_persisted_records
+            .persisted_records
             .index_merge_result
             .old_file_indices_removed;
         ma::assert_ge!(
@@ -213,7 +210,7 @@ impl UnpersistedRecords {
             .drain(0..old_merged_file_indices.len());
 
         let new_merged_file_indices = &task
-            .iceberg_persisted_records
+            .persisted_records
             .index_merge_result
             .new_file_indices_imported;
         ma::assert_ge!(
@@ -225,7 +222,7 @@ impl UnpersistedRecords {
     }
 
     fn prune_persisted_compacted_data(&mut self, task: &SnapshotTask) {
-        let persisted_compaction_res = &task.iceberg_persisted_records.data_compaction_result;
+        let persisted_compaction_res = &task.persisted_records.data_compaction_result;
 
         ma::assert_ge!(
             self.compacted_data_files_to_add.len(),

--- a/src/moonlink/src/storage/mooncake_table/replay/replay_events.rs
+++ b/src/moonlink/src/storage/mooncake_table/replay/replay_events.rs
@@ -9,7 +9,7 @@ use crate::storage::iceberg::puffin_utils::PuffinBlobRef;
 use crate::storage::mooncake_table::table_snapshot::IcebergSnapshotDataCompactionPayload;
 use crate::storage::mooncake_table::{
     DataCompactionPayload, FileIndiceMergePayload, IcebergSnapshotImportPayload,
-    IcebergSnapshotIndexMergePayload, IcebergSnapshotPayload,
+    IcebergSnapshotIndexMergePayload, PersistenceSnapshotPayload,
 };
 use crate::storage::snapshot_options::MaintenanceOption;
 use crate::storage::snapshot_options::SnapshotOption;
@@ -135,7 +135,7 @@ pub struct IcebergDataCompactionEvent {
     pub old_file_indices_to_remove: Vec<Vec<FileId>>,
 }
 
-/// For the ease of serde, replay event only stores necessary part of [`IcebergSnapshotPayload`].
+/// For the ease of serde, replay event only stores necessary part of [`PersistenceSnapshotPayload`].
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct IcebergSnapshotEventInitiation {
     /// Event id.
@@ -403,7 +403,7 @@ pub fn get_iceberg_data_compaction_payload(
 }
 pub fn create_iceberg_snapshot_event_initiation(
     uuid: uuid::Uuid,
-    payload: &IcebergSnapshotPayload,
+    payload: &PersistenceSnapshotPayload,
 ) -> IcebergSnapshotEventInitiation {
     IcebergSnapshotEventInitiation {
         uuid,

--- a/src/moonlink/src/storage/mooncake_table/replay/replay_events.rs
+++ b/src/moonlink/src/storage/mooncake_table/replay/replay_events.rs
@@ -8,8 +8,8 @@ use crate::storage::compaction::table_compaction::SingleFileToCompact;
 use crate::storage::iceberg::puffin_utils::PuffinBlobRef;
 use crate::storage::mooncake_table::table_snapshot::IcebergSnapshotDataCompactionPayload;
 use crate::storage::mooncake_table::{
-    DataCompactionPayload, FileIndiceMergePayload, IcebergSnapshotImportPayload,
-    IcebergSnapshotIndexMergePayload, PersistenceSnapshotPayload,
+    DataCompactionPayload, FileIndiceMergePayload, IcebergSnapshotIndexMergePayload,
+    PersistenceSnapshotImportPayload, PersistenceSnapshotPayload,
 };
 use crate::storage::snapshot_options::MaintenanceOption;
 use crate::storage::snapshot_options::SnapshotOption;
@@ -97,7 +97,7 @@ pub struct MooncakeSnapshotEventCompletion {
 /// Iceberg snapshot
 /// =====================
 ///
-/// For the ease of serde, replay event only stores necessary part of [`IcebergSnapshotImportPayload`].
+/// For the ease of serde, replay event only stores necessary part of [`PersistenceSnapshotImportPayload`].
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct IcebergImportEvent {
     /// New data files to introduce to the iceberg table.
@@ -308,8 +308,8 @@ pub fn create_mooncake_snapshot_event_completion(
     MooncakeSnapshotEventCompletion { uuid, lsn }
 }
 /// Create iceberg snapshot events.
-pub fn get_iceberg_snapshot_import_payload(
-    payload: &IcebergSnapshotImportPayload,
+pub fn get_persistence_snapshot_import_payload(
+    payload: &PersistenceSnapshotImportPayload,
 ) -> IcebergImportEvent {
     IcebergImportEvent {
         data_files: payload
@@ -409,7 +409,7 @@ pub fn create_iceberg_snapshot_event_initiation(
         uuid,
         flush_lsn: payload.flush_lsn,
         committed_deletion_logs: payload.committed_deletion_logs.clone(),
-        import_payload: get_iceberg_snapshot_import_payload(&payload.import_payload),
+        import_payload: get_persistence_snapshot_import_payload(&payload.import_payload),
         index_merge_payload: get_iceberg_index_merge_payload(&payload.index_merge_payload),
         data_compaction_payload: get_iceberg_data_compaction_payload(
             &payload.data_compaction_payload,

--- a/src/moonlink/src/storage/mooncake_table/replay/replay_events.rs
+++ b/src/moonlink/src/storage/mooncake_table/replay/replay_events.rs
@@ -6,10 +6,10 @@ use serde::{Deserialize, Serialize};
 use crate::row::MoonlinkRow;
 use crate::storage::compaction::table_compaction::SingleFileToCompact;
 use crate::storage::iceberg::puffin_utils::PuffinBlobRef;
-use crate::storage::mooncake_table::table_snapshot::IcebergSnapshotDataCompactionPayload;
+use crate::storage::mooncake_table::table_snapshot::PersistenceSnapshotDataCompactionPayload;
 use crate::storage::mooncake_table::{
-    DataCompactionPayload, FileIndiceMergePayload, IcebergSnapshotIndexMergePayload,
-    PersistenceSnapshotImportPayload, PersistenceSnapshotPayload,
+    DataCompactionPayload, FileIndiceMergePayload, PersistenceSnapshotImportPayload,
+    PersistenceSnapshotIndexMergePayload, PersistenceSnapshotPayload,
 };
 use crate::storage::snapshot_options::MaintenanceOption;
 use crate::storage::snapshot_options::SnapshotOption;
@@ -109,7 +109,7 @@ pub struct IcebergImportEvent {
     pub file_indices: Vec<Vec<FileId>>,
 }
 
-/// For the ease of serde, replay event only stores necessary part of [`IcebergSnapshotIndexMergePayload`].
+/// For the ease of serde, replay event only stores necessary part of [`PersistenceSnapshotIndexMergePayload`].
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct IcebergIndexMergeEvent {
     /// New file indices to import.
@@ -120,7 +120,7 @@ pub struct IcebergIndexMergeEvent {
     pub old_file_indices: Vec<Vec<FileId>>,
 }
 
-/// For the ease of serde, replay event only stores necessary part of [`IcebergSnapshotDataCompactionPayload`].
+/// For the ease of serde, replay event only stores necessary part of [`PersistenceSnapshotDataCompactionPayload`].
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct IcebergDataCompactionEvent {
     /// New data files to import.
@@ -336,7 +336,7 @@ pub fn get_persistence_snapshot_import_payload(
     }
 }
 pub fn get_iceberg_index_merge_payload(
-    payload: &IcebergSnapshotIndexMergePayload,
+    payload: &PersistenceSnapshotIndexMergePayload,
 ) -> IcebergIndexMergeEvent {
     IcebergIndexMergeEvent {
         new_file_indices: payload
@@ -364,7 +364,7 @@ pub fn get_iceberg_index_merge_payload(
     }
 }
 pub fn get_iceberg_data_compaction_payload(
-    payload: &IcebergSnapshotDataCompactionPayload,
+    payload: &PersistenceSnapshotDataCompactionPayload,
 ) -> IcebergDataCompactionEvent {
     IcebergDataCompactionEvent {
         new_data_files_to_import: payload

--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -80,10 +80,10 @@ pub(crate) struct SnapshotTableState {
     /// Table notifier.
     pub(super) table_notify: Option<Sender<TableEvent>>,
 
-    /// ---- Items not persisted to iceberg snapshot ----
+    /// ---- Items not persisted to table snapshot ----
     ///
-    /// Iceberg snapshot is created in an async style, which means it doesn't correspond 1-1 to mooncake snapshot, so we need to ensure idempotency for iceberg snapshot payload.
-    /// The following fields record unpersisted content, which will be placed in iceberg payload everytime.
+    /// Table snapshot is created in an async style, which means it doesn't correspond 1-1 to mooncake snapshot, so we need to ensure idempotency for table snapshot payload.
+    /// The following fields record unpersisted content, which will be placed in table payload everytime.
     pub(super) unpersisted_records: UnpersistedRecords,
 
     /// Batch ID counter for non-streaming operations
@@ -96,7 +96,7 @@ pub struct MooncakeSnapshotOutput {
     pub(crate) uuid: uuid::Uuid,
     /// Committed LSN for mooncake snapshot.
     pub(crate) commit_lsn: u64,
-    /// Iceberg snapshot payload.
+    /// Persistence snapshot payload.
     pub(crate) persistence_snapshot_payload: Option<PersistenceSnapshotPayload>,
     /// File indice merge payload.
     pub(crate) file_indices_merge_payload: IndexMergeMaintenanceStatus,
@@ -133,7 +133,7 @@ impl std::fmt::Debug for MooncakeSnapshotOutput {
 
 /// Committed deletion record to persist.
 pub(super) struct CommittedDeletionToPersist {
-    /// Commit deletion log included in the current iceberg persistence operation, which is used to prune snapshot deletion record after persistence finished.
+    /// Commit deletion log included in the current table persistence operation, which is used to prune snapshot deletion record after persistence finished.
     pub(super) committed_deletion_logs: HashSet<(FileId, usize /*row idx*/)>,
     /// Maps from data file to its changed deletion vector (which only contains newly deleted rows).
     pub(super) new_deletions_to_persist: HashMap<MooncakeDataFileRef, BatchDeletionVector>,

--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -589,7 +589,7 @@ impl SnapshotTableState {
         let flush_by_new_files_or_maintenance = self
             .unpersisted_records
             .if_persist_by_new_files_or_maintenance(opt.force_create);
-        let force_empty_iceberg_payload = task.force_empty_iceberg_payload;
+        let force_empty_persistence_payload = task.force_empty_persistence_payload;
 
         // Decide whether to perform a data compaction.
         let data_compaction_payload = self.get_payload_to_compact(&opt.data_compaction_option);
@@ -612,7 +612,7 @@ impl SnapshotTableState {
         let flush_lsn = self.current_snapshot.flush_lsn.unwrap_or(0);
         let largest_flush_lsn = self.current_snapshot.largest_flush_lsn.unwrap_or(0);
         if opt.iceberg_snapshot_option != IcebergSnapshotOption::Skip
-            && (force_empty_iceberg_payload || flush_by_table_write)
+            && (force_empty_persistence_payload || flush_by_table_write)
             && flush_lsn < task.min_ongoing_flush_lsn
             && flush_lsn == largest_flush_lsn
         {
@@ -624,7 +624,7 @@ impl SnapshotTableState {
             // Only create iceberg snapshot when there's something to import.
             if !committed_deletion_logs.new_deletions_to_persist.is_empty()
                 || flush_by_new_files_or_maintenance
-                || force_empty_iceberg_payload
+                || force_empty_persistence_payload
             {
                 iceberg_snapshot_payload = Some(self.get_iceberg_snapshot_payload(
                     &opt.iceberg_snapshot_option,

--- a/src/moonlink/src/storage/mooncake_table/snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot.rs
@@ -256,7 +256,7 @@ impl SnapshotTableState {
     /// Prune committed deletion logs for the given persisted records.
     fn prune_committed_deletion_logs(&mut self, task: &SnapshotTask) {
         // No iceberg snapshot persisted between two mooncake snapshot.
-        if task.iceberg_persisted_records.flush_lsn.is_none() {
+        if task.persisted_records.flush_lsn.is_none() {
             return;
         }
 
@@ -486,7 +486,7 @@ impl SnapshotTableState {
         // Validate mooncake table operation invariants.
         self.validate_mooncake_table_invariants(&task, &opt);
         // Validate persistence results.
-        task.iceberg_persisted_records
+        task.persisted_records
             .validate_imported_files_remote(&self.iceberg_warehouse_location);
 
         // Calculate the expected disk files number after current snapshot update.

--- a/src/moonlink/src/storage/mooncake_table/snapshot_persistence.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot_persistence.rs
@@ -243,10 +243,10 @@ impl SnapshotTableState {
         // Get persisted data files and file indices.
         // TODO(hjiang): Revisit whether we need separate fields in snapshot task.
         let persisted_data_files = task
-            .iceberg_persisted_records
+            .persisted_records
             .get_data_files_to_reflect_persistence();
         let (index_blocks_to_remove, persisted_file_indices) = task
-            .iceberg_persisted_records
+            .persisted_records
             .get_file_indices_to_reflect_persistence();
 
         // Record data files number and file indices number for persistence reflection, which is not supposed to change.
@@ -268,10 +268,7 @@ impl SnapshotTableState {
         // Step-3: Handle persisted deletion vector.
         let cur_evicted_files = self
             .update_deletion_vector_to_persisted(
-                task.iceberg_persisted_records
-                    .import_result
-                    .puffin_blob_ref
-                    .clone(),
+                task.persisted_records.import_result.puffin_blob_ref.clone(),
             )
             .await;
         evicted_files_to_delete.extend(cur_evicted_files);

--- a/src/moonlink/src/storage/mooncake_table/snapshot_persistence.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot_persistence.rs
@@ -2,11 +2,11 @@ use crate::create_data_file;
 use crate::storage::iceberg::puffin_utils::PuffinBlobRef;
 use crate::storage::index::FileIndex;
 use crate::storage::mooncake_table::snapshot::CommittedDeletionToPersist;
-use crate::storage::mooncake_table::table_snapshot::IcebergSnapshotDataCompactionPayload;
+use crate::storage::mooncake_table::table_snapshot::PersistenceSnapshotDataCompactionPayload;
 use crate::storage::mooncake_table::PersistenceSnapshotPayload;
 use crate::storage::mooncake_table::SnapshotTask;
 use crate::storage::mooncake_table::{
-    IcebergSnapshotIndexMergePayload, PersistenceSnapshotImportPayload,
+    PersistenceSnapshotImportPayload, PersistenceSnapshotIndexMergePayload,
 };
 use crate::storage::snapshot_options::IcebergSnapshotOption;
 use crate::storage::storage_utils::FileId;
@@ -44,7 +44,7 @@ impl SnapshotTableState {
                 new_deletion_vector: committed_deletion_to_persist.new_deletions_to_persist,
                 file_indices: self.unpersisted_records.get_unpersisted_file_indices(),
             },
-            index_merge_payload: IcebergSnapshotIndexMergePayload {
+            index_merge_payload: PersistenceSnapshotIndexMergePayload {
                 new_file_indices_to_import: self
                     .unpersisted_records
                     .get_merged_file_indices_to_add(),
@@ -52,7 +52,7 @@ impl SnapshotTableState {
                     .unpersisted_records
                     .get_merged_file_indices_to_remove(),
             },
-            data_compaction_payload: IcebergSnapshotDataCompactionPayload {
+            data_compaction_payload: PersistenceSnapshotDataCompactionPayload {
                 new_data_files_to_import: self
                     .unpersisted_records
                     .get_compacted_data_files_to_add(),

--- a/src/moonlink/src/storage/mooncake_table/snapshot_persistence.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot_persistence.rs
@@ -6,7 +6,7 @@ use crate::storage::mooncake_table::table_snapshot::IcebergSnapshotDataCompactio
 use crate::storage::mooncake_table::PersistenceSnapshotPayload;
 use crate::storage::mooncake_table::SnapshotTask;
 use crate::storage::mooncake_table::{
-    IcebergSnapshotImportPayload, IcebergSnapshotIndexMergePayload,
+    IcebergSnapshotIndexMergePayload, PersistenceSnapshotImportPayload,
 };
 use crate::storage::snapshot_options::IcebergSnapshotOption;
 use crate::storage::storage_utils::FileId;
@@ -39,7 +39,7 @@ impl SnapshotTableState {
             flush_lsn,
             new_table_schema: None,
             committed_deletion_logs: committed_deletion_to_persist.committed_deletion_logs,
-            import_payload: IcebergSnapshotImportPayload {
+            import_payload: PersistenceSnapshotImportPayload {
                 data_files: self.unpersisted_records.get_unpersisted_data_files(),
                 new_deletion_vector: committed_deletion_to_persist.new_deletions_to_persist,
                 file_indices: self.unpersisted_records.get_unpersisted_file_indices(),

--- a/src/moonlink/src/storage/mooncake_table/snapshot_persistence.rs
+++ b/src/moonlink/src/storage/mooncake_table/snapshot_persistence.rs
@@ -3,7 +3,7 @@ use crate::storage::iceberg::puffin_utils::PuffinBlobRef;
 use crate::storage::index::FileIndex;
 use crate::storage::mooncake_table::snapshot::CommittedDeletionToPersist;
 use crate::storage::mooncake_table::table_snapshot::IcebergSnapshotDataCompactionPayload;
-use crate::storage::mooncake_table::IcebergSnapshotPayload;
+use crate::storage::mooncake_table::PersistenceSnapshotPayload;
 use crate::storage::mooncake_table::SnapshotTask;
 use crate::storage::mooncake_table::{
     IcebergSnapshotImportPayload, IcebergSnapshotIndexMergePayload,
@@ -28,13 +28,13 @@ impl SnapshotTableState {
         self.committed_deletion_log.len() >= deletion_record_snapshot_threshold
     }
 
-    pub(super) fn get_iceberg_snapshot_payload(
+    pub(super) fn get_persistence_snapshot_payload(
         &self,
         opt: &IcebergSnapshotOption,
         flush_lsn: u64,
         committed_deletion_to_persist: CommittedDeletionToPersist,
-    ) -> IcebergSnapshotPayload {
-        IcebergSnapshotPayload {
+    ) -> PersistenceSnapshotPayload {
+        PersistenceSnapshotPayload {
             uuid: opt.get_event_id().unwrap(),
             flush_lsn,
             new_table_schema: None,

--- a/src/moonlink/src/storage/mooncake_table/table_creation_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_creation_test_utils.rs
@@ -37,7 +37,7 @@ use tokio::sync::mpsc::Receiver;
 
 impl MooncakeTable {
     #[cfg(test)]
-    pub(crate) fn set_iceberg_snapshot_lsn(&mut self, lsn: u64) {
+    pub(crate) fn set_persistence_snapshot_lsn(&mut self, lsn: u64) {
         self.last_persistence_snapshot_lsn = Some(lsn);
     }
 }

--- a/src/moonlink/src/storage/mooncake_table/table_creation_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_creation_test_utils.rs
@@ -38,7 +38,7 @@ use tokio::sync::mpsc::Receiver;
 impl MooncakeTable {
     #[cfg(test)]
     pub(crate) fn set_iceberg_snapshot_lsn(&mut self, lsn: u64) {
-        self.last_iceberg_snapshot_lsn = Some(lsn);
+        self.last_persistence_snapshot_lsn = Some(lsn);
     }
 }
 

--- a/src/moonlink/src/storage/mooncake_table/table_operation_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_operation_test_utils.rs
@@ -653,7 +653,7 @@ pub(crate) async fn alter_table_and_persist_to_iceberg(
     table: &mut MooncakeTable,
     notify_rx: &mut Receiver<TableEvent>,
 ) -> Arc<MooncakeTableMetadata> {
-    table.force_empty_iceberg_payload();
+    table.force_empty_persistence_payload();
     // Create a mooncake and iceberg snapshot to reflect both data files and schema changes.
     let (_, iceberg_snapshot_payload, _, data_compaction_payload, mut evicted_files_to_delete) =
         create_mooncake_snapshot_for_test(table, notify_rx).await;

--- a/src/moonlink/src/storage/mooncake_table/table_operation_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_operation_test_utils.rs
@@ -8,7 +8,7 @@ use crate::storage::io_utils;
 use crate::storage::mooncake_table::disk_slice::DiskSliceWriter;
 use crate::storage::mooncake_table::{
     AlterTableRequest, DataCompactionPayload, DataCompactionResult, FileIndiceMergePayload,
-    FileIndiceMergeResult, IcebergSnapshotPayload, IcebergSnapshotResult,
+    FileIndiceMergeResult, IcebergSnapshotResult, PersistenceSnapshotPayload,
     TableMetadata as MooncakeTableMetadata,
 };
 use crate::storage::snapshot_options::SnapshotOption;
@@ -290,7 +290,7 @@ pub(crate) async fn sync_mooncake_snapshot(
     receiver: &mut Receiver<TableEvent>,
 ) -> (
     u64,
-    Option<IcebergSnapshotPayload>,
+    Option<PersistenceSnapshotPayload>,
     IndexMergeMaintenanceStatus,
     DataCompactionMaintenanceStatus,
     Vec<String>,
@@ -303,7 +303,7 @@ pub(crate) async fn sync_mooncake_snapshot(
     {
         (
             mooncake_snapshot_result.commit_lsn,
-            mooncake_snapshot_result.iceberg_snapshot_payload,
+            mooncake_snapshot_result.persistence_snapshot_payload,
             mooncake_snapshot_result.file_indices_merge_payload,
             mooncake_snapshot_result.data_compaction_payload,
             mooncake_snapshot_result.evicted_data_files_to_delete,
@@ -357,7 +357,7 @@ pub(crate) async fn create_mooncake_snapshot_for_test(
     receiver: &mut Receiver<TableEvent>,
 ) -> (
     u64,
-    Option<IcebergSnapshotPayload>,
+    Option<PersistenceSnapshotPayload>,
     IndexMergeMaintenanceStatus,
     DataCompactionMaintenanceStatus,
     Vec<String>,
@@ -380,12 +380,17 @@ pub(crate) async fn create_mooncake_and_persist_for_test(
     receiver: &mut Receiver<TableEvent>,
 ) {
     // Create mooncake snapshot and block wait completion.
-    let (_, iceberg_snapshot_payload, _, data_compaction_payload, mut evicted_data_files_to_delete) =
-        create_mooncake_snapshot_for_test(table, receiver).await;
+    let (
+        _,
+        persistence_snapshot_payload,
+        _,
+        data_compaction_payload,
+        mut evicted_data_files_to_delete,
+    ) = create_mooncake_snapshot_for_test(table, receiver).await;
 
     // Create iceberg snapshot if possible.
-    if let Some(iceberg_snapshot_payload) = iceberg_snapshot_payload {
-        table.persist_iceberg_snapshot(iceberg_snapshot_payload);
+    if let Some(persistence_snapshot_payload) = persistence_snapshot_payload {
+        table.persist_iceberg_snapshot(persistence_snapshot_payload);
         let iceberg_snapshot_result = sync_iceberg_snapshot(receiver).await;
         table.set_iceberg_snapshot_res(iceberg_snapshot_result);
     }
@@ -404,17 +409,17 @@ pub(crate) async fn create_mooncake_and_persist_for_test(
 
 /// Test util function, which persist iceberg snapshot and reflect the change to mooncake snapshot.
 pub(crate) async fn create_iceberg_snapshot_and_reflect_to_mooncake_snapshot(
-    iceberg_snapshot_payload: IcebergSnapshotPayload,
+    persistence_snapshot_payload: PersistenceSnapshotPayload,
     table: &mut MooncakeTable,
     receiver: &mut Receiver<TableEvent>,
 ) -> (
     u64,
-    Option<IcebergSnapshotPayload>,
+    Option<PersistenceSnapshotPayload>,
     IndexMergeMaintenanceStatus,
     DataCompactionMaintenanceStatus,
     Vec<String>,
 ) {
-    table.persist_iceberg_snapshot(iceberg_snapshot_payload);
+    table.persist_iceberg_snapshot(persistence_snapshot_payload);
     let iceberg_snapshot_result = sync_iceberg_snapshot(receiver).await;
     table.set_iceberg_snapshot_res(iceberg_snapshot_result);
     create_mooncake_snapshot_for_test(table, receiver).await
@@ -425,8 +430,13 @@ pub(crate) async fn sync_mooncake_snapshot_and_create_new_by_iceberg_payload(
     table: &mut MooncakeTable,
     receiver: &mut Receiver<TableEvent>,
 ) {
-    let (_, iceberg_snapshot_payload, _, data_compaction_payload, mut evicted_data_files_to_delete) =
-        sync_mooncake_snapshot(table, receiver).await;
+    let (
+        _,
+        persistence_snapshot_payload,
+        _,
+        data_compaction_payload,
+        mut evicted_data_files_to_delete,
+    ) = sync_mooncake_snapshot(table, receiver).await;
 
     // Unpin reference count made for compaction.
     if let Some(payload) = data_compaction_payload.take_payload() {
@@ -438,8 +448,8 @@ pub(crate) async fn sync_mooncake_snapshot_and_create_new_by_iceberg_payload(
         .await
         .unwrap();
 
-    let iceberg_snapshot_payload = iceberg_snapshot_payload.unwrap();
-    table.persist_iceberg_snapshot(iceberg_snapshot_payload);
+    let persistence_snapshot_payload = persistence_snapshot_payload.unwrap();
+    table.persist_iceberg_snapshot(persistence_snapshot_payload);
     let iceberg_snapshot_result = sync_iceberg_snapshot(receiver).await;
     table.set_iceberg_snapshot_res(iceberg_snapshot_result);
 
@@ -458,10 +468,10 @@ pub(crate) async fn sync_mooncake_snapshot_and_create_new_by_iceberg_payload(
 /// Test util function to perform an iceberg snapshot, block wait its completion and gets its result.
 pub(crate) async fn create_iceberg_snapshot(
     table: &mut MooncakeTable,
-    iceberg_snapshot_payload: Option<IcebergSnapshotPayload>,
+    persistence_snapshot_payload: Option<PersistenceSnapshotPayload>,
     notify_rx: &mut Receiver<TableEvent>,
 ) -> Result<IcebergSnapshotResult> {
-    table.persist_iceberg_snapshot(iceberg_snapshot_payload.unwrap());
+    table.persist_iceberg_snapshot(persistence_snapshot_payload.unwrap());
     let notification = notify_rx.recv().await.unwrap();
     match notification {
         TableEvent::IcebergSnapshotResult {
@@ -501,29 +511,29 @@ pub(crate) async fn create_mooncake_and_persist_for_data_compaction_for_test(
     assert!(table.try_create_mooncake_snapshot(force_snapshot_option.clone()));
 
     // Create iceberg snapshot.
-    let (_, iceberg_snapshot_payload, _, _, evicted_data_files_to_delete) =
+    let (_, persistence_snapshot_payload, _, _, evicted_data_files_to_delete) =
         sync_mooncake_snapshot(table, receiver).await;
     // Delete evicted object storage cache entries immediately to make sure later accesses all happen on persisted files.
     io_utils::delete_local_files(&evicted_data_files_to_delete)
         .await
         .unwrap();
 
-    if let Some(iceberg_snapshot_payload) = iceberg_snapshot_payload {
-        table.persist_iceberg_snapshot(iceberg_snapshot_payload);
+    if let Some(persistence_snapshot_payload) = persistence_snapshot_payload {
+        table.persist_iceberg_snapshot(persistence_snapshot_payload);
         let iceberg_snapshot_result = sync_iceberg_snapshot(receiver).await;
         table.set_iceberg_snapshot_res(iceberg_snapshot_result);
     }
 
     // Get data compaction payload.
     assert!(table.try_create_mooncake_snapshot(force_snapshot_option.clone()));
-    let (_, iceberg_snapshot_payload, _, data_compaction_payload, evicted_data_files_to_delete) =
+    let (_, persistence_snapshot_payload, _, data_compaction_payload, evicted_data_files_to_delete) =
         sync_mooncake_snapshot(table, receiver).await;
     // Delete evicted object storage cache entries immediately to make sure later accesses all happen on persisted files.
     io_utils::delete_local_files(&evicted_data_files_to_delete)
         .await
         .unwrap();
 
-    assert!(iceberg_snapshot_payload.is_none());
+    assert!(persistence_snapshot_payload.is_none());
     let data_compaction_payload = data_compaction_payload.take_payload().unwrap();
 
     // Perform and block wait data compaction.
@@ -570,29 +580,34 @@ pub(crate) async fn create_mooncake_and_iceberg_snapshot_for_index_merge_for_tes
     assert!(table.try_create_mooncake_snapshot(force_snapshot_option.clone()));
 
     // Create iceberg snapshot.
-    let (_, iceberg_snapshot_payload, _, _, evicted_data_files_to_delete) =
+    let (_, persistence_snapshot_payload, _, _, evicted_data_files_to_delete) =
         sync_mooncake_snapshot(table, receiver).await;
     // Delete evicted object storage cache entries immediately to make sure later accesses all happen on persisted files.
     io_utils::delete_local_files(&evicted_data_files_to_delete)
         .await
         .unwrap();
 
-    if let Some(iceberg_snapshot_payload) = iceberg_snapshot_payload {
-        table.persist_iceberg_snapshot(iceberg_snapshot_payload);
+    if let Some(persistence_snapshot_payload) = persistence_snapshot_payload {
+        table.persist_iceberg_snapshot(persistence_snapshot_payload);
         let iceberg_snapshot_result = sync_iceberg_snapshot(receiver).await;
         table.set_iceberg_snapshot_res(iceberg_snapshot_result);
     }
 
     // Perform index merge.
     assert!(table.try_create_mooncake_snapshot(force_snapshot_option.clone()));
-    let (_, iceberg_snapshot_payload, file_indice_merge_payload, _, evicted_data_files_to_delete) =
-        sync_mooncake_snapshot(table, receiver).await;
+    let (
+        _,
+        persistence_snapshot_payload,
+        file_indice_merge_payload,
+        _,
+        evicted_data_files_to_delete,
+    ) = sync_mooncake_snapshot(table, receiver).await;
     // Delete evicted object storage cache entries immediately to make sure later accesses all happen on persisted files.
     io_utils::delete_local_files(&evicted_data_files_to_delete)
         .await
         .unwrap();
 
-    assert!(iceberg_snapshot_payload.is_none());
+    assert!(persistence_snapshot_payload.is_none());
     let file_indice_merge_payload = file_indice_merge_payload.take_payload().unwrap();
 
     table.perform_index_merge(file_indice_merge_payload);
@@ -655,7 +670,7 @@ pub(crate) async fn alter_table_and_persist_to_iceberg(
 ) -> Arc<MooncakeTableMetadata> {
     table.force_empty_persistence_payload();
     // Create a mooncake and iceberg snapshot to reflect both data files and schema changes.
-    let (_, iceberg_snapshot_payload, _, data_compaction_payload, mut evicted_files_to_delete) =
+    let (_, persistence_snapshot_payload, _, data_compaction_payload, mut evicted_files_to_delete) =
         create_mooncake_snapshot_for_test(table, notify_rx).await;
 
     // Unpin previously pinned files.
@@ -668,15 +683,15 @@ pub(crate) async fn alter_table_and_persist_to_iceberg(
         .await
         .unwrap();
 
-    if let Some(mut iceberg_snapshot_payload) = iceberg_snapshot_payload {
+    if let Some(mut persistence_snapshot_payload) = persistence_snapshot_payload {
         let alter_table_request = AlterTableRequest {
             new_columns: vec![],
             dropped_columns: vec!["age".to_string()],
         };
         let new_table_metadata = table.alter_table(alter_table_request);
-        iceberg_snapshot_payload.new_table_schema = Some(new_table_metadata.clone());
+        persistence_snapshot_payload.new_table_schema = Some(new_table_metadata.clone());
         let iceberg_snapshot_result =
-            create_iceberg_snapshot(table, Some(iceberg_snapshot_payload), notify_rx).await;
+            create_iceberg_snapshot(table, Some(persistence_snapshot_payload), notify_rx).await;
         table.set_iceberg_snapshot_res(iceberg_snapshot_result.unwrap());
         new_table_metadata
     } else {

--- a/src/moonlink/src/storage/mooncake_table/table_operation_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_operation_test_utils.rs
@@ -8,7 +8,7 @@ use crate::storage::io_utils;
 use crate::storage::mooncake_table::disk_slice::DiskSliceWriter;
 use crate::storage::mooncake_table::{
     AlterTableRequest, DataCompactionPayload, DataCompactionResult, FileIndiceMergePayload,
-    FileIndiceMergeResult, IcebergSnapshotResult, PersistenceSnapshotPayload,
+    FileIndiceMergeResult, PersistenceSnapshotPayload, PersistenceSnapshotResult,
     TableMetadata as MooncakeTableMetadata,
 };
 use crate::storage::snapshot_options::SnapshotOption;
@@ -314,9 +314,9 @@ pub(crate) async fn sync_mooncake_snapshot(
 }
 pub(crate) async fn sync_iceberg_snapshot(
     receiver: &mut Receiver<TableEvent>,
-) -> IcebergSnapshotResult {
+) -> PersistenceSnapshotResult {
     let notification = receiver.recv().await.unwrap();
-    if let TableEvent::IcebergSnapshotResult {
+    if let TableEvent::PersistenceSnapshotResult {
         iceberg_snapshot_result,
     } = notification
     {
@@ -470,11 +470,11 @@ pub(crate) async fn create_iceberg_snapshot(
     table: &mut MooncakeTable,
     persistence_snapshot_payload: Option<PersistenceSnapshotPayload>,
     notify_rx: &mut Receiver<TableEvent>,
-) -> Result<IcebergSnapshotResult> {
+) -> Result<PersistenceSnapshotResult> {
     table.persist_iceberg_snapshot(persistence_snapshot_payload.unwrap());
     let notification = notify_rx.recv().await.unwrap();
     match notification {
-        TableEvent::IcebergSnapshotResult {
+        TableEvent::PersistenceSnapshotResult {
             iceberg_snapshot_result,
         } => iceberg_snapshot_result,
         _ => {

--- a/src/moonlink/src/storage/mooncake_table/table_snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_snapshot.rs
@@ -133,7 +133,7 @@ impl IcebergSnapshotDataCompactionPayload {
 }
 
 #[derive(Clone)]
-pub struct IcebergSnapshotPayload {
+pub struct PersistenceSnapshotPayload {
     /// Background event id.
     pub(crate) uuid: uuid::Uuid,
     /// Flush LSN.
@@ -150,9 +150,9 @@ pub struct IcebergSnapshotPayload {
     pub(crate) data_compaction_payload: IcebergSnapshotDataCompactionPayload,
 }
 
-impl std::fmt::Debug for IcebergSnapshotPayload {
+impl std::fmt::Debug for PersistenceSnapshotPayload {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("IcebergSnapshotPayload")
+        f.debug_struct("PersistenceSnapshotPayload")
             .field("uuid", &self.uuid)
             .field("flush_lsn", &self.flush_lsn)
             .field(
@@ -166,7 +166,7 @@ impl std::fmt::Debug for IcebergSnapshotPayload {
     }
 }
 
-impl IcebergSnapshotPayload {
+impl PersistenceSnapshotPayload {
     /// Get the number of new files created in iceberg table.
     pub fn get_new_file_ids_num(&self) -> u32 {
         // Only deletion vector puffin blobs create files with new file ids.
@@ -491,7 +491,7 @@ impl std::fmt::Debug for FileIndiceMergeResult {
 
 /// Util functions to take all data files to import.
 pub fn take_data_files_to_import(
-    snapshot_payload: &mut IcebergSnapshotPayload,
+    snapshot_payload: &mut PersistenceSnapshotPayload,
 ) -> Vec<MooncakeDataFileRef> {
     let mut new_data_files = std::mem::take(&mut snapshot_payload.import_payload.data_files);
     new_data_files.extend(std::mem::take(
@@ -504,7 +504,7 @@ pub fn take_data_files_to_import(
 
 /// Util functions to take all data files to remove.
 pub fn take_data_files_to_remove(
-    snapshot_payload: &mut IcebergSnapshotPayload,
+    snapshot_payload: &mut PersistenceSnapshotPayload,
 ) -> Vec<MooncakeDataFileRef> {
     std::mem::take(
         &mut snapshot_payload
@@ -515,7 +515,7 @@ pub fn take_data_files_to_remove(
 
 /// Util functions to take all file indices to import.
 pub fn take_file_indices_to_import(
-    snapshot_payload: &mut IcebergSnapshotPayload,
+    snapshot_payload: &mut PersistenceSnapshotPayload,
 ) -> Vec<MooncakeFileIndex> {
     let mut new_file_indices = std::mem::take(&mut snapshot_payload.import_payload.file_indices);
     new_file_indices.extend(std::mem::take(
@@ -533,7 +533,7 @@ pub fn take_file_indices_to_import(
 
 /// Util function to take all file indices to remove.
 pub fn take_file_indices_to_remove(
-    snapshot_payload: &mut IcebergSnapshotPayload,
+    snapshot_payload: &mut PersistenceSnapshotPayload,
 ) -> Vec<MooncakeFileIndex> {
     let mut old_file_indices = std::mem::take(
         &mut snapshot_payload

--- a/src/moonlink/src/storage/mooncake_table/table_snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_snapshot.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 ///
 /// Iceberg snapshot payload by write operations.
 #[derive(Clone, Default)]
-pub struct IcebergSnapshotImportPayload {
+pub struct PersistenceSnapshotImportPayload {
     /// New data files to introduce to the iceberg table.
     pub(crate) data_files: Vec<MooncakeDataFileRef>,
     /// Maps from data filepath to its latest deletion vector.
@@ -28,9 +28,9 @@ pub struct IcebergSnapshotImportPayload {
     pub(crate) file_indices: Vec<MooncakeFileIndex>,
 }
 
-impl std::fmt::Debug for IcebergSnapshotImportPayload {
+impl std::fmt::Debug for PersistenceSnapshotImportPayload {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("IcebergSnapshotImportPayload")
+        f.debug_struct("PersistenceSnapshotImportPayload")
             .field("data files count", &self.data_files.len())
             .field("new deletion vector count", &self.new_deletion_vector.len())
             .field("file indices count", &self.file_indices.len())
@@ -40,14 +40,14 @@ impl std::fmt::Debug for IcebergSnapshotImportPayload {
 
 /// Iceberg snapshot payload by index merge operations.
 #[derive(Clone, Default)]
-pub struct IcebergSnapshotIndexMergePayload {
+pub struct PersistenceSnapshotIndexMergePayload {
     /// New file indices to import to the iceberg table.
     pub(crate) new_file_indices_to_import: Vec<MooncakeFileIndex>,
     /// Merged file indices to remove from the iceberg table.
     pub(crate) old_file_indices_to_remove: Vec<MooncakeFileIndex>,
 }
 
-impl IcebergSnapshotIndexMergePayload {
+impl PersistenceSnapshotIndexMergePayload {
     /// Return whether the payload is empty.
     pub fn is_empty(&self) -> bool {
         if self.new_file_indices_to_import.is_empty() {
@@ -60,9 +60,9 @@ impl IcebergSnapshotIndexMergePayload {
     }
 }
 
-impl std::fmt::Debug for IcebergSnapshotIndexMergePayload {
+impl std::fmt::Debug for PersistenceSnapshotIndexMergePayload {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("IcebergSnapshotIndexMergePayload")
+        f.debug_struct("PersistenceSnapshotIndexMergePayload")
             .field(
                 "new file indices to import count",
                 &self.new_file_indices_to_import.len(),
@@ -77,7 +77,7 @@ impl std::fmt::Debug for IcebergSnapshotIndexMergePayload {
 
 /// Iceberg snapshot payload by data file compaction operations.
 #[derive(Clone, Default)]
-pub struct IcebergSnapshotDataCompactionPayload {
+pub struct PersistenceSnapshotDataCompactionPayload {
     /// New data files to import to the iceberg table.
     pub(crate) new_data_files_to_import: Vec<MooncakeDataFileRef>,
     /// Old data files to remove from the iceberg table.
@@ -90,9 +90,9 @@ pub struct IcebergSnapshotDataCompactionPayload {
     pub(crate) data_file_records_remap: HashMap<RecordLocation, RemappedRecordLocation>,
 }
 
-impl std::fmt::Debug for IcebergSnapshotDataCompactionPayload {
+impl std::fmt::Debug for PersistenceSnapshotDataCompactionPayload {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("IcebergSnapshotDataCompactionPayload")
+        f.debug_struct("PersistenceSnapshotDataCompactionPayload")
             .field(
                 "new data files to import count",
                 &self.new_data_files_to_import.len(),
@@ -117,7 +117,7 @@ impl std::fmt::Debug for IcebergSnapshotDataCompactionPayload {
     }
 }
 
-impl IcebergSnapshotDataCompactionPayload {
+impl PersistenceSnapshotDataCompactionPayload {
     /// Return whether data compaction payload is empty.
     pub fn is_empty(&self) -> bool {
         if self.old_data_files_to_remove.is_empty() {
@@ -143,11 +143,11 @@ pub struct PersistenceSnapshotPayload {
     /// New mooncake table schema.
     pub(crate) new_table_schema: Option<Arc<MooncakeTableMetadata>>,
     /// Payload by import operations.
-    pub(crate) import_payload: IcebergSnapshotImportPayload,
+    pub(crate) import_payload: PersistenceSnapshotImportPayload,
     /// Payload by index merge operations.
-    pub(crate) index_merge_payload: IcebergSnapshotIndexMergePayload,
+    pub(crate) index_merge_payload: PersistenceSnapshotIndexMergePayload,
     /// Payload by data file compaction operations.
-    pub(crate) data_compaction_payload: IcebergSnapshotDataCompactionPayload,
+    pub(crate) data_compaction_payload: PersistenceSnapshotDataCompactionPayload,
 }
 
 impl std::fmt::Debug for PersistenceSnapshotPayload {

--- a/src/moonlink/src/storage/mooncake_table/table_snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_snapshot.rs
@@ -311,7 +311,7 @@ impl std::fmt::Debug for PersistenceSnapshotIndexMergeResult {
 
 /// Iceberg snapshot data file compaction result.
 #[derive(Clone, Default)]
-pub struct IcebergSnapshotDataCompactionResult {
+pub struct PersistenceSnapshotDataCompactionResult {
     /// New data files which are importedthe iceberg table.
     pub(crate) new_data_files_imported: Vec<MooncakeDataFileRef>,
     /// Old data files which are removed from the iceberg table.
@@ -324,7 +324,7 @@ pub struct IcebergSnapshotDataCompactionResult {
     pub(crate) data_file_records_remap: HashMap<RecordLocation, RemappedRecordLocation>,
 }
 
-impl IcebergSnapshotDataCompactionResult {
+impl PersistenceSnapshotDataCompactionResult {
     /// Return whether data compaction result is empty.
     pub fn is_empty(&self) -> bool {
         if self.old_data_files_removed.is_empty() {
@@ -340,9 +340,9 @@ impl IcebergSnapshotDataCompactionResult {
     }
 }
 
-impl std::fmt::Debug for IcebergSnapshotDataCompactionResult {
+impl std::fmt::Debug for PersistenceSnapshotDataCompactionResult {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("IcebergSnapshotDataCompactionResult")
+        f.debug_struct("PersistenceSnapshotDataCompactionResult")
             .field(
                 "new data files imported count",
                 &self.new_data_files_imported.len(),
@@ -367,7 +367,7 @@ impl std::fmt::Debug for IcebergSnapshotDataCompactionResult {
     }
 }
 
-pub struct IcebergSnapshotResult {
+pub struct PersistenceSnapshotResult {
     /// Background event id.
     pub(crate) uuid: uuid::Uuid,
     /// Table manager is (1) not `Sync` safe; (2) only used at iceberg snapshot creation, so we `move` it around every snapshot.
@@ -383,14 +383,14 @@ pub struct IcebergSnapshotResult {
     /// Iceberg index merge result.
     pub(crate) index_merge_result: PersistenceSnapshotIndexMergeResult,
     /// Iceberg data file compaction result.
-    pub(crate) data_compaction_result: IcebergSnapshotDataCompactionResult,
+    pub(crate) data_compaction_result: PersistenceSnapshotDataCompactionResult,
     /// Evicted files to delete by object storage cache.
     pub(crate) evicted_files_to_delete: Vec<String>,
 }
 
-impl Clone for IcebergSnapshotResult {
+impl Clone for PersistenceSnapshotResult {
     fn clone(&self) -> Self {
-        IcebergSnapshotResult {
+        PersistenceSnapshotResult {
             uuid: self.uuid,
             table_manager: None,
             flush_lsn: self.flush_lsn,
@@ -404,7 +404,7 @@ impl Clone for IcebergSnapshotResult {
     }
 }
 
-impl IcebergSnapshotResult {
+impl PersistenceSnapshotResult {
     /// Return whether iceberg snapshot result contains table maintenance persistence result.
     pub fn contains_maintenance_result(&self) -> bool {
         if !self.index_merge_result.is_empty() {
@@ -417,9 +417,9 @@ impl IcebergSnapshotResult {
     }
 }
 
-impl std::fmt::Debug for IcebergSnapshotResult {
+impl std::fmt::Debug for PersistenceSnapshotResult {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("IcebergSnapshotResult")
+        f.debug_struct("PersistenceSnapshotResult")
             .field("uuid", &self.uuid)
             .field("flush_lsn", &self.flush_lsn)
             .field(

--- a/src/moonlink/src/storage/mooncake_table/table_snapshot.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_snapshot.rs
@@ -244,7 +244,7 @@ impl IcebergSnapshotPayload {
 ///
 /// Iceberg snapshot import result.
 #[derive(Clone, Default)]
-pub struct IcebergSnapshotImportResult {
+pub struct PersistenceSnapshotImportResult {
     /// Persisted data files.
     pub(crate) new_data_files: Vec<MooncakeDataFileRef>,
     /// Persisted puffin blob reference.
@@ -253,7 +253,7 @@ pub struct IcebergSnapshotImportResult {
     pub(crate) new_file_indices: Vec<MooncakeFileIndex>,
 }
 
-impl IcebergSnapshotImportResult {
+impl PersistenceSnapshotImportResult {
     /// Return whether import result is empty.
     pub fn is_empty(&self) -> bool {
         self.new_data_files.is_empty()
@@ -262,9 +262,9 @@ impl IcebergSnapshotImportResult {
     }
 }
 
-impl std::fmt::Debug for IcebergSnapshotImportResult {
+impl std::fmt::Debug for PersistenceSnapshotImportResult {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("IcebergSnapshotImportResult")
+        f.debug_struct("PersistenceSnapshotImportResult")
             .field("new data file count", &self.new_data_files.len())
             .field("new file indices count", &self.new_file_indices.len())
             .field("puffin blob ref count", &self.puffin_blob_ref.len())
@@ -274,14 +274,14 @@ impl std::fmt::Debug for IcebergSnapshotImportResult {
 
 /// Iceberg snapshot index merge result.
 #[derive(Clone, Default)]
-pub struct IcebergSnapshotIndexMergeResult {
+pub struct PersistenceSnapshotIndexMergeResult {
     /// New file indices which are imported the iceberg table.
     pub(crate) new_file_indices_imported: Vec<MooncakeFileIndex>,
     /// Merged file indices which are removed from the iceberg table.
     pub(crate) old_file_indices_removed: Vec<MooncakeFileIndex>,
 }
 
-impl IcebergSnapshotIndexMergeResult {
+impl PersistenceSnapshotIndexMergeResult {
     /// Return whether index merge result is empty.
     pub fn is_empty(&self) -> bool {
         if self.new_file_indices_imported.is_empty() {
@@ -294,9 +294,9 @@ impl IcebergSnapshotIndexMergeResult {
     }
 }
 
-impl std::fmt::Debug for IcebergSnapshotIndexMergeResult {
+impl std::fmt::Debug for PersistenceSnapshotIndexMergeResult {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("IcebergSnapshotIndexMergeResult")
+        f.debug_struct("PersistenceSnapshotIndexMergeResult")
             .field(
                 "new file indices imported count",
                 &self.new_file_indices_imported.len(),
@@ -379,9 +379,9 @@ pub struct IcebergSnapshotResult {
     /// Committed deletion logs included in the current iceberg snapshot persistence operation, which is used to prune after persistence completion.
     pub(crate) committed_deletion_logs: HashSet<(FileId, usize /*row idx*/)>,
     /// Iceberg import result.
-    pub(crate) import_result: IcebergSnapshotImportResult,
+    pub(crate) import_result: PersistenceSnapshotImportResult,
     /// Iceberg index merge result.
-    pub(crate) index_merge_result: IcebergSnapshotIndexMergeResult,
+    pub(crate) index_merge_result: PersistenceSnapshotIndexMergeResult,
     /// Iceberg data file compaction result.
     pub(crate) data_compaction_result: IcebergSnapshotDataCompactionResult,
     /// Evicted files to delete by object storage cache.

--- a/src/moonlink/src/storage/mooncake_table/tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/tests.rs
@@ -626,7 +626,7 @@ async fn test_snapshot_store_failure() {
         .await
         .unwrap();
 
-    let (_, iceberg_snapshot_payload, _, _, evicted_data_files_cache) =
+    let (_, persistence_snapshot_payload, _, _, evicted_data_files_cache) =
         create_mooncake_snapshot_for_test(&mut table, &mut event_completion_rx).await;
     for cur_file in evicted_data_files_cache.into_iter() {
         tokio::fs::remove_file(&cur_file).await.unwrap();
@@ -634,7 +634,7 @@ async fn test_snapshot_store_failure() {
 
     let iceberg_snapshot_result = create_iceberg_snapshot(
         &mut table,
-        iceberg_snapshot_payload,
+        persistence_snapshot_payload,
         &mut event_completion_rx,
     )
     .await;
@@ -1790,13 +1790,13 @@ async fn test_iceberg_snapshot_blocked_by_ongoing_flushes() -> Result<()> {
     assert!(created, "Mooncake snapshot should be created");
 
     // Wait for mooncake snapshot completion
-    let (commit_lsn, iceberg_snapshot_payload, _, _, _) =
+    let (commit_lsn, persistence_snapshot_payload, _, _, _) =
         sync_mooncake_snapshot(&mut table, &mut event_completion_rx).await;
 
     assert_eq!(commit_lsn, 2, "Should have committed data up to LSN 2");
 
     // Test the table handler constraint logic
-    if let Some(payload) = iceberg_snapshot_payload {
+    if let Some(payload) = persistence_snapshot_payload {
         let min_pending = table.get_min_ongoing_flush_lsn();
 
         // The table handler should block this iceberg snapshot due to pending flushes
@@ -1827,11 +1827,11 @@ async fn test_iceberg_snapshot_blocked_by_ongoing_flushes() -> Result<()> {
     });
     assert!(created, "Second mooncake snapshot should be created");
 
-    let (_, iceberg_snapshot_payload, _, _, _) =
+    let (_, persistence_snapshot_payload, _, _, _) =
         sync_mooncake_snapshot(&mut table, &mut event_completion_rx).await;
 
     // Now table handler should allow iceberg snapshot
-    if let Some(payload) = iceberg_snapshot_payload {
+    if let Some(payload) = persistence_snapshot_payload {
         let min_pending = table.get_min_ongoing_flush_lsn();
         let can_initiate = TableHandlerState::can_initiate_iceberg_snapshot(
             payload.flush_lsn,
@@ -1892,11 +1892,11 @@ async fn test_out_of_order_flush_completion_with_iceberg_snapshots() -> Result<(
     });
     assert!(created);
 
-    let (_, iceberg_snapshot_payload, _, _, _) =
+    let (_, persistence_snapshot_payload, _, _, _) =
         sync_mooncake_snapshot(&mut table, &mut event_completion_rx).await;
 
     // Test constraint with min pending flush LSN = 10
-    if let Some(payload) = iceberg_snapshot_payload {
+    if let Some(payload) = persistence_snapshot_payload {
         let can_initiate = TableHandlerState::can_initiate_iceberg_snapshot(
             payload.flush_lsn,
             10, // min_ongoing_flush_lsn

--- a/src/moonlink/src/storage/mooncake_table/tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/tests.rs
@@ -522,7 +522,7 @@ async fn test_table_recovery() {
     )
     .await
     .unwrap();
-    assert_eq!(recovered_table.last_iceberg_snapshot_lsn.unwrap(), 100);
+    assert_eq!(recovered_table.last_persistence_snapshot_lsn.unwrap(), 100);
 }
 
 /// ---- Mock unit test ----

--- a/src/moonlink/src/storage/mooncake_table/tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/tests.rs
@@ -1804,7 +1804,7 @@ async fn test_iceberg_snapshot_blocked_by_ongoing_flushes() -> Result<()> {
             payload.flush_lsn,
             min_pending,
             true,  // iceberg_snapshot_result_consumed
-            false, // iceberg_snapshot_ongoing
+            false, // persistence_snapshot_ongoing
         );
 
         assert!(!can_initiate,

--- a/src/moonlink/src/storage/mooncake_table/tests.rs
+++ b/src/moonlink/src/storage/mooncake_table/tests.rs
@@ -632,13 +632,13 @@ async fn test_snapshot_store_failure() {
         tokio::fs::remove_file(&cur_file).await.unwrap();
     }
 
-    let iceberg_snapshot_result = create_iceberg_snapshot(
+    let persistence_snapshot_result = create_iceberg_snapshot(
         &mut table,
         persistence_snapshot_payload,
         &mut event_completion_rx,
     )
     .await;
-    assert!(iceberg_snapshot_result.is_err());
+    assert!(persistence_snapshot_result.is_err());
 }
 
 #[tokio::test]
@@ -1803,7 +1803,7 @@ async fn test_iceberg_snapshot_blocked_by_ongoing_flushes() -> Result<()> {
         let can_initiate = TableHandlerState::can_initiate_iceberg_snapshot(
             payload.flush_lsn,
             min_pending,
-            true,  // iceberg_snapshot_result_consumed
+            true,  // persistence_snapshot_result_consumed
             false, // persistence_snapshot_ongoing
         );
 

--- a/src/moonlink/src/storage/wal.rs
+++ b/src/moonlink/src/storage/wal.rs
@@ -256,7 +256,7 @@ impl WalTransactionState {
     /// and its completion file number < lowest_file_kept.
     fn is_captured_in_iceberg_snapshot(
         &self,
-        iceberg_snapshot_lsn: u64,
+        persistence_snapshot_lsn: u64,
         _lowest_file_kept: Option<u64>,
     ) -> bool {
         let completion_lsn_and_file = self.get_completion_lsn_and_file();
@@ -271,12 +271,12 @@ impl WalTransactionState {
                     self.check_completed_xact_consistent_with_iceberg_snapshot(
                         completion_lsn,
                         _completion_file_number,
-                        iceberg_snapshot_lsn,
+                        persistence_snapshot_lsn,
                         iceberg_snapshot_wal_file_num,
                     );
                 }
             }
-            if completion_lsn <= iceberg_snapshot_lsn {
+            if completion_lsn <= persistence_snapshot_lsn {
                 return true;
             }
         }
@@ -288,16 +288,16 @@ impl WalTransactionState {
         &self,
         completion_lsn: u64,
         completion_file_number: u64,
-        iceberg_snapshot_lsn: u64,
+        persistence_snapshot_lsn: u64,
         lowest_file_kept: u64,
     ) {
-        if completion_lsn > iceberg_snapshot_lsn {
+        if completion_lsn > persistence_snapshot_lsn {
             // If the transaction completed after the iceberg snapshot LSN,
             // its completion file HAS to be newer than or equal to the lowest file we're keeping
             // to prevent data loss.
             assert!(
                 completion_file_number >= lowest_file_kept,
-                "Transaction completed at LSN {completion_lsn} (after iceberg snapshot LSN {iceberg_snapshot_lsn}), \
+                "Transaction completed at LSN {completion_lsn} (after iceberg snapshot LSN {persistence_snapshot_lsn}), \
                 but its completion file {completion_file_number} is older than lowest file to keep {lowest_file_kept}"
             );
         }
@@ -328,7 +328,7 @@ pub struct PersistentWalMetadata {
     /// The list of all main transactions in the WAL that is persisted.
     main_transaction_tracker: Vec<WalTransactionState>,
     /// The LSN of the last iceberg snapshot that was persisted just before the WAL was persisted.
-    iceberg_snapshot_lsn: Option<u64>,
+    persistence_snapshot_lsn: Option<u64>,
     /// The mooncake table ID for this WAL.
     mooncake_table_id: String,
 }
@@ -340,7 +340,7 @@ impl PersistentWalMetadata {
         live_wal_files_tracker: Vec<WalFileInfo>,
         active_transactions: HashMap<u32, WalTransactionState>,
         main_transaction_tracker: Vec<WalTransactionState>,
-        iceberg_snapshot_lsn: Option<u64>,
+        persistence_snapshot_lsn: Option<u64>,
         mooncake_table_id: String,
     ) -> Self {
         Self {
@@ -349,7 +349,7 @@ impl PersistentWalMetadata {
             live_wal_files_tracker,
             active_transactions,
             main_transaction_tracker,
-            iceberg_snapshot_lsn,
+            persistence_snapshot_lsn,
             mooncake_table_id,
         }
     }
@@ -374,8 +374,8 @@ impl PersistentWalMetadata {
         &self.main_transaction_tracker
     }
 
-    pub fn get_iceberg_snapshot_lsn(&self) -> Option<u64> {
-        self.iceberg_snapshot_lsn
+    pub fn get_persistence_snapshot_lsn(&self) -> Option<u64> {
+        self.persistence_snapshot_lsn
     }
 
     pub fn get_mooncake_table_id(&self) -> &str {
@@ -391,7 +391,7 @@ impl PersistentWalMetadata {
 pub struct PreparePersistentUpdate {
     persistent_wal_metadata: PersistentWalMetadata,
     files_to_delete: Vec<WalFileInfo>,
-    accompanying_iceberg_snapshot_lsn: Option<u64>,
+    accompanying_persistence_snapshot_lsn: Option<u64>,
     files_to_persist: Option<(Vec<WalEvent>, WalFileInfo)>,
 }
 
@@ -399,13 +399,13 @@ impl PreparePersistentUpdate {
     pub fn new(
         persistent_wal_metadata: PersistentWalMetadata,
         files_to_delete: Vec<WalFileInfo>,
-        accompanying_iceberg_snapshot_lsn: Option<u64>,
+        accompanying_persistence_snapshot_lsn: Option<u64>,
         files_to_persist: Option<(Vec<WalEvent>, WalFileInfo)>,
     ) -> Self {
         Self {
             persistent_wal_metadata,
             files_to_delete,
-            accompanying_iceberg_snapshot_lsn,
+            accompanying_persistence_snapshot_lsn,
             files_to_persist,
         }
     }
@@ -526,28 +526,28 @@ impl WalManager {
     /// Remove all xacts that have been captured in the most recent iceberg snapshot.
     fn compute_cleanedup_xacts(
         &self,
-        iceberg_snapshot_lsn: Option<u64>,
+        persistence_snapshot_lsn: Option<u64>,
         files_to_delete: &[WalFileInfo],
     ) -> (HashMap<u32, WalTransactionState>, Vec<WalTransactionState>) {
-        if iceberg_snapshot_lsn.is_none() {
+        if persistence_snapshot_lsn.is_none() {
             return (
                 self.active_transactions.clone(),
                 self.main_transaction_tracker.clone(),
             );
         }
 
-        let iceberg_snapshot_lsn = iceberg_snapshot_lsn.unwrap();
+        let persistence_snapshot_lsn = persistence_snapshot_lsn.unwrap();
 
         let lowest_file_kept = files_to_delete.last().map(|file| file.file_number + 1);
         let mut cleanedup_xacts = self.active_transactions.clone();
         // remove all xacts that are captured in the iceberg snapshot
         cleanedup_xacts.retain(|_, state| {
-            !state.is_captured_in_iceberg_snapshot(iceberg_snapshot_lsn, lowest_file_kept)
+            !state.is_captured_in_iceberg_snapshot(persistence_snapshot_lsn, lowest_file_kept)
         });
         let mut cleanedup_main_xacts = self.main_transaction_tracker.clone();
         // remove all main xacts that are captured in the iceberg snapshot
         cleanedup_main_xacts.retain(|state| {
-            !state.is_captured_in_iceberg_snapshot(iceberg_snapshot_lsn, lowest_file_kept)
+            !state.is_captured_in_iceberg_snapshot(persistence_snapshot_lsn, lowest_file_kept)
         });
 
         (cleanedup_xacts, cleanedup_main_xacts)
@@ -747,9 +747,9 @@ impl WalManager {
     ///  determine the lowest file number to be kept.
     /// List of files returned is sorted in ascending order of file number.
     /// Should be called in preparation to asynchronously delete the files.
-    pub fn get_files_to_truncate(&self, iceberg_snapshot_lsn: u64) -> Vec<WalFileInfo> {
+    pub fn get_files_to_truncate(&self, persistence_snapshot_lsn: u64) -> Vec<WalFileInfo> {
         // get all file numbers less than the lowest file to keep as we can then delete them
-        let lowest_file_to_keep = self.get_lowest_file_to_keep(iceberg_snapshot_lsn);
+        let lowest_file_to_keep = self.get_lowest_file_to_keep(persistence_snapshot_lsn);
 
         if !self.live_wal_files_tracker.is_empty() {
             ma::assert_ge!(
@@ -795,7 +795,7 @@ impl WalManager {
     /// ------------------------------
     pub fn prepare_metadata(
         &self,
-        iceberg_snapshot_lsn: Option<u64>,
+        persistence_snapshot_lsn: Option<u64>,
         files_to_delete: Vec<WalFileInfo>,
         files_to_persist: Option<WalFileInfo>,
     ) -> PersistentWalMetadata {
@@ -803,14 +803,14 @@ impl WalManager {
             self.compute_updated_live_wal_file_tracker(&files_to_delete, &files_to_persist);
 
         let (cleanedup_xacts, cleanedup_main_xacts) =
-            self.compute_cleanedup_xacts(iceberg_snapshot_lsn, &files_to_delete);
+            self.compute_cleanedup_xacts(persistence_snapshot_lsn, &files_to_delete);
         PersistentWalMetadata::new(
             self.curr_file_number,
             self.highest_completion_lsn,
             live_wal_files_tracker,
             cleanedup_xacts,
             cleanedup_main_xacts,
-            iceberg_snapshot_lsn,
+            persistence_snapshot_lsn,
             self.wal_config.get_mooncake_table_id().to_string(),
         )
     }
@@ -820,10 +820,10 @@ impl WalManager {
     // ------------------------------
     pub fn prepare_persistent_update(
         &mut self,
-        iceberg_snapshot_lsn: Option<u64>,
+        persistence_snapshot_lsn: Option<u64>,
     ) -> PreparePersistentUpdate {
-        let files_to_truncate = if let Some(iceberg_snapshot_lsn) = iceberg_snapshot_lsn {
-            self.get_files_to_truncate(iceberg_snapshot_lsn)
+        let files_to_truncate = if let Some(persistence_snapshot_lsn) = persistence_snapshot_lsn {
+            self.get_files_to_truncate(persistence_snapshot_lsn)
         } else {
             vec![]
         };
@@ -831,7 +831,7 @@ impl WalManager {
         let next_files_to_persist = self.extract_next_persistence_file();
 
         let metadata_to_persist = self.prepare_metadata(
-            iceberg_snapshot_lsn,
+            persistence_snapshot_lsn,
             files_to_truncate.clone(),
             next_files_to_persist
                 .as_ref()
@@ -841,7 +841,7 @@ impl WalManager {
         PreparePersistentUpdate::new(
             metadata_to_persist,
             files_to_truncate,
-            iceberg_snapshot_lsn,
+            persistence_snapshot_lsn,
             next_files_to_persist,
         )
     }
@@ -983,9 +983,9 @@ impl WalManager {
     // Handling completed persistence and truncation
     // ------------------------------
 
-    fn clean_up_xacts(&mut self, iceberg_snapshot_lsn: u64, files_to_delete: &[WalFileInfo]) {
+    fn clean_up_xacts(&mut self, persistence_snapshot_lsn: u64, files_to_delete: &[WalFileInfo]) {
         let (cleanedup_xacts, cleanedup_main_xacts) =
-            self.compute_cleanedup_xacts(Some(iceberg_snapshot_lsn), files_to_delete);
+            self.compute_cleanedup_xacts(Some(persistence_snapshot_lsn), files_to_delete);
         self.active_transactions = cleanedup_xacts;
         self.main_transaction_tracker = cleanedup_main_xacts;
     }
@@ -1006,9 +1006,9 @@ impl WalManager {
         &mut self,
         persistence_update_result: &WalPersistenceUpdateResult,
     ) {
-        let accompanying_iceberg_snapshot_lsn = persistence_update_result
+        let accompanying_persistence_snapshot_lsn = persistence_update_result
             .prepare_persistent_update
-            .accompanying_iceberg_snapshot_lsn;
+            .accompanying_persistence_snapshot_lsn;
 
         self.update_live_wal_file_tracker(
             &persistence_update_result
@@ -1020,9 +1020,9 @@ impl WalManager {
                 .as_ref()
                 .map(|(_, file_info)| file_info.clone()),
         );
-        if let Some(accompanying_iceberg_snapshot_lsn) = accompanying_iceberg_snapshot_lsn {
+        if let Some(accompanying_persistence_snapshot_lsn) = accompanying_persistence_snapshot_lsn {
             self.clean_up_xacts(
-                accompanying_iceberg_snapshot_lsn,
+                accompanying_persistence_snapshot_lsn,
                 &persistence_update_result
                     .prepare_persistent_update
                     .files_to_delete,
@@ -1055,13 +1055,13 @@ impl WalManager {
                     // if the xact has completed
                     if let Some((completion_lsn, _)) = xact_state.get_completion_lsn_and_file() {
                         // we first check that completion LSN has to be greater than the iceberg snapshot lsn
-                        if let Some(iceberg_snapshot_lsn) = persistence_update_result
+                        if let Some(persistence_snapshot_lsn) = persistence_update_result
                             .prepare_persistent_update
-                            .accompanying_iceberg_snapshot_lsn
+                            .accompanying_persistence_snapshot_lsn
                         {
                             ma::assert_gt!(
-                                completion_lsn, iceberg_snapshot_lsn,
-                                "completion lsn {completion_lsn} should be greater than the iceberg snapshot lsn {iceberg_snapshot_lsn}"
+                                completion_lsn, persistence_snapshot_lsn,
+                                "completion lsn {completion_lsn} should be greater than the iceberg snapshot lsn {persistence_snapshot_lsn}"
                             );
                         }
                         // now, if completion lsn is <= the persisted wal highest seen lsn, then it should be in the persisted metadata
@@ -1368,7 +1368,7 @@ impl std::fmt::Debug for PersistentWalMetadata {
         f.debug_struct("PersistentWalMetadata")
             .field("curr_file_number", &self.curr_file_number)
             .field("highest_completion_lsn", &self.highest_completion_lsn)
-            .field("iceberg_snapshot_lsn", &self.iceberg_snapshot_lsn)
+            .field("persistence_snapshot_lsn", &self.persistence_snapshot_lsn)
             .field(
                 "live wal files tracker number",
                 &self.live_wal_files_tracker.len(),
@@ -1397,8 +1397,8 @@ impl std::fmt::Debug for PreparePersistentUpdate {
         f.debug_struct("PreparePersistentUpdate")
             .field("persistent_wal_metadata", &self.persistent_wal_metadata)
             .field(
-                "accompanying_iceberg_snapshot_lsn",
-                &self.accompanying_iceberg_snapshot_lsn,
+                "accompanying_persistence_snapshot_lsn",
+                &self.accompanying_persistence_snapshot_lsn,
             )
             .field("files to delete number", &self.files_to_delete.len())
             .field("files to persist number", &files_to_persist_num)

--- a/src/moonlink/src/storage/wal/test_utils.rs
+++ b/src/moonlink/src/storage/wal/test_utils.rs
@@ -26,9 +26,10 @@ impl WalManager {
     /// and then call handle_completed_wal_persistence_update to update the wal.
     pub async fn do_wal_persistence_update_for_test(
         &mut self,
-        last_iceberg_snapshot_lsn: Option<u64>,
+        last_persistence_snapshot_lsn: Option<u64>,
     ) -> Result<()> {
-        let prepare_persistent_update = self.prepare_persistent_update(last_iceberg_snapshot_lsn);
+        let prepare_persistent_update =
+            self.prepare_persistent_update(last_persistence_snapshot_lsn);
 
         let (event_sender, mut event_receiver) = tokio::sync::mpsc::channel::<TableEvent>(100);
 

--- a/src/moonlink/src/table_handler.rs
+++ b/src/moonlink/src/table_handler.rs
@@ -507,7 +507,7 @@ impl TableHandler {
                         if TableHandlerState::can_initiate_iceberg_snapshot(
                             mooncake_snapshot_result.commit_lsn,
                             min_pending_flush_lsn,
-                            table_handler_state.iceberg_snapshot_result_consumed,
+                            table_handler_state.persistence_snapshot_result_consumed,
                             table_handler_state.persistence_snapshot_ongoing,
                         ) {
                             if let Some(persistence_snapshot_payload) =
@@ -609,10 +609,10 @@ impl TableHandler {
                         }
                     }
                     TableEvent::PersistenceSnapshotResult {
-                        iceberg_snapshot_result,
+                        persistence_snapshot_result,
                     } => {
                         table_handler_state.persistence_snapshot_ongoing = false;
-                        match iceberg_snapshot_result {
+                        match persistence_snapshot_result {
                             Ok(snapshot_res) => {
                                 // Record iceberg snapshot completion.
                                 // Notice: operation completion record should be the first thing to do on event notification, and contains all information.
@@ -642,8 +642,8 @@ impl TableHandler {
                                     .flush_lsn_tx
                                     .send(iceberg_flush_lsn)
                                     .unwrap();
-                                table.set_iceberg_snapshot_res(snapshot_res);
-                                table_handler_state.iceberg_snapshot_result_consumed = false;
+                                table.set_persistence_snapshot_res(snapshot_res);
+                                table_handler_state.persistence_snapshot_result_consumed = false;
 
                                 // Notify all waiters with LSN satisfied.
                                 let replication_lsn = *replication_lsn_rx.borrow();

--- a/src/moonlink/src/table_handler.rs
+++ b/src/moonlink/src/table_handler.rs
@@ -608,7 +608,7 @@ impl TableHandler {
                             }
                         }
                     }
-                    TableEvent::IcebergSnapshotResult {
+                    TableEvent::PersistenceSnapshotResult {
                         iceberg_snapshot_result,
                     } => {
                         table_handler_state.persistence_snapshot_ongoing = false;

--- a/src/moonlink/src/table_handler.rs
+++ b/src/moonlink/src/table_handler.rs
@@ -389,7 +389,7 @@ impl TableHandler {
                         }
 
                         if table_handler_state.has_pending_force_snapshot_request()
-                            && !table_handler_state.iceberg_snapshot_ongoing
+                            && !table_handler_state.persistence_snapshot_ongoing
                         {
                             // flush if needed
                             if let Some(commit_lsn) = table_handler_state.table_consistent_view_lsn
@@ -445,7 +445,7 @@ impl TableHandler {
                             table_handler_state.table_maintenance_process_status =
                                 MaintenanceProcessStatus::InPersist;
                         }
-                        table_handler_state.iceberg_snapshot_ongoing = true;
+                        table_handler_state.persistence_snapshot_ongoing = true;
                         if table_handler_state
                             .should_complete_alter_table(iceberg_snapshot_payload.flush_lsn)
                         {
@@ -508,7 +508,7 @@ impl TableHandler {
                             mooncake_snapshot_result.commit_lsn,
                             min_pending_flush_lsn,
                             table_handler_state.iceberg_snapshot_result_consumed,
-                            table_handler_state.iceberg_snapshot_ongoing,
+                            table_handler_state.persistence_snapshot_ongoing,
                         ) {
                             if let Some(iceberg_snapshot_payload) =
                                 mooncake_snapshot_result.iceberg_snapshot_payload
@@ -611,7 +611,7 @@ impl TableHandler {
                     TableEvent::IcebergSnapshotResult {
                         iceberg_snapshot_result,
                     } => {
-                        table_handler_state.iceberg_snapshot_ongoing = false;
+                        table_handler_state.persistence_snapshot_ongoing = false;
                         match iceberg_snapshot_result {
                             Ok(snapshot_res) => {
                                 // Record iceberg snapshot completion.

--- a/src/moonlink/src/table_handler.rs
+++ b/src/moonlink/src/table_handler.rs
@@ -256,10 +256,12 @@ impl TableHandler {
 
                         // Fast-path: if iceberg snapshot requirement is already satisfied, notify directly.
                         let requested_lsn = requested_lsn.unwrap();
-                        let last_iceberg_snapshot_lsn = table.get_iceberg_snapshot_lsn();
+                        let last_persistence_snapshot_lsn = table.get_iceberg_snapshot_lsn();
                         let replication_lsn = *replication_lsn_rx.borrow();
-                        let persisted_table_lsn = table_handler_state
-                            .get_persisted_table_lsn(last_iceberg_snapshot_lsn, replication_lsn);
+                        let persisted_table_lsn = table_handler_state.get_persisted_table_lsn(
+                            last_persistence_snapshot_lsn,
+                            replication_lsn,
+                        );
 
                         if persisted_table_lsn >= requested_lsn {
                             table_handler_state.notify_persisted_table_lsn(persisted_table_lsn);

--- a/src/moonlink/src/table_handler.rs
+++ b/src/moonlink/src/table_handler.rs
@@ -413,7 +413,7 @@ impl TableHandler {
                                 if let SpecialTableState::AlterTable { .. } =
                                     table_handler_state.special_table_state
                                 {
-                                    table.force_empty_iceberg_payload();
+                                    table.force_empty_persistence_payload();
                                 }
                                 assert!(table.try_create_mooncake_snapshot(
                                     table_handler_state.get_mooncake_snapshot_option(
@@ -797,7 +797,7 @@ impl TableHandler {
                             if rows_persisted == 0
                                 && table_handler_state.has_pending_force_snapshot_request()
                             {
-                                table.force_empty_iceberg_payload();
+                                table.force_empty_persistence_payload();
                             }
                         }
                         Some(Err(e)) => {

--- a/src/moonlink/src/table_handler/chaos_replay.rs
+++ b/src/moonlink/src/table_handler/chaos_replay.rs
@@ -10,7 +10,7 @@ use crate::storage::mooncake_table::DiskSliceWriter;
 use crate::storage::mooncake_table::MooncakeTable;
 use crate::storage::mooncake_table::TableMetadata;
 use crate::storage::mooncake_table::{
-    table_creation_test_utils::*, FileIndiceMergeResult, IcebergSnapshotResult,
+    table_creation_test_utils::*, FileIndiceMergeResult, PersistenceSnapshotResult,
 };
 use crate::storage::mooncake_table_config::DiskSliceWriterConfig;
 use crate::table_handler::chaos_table_metadata::ReplayTableMetadata;
@@ -44,7 +44,7 @@ struct CompletedMooncakeSnapshot {
 #[derive(Clone, Debug)]
 struct CompletedIcebergSnapshot {
     /// Result of iceberg snapshot.
-    iceberg_snapshot_result: IcebergSnapshotResult,
+    iceberg_snapshot_result: PersistenceSnapshotResult,
 }
 
 #[derive(Clone, Debug)]
@@ -351,7 +351,7 @@ pub(crate) async fn replay(replay_filepath: &str) {
                         .is_none());
                     event_notification.notify_waiters();
                 }
-                TableEvent::IcebergSnapshotResult {
+                TableEvent::PersistenceSnapshotResult {
                     iceberg_snapshot_result,
                 } => {
                     let iceberg_snapshot_result = iceberg_snapshot_result.unwrap();

--- a/src/moonlink/src/table_handler/failure_tests.rs
+++ b/src/moonlink/src/table_handler/failure_tests.rs
@@ -1,7 +1,7 @@
 use super::test_utils::*;
 use crate::storage::filesystem::accessor::filesystem_accessor::FileSystemAccessor;
 use crate::storage::mooncake_table::table_creation_test_utils::*;
-use crate::storage::mooncake_table::IcebergSnapshotPayload;
+use crate::storage::mooncake_table::PersistenceSnapshotPayload;
 use crate::storage::mooncake_table::Snapshot as MooncakeSnapshot;
 use crate::storage::mooncake_table::TableMetadata as MooncakeTableMetadata;
 use crate::storage::mooncake_table_config::MooncakeTableConfig;
@@ -188,7 +188,7 @@ async fn test_force_index_merge_with_failed_iceberg_persistence() {
     mock_table_manager
         .expect_sync_snapshot()
         .times(1)
-        .returning(|snapshot_payload: IcebergSnapshotPayload, _| {
+        .returning(|snapshot_payload: PersistenceSnapshotPayload, _| {
             Box::pin(async move {
                 let mock_persistence_result = PersistenceResult {
                     remote_data_files: snapshot_payload.import_payload.data_files.clone(),
@@ -202,7 +202,7 @@ async fn test_force_index_merge_with_failed_iceberg_persistence() {
     mock_table_manager
         .expect_sync_snapshot()
         .times(1)
-        .returning(|snapshot_payload: IcebergSnapshotPayload, _| {
+        .returning(|snapshot_payload: PersistenceSnapshotPayload, _| {
             Box::pin(async move {
                 let mock_persistence_result = PersistenceResult {
                     remote_data_files: snapshot_payload.import_payload.data_files.clone(),
@@ -297,7 +297,7 @@ async fn test_force_data_compaction_with_failed_iceberg_persistence() {
     mock_table_manager
         .expect_sync_snapshot()
         .times(1)
-        .returning(|snapshot_payload: IcebergSnapshotPayload, _| {
+        .returning(|snapshot_payload: PersistenceSnapshotPayload, _| {
             Box::pin(async move {
                 let mock_persistence_result = PersistenceResult {
                     remote_data_files: snapshot_payload.import_payload.data_files.clone(),
@@ -311,7 +311,7 @@ async fn test_force_data_compaction_with_failed_iceberg_persistence() {
     mock_table_manager
         .expect_sync_snapshot()
         .times(1)
-        .returning(|snapshot_payload: IcebergSnapshotPayload, _| {
+        .returning(|snapshot_payload: PersistenceSnapshotPayload, _| {
             Box::pin(async move {
                 let mock_persistence_result = PersistenceResult {
                     remote_data_files: snapshot_payload.import_payload.data_files.clone(),
@@ -407,7 +407,7 @@ async fn test_force_full_compaction_with_failed_iceberg_persistence() {
     mock_table_manager
         .expect_sync_snapshot()
         .times(1)
-        .returning(|snapshot_payload: IcebergSnapshotPayload, _| {
+        .returning(|snapshot_payload: PersistenceSnapshotPayload, _| {
             Box::pin(async move {
                 let mock_persistence_result = PersistenceResult {
                     remote_data_files: snapshot_payload.import_payload.data_files.clone(),
@@ -421,7 +421,7 @@ async fn test_force_full_compaction_with_failed_iceberg_persistence() {
     mock_table_manager
         .expect_sync_snapshot()
         .times(1)
-        .returning(|snapshot_payload: IcebergSnapshotPayload, _| {
+        .returning(|snapshot_payload: PersistenceSnapshotPayload, _| {
             Box::pin(async move {
                 let mock_persistence_result = PersistenceResult {
                     remote_data_files: snapshot_payload.import_payload.data_files.clone(),

--- a/src/moonlink/src/table_handler/table_handler_state.rs
+++ b/src/moonlink/src/table_handler/table_handler_state.rs
@@ -136,7 +136,7 @@ impl TableHandlerState {
         table_maintenance_completion_tx: broadcast::Sender<Result<()>>,
         force_snapshot_completion_tx: watch::Sender<Option<Result<u64>>>,
         initial_persistence_lsn: Option<u64>,
-        iceberg_snapshot_lsn: Option<u64>,
+        persistence_snapshot_lsn: Option<u64>,
     ) -> Self {
         Self {
             iceberg_snapshot_result_consumed: true,
@@ -147,7 +147,7 @@ impl TableHandlerState {
             latest_commit_lsn: None,
             special_table_state: SpecialTableState::Normal,
             // Force snapshot fields.
-            table_consistent_view_lsn: iceberg_snapshot_lsn,
+            table_consistent_view_lsn: persistence_snapshot_lsn,
             largest_force_snapshot_lsn: None,
             force_snapshot_completion_tx,
             // Table maintenance fields.
@@ -252,23 +252,23 @@ impl TableHandlerState {
     /// In the above situation, LSN-1 is "iceberg snapshot LSN", while LSN-2 is "persisted table LSN".
     pub(crate) fn get_persisted_table_lsn(
         &self,
-        iceberg_snapshot_lsn: Option<u64>,
+        persistence_snapshot_lsn: Option<u64>,
         replication_lsn: u64,
     ) -> u64 {
         // Case-1: there're no activities in the current table, replication LSN indicates current status.
-        if iceberg_snapshot_lsn.is_none() && self.table_consistent_view_lsn.is_none() {
+        if persistence_snapshot_lsn.is_none() && self.table_consistent_view_lsn.is_none() {
             return replication_lsn;
         }
 
         // Case-2: if there're no updates since last iceberg snapshot, replication LSN indicates persisted table LSN.
-        if iceberg_snapshot_lsn == self.table_consistent_view_lsn {
+        if persistence_snapshot_lsn == self.table_consistent_view_lsn {
             // Notice: replication LSN comes from replication events, so if all events have been processed (i.e., a clean recovery case), replication LSN is 0.
-            return std::cmp::max(replication_lsn, iceberg_snapshot_lsn.unwrap());
+            return std::cmp::max(replication_lsn, persistence_snapshot_lsn.unwrap());
         }
 
         // Case-3: iceberg snapshot LSN indicates the persisted table LSN.
         // No guarantee an iceberg snapshot has been persisted here.
-        iceberg_snapshot_lsn.unwrap_or(0)
+        persistence_snapshot_lsn.unwrap_or(0)
     }
 
     /// Notify the persisted table LSN.
@@ -288,11 +288,11 @@ impl TableHandlerState {
     /// Update requested iceberg snapshot LSNs, if applicable.
     pub(crate) fn update_iceberg_persisted_lsn(
         &mut self,
-        iceberg_snapshot_lsn: u64,
+        persistence_snapshot_lsn: u64,
         replication_lsn: u64,
     ) {
         let persisted_table_lsn =
-            self.get_persisted_table_lsn(Some(iceberg_snapshot_lsn), replication_lsn);
+            self.get_persisted_table_lsn(Some(persistence_snapshot_lsn), replication_lsn);
         self.notify_persisted_table_lsn(persisted_table_lsn);
 
         if let Some(largest_force_snapshot_lsn) = self.largest_force_snapshot_lsn {
@@ -373,13 +373,13 @@ impl TableHandlerState {
         };
     }
 
-    pub(crate) fn should_complete_alter_table(&self, iceberg_snapshot_lsn: u64) -> bool {
+    pub(crate) fn should_complete_alter_table(&self, persistence_snapshot_lsn: u64) -> bool {
         if let SpecialTableState::AlterTable {
             alter_table_lsn, ..
         } = self.special_table_state
         {
-            ma::assert_le!(iceberg_snapshot_lsn, alter_table_lsn);
-            iceberg_snapshot_lsn == alter_table_lsn
+            ma::assert_le!(persistence_snapshot_lsn, alter_table_lsn);
+            persistence_snapshot_lsn == alter_table_lsn
         } else {
             false
         }

--- a/src/moonlink/src/table_handler/test_utils.rs
+++ b/src/moonlink/src/table_handler/test_utils.rs
@@ -489,13 +489,13 @@ impl TestEnvironment {
     pub async fn check_wal_metadata_invariants(
         &self,
         metadata: &PersistentWalMetadata,
-        iceberg_snapshot_lsn: Option<u64>,
+        persistence_snapshot_lsn: Option<u64>,
         should_contain_xact_ids: Vec<u32>,
         should_not_contain_xact_ids: Vec<u32>,
     ) {
         assert_eq!(
-            metadata.get_iceberg_snapshot_lsn(),
-            iceberg_snapshot_lsn,
+            metadata.get_persistence_snapshot_lsn(),
+            persistence_snapshot_lsn,
             "iceberg snapshot lsn should be the same"
         );
 
@@ -513,7 +513,7 @@ impl TestEnvironment {
             if let WalTransactionState::Commit { completion_lsn, .. }
             | WalTransactionState::Abort { completion_lsn, .. } = xact_state
             {
-                if let Some(lsn) = iceberg_snapshot_lsn {
+                if let Some(lsn) = persistence_snapshot_lsn {
                     ma::assert_gt!(
                         *completion_lsn,
                         lsn,
@@ -534,7 +534,7 @@ impl TestEnvironment {
             if let WalTransactionState::Commit { completion_lsn, .. }
             | WalTransactionState::Abort { completion_lsn, .. } = xact
             {
-                if let Some(lsn) = iceberg_snapshot_lsn {
+                if let Some(lsn) = persistence_snapshot_lsn {
                     ma::assert_gt!(
                         *completion_lsn,
                         lsn,

--- a/src/moonlink/src/table_handler/tests.rs
+++ b/src/moonlink/src/table_handler/tests.rs
@@ -1686,7 +1686,7 @@ async fn test_discard_duplicate_writes() {
     )
     .await
     .unwrap();
-    mooncake_table.set_iceberg_snapshot_lsn(10);
+    mooncake_table.set_persistence_snapshot_lsn(10);
     let env = TestEnvironment::new_with_mooncake_table(temp_dir, mooncake_table).await;
 
     // Perform non-streaming write operation which should be discarded.
@@ -2044,39 +2044,39 @@ fn test_get_persisted_table_lsn() {
         table_maintenance_completion_tx,
         force_snapshot_completion_tx,
         /*initial_persistence_lsn=*/ None,
-        /*iceberg_snapshot_lsn=*/ None,
+        /*persistence_snapshot_lsn=*/ None,
     );
 
     // Case-1: no table activity since for the current table.
     {
-        let iceberg_snapshot_lsn = None;
+        let persistence_snapshot_lsn = None;
         let replication_lsn = 1;
         table_handler_state.table_consistent_view_lsn = None;
 
         let persisted_table_lsn =
-            table_handler_state.get_persisted_table_lsn(iceberg_snapshot_lsn, replication_lsn);
+            table_handler_state.get_persisted_table_lsn(persistence_snapshot_lsn, replication_lsn);
         assert_eq!(persisted_table_lsn, 1);
     }
 
     // Case-2: table is at a consistent state, but iceberg persistence doesn't catch up.
     {
-        let iceberg_snapshot_lsn = Some(1);
+        let persistence_snapshot_lsn = Some(1);
         let replication_lsn = 2;
         table_handler_state.table_consistent_view_lsn = Some(2);
 
         let persisted_table_lsn =
-            table_handler_state.get_persisted_table_lsn(iceberg_snapshot_lsn, replication_lsn);
+            table_handler_state.get_persisted_table_lsn(persistence_snapshot_lsn, replication_lsn);
         assert_eq!(persisted_table_lsn, 1);
     }
 
     // Case-3: iceberg snapshot matches table consistent view.
     {
-        let iceberg_snapshot_lsn = Some(1);
+        let persistence_snapshot_lsn = Some(1);
         let replication_lsn = 2;
         table_handler_state.table_consistent_view_lsn = Some(1);
 
         let persisted_table_lsn =
-            table_handler_state.get_persisted_table_lsn(iceberg_snapshot_lsn, replication_lsn);
+            table_handler_state.get_persisted_table_lsn(persistence_snapshot_lsn, replication_lsn);
         assert_eq!(persisted_table_lsn, 2);
     }
 }

--- a/src/moonlink/src/table_notify.rs
+++ b/src/moonlink/src/table_notify.rs
@@ -190,7 +190,7 @@ pub enum TableEvent {
     /// Iceberg snapshot completes.
     PersistenceSnapshotResult {
         /// Result for iceberg snapshot.
-        iceberg_snapshot_result: Result<PersistenceSnapshotResult>,
+        persistence_snapshot_result: Result<PersistenceSnapshotResult>,
     },
     /// Index merge completes.
     IndexMergeResult {

--- a/src/moonlink/src/table_notify.rs
+++ b/src/moonlink/src/table_notify.rs
@@ -5,8 +5,8 @@ use crate::storage::mooncake_table::DataCompactionResult;
 use crate::storage::mooncake_table::DiskSliceWriter;
 use crate::storage::mooncake_table::FileIndiceMergePayload;
 use crate::storage::mooncake_table::FileIndiceMergeResult;
-use crate::storage::mooncake_table::IcebergSnapshotPayload;
 use crate::storage::mooncake_table::IcebergSnapshotResult;
+use crate::storage::mooncake_table::PersistenceSnapshotPayload;
 use crate::storage::wal::WalPersistenceUpdateResult;
 use crate::Result;
 use crate::StorageConfig;
@@ -185,7 +185,7 @@ pub enum TableEvent {
     /// Regular iceberg persistence.
     RegularIcebergSnapshot {
         /// Payload used to create a new iceberg snapshot.
-        iceberg_snapshot_payload: IcebergSnapshotPayload,
+        persistence_snapshot_payload: PersistenceSnapshotPayload,
     },
     /// Iceberg snapshot completes.
     IcebergSnapshotResult {

--- a/src/moonlink/src/table_notify.rs
+++ b/src/moonlink/src/table_notify.rs
@@ -5,8 +5,8 @@ use crate::storage::mooncake_table::DataCompactionResult;
 use crate::storage::mooncake_table::DiskSliceWriter;
 use crate::storage::mooncake_table::FileIndiceMergePayload;
 use crate::storage::mooncake_table::FileIndiceMergeResult;
-use crate::storage::mooncake_table::IcebergSnapshotResult;
 use crate::storage::mooncake_table::PersistenceSnapshotPayload;
+use crate::storage::mooncake_table::PersistenceSnapshotResult;
 use crate::storage::wal::WalPersistenceUpdateResult;
 use crate::Result;
 use crate::StorageConfig;
@@ -188,9 +188,9 @@ pub enum TableEvent {
         persistence_snapshot_payload: PersistenceSnapshotPayload,
     },
     /// Iceberg snapshot completes.
-    IcebergSnapshotResult {
+    PersistenceSnapshotResult {
         /// Result for iceberg snapshot.
-        iceberg_snapshot_result: Result<IcebergSnapshotResult>,
+        iceberg_snapshot_result: Result<PersistenceSnapshotResult>,
     },
     /// Index merge completes.
     IndexMergeResult {

--- a/src/moonlink_connectors/src/pg_replicate.rs
+++ b/src/moonlink_connectors/src/pg_replicate.rs
@@ -659,11 +659,11 @@ fn compute_confirmed_wal_flush_lsn(
     let mut confirmed_lsn: Option<u64> = None;
     for (table_id, wal_rx) in wal_flush_lsn_rxs.iter() {
         let wal_lsn = *wal_rx.borrow();
-        let iceberg_lsn = flush_lsn_rxs
+        let persistence_lsn = flush_lsn_rxs
             .get(table_id)
             .map(|rx| *rx.borrow())
             .unwrap_or(0);
-        let effective_lsn = if wal_lsn > 0 { wal_lsn } else { iceberg_lsn };
+        let effective_lsn = if wal_lsn > 0 { wal_lsn } else { persistence_lsn };
         confirmed_lsn = Some(match confirmed_lsn {
             Some(v) => v.min(effective_lsn),
             None => effective_lsn,

--- a/src/moonlink_connectors/src/pg_replicate.rs
+++ b/src/moonlink_connectors/src/pg_replicate.rs
@@ -573,7 +573,7 @@ impl PostgresConnection {
                 table_resources.event_sender.clone(),
                 table_resources.wal_persistence_metadata.clone(),
                 table_resources.wal_file_accessor.clone(),
-                table_resources.last_iceberg_snapshot_lsn,
+                table_resources.last_persistence_snapshot_lsn,
             )
             .await?;
             debug!(

--- a/src/moonlink_connectors/src/pg_replicate.rs
+++ b/src/moonlink_connectors/src/pg_replicate.rs
@@ -663,7 +663,11 @@ fn compute_confirmed_wal_flush_lsn(
             .get(table_id)
             .map(|rx| *rx.borrow())
             .unwrap_or(0);
-        let effective_lsn = if wal_lsn > 0 { wal_lsn } else { persistence_lsn };
+        let effective_lsn = if wal_lsn > 0 {
+            wal_lsn
+        } else {
+            persistence_lsn
+        };
         confirmed_lsn = Some(match confirmed_lsn {
             Some(v) => v.min(effective_lsn),
             None => effective_lsn,

--- a/src/moonlink_connectors/src/pg_replicate/table_init.rs
+++ b/src/moonlink_connectors/src/pg_replicate/table_init.rs
@@ -154,14 +154,14 @@ pub async fn build_table_components(
     )
     .await?;
 
-    let last_persistence_snapshot_lsn = table.get_iceberg_snapshot_lsn();
+    let last_persistence_snapshot_lsn = table.get_persistence_snapshot_lsn();
 
     let (commit_lsn_tx, commit_lsn_rx) = watch::channel(0u64);
     // Make a receiver first before possible mark operation, otherwise all receiver initializes with 0.
     let replication_lsn_tx = replication_state.subscribe();
-    if let Some(iceberg_snapshot_lsn) = last_persistence_snapshot_lsn {
-        commit_lsn_tx.send(iceberg_snapshot_lsn).unwrap();
-        replication_state.mark(iceberg_snapshot_lsn);
+    if let Some(persistence_snapshot_lsn) = last_persistence_snapshot_lsn {
+        commit_lsn_tx.send(persistence_snapshot_lsn).unwrap();
+        replication_state.mark(persistence_snapshot_lsn);
     }
 
     let read_state_manager = ReadStateManager::new(

--- a/src/moonlink_connectors/src/pg_replicate/table_init.rs
+++ b/src/moonlink_connectors/src/pg_replicate/table_init.rs
@@ -49,7 +49,7 @@ pub struct TableResources {
     pub wal_flush_lsn_rx: Option<watch::Receiver<u64>>,
     pub wal_file_accessor: Arc<dyn BaseFileSystemAccess>,
     pub wal_persistence_metadata: Option<PersistentWalMetadata>,
-    pub last_iceberg_snapshot_lsn: Option<u64>,
+    pub last_persistence_snapshot_lsn: Option<u64>,
 }
 
 /// Util function to delete and re-create the given directory.
@@ -154,12 +154,12 @@ pub async fn build_table_components(
     )
     .await?;
 
-    let last_iceberg_snapshot_lsn = table.get_iceberg_snapshot_lsn();
+    let last_persistence_snapshot_lsn = table.get_iceberg_snapshot_lsn();
 
     let (commit_lsn_tx, commit_lsn_rx) = watch::channel(0u64);
     // Make a receiver first before possible mark operation, otherwise all receiver initializes with 0.
     let replication_lsn_tx = replication_state.subscribe();
-    if let Some(iceberg_snapshot_lsn) = last_iceberg_snapshot_lsn {
+    if let Some(iceberg_snapshot_lsn) = last_persistence_snapshot_lsn {
         commit_lsn_tx.send(iceberg_snapshot_lsn).unwrap();
         replication_state.mark(iceberg_snapshot_lsn);
     }
@@ -201,7 +201,7 @@ pub async fn build_table_components(
         wal_flush_lsn_rx: Some(wal_flush_lsn_rx),
         wal_file_accessor,
         wal_persistence_metadata,
-        last_iceberg_snapshot_lsn,
+        last_persistence_snapshot_lsn,
     };
     Ok(table_resource)
 }


### PR DESCRIPTION
## Summary

Iceberg acts as storage layer in moonlink, which is irrelevant from mooncake core concepts, like mooncake table and snapshot; current implementation is not coupled with iceberg, but concept leaked everywhere.
This PR updates most of naming in moonlink, left ones will be followup later.

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
