### PR TITLE
fix(dev): devcontainer setting error

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,12 +1,11 @@
-FROM mcr.microsoft.com/devcontainers/rust:latest
+FROM mcr.microsoft.com/devcontainers/rust:bookworm
 
 RUN apt update \
- && apt install -y \
-    python3-pip \
-    mold \
- && apt install -y mold \
- && rm -rf /var/lib/apt/lists/* \
- && ln -fs /usr/bin/mold /usr/bin/ld
+   && apt install -y \
+   python3-pip \
+   && apt install -y mold \
+   && rm -rf /var/lib/apt/lists/* \
+   && ln -fs /usr/bin/mold /usr/bin/ld
 
 USER vscode
 


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

In Debian 13 (Trixie), the APT repositories do not contain docker-ce and docker-ce-cli, making it impossible to locate and install the corresponding packages. Therefore, we have reverted to the stable Debian 12 (Bookworm) version

## Related Issues

Closes #<issue-number> or links to related issues.

## Changes

- 
- 
- 

## Checklist

- [ ] Code builds correctly
- [ ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [ ] I have reviewed my own changes
