### PR TITLE
[1/N] Basic delta store and load for data files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,6 +427,7 @@ version = "55.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af7686986a3bf2254c9fb130c623cdcb2f8e1f15763e7c71c310f0834da3d292"
 dependencies = [
+ "bitflags 2.9.4",
  "serde",
  "serde_json",
 ]
@@ -1584,10 +1585,11 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "comfy-table"
-version = "7.2.0"
+version = "7.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f8e18d0dca9578507f13f9803add0df13362b02c501c1c17734f0dbb52eaf0b"
+checksum = "4a65ebfec4fb190b6f90e944a817d60499ee0744e582530e2c9900a22e591d9a"
 dependencies = [
+ "crossterm",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -1691,6 +1693,15 @@ name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
+
+[[package]]
+name = "convert_case"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "core-foundation"
@@ -1856,6 +1867,28 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.9.4",
+ "crossterm_winapi",
+ "parking_lot",
+ "rustix 0.38.44",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crunchy"
@@ -2031,7 +2064,7 @@ dependencies = [
  "parquet",
  "rand 0.9.2",
  "regex",
- "sqlparser",
+ "sqlparser 0.55.0",
  "tempfile",
  "tokio",
  "url",
@@ -2137,7 +2170,7 @@ dependencies = [
  "parquet",
  "paste",
  "recursive",
- "sqlparser",
+ "sqlparser 0.55.0",
  "tokio",
  "web-time",
 ]
@@ -2341,7 +2374,7 @@ dependencies = [
  "paste",
  "recursive",
  "serde_json",
- "sqlparser",
+ "sqlparser 0.55.0",
 ]
 
 [[package]]
@@ -2659,7 +2692,7 @@ dependencies = [
  "log",
  "recursive",
  "regex",
- "sqlparser",
+ "sqlparser 0.55.0",
 ]
 
 [[package]]
@@ -2669,6 +2702,121 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef552e6f588e446098f6ba40d89ac146c8c7b64aade83c051ee00bb5d2bc18d"
 dependencies = [
  "uuid",
+]
+
+[[package]]
+name = "delta_kernel"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a889d7dae18cc716c0ea061e8d199e9c60b8b8fd9c15a52be6aee0eff1e7c6fe"
+dependencies = [
+ "arrow",
+ "bytes",
+ "chrono",
+ "comfy-table",
+ "delta_kernel_derive",
+ "futures",
+ "indexmap 2.11.0",
+ "itertools 0.14.0",
+ "object_store",
+ "parquet",
+ "reqwest",
+ "roaring",
+ "rustc_version",
+ "serde",
+ "serde_json",
+ "strum 0.27.2",
+ "thiserror 2.0.16",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid",
+ "z85",
+]
+
+[[package]]
+name = "delta_kernel_derive"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d6f7437b6725b3fb184ce0cbe89c9d1fad8782235bf5ea1e8a13fc69bc5cca"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "deltalake"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19aee5cc7555b3ea96c7fa552ce21c05332db55235e7f4a8a9d1400157c61030"
+dependencies = [
+ "delta_kernel",
+ "deltalake-core",
+]
+
+[[package]]
+name = "deltalake-core"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589ff38c0c6ce383bd83f0a618d76940d53404593210093ee5e2a9b1cff9d579"
+dependencies = [
+ "arrow",
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-ipc",
+ "arrow-json",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "async-trait",
+ "bytes",
+ "cfg-if",
+ "chrono",
+ "dashmap",
+ "delta_kernel",
+ "deltalake-derive",
+ "dirs",
+ "either",
+ "futures",
+ "humantime",
+ "indexmap 2.11.0",
+ "itertools 0.14.0",
+ "maplit",
+ "num_cpus",
+ "object_store",
+ "parking_lot",
+ "parquet",
+ "percent-encoding",
+ "percent-encoding-rfc3986",
+ "rand 0.8.5",
+ "regex",
+ "serde",
+ "serde_json",
+ "sqlparser 0.56.0",
+ "strum 0.27.2",
+ "thiserror 2.0.16",
+ "tokio",
+ "tracing",
+ "url",
+ "uuid",
+ "validator",
+]
+
+[[package]]
+name = "deltalake-derive"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "751cfe39c31f065104f3c2238d0e423849a4e4f2e2b8adf923d8276a59da7f3a"
+dependencies = [
+ "convert_case",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4400,6 +4548,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "maplit"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4554,6 +4708,7 @@ dependencies = [
  "chrono",
  "crc32fast",
  "criterion",
+ "deltalake",
  "fastbloom",
  "function_name",
  "futures",
@@ -5077,6 +5232,7 @@ dependencies = [
  "futures",
  "http 1.3.1",
  "http-body-util",
+ "httparse",
  "humantime",
  "hyper 1.7.0",
  "itertools 0.14.0",
@@ -5418,6 +5574,12 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "percent-encoding-rfc3986"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3637c05577168127568a64e9dc5a6887da720efef07b3d9472d45f63ab191166"
 
 [[package]]
 name = "petgraph"
@@ -5780,6 +5942,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
 dependencies = [
  "toml_edit",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -7188,6 +7372,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "sqlparser"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e68feb51ffa54fc841e086f58da543facfe3d7ae2a60d69b0a8cbbd30d16ae8d"
+dependencies = [
+ "log",
+ "recursive",
+]
+
+[[package]]
 name = "sqlparser_derive"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8257,8 +8451,39 @@ checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
  "getrandom 0.3.3",
  "js-sys",
+ "rand 0.9.2",
  "serde",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "validator"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0b4a29d8709210980a09379f27ee31549b73292c87ab9899beee1c0d3be6303"
+dependencies = [
+ "idna",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "url",
+ "validator_derive",
+]
+
+[[package]]
+name = "validator_derive"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bac855a2ce6f843beb229757e6e570a42e837bcb15e5f449dd48d5747d41bf77"
+dependencies = [
+ "darling 0.20.11",
+ "once_cell",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -8910,6 +9135,12 @@ dependencies = [
  "syn 2.0.106",
  "synstructure",
 ]
+
+[[package]]
+name = "z85"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b3a41ce106832b4da1c065baa4c31cf640cf965fa1483816402b7f6b96f0a64"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ const_format = "0.2"
 crc32fast = "1"
 datafusion = "49"
 datafusion-cli = "49"
+deltalake = "0.28"
 fastbloom = "0.12"
 futures = { version = "0.3", default-features = false }
 hashbrown = "0.15"

--- a/src/moonlink/Cargo.toml
+++ b/src/moonlink/Cargo.toml
@@ -57,6 +57,7 @@ bitstream-io = { workspace = true }
 bytes = { workspace = true }
 chrono = { workspace = true }
 crc32fast = { workspace = true }
+deltalake = { workspace = true }
 fastbloom = { workspace = true }
 function_name = { version = "0.3", optional = true }
 futures = { workspace = true }

--- a/src/moonlink/src/error.rs
+++ b/src/moonlink/src/error.rs
@@ -1,4 +1,5 @@
 use arrow::error::ArrowError;
+use deltalake::DeltaTableError;
 use iceberg::Error as IcebergError;
 use moonlink_error::io_error_utils::get_io_error_status;
 use moonlink_error::{ErrorStatus, ErrorStruct};
@@ -27,6 +28,9 @@ pub enum Error {
 
     #[error("{0}")]
     IcebergError(ErrorStruct),
+
+    #[error("{0}")]
+    DeltaLakeError(ErrorStruct),
 
     #[error("{0}")]
     OpenDal(ErrorStruct),
@@ -105,6 +109,15 @@ impl From<IcebergError> for Error {
         Error::IcebergError(
             ErrorStruct::new("Iceberg error".to_string(), status).with_source(source),
         )
+    }
+}
+
+impl From<DeltaTableError> for Error {
+    #[track_caller]
+    fn from(source: DeltaTableError) -> Self {
+        let status = ErrorStatus::Permanent;
+
+        Error::Json(ErrorStruct::new("Delta table error".to_string(), status).with_source(source))
     }
 }
 
@@ -194,6 +207,7 @@ impl Error {
             | Error::Parquet(err)
             | Error::WatchChannelRecvError(err)
             | Error::IcebergError(err)
+            | Error::DeltaLakeError(err)
             | Error::OpenDal(err)
             | Error::JoinError(err)
             | Error::PbToMoonlinkRowError(err)

--- a/src/moonlink/src/error.rs
+++ b/src/moonlink/src/error.rs
@@ -242,7 +242,7 @@ mod tests {
         if let Error::Io(ref inner) = io_error {
             let loc = inner.location.as_ref().unwrap();
             assert!(loc.contains("src/moonlink/src/error.rs"));
-            assert!(loc.contains("212"));
+            assert!(loc.contains("226"));
             assert!(loc.contains("9"));
         }
     }

--- a/src/moonlink/src/storage.rs
+++ b/src/moonlink/src/storage.rs
@@ -1,6 +1,8 @@
+// TODO(hjiang): make both iceberg and deltalake a features.
 pub(crate) mod async_bitwriter;
 pub(crate) mod cache;
 pub(crate) mod compaction;
+pub(crate) mod deltalake;
 pub(crate) mod filesystem;
 pub(crate) mod iceberg;
 pub(crate) mod index;

--- a/src/moonlink/src/storage/deltalake.rs
+++ b/src/moonlink/src/storage/deltalake.rs
@@ -4,3 +4,6 @@ pub(crate) mod deltalake_table_manager;
 pub(crate) mod deltalake_table_syncer;
 pub(crate) mod io_utils;
 pub(crate) mod utils;
+
+#[cfg(test)]
+mod test;

--- a/src/moonlink/src/storage/deltalake.rs
+++ b/src/moonlink/src/storage/deltalake.rs
@@ -1,0 +1,5 @@
+pub(crate) mod deltalake_table_config;
+pub(crate) mod deltalake_table_loader;
+pub(crate) mod deltalake_table_manager;
+pub(crate) mod deltalake_table_syncer;
+pub(crate) mod io_utils;

--- a/src/moonlink/src/storage/deltalake.rs
+++ b/src/moonlink/src/storage/deltalake.rs
@@ -3,3 +3,4 @@ pub(crate) mod deltalake_table_loader;
 pub(crate) mod deltalake_table_manager;
 pub(crate) mod deltalake_table_syncer;
 pub(crate) mod io_utils;
+pub(crate) mod utils;

--- a/src/moonlink/src/storage/deltalake/deltalake_table_config.rs
+++ b/src/moonlink/src/storage/deltalake/deltalake_table_config.rs
@@ -1,4 +1,4 @@
-use crate::{storage::filesystem::accessor_config::AccessorConfig, StorageConfig};
+use crate::storage::filesystem::accessor_config::AccessorConfig;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]

--- a/src/moonlink/src/storage/deltalake/deltalake_table_config.rs
+++ b/src/moonlink/src/storage/deltalake/deltalake_table_config.rs
@@ -1,0 +1,12 @@
+use crate::{storage::filesystem::accessor_config::AccessorConfig, StorageConfig};
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct DeltalakeTableConfig {
+    /// Deltalake table name.
+    pub table_name: String,
+    /// Deltalake location.
+    pub location: String,
+    /// Accessor config for accessing data files.
+    pub data_accessor_config: AccessorConfig,
+}

--- a/src/moonlink/src/storage/deltalake/deltalake_table_loader.rs
+++ b/src/moonlink/src/storage/deltalake/deltalake_table_loader.rs
@@ -4,6 +4,7 @@ use deltalake::kernel::Add;
 use deltalake::DeltaTable;
 
 use crate::storage::deltalake::deltalake_table_manager::DeltalakeTableManager;
+use crate::storage::iceberg::iceberg_table_manager::MOONCAKE_TABLE_FLUSH_LSN;
 use crate::storage::index::MooncakeIndex;
 use crate::storage::mooncake_table::delete_vector::BatchDeletionVector;
 use crate::storage::mooncake_table::{DiskFileEntry, Snapshot as MooncakeSnapshot};
@@ -35,8 +36,9 @@ impl DeltalakeTableManager {
     async fn get_flush_lsn(table: &DeltaTable) -> Result<u64> {
         let commit_infos = table.history(/*limit=*/ Some(1)).await?;
         let latest_commit = commit_infos.last().unwrap();
-        println!("lastest commit = {:?}", latest_commit);
-        Ok(1)
+        let flush_lsn_json = latest_commit.info.get(MOONCAKE_TABLE_FLUSH_LSN).unwrap();
+        let flush_lsn = flush_lsn_json.as_u64().unwrap();
+        Ok(flush_lsn)
     }
 
     pub(crate) async fn load_snapshot_from_table_impl(

--- a/src/moonlink/src/storage/deltalake/deltalake_table_loader.rs
+++ b/src/moonlink/src/storage/deltalake/deltalake_table_loader.rs
@@ -1,0 +1,10 @@
+use crate::storage::deltalake::deltalake_table_manager::DeltalakeTableManager;
+use crate::storage::mooncake_table::Snapshot as MooncakeSnapshot;
+use crate::Result;
+
+impl DeltalakeTableManager {
+    pub(crate) async fn load_snapshot_from_table_impl(
+        &mut self,
+    ) -> Result<(u32, MooncakeSnapshot)> {
+    }
+}

--- a/src/moonlink/src/storage/deltalake/deltalake_table_loader.rs
+++ b/src/moonlink/src/storage/deltalake/deltalake_table_loader.rs
@@ -1,10 +1,89 @@
+use std::collections::{HashMap, HashSet};
+
+use deltalake::kernel::Add;
+use deltalake::DeltaTable;
+
 use crate::storage::deltalake::deltalake_table_manager::DeltalakeTableManager;
-use crate::storage::mooncake_table::Snapshot as MooncakeSnapshot;
-use crate::Result;
+use crate::storage::index::MooncakeIndex;
+use crate::storage::mooncake_table::delete_vector::BatchDeletionVector;
+use crate::storage::mooncake_table::{DiskFileEntry, Snapshot as MooncakeSnapshot};
+use crate::storage::storage_utils::MooncakeDataFileRef;
+use crate::{create_data_file, Result};
 
 impl DeltalakeTableManager {
+    fn load_data_files(
+        adds: Vec<Add>,
+        next_file_id: &mut i32,
+    ) -> HashMap<MooncakeDataFileRef, DiskFileEntry> {
+        let mut disk_files = HashMap::with_capacity(adds.len());
+        for cur_add in adds.into_iter() {
+            let cur_file_id = *next_file_id;
+            *next_file_id += 1;
+            let data_file = create_data_file(cur_file_id as u64, cur_add.path.clone());
+            let disk_file_entry = DiskFileEntry {
+                cache_handle: None,
+                num_rows: 0, // TODO(hjiang): Record and recover.
+                file_size: cur_add.size as usize,
+                committed_deletion_vector: BatchDeletionVector::new(/*max_rows=*/ 0),
+                puffin_deletion_blob: None,
+            };
+            assert!(disk_files.insert(data_file, disk_file_entry).is_none());
+        }
+        disk_files
+    }
+
+    async fn get_flush_lsn(table: &DeltaTable) -> Result<u64> {
+        let commit_infos = table.history(/*limit=*/ Some(1)).await?;
+        let latest_commit = commit_infos.last().unwrap();
+        println!("lastest commit = {:?}", latest_commit);
+        Ok(1)
+    }
+
     pub(crate) async fn load_snapshot_from_table_impl(
         &mut self,
     ) -> Result<(u32, MooncakeSnapshot)> {
+        assert!(!self.snapshot_loaded);
+        self.snapshot_loaded = true;
+
+        // Unique file id to assign to every data file.
+        let mut next_file_id = 0;
+
+        // Handle cases where delta table doesn't exist.
+        self.initialize_table_if_exists().await?;
+        if self.table.is_none() {
+            let empty_mooncake_snapshot =
+                MooncakeSnapshot::new(self.mooncake_table_metadata.clone());
+            return Ok((next_file_id as u32, empty_mooncake_snapshot));
+        }
+        // TODO(hjiang): Validate schema before operation.
+
+        // Handle cases where no snapshot.
+        let table = self.table.as_ref().unwrap();
+        let snapshot = table.snapshot();
+        if snapshot.is_err() {
+            let empty_mooncake_snapshot =
+                MooncakeSnapshot::new(self.mooncake_table_metadata.clone());
+            return Ok((next_file_id as u32, empty_mooncake_snapshot));
+        }
+
+        let snapshot = snapshot.unwrap();
+        let flush_lsn = Self::get_flush_lsn(table).await?;
+
+        let log_store = table.log_store();
+        let adds = snapshot.file_actions(&*log_store).await?;
+        let disk_files = Self::load_data_files(adds, &mut next_file_id);
+
+        let mooncake_snapshot = MooncakeSnapshot {
+            metadata: self.mooncake_table_metadata.clone(),
+            disk_files,
+            snapshot_version: flush_lsn,
+            flush_lsn: Some(flush_lsn),
+            largest_flush_lsn: Some(flush_lsn),
+            indices: MooncakeIndex {
+                in_memory_index: HashSet::new(),
+                file_indices: Vec::new(),
+            },
+        };
+        Ok((next_file_id as u32, mooncake_snapshot))
     }
 }

--- a/src/moonlink/src/storage/deltalake/deltalake_table_loader.rs
+++ b/src/moonlink/src/storage/deltalake/deltalake_table_loader.rs
@@ -12,6 +12,7 @@ use crate::storage::storage_utils::MooncakeDataFileRef;
 use crate::{create_data_file, Result};
 
 impl DeltalakeTableManager {
+    #[allow(unused)]
     fn load_data_files(
         adds: Vec<Add>,
         next_file_id: &mut i32,
@@ -33,6 +34,7 @@ impl DeltalakeTableManager {
         disk_files
     }
 
+    #[allow(unused)]
     async fn get_flush_lsn(table: &DeltaTable) -> Result<u64> {
         let commit_infos = table.history(/*limit=*/ Some(1)).await?;
         let latest_commit = commit_infos.last().unwrap();
@@ -41,6 +43,7 @@ impl DeltalakeTableManager {
         Ok(flush_lsn)
     }
 
+    #[allow(unused)]
     pub(crate) async fn load_snapshot_from_table_impl(
         &mut self,
     ) -> Result<(u32, MooncakeSnapshot)> {

--- a/src/moonlink/src/storage/deltalake/deltalake_table_manager.rs
+++ b/src/moonlink/src/storage/deltalake/deltalake_table_manager.rs
@@ -49,6 +49,7 @@ pub struct DeltalakeTableManager {
 }
 
 impl DeltalakeTableManager {
+    #[allow(unused)]
     pub async fn new(
         mooncake_table_metadata: Arc<MooncakeTableMetadata>,
         object_storage_cache: Arc<dyn CacheTrait>,
@@ -66,12 +67,14 @@ impl DeltalakeTableManager {
         })
     }
 
+    #[allow(unused)]
     pub(crate) async fn initialize_table_if_exists(&mut self) -> Result<()> {
         assert!(self.table.is_none());
         self.table = utils::get_deltalake_table_if_exists(&self.config).await?;
         Ok(())
     }
 
+    #[allow(unused)]
     pub async fn sync_snapshot(
         &mut self,
         snapshot_payload: PersistenceSnapshotPayload,
@@ -83,6 +86,7 @@ impl DeltalakeTableManager {
         Ok(persistence_result)
     }
 
+    #[allow(unused)]
     pub async fn load_snapshot_from_table(&mut self) -> Result<(u32, MooncakeSnapshot)> {
         let snapshot = self.load_snapshot_from_table_impl().await?;
         Ok(snapshot)

--- a/src/moonlink/src/storage/deltalake/deltalake_table_manager.rs
+++ b/src/moonlink/src/storage/deltalake/deltalake_table_manager.rs
@@ -1,0 +1,82 @@
+use deltalake::kernel::engine::arrow_conversion::TryFromArrow;
+use deltalake::operations::create::CreateBuilder;
+use deltalake::DeltaTable;
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::error::Result;
+use crate::storage::deltalake::deltalake_table_config::DeltalakeTableConfig;
+use crate::storage::iceberg::table_manager::PersistenceFileParams;
+use crate::storage::iceberg::table_manager::PersistenceResult;
+use crate::storage::mooncake_table::{
+    PersistenceSnapshotPayload, TableMetadata as MooncakeTableMetadata,
+};
+use crate::storage::storage_utils::FileId;
+use crate::{BaseFileSystemAccess, CacheTrait};
+
+#[derive(Clone, Debug)]
+pub(crate) struct DataFileEntry {
+    /// Remote filepath.
+    pub(crate) remote_filepath: String,
+}
+
+// TODO(hjiang): Use the same table manager interface as iceberg one.
+#[derive(Debug)]
+pub struct DeltalakeTableManager {
+    /// Deltalake table configuration.
+    pub(crate) config: DeltalakeTableConfig,
+
+    /// Deltalake table.
+    pub(crate) table: DeltaTable,
+
+    /// Object storage cache.
+    pub(crate) object_storage_cache: Arc<dyn CacheTrait>,
+
+    /// Filesystem accessor.
+    pub(crate) filesystem_accessor: Arc<dyn BaseFileSystemAccess>,
+
+    /// Maps from file id to file entry.
+    pub(crate) persisted_data_files: HashMap<FileId, DataFileEntry>,
+}
+
+impl DeltalakeTableManager {
+    pub async fn new(
+        mooncake_table_metadata: Arc<MooncakeTableMetadata>,
+        object_storage_cache: Arc<dyn CacheTrait>,
+        filesystem_accessor: Arc<dyn BaseFileSystemAccess>,
+        config: DeltalakeTableConfig,
+    ) -> Result<DeltalakeTableManager> {
+        let arrow_schema = mooncake_table_metadata.schema.as_ref();
+        let delta_schema_struct = deltalake::kernel::Schema::try_from_arrow(arrow_schema).unwrap();
+        let delta_schema_fields = delta_schema_struct
+            .fields
+            .iter()
+            .map(|(_, cur_field)| cur_field.clone())
+            .collect::<Vec<_>>();
+
+        let table = CreateBuilder::new()
+            .with_location(config.location.clone())
+            .with_columns(delta_schema_fields)
+            .with_save_mode(deltalake::protocol::SaveMode::ErrorIfExists)
+            .await?;
+        Ok(Self {
+            config,
+            table,
+            object_storage_cache,
+            filesystem_accessor,
+            persisted_data_files: HashMap::new(),
+        })
+    }
+
+    async fn sync_snapshot(
+        &mut self,
+        snapshot_payload: PersistenceSnapshotPayload,
+        file_params: PersistenceFileParams,
+    ) -> Result<PersistenceResult> {
+        let persistence_result = self
+            .sync_snapshot_impl(snapshot_payload, file_params)
+            .await?;
+        Ok(persistence_result)
+    }
+}

--- a/src/moonlink/src/storage/deltalake/deltalake_table_manager.rs
+++ b/src/moonlink/src/storage/deltalake/deltalake_table_manager.rs
@@ -1,16 +1,14 @@
-use deltalake::kernel::engine::arrow_conversion::TryFromArrow;
-use deltalake::operations::create::CreateBuilder;
-use deltalake::DeltaTable;
-
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use deltalake::DeltaTable;
+
 use crate::error::Result;
-use crate::storage::mooncake_table::Snapshot as MooncakeSnapshot;
 use crate::storage::deltalake::deltalake_table_config::DeltalakeTableConfig;
 use crate::storage::deltalake::utils;
 use crate::storage::iceberg::table_manager::PersistenceFileParams;
 use crate::storage::iceberg::table_manager::PersistenceResult;
+use crate::storage::mooncake_table::Snapshot as MooncakeSnapshot;
 use crate::storage::mooncake_table::{
     PersistenceSnapshotPayload, TableMetadata as MooncakeTableMetadata,
 };
@@ -24,6 +22,7 @@ pub(crate) struct DataFileEntry {
 }
 
 // TODO(hjiang): Use the same table manager interface as iceberg one.
+#[allow(unused)]
 #[derive(Debug)]
 pub struct DeltalakeTableManager {
     /// Mooncake table metadata.
@@ -72,7 +71,7 @@ impl DeltalakeTableManager {
         Ok(())
     }
 
-    async fn sync_snapshot(
+    pub async fn sync_snapshot(
         &mut self,
         snapshot_payload: PersistenceSnapshotPayload,
         file_params: PersistenceFileParams,
@@ -83,7 +82,7 @@ impl DeltalakeTableManager {
         Ok(persistence_result)
     }
 
-    async fn load_snapshot_from_table(&mut self) -> Result<(u32, MooncakeSnapshot)> {
+    pub async fn load_snapshot_from_table(&mut self) -> Result<(u32, MooncakeSnapshot)> {
         let snapshot = self.load_snapshot_from_table_impl().await?;
         Ok(snapshot)
     }

--- a/src/moonlink/src/storage/deltalake/deltalake_table_manager.rs
+++ b/src/moonlink/src/storage/deltalake/deltalake_table_manager.rs
@@ -15,6 +15,7 @@ use crate::storage::mooncake_table::{
 use crate::storage::storage_utils::FileId;
 use crate::{BaseFileSystemAccess, CacheTrait};
 
+#[allow(unused)]
 #[derive(Clone, Debug)]
 pub(crate) struct DataFileEntry {
     /// Remote filepath.

--- a/src/moonlink/src/storage/deltalake/deltalake_table_syncer.rs
+++ b/src/moonlink/src/storage/deltalake/deltalake_table_syncer.rs
@@ -7,8 +7,8 @@ use serde_json::Value;
 
 use crate::create_data_file;
 use crate::error::Result;
-use crate::storage::deltalake::deltalake_table_manager::*;
 use crate::storage::deltalake::io_utils::upload_data_file_to_delta;
+use crate::storage::deltalake::{deltalake_table_manager::*, utils};
 use crate::storage::iceberg::iceberg_table_manager::MOONCAKE_TABLE_FLUSH_LSN;
 use crate::storage::iceberg::parquet_utils;
 use crate::storage::iceberg::table_manager::PersistenceFileParams;
@@ -21,6 +21,15 @@ impl DeltalakeTableManager {
         mut snapshot_payload: PersistenceSnapshotPayload,
         _file_params: PersistenceFileParams,
     ) -> Result<PersistenceResult> {
+        let table = utils::get_or_create_deltalake_table(
+            self.mooncake_table_metadata.clone(),
+            self.object_storage_cache.clone(),
+            self.filesystem_accessor.clone(),
+            self.config.clone(),
+        )
+        .await?;
+        self.table = Some(table);
+
         let new_data_files = take_data_files_to_import(&mut snapshot_payload);
         let mut new_remote_data_files = Vec::new();
         let mut delta_actions = Vec::new();

--- a/src/moonlink/src/storage/deltalake/deltalake_table_syncer.rs
+++ b/src/moonlink/src/storage/deltalake/deltalake_table_syncer.rs
@@ -1,0 +1,88 @@
+use std::collections::HashMap;
+
+use deltalake::kernel::transaction::CommitBuilder;
+use deltalake::kernel::{Action, Add};
+use deltalake::protocol::DeltaOperation;
+use serde_json::Value;
+
+use crate::create_data_file;
+use crate::error::Result;
+use crate::storage::deltalake::deltalake_table_manager::*;
+use crate::storage::deltalake::io_utils::upload_data_file_to_delta;
+use crate::storage::iceberg::deletion_vector::MOONCAKE_DELETION_VECTOR_NUM_ROWS;
+use crate::storage::iceberg::iceberg_table_manager::MOONCAKE_TABLE_FLUSH_LSN;
+use crate::storage::iceberg::parquet_utils;
+use crate::storage::iceberg::table_manager::PersistenceFileParams;
+use crate::storage::iceberg::table_manager::PersistenceResult;
+use crate::storage::mooncake_table::{take_data_files_to_import, PersistenceSnapshotPayload};
+
+impl DeltalakeTableManager {
+    pub(crate) async fn sync_snapshot_impl(
+        &mut self,
+        mut snapshot_payload: PersistenceSnapshotPayload,
+        _file_params: PersistenceFileParams,
+    ) -> Result<PersistenceResult> {
+        let new_data_files = take_data_files_to_import(&mut snapshot_payload);
+        let mut new_remote_data_files = Vec::new();
+        let mut delta_actions = Vec::new();
+
+        // Upload new data files under the given location.
+        for cur_local_data_file in new_data_files.into_iter() {
+            let (_parquet_metadata, file_size) =
+                parquet_utils::get_parquet_metadata(&cur_local_data_file.file_path()).await?;
+            let remote_filepath = upload_data_file_to_delta(
+                &self.table,
+                &cur_local_data_file.file_path,
+                &*self.filesystem_accessor,
+            )
+            .await?;
+            new_remote_data_files.push(create_data_file(
+                cur_local_data_file.file_id().0,
+                remote_filepath.clone(),
+            ));
+            let data_file_entry = DataFileEntry {
+                remote_filepath: remote_filepath.clone(),
+            };
+            assert!(self
+                .persisted_data_files
+                .insert(cur_local_data_file.file_id(), data_file_entry)
+                .is_none());
+            let add_action = Add {
+                path: remote_filepath.clone(),
+                size: file_size as i64,
+                data_change: true,
+                ..Default::default() // TODO(hjiang): Add additional stats, like min/max, row count, etc.
+            };
+            delta_actions.push(Action::Add(add_action));
+        }
+
+        // Record remote filepath to delta table.
+        let write_op = DeltaOperation::Write {
+            mode: deltalake::protocol::SaveMode::Append,
+            partition_by: None,
+            predicate: None,
+        };
+        // TODO(hjiang): Add retry attempts.
+        let app_metadata = HashMap::<String, Value>::from([(
+            MOONCAKE_TABLE_FLUSH_LSN.to_string(),
+            serde_json::from_str(&snapshot_payload.flush_lsn.to_string()).unwrap(),
+        )]);
+        CommitBuilder::default()
+            .with_actions(delta_actions)
+            .with_app_metadata(app_metadata)
+            .build(
+                Some(self.table.snapshot()?),
+                self.table.log_store().clone(),
+                write_op,
+            )
+            .await?;
+
+        let persistence_result = PersistenceResult {
+            remote_data_files: new_remote_data_files,
+            remote_file_indices: Vec::new(),
+            puffin_blob_ref: HashMap::new(),
+            evicted_files_to_delete: Vec::new(),
+        };
+        return Ok(persistence_result);
+    }
+}

--- a/src/moonlink/src/storage/deltalake/deltalake_table_syncer.rs
+++ b/src/moonlink/src/storage/deltalake/deltalake_table_syncer.rs
@@ -16,6 +16,7 @@ use crate::storage::iceberg::table_manager::PersistenceResult;
 use crate::storage::mooncake_table::{take_data_files_to_import, PersistenceSnapshotPayload};
 
 impl DeltalakeTableManager {
+    #[allow(unused)]
     pub(crate) async fn sync_snapshot_impl(
         &mut self,
         mut snapshot_payload: PersistenceSnapshotPayload,
@@ -37,9 +38,9 @@ impl DeltalakeTableManager {
         // Upload new data files under the given location.
         for cur_local_data_file in new_data_files.into_iter() {
             let (_parquet_metadata, file_size) =
-                parquet_utils::get_parquet_metadata(&cur_local_data_file.file_path()).await?;
+                parquet_utils::get_parquet_metadata(cur_local_data_file.file_path()).await?;
             let remote_filepath = upload_data_file_to_delta(
-                &self.table.as_ref().unwrap(),
+                self.table.as_ref().unwrap(),
                 &cur_local_data_file.file_path,
                 &*self.filesystem_accessor,
             )
@@ -91,6 +92,6 @@ impl DeltalakeTableManager {
             puffin_blob_ref: HashMap::new(),
             evicted_files_to_delete: Vec::new(),
         };
-        return Ok(persistence_result);
+        Ok(persistence_result)
     }
 }

--- a/src/moonlink/src/storage/deltalake/io_utils.rs
+++ b/src/moonlink/src/storage/deltalake/io_utils.rs
@@ -3,6 +3,7 @@ use deltalake::DeltaTable;
 use crate::{BaseFileSystemAccess, Result};
 
 /// Get a unique filepath for iceberg table data filepath.
+#[allow(unused)]
 fn generate_unique_data_filepath(table: &DeltaTable, local_filepath: &String) -> String {
     let filename_without_suffix = std::path::Path::new(local_filepath)
         .file_stem()
@@ -21,6 +22,7 @@ fn generate_unique_data_filepath(table: &DeltaTable, local_filepath: &String) ->
 }
 
 /// Upload the given data file to delta table.
+#[allow(unused)]
 pub(crate) async fn upload_data_file_to_delta(
     table: &DeltaTable,
     local_filepath: &String,

--- a/src/moonlink/src/storage/deltalake/io_utils.rs
+++ b/src/moonlink/src/storage/deltalake/io_utils.rs
@@ -1,0 +1,35 @@
+use deltalake::DeltaTable;
+
+use crate::{BaseFileSystemAccess, Result};
+
+/// Get a unique filepath for iceberg table data filepath.
+fn generate_unique_data_filepath(table: &DeltaTable, local_filepath: &String) -> String {
+    let filename_without_suffix = std::path::Path::new(local_filepath)
+        .file_stem()
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string();
+    let table_uri = table.table_uri();
+    let remote_filepath = format!(
+        "{}.{}-{}.parquet",
+        table_uri,
+        filename_without_suffix,
+        uuid::Uuid::now_v7()
+    );
+    remote_filepath
+}
+
+/// Upload the given data file to delta table.
+pub(crate) async fn upload_data_file_to_delta(
+    table: &DeltaTable,
+    local_filepath: &String,
+    filesystem_accessor: &dyn BaseFileSystemAccess,
+) -> Result<String> {
+    let remote_filepath = generate_unique_data_filepath(table, local_filepath);
+    // Import local parquet file to remote.
+    filesystem_accessor
+        .copy_from_local_to_remote(local_filepath, &remote_filepath)
+        .await?;
+    Ok(remote_filepath)
+}

--- a/src/moonlink/src/storage/deltalake/test.rs
+++ b/src/moonlink/src/storage/deltalake/test.rs
@@ -10,8 +10,7 @@ use crate::storage::mooncake_table::table_creation_test_utils::{
 use crate::storage::mooncake_table::table_operation_test_utils::create_local_parquet_file;
 use crate::storage::mooncake_table::{
     PersistenceSnapshotDataCompactionPayload, PersistenceSnapshotImportPayload,
-    PersistenceSnapshotIndexMergePayload, PersistenceSnapshotPayload, Snapshot as MooncakeSnapshot,
-    TableMetadata as MooncakeTableMetadata,
+    PersistenceSnapshotIndexMergePayload, PersistenceSnapshotPayload,
 };
 use crate::{create_data_file, FileSystemAccessor, ObjectStorageCache};
 

--- a/src/moonlink/src/storage/deltalake/test.rs
+++ b/src/moonlink/src/storage/deltalake/test.rs
@@ -1,0 +1,81 @@
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use tempfile::TempDir;
+
+use crate::storage::deltalake::deltalake_table_manager::DeltalakeTableManager;
+use crate::storage::iceberg::table_manager::{PersistenceFileParams, PersistenceResult};
+use crate::storage::mooncake_table::table_creation_test_utils::{
+    create_test_table_metadata, get_delta_table_config,
+};
+use crate::storage::mooncake_table::table_operation_test_utils::create_local_parquet_file;
+use crate::storage::mooncake_table::{
+    PersistenceSnapshotDataCompactionPayload, PersistenceSnapshotImportPayload,
+    PersistenceSnapshotIndexMergePayload, PersistenceSnapshotPayload, Snapshot as MooncakeSnapshot,
+    TableMetadata as MooncakeTableMetadata,
+};
+use crate::{create_data_file, FileSystemAccessor, ObjectStorageCache};
+
+#[tokio::test]
+async fn test_basic_store_and_load() {
+    const TEST_FLUSH_LSN: u64 = 10;
+
+    let temp_dir = TempDir::new().unwrap();
+    let table_path = temp_dir.path().to_str().unwrap().to_string();
+    let mooncake_table_metadata = create_test_table_metadata(table_path.clone());
+    let filesystem_accessor = FileSystemAccessor::default_for_test(&temp_dir);
+    let delta_table_config = get_delta_table_config(&temp_dir);
+
+    let mut delta_table_manager = DeltalakeTableManager::new(
+        mooncake_table_metadata.clone(),
+        Arc::new(ObjectStorageCache::default_for_test(&temp_dir)), // Use independent object storage cache.
+        filesystem_accessor.clone(),
+        delta_table_config.clone(),
+    )
+    .await
+    .unwrap();
+
+    // Perform persistence operation.
+    let filepath = create_local_parquet_file(&temp_dir).await;
+    let persistence_payload = PersistenceSnapshotPayload {
+        uuid: uuid::Uuid::new_v4(),
+        flush_lsn: TEST_FLUSH_LSN,
+        committed_deletion_logs: HashSet::new(),
+        new_table_schema: None,
+        import_payload: PersistenceSnapshotImportPayload {
+            data_files: vec![create_data_file(0, filepath)],
+            new_deletion_vector: HashMap::new(),
+            file_indices: Vec::new(),
+        },
+        index_merge_payload: PersistenceSnapshotIndexMergePayload::default(),
+        data_compaction_payload: PersistenceSnapshotDataCompactionPayload::default(),
+    };
+
+    let persist_result: PersistenceResult = delta_table_manager
+        .sync_snapshot(
+            persistence_payload,
+            PersistenceFileParams {
+                table_auto_incr_ids: 0..1,
+            },
+        )
+        .await
+        .unwrap();
+
+    // Check persistence result.
+    assert_eq!(persist_result.remote_data_files.len(), 1);
+
+    // Load latest snapshot from delta table.
+    let mut reload_mgr = DeltalakeTableManager::new(
+        mooncake_table_metadata.clone(),
+        Arc::new(ObjectStorageCache::default_for_test(&temp_dir)), // Use independent object storage cache.
+        filesystem_accessor.clone(),
+        delta_table_config.clone(),
+    )
+    .await
+    .unwrap();
+    let (next_file_id, snapshot) = reload_mgr.load_snapshot_from_table().await.unwrap();
+
+    // Validate loaded mooncake snapshot.
+    assert_eq!(next_file_id, 1);
+    assert_eq!(snapshot.disk_files.len(), 1);
+    assert_eq!(snapshot.flush_lsn.unwrap(), TEST_FLUSH_LSN);
+}

--- a/src/moonlink/src/storage/deltalake/utils.rs
+++ b/src/moonlink/src/storage/deltalake/utils.rs
@@ -13,6 +13,7 @@ use crate::Result;
 /// - If the table doesn't exist → create a new one using the Arrow schema.
 /// - If it already exists → load and return.
 /// - This mirrors the Iceberg `get_or_create_iceberg_table` pattern.
+#[allow(unused)]
 pub(crate) async fn get_or_create_deltalake_table(
     mooncake_table_metadata: Arc<MooncakeTableMetadata>,
     _object_storage_cache: Arc<dyn CacheTrait>,
@@ -40,6 +41,7 @@ pub(crate) async fn get_or_create_deltalake_table(
     }
 }
 
+#[allow(unused)]
 pub(crate) async fn get_deltalake_table_if_exists(
     config: &DeltalakeTableConfig,
 ) -> Result<Option<DeltaTable>> {

--- a/src/moonlink/src/storage/deltalake/utils.rs
+++ b/src/moonlink/src/storage/deltalake/utils.rs
@@ -1,16 +1,10 @@
-use arrow::datatypes::Schema as ArrowSchema;
 use deltalake::kernel::engine::arrow_conversion::TryFromArrow;
-use deltalake::{
-    kernel::Schema as DeltaSchema, open_table, operations::create::CreateBuilder,
-    protocol::SaveMode, DeltaOps, DeltaTable,
-};
+use deltalake::{open_table, operations::create::CreateBuilder, DeltaTable};
 use std::sync::Arc;
 
 use crate::storage::deltalake::deltalake_table_config::DeltalakeTableConfig;
 use crate::storage::filesystem::accessor::base_filesystem_accessor::BaseFileSystemAccess;
-use crate::storage::mooncake_table::{
-    PersistenceSnapshotPayload, TableMetadata as MooncakeTableMetadata,
-};
+use crate::storage::mooncake_table::TableMetadata as MooncakeTableMetadata;
 use crate::CacheTrait;
 use crate::Result;
 
@@ -21,8 +15,8 @@ use crate::Result;
 /// - This mirrors the Iceberg `get_or_create_iceberg_table` pattern.
 pub(crate) async fn get_or_create_deltalake_table(
     mooncake_table_metadata: Arc<MooncakeTableMetadata>,
-    object_storage_cache: Arc<dyn CacheTrait>,
-    filesystem_accessor: Arc<dyn BaseFileSystemAccess>,
+    _object_storage_cache: Arc<dyn CacheTrait>,
+    _filesystem_accessor: Arc<dyn BaseFileSystemAccess>,
     config: DeltalakeTableConfig,
 ) -> Result<DeltaTable> {
     match open_table(config.location.clone()).await {

--- a/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
+++ b/src/moonlink/src/storage/iceberg/iceberg_table_manager.rs
@@ -32,7 +32,7 @@ use uuid::Uuid;
 /// TODO(hjiang): store snapshot property in snapshot summary, instead of table property.
 ///
 /// Key for iceberg snapshot property, to record flush lsn.
-pub(super) const MOONCAKE_TABLE_FLUSH_LSN: &str = "moonlink.table-flush-lsn";
+pub(crate) const MOONCAKE_TABLE_FLUSH_LSN: &str = "moonlink.table-flush-lsn";
 
 #[derive(Clone, Debug)]
 pub(crate) struct DataFileEntry {

--- a/src/moonlink/src/storage/iceberg/parquet_utils.rs
+++ b/src/moonlink/src/storage/iceberg/parquet_utils.rs
@@ -248,7 +248,7 @@ fn parquet_to_data_file_builder(
 // ================================
 //
 // Get parquet metadata and file size for the given local parquet file.
-async fn get_parquet_metadata(
+pub(crate) async fn get_parquet_metadata(
     local_parquet_file: &str,
 ) -> IcebergResult<(ParquetMetaData, usize /*file size*/)> {
     let file_io = FileIOBuilder::new_fs_io().build().unwrap();

--- a/src/moonlink/src/storage/mooncake_table/table_creation_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_creation_test_utils.rs
@@ -3,6 +3,7 @@ use crate::row::IdentityProp;
 /// This module contains table creation tests utils.
 use crate::storage::cache::object_storage::base_cache::CacheTrait;
 use crate::storage::compaction::compaction_config::DataCompactionConfig;
+use crate::storage::deltalake::deltalake_table_config::DeltalakeTableConfig;
 use crate::storage::filesystem::accessor::base_filesystem_accessor::BaseFileSystemAccess;
 use crate::storage::filesystem::accessor::factory::create_filesystem_accessor;
 use crate::storage::filesystem::accessor_config::AccessorConfig;
@@ -39,6 +40,21 @@ impl MooncakeTable {
     #[cfg(test)]
     pub(crate) fn set_persistence_snapshot_lsn(&mut self, lsn: u64) {
         self.last_persistence_snapshot_lsn = Some(lsn);
+    }
+}
+
+/// Test util function to get delta table config for local filesystem.
+pub(crate) fn get_delta_table_config(temp_dir: &TempDir) -> DeltalakeTableConfig {
+    let root_directory = temp_dir.path().to_str().unwrap().to_string();
+    let storage_config = StorageConfig::FileSystem {
+        root_directory: root_directory.clone(),
+        atomic_write_dir: None,
+    };
+    let accessor_config = AccessorConfig::new_with_storage_config(storage_config);
+    DeltalakeTableConfig {
+        table_name: DELTA_TEST_TABLE.to_string(),
+        location: root_directory,
+        data_accessor_config: accessor_config,
     }
 }
 

--- a/src/moonlink/src/storage/mooncake_table/table_operation_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_operation_test_utils.rs
@@ -58,7 +58,7 @@ pub(crate) async fn create_local_parquet_file(tempdir: &TempDir) -> String {
     )
     .unwrap();
 
-    write_parquet_file(&file_path.as_path(), &[record_batch]).await;
+    write_parquet_file(file_path.as_path(), &[record_batch]).await;
     file_path.to_str().unwrap().to_string()
 }
 

--- a/src/moonlink/src/storage/mooncake_table/table_operation_test_utils.rs
+++ b/src/moonlink/src/storage/mooncake_table/table_operation_test_utils.rs
@@ -1,11 +1,16 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use arrow_array::{Int32Array, RecordBatch, StringArray};
+use parquet::arrow::AsyncArrowWriter;
+use tempfile::TempDir;
 use tokio::sync::mpsc::Receiver;
+use tracing::{debug, error};
 
 use crate::row::MoonlinkRow;
 use crate::storage::io_utils;
 use crate::storage::mooncake_table::disk_slice::DiskSliceWriter;
+use crate::storage::mooncake_table::table_creation_test_utils::create_test_arrow_schema;
 use crate::storage::mooncake_table::{
     AlterTableRequest, DataCompactionPayload, DataCompactionResult, FileIndiceMergePayload,
     FileIndiceMergeResult, PersistenceSnapshotPayload, PersistenceSnapshotResult,
@@ -18,12 +23,44 @@ use crate::table_notify::{
 };
 use crate::{MooncakeTable, ReadStateFilepathRemap, SnapshotReadOutput};
 use crate::{ReadState, Result};
-use tracing::{debug, error};
 
 #[cfg(test)]
 use crate::storage::verify_files_and_deletions;
 #[cfg(test)]
 use crate::union_read::decode_read_state_for_testing;
+
+/// ===============================
+/// Create parquet
+/// ===============================
+async fn write_parquet_file(path: &std::path::Path, batches: &[RecordBatch]) {
+    let file = tokio::fs::File::create(path).await.unwrap();
+    let mut writer =
+        AsyncArrowWriter::try_new(file, create_test_arrow_schema(), /*props=*/ None).unwrap();
+    for batch in batches.iter() {
+        writer.write(batch).await.unwrap();
+    }
+    writer.close().await.unwrap();
+}
+
+/// Create a parquet file in the given temporary directory, and return parquet filepath.
+pub(crate) async fn create_local_parquet_file(tempdir: &TempDir) -> String {
+    let file_path = tempdir
+        .path()
+        .join(format!("{}.parquet", uuid::Uuid::now_v7()));
+    let arrow_schema = create_test_arrow_schema();
+
+    let ids = Int32Array::from(vec![1, 2, 3]);
+    let names = StringArray::from(vec![Some("Alice"), Some("Bob"), None]);
+    let ages = Int32Array::from(vec![10, 20, 30]);
+    let record_batch = RecordBatch::try_new(
+        arrow_schema.clone(),
+        vec![Arc::new(ids), Arc::new(names), Arc::new(ages)],
+    )
+    .unwrap();
+
+    write_parquet_file(&file_path.as_path(), &[record_batch]).await;
+    file_path.to_str().unwrap().to_string()
+}
 
 /// ===============================
 /// Flush

--- a/src/moonlink/src/storage/mooncake_table/test_utils_commons.rs
+++ b/src/moonlink/src/storage/mooncake_table/test_utils_commons.rs
@@ -13,6 +13,8 @@ pub(crate) const ICEBERG_TEST_NAMESPACE: &str = "namespace";
 pub(crate) const ICEBERG_TEST_TABLE: &str = "test_table";
 #[cfg(feature = "catalog-rest")]
 pub(crate) const REST_CATALOG_TEST_URI: &str = "http://iceberg-rest.local:8181";
+/// Delta test table name.
+pub(crate) const DELTA_TEST_TABLE: &str = "test_table";
 /// Test constant for table id.
 pub(crate) const TEST_TABLE_ID: TableId = TableId(0);
 /// File attributes for a fake file.


### PR DESCRIPTION
## Summary

There're a few items for delta support MVP.
- Support data files sync and load
- Support deletion vector sync and load
- Support deletion vector upload for a data file
- Support index store and load
  + There's no puffin blob concept in delta as in iceberg, I will check further; in the worst case we could make assumption on its location, or record index file location in customized user-filled metadata.
- Support data files, deletion vectors and file indices removal (due to data compaction and index merge)
- Continue cleanup iceberg/delta concepts in mooncake and snapshot layer, extract common utils for them
- Integrate delta into mooncake table, snapshot, backend and metadata store

This PR does the first item: only data file store and load.

## Checklist

- [x] Code builds correctly
- [x] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x] I have reviewed my own changes
