### PR TITLE
Add bearer token auth

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,15 @@
 [workspace]
 members = [
-    "src/moonlink",
-    "src/moonlink_backend",
-    "src/moonlink_connectors",
-    "src/moonlink_datafusion",
-    "src/moonlink_error",
-    "src/moonlink_metadata_store",
-    "src/moonlink_proto",
-    "src/moonlink_rpc",
-    "src/moonlink_service",
-    "src/moonlink_table_metadata",
+  "src/moonlink",
+  "src/moonlink_backend",
+  "src/moonlink_connectors",
+  "src/moonlink_datafusion",
+  "src/moonlink_error",
+  "src/moonlink_metadata_store",
+  "src/moonlink_proto",
+  "src/moonlink_rpc",
+  "src/moonlink_service",
+  "src/moonlink_table_metadata",
 ]
 resolver = "2"
 
@@ -81,8 +81,8 @@ opentelemetry-otlp = { version = "0.31", default-features = false, features = [
   "metrics",
 ] }
 opentelemetry-stdout = { version = "0.31", default-features = false, features = [
-    "trace",
-    "metrics",
+  "trace",
+  "metrics",
 ] }
 opentelemetry_sdk = { version = "0.31", default-features = false, features = [
   "trace",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,15 @@
 [workspace]
 members = [
-  "src/moonlink",
-  "src/moonlink_backend",
-  "src/moonlink_connectors",
-  "src/moonlink_datafusion",
-  "src/moonlink_error",
-  "src/moonlink_metadata_store",
-  "src/moonlink_proto",
-  "src/moonlink_rpc",
-  "src/moonlink_service",
-  "src/moonlink_table_metadata",
+    "src/moonlink",
+    "src/moonlink_backend",
+    "src/moonlink_connectors",
+    "src/moonlink_datafusion",
+    "src/moonlink_error",
+    "src/moonlink_metadata_store",
+    "src/moonlink_proto",
+    "src/moonlink_rpc",
+    "src/moonlink_service",
+    "src/moonlink_table_metadata",
 ]
 resolver = "2"
 

--- a/src/moonlink_service/src/rest_api.rs
+++ b/src/moonlink_service/src/rest_api.rs
@@ -418,7 +418,7 @@ async fn auth_middleware(
         .and_then(|header| header.to_str().ok());
 
     match auth_header {
-        Some(header) if header == &expected_header => Ok(next.run(request).await),
+        Some(header) if header == expected_header => Ok(next.run(request).await),
         _ => Err((
             StatusCode::UNAUTHORIZED,
             Json(ErrorResponse {

--- a/src/moonlink_service/src/rest_api.rs
+++ b/src/moonlink_service/src/rest_api.rs
@@ -2,8 +2,9 @@ use apache_avro::Schema as AvroSchema;
 use arrow_ipc::writer::StreamWriter;
 use axum::{
     error_handling::HandleErrorLayer,
-    extract::{Path, State},
-    http::{Method, StatusCode},
+    extract::{Path, Request, State},
+    http::{HeaderMap, Method, StatusCode},
+    middleware::{self, Next},
     response::{Json, Response},
     routing::{delete, get, post},
     BoxError, Router,
@@ -39,13 +40,26 @@ pub struct ApiState {
     pub backend: Arc<moonlink_backend::MoonlinkBackend>,
     /// Maps from source table name to schema id.
     pub kafka_schema_id_cache: Arc<RwLock<HashMap<String, u64>>>,
+    /// Bearer token for authentication (cached at startup)
+    pub bearer_token: Option<String>,
 }
 
 impl ApiState {
     pub fn new(backend: Arc<moonlink_backend::MoonlinkBackend>) -> Self {
+        let bearer_token = std::env::var("MOONLINK_REST_TOKEN")
+            .ok()
+            .filter(|token| !token.is_empty());
+
+        if bearer_token.is_some() {
+            info!("Bearer token authentication enabled for REST API");
+        } else {
+            info!("Bearer token authentication disabled for REST API");
+        }
+
         Self {
             backend,
             kafka_schema_id_cache: Arc::new(RwLock::new(HashMap::new())),
+            bearer_token,
         }
     }
 }
@@ -386,6 +400,34 @@ fn get_backend_error_status_code(error: &moonlink_backend::Error) -> StatusCode 
     }
 }
 
+async fn auth_middleware(
+    state: State<ApiState>,
+    headers: HeaderMap,
+    request: Request,
+    next: Next,
+) -> Result<Response, (StatusCode, Json<ErrorResponse>)> {
+    // Use cached bearer token from state (no env var lookup)
+    let Some(ref auth_token) = state.bearer_token else {
+        // No token configured, skip auth
+        return Ok(next.run(request).await);
+    };
+
+    let expected_header = format!("Bearer {}", auth_token);
+    let auth_header = headers
+        .get("authorization")
+        .and_then(|header| header.to_str().ok());
+
+    match auth_header {
+        Some(header) if header == &expected_header => Ok(next.run(request).await),
+        _ => Err((
+            StatusCode::UNAUTHORIZED,
+            Json(ErrorResponse {
+                message: "Invalid or missing bearer token".to_string(),
+            }),
+        )),
+    }
+}
+
 /// Create the router with all API endpoints    
 pub fn create_router(state: ApiState) -> Router {
     let timeout_layer = ServiceBuilder::new()
@@ -421,7 +463,11 @@ pub fn create_router(state: ApiState) -> Router {
         .route("/tables/{table}/optimize", post(optimize_table))
         .route("/tables/{table}/snapshot", post(create_snapshot))
         .route("/tables/{table}/flush", post(flush_table))
-        .with_state(state)
+        .with_state(state.clone())
+        .layer(middleware::from_fn_with_state(
+            state.clone(),
+            auth_middleware,
+        ))
         .layer(
             CorsLayer::new()
                 .allow_origin(Any)


### PR DESCRIPTION
<!-- .github/PULL_REQUEST_TEMPLATE.md -->

## Summary

add simple auth token check when the environment variable configured

without the environment variable configured, it just bypass the authentication

## Related Issues



## Changes

- 
- 
- 

## Checklist

- [ x] Code builds correctly
- [x ] Tests have been added or updated
- [ ] Documentation updated if necessary
- [x ] I have reviewed my own changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds optional bearer token authentication (via `MOONLINK_REST_TOKEN`) enforced by Axum middleware with 401 on missing/invalid token, plus tests.
> 
> - **REST API (Axum)**:
>   - **Auth Middleware**: Add `auth_middleware` that validates `Authorization: Bearer <token>` against `MOONLINK_REST_TOKEN` cached in `ApiState`.
>     - If unset, auth is bypassed; if set and invalid/missing, returns `401` with JSON error.
>   - **Router**: Wire middleware with `.layer(middleware::from_fn_with_state(...))`; update `ApiState` to include `bearer_token` and initialize from env.
>   - Minor handler/import updates to support middleware (`Request`, `HeaderMap`, `State` cloning).
> - **Tests**:
>   - Add `test_bearer_token_authentication` in `src/moonlink_service/src/test.rs` covering no header, wrong format, and correct token cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f211c72f7862586079e299dbdcbd3f7ede26434. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->